### PR TITLE
fix(windows): hook server named pipe + mempalace CLI detection

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -23,7 +23,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, createHash } from 'node:crypto';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -130,10 +130,20 @@ export class HiveManager {
   private agentDir(id: string): string {
     return join(this.root()!, 'agents', id);
   }
-  /** Unix-domain socket the cth-hook shim talks to (Phase 1 autonomy). */
+  /** IPC endpoint the cth-hook shim talks to (Phase 1 autonomy).
+   *  On POSIX this is a Unix-domain socket file under the hive root. On Windows,
+   *  Node's `net` IPC uses named pipes (a flat `\\.\pipe\` namespace, not the
+   *  filesystem), so a raw file path fails to bind with EACCES — derive a stable,
+   *  per-root pipe name instead. Both the server (`listen`) and the shim
+   *  (`createConnection`) read this same value, so they stay in sync. */
   sockPath(): string | null {
     const root = this.root();
-    return root ? join(root, 'hooks.sock') : null;
+    if (!root) return null;
+    if (process.platform === 'win32') {
+      const id = createHash('sha1').update(root).digest('hex').slice(0, 12);
+      return `\\\\.\\pipe\\munder-difflin-${id}`;
+    }
+    return join(root, 'hooks.sock');
   }
   private shimPath(): string | null {
     const root = this.root();

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -57,19 +57,36 @@ export class MemoryManager {
   bin(): string | null {
     if (this.binCache !== undefined) return this.binCache;
     let found: string | null = null;
+    const isWin = process.platform === 'win32';
+    // 1) Ask the shell/PATH resolver. Windows has no POSIX shell + uses `where`
+    //    and a `.exe` suffix; everything else goes through the login shell.
     try {
-      const res = spawnSync(process.env.SHELL ?? '/bin/zsh', ['-ilc', 'which mempalace'], {
-        encoding: 'utf8', timeout: 3000
-      });
-      const p = res.stdout.trim().split('\n').pop();
-      if (p && existsSync(p)) found = p;
+      if (isWin) {
+        const res = spawnSync('where', ['mempalace'], { encoding: 'utf8', timeout: 3000 });
+        const p = res.stdout.trim().split(/\r?\n/)[0]?.trim();
+        if (p && existsSync(p)) found = p;
+      } else {
+        const res = spawnSync(process.env.SHELL ?? '/bin/zsh', ['-ilc', 'which mempalace'], {
+          encoding: 'utf8', timeout: 3000
+        });
+        const p = res.stdout.trim().split('\n').pop();
+        if (p && existsSync(p)) found = p;
+      }
     } catch { /* fall through */ }
+    // 2) Probe common install locations (uv tool / homebrew / pip).
     if (!found) {
-      for (const c of [
-        `${process.env.HOME ?? ''}/.local/bin/mempalace`,
-        '/opt/homebrew/bin/mempalace',
-        '/usr/local/bin/mempalace'
-      ]) if (existsSync(c)) { found = c; break; }
+      const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+      const candidates = isWin
+        ? [
+            join(home, '.local', 'bin', 'mempalace.exe'),
+            join(process.env.LOCALAPPDATA ?? '', 'Programs', 'Python', 'Scripts', 'mempalace.exe')
+          ]
+        : [
+            `${home}/.local/bin/mempalace`,
+            '/opt/homebrew/bin/mempalace',
+            '/usr/local/bin/mempalace'
+          ];
+      for (const c of candidates) if (c && existsSync(c)) { found = c; break; }
     }
     this.binCache = found;
     return found;


### PR DESCRIPTION
## What

Makes two Windows-only code paths work, both strictly gated on
`process.platform === 'win32'` so macOS/Linux behavior is unchanged.

### 1. Hook server: named pipe on Windows
`HiveManager.sockPath()` returned a Unix-domain socket *file path*
(`<hiveRoot>/hooks.sock`) that was passed straight to `server.listen()`.
On Windows, Node's `net` IPC is implemented with **named pipes** (a flat
`\.\pipe\` namespace, not the filesystem), so a raw file path fails to
bind:

```
[hive] hook server error: Error: listen EACCES: permission denied
  D:\...\harness\hive\hooks.sock
```

The whole autonomy/hook plane (avatar activity, Stop-loop inbox drain)
never came up. Fix: on Windows derive a stable, per-root pipe name
(`\.\pipe\munder-difflin-<sha1(root)>`). Both the server (`listen`) and
the `cth-hook` shim (`createConnection`) read the same `sockPath()`, so
they stay in sync. POSIX still returns `<root>/hooks.sock`.

### 2. mempalace detection on Windows
`MemoryManager.bin()` only resolved the CLI via a POSIX login shell
(`$SHELL -ilc 'which mempalace'`) and Unix fallback paths with no `.exe`
suffix. On Windows neither matched, so semantic memory was reported as
unavailable and **HIVE MEMORY always showed "Not set up"** even after
`uv tool install mempalace`. Fix: on Windows use `where` and probe
`%USERPROFILE%\.local\bin\mempalace.exe` (the uv tool install target).

## macOS / Linux impact
None. Both changes branch on `win32`; the POSIX path is identical to
before (verified by inspection + `npm run typecheck`).

## Testing
- `npm run typecheck` passes.
- Verified on Windows 11 (Node 24, Electron 32): hook server now binds a
  named pipe, agents report activity, and `mempalace` is detected so the
  HIVE MEMORY panel activates and the shared palace is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
