### PR TITLE
fix: skip redundant pty resizes - boot banner no longer stacks in scrollback

### DIFF
--- a/src/renderer/src/components/PtyTerminalView.tsx
+++ b/src/renderer/src/components/PtyTerminalView.tsx
@@ -158,8 +158,16 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
     // up to read history back down to the bottom.
     const tryFit = (scrollToEnd = false) => {
       try {
+        const before = { cols: entry.term.cols, rows: entry.term.rows };
         entry.fit.fit();
-        window.cth.resizePty(ptyId, entry.term.cols, entry.term.rows);
+        // Only poke the pty when the grid ACTUALLY changed: every resize makes
+        // the Claude TUI repaint its whole screen, and each repaint pushes the
+        // previous frame into scrollback — the attach-time refit cascade (rAF,
+        // 60ms, 240ms, font-load) used to stack the boot banner three times
+        // before the user ever typed anything.
+        if (entry.term.cols !== before.cols || entry.term.rows !== before.rows) {
+          window.cth.resizePty(ptyId, entry.term.cols, entry.term.rows);
+        }
         entry.term.refresh(0, Math.max(0, entry.term.rows - 1));
       } catch { /* host may not be sized yet */ }
       if (scrollToEnd) {


### PR DESCRIPTION
Rebased onto v0.2.1. Since you already merged the scroll fix itself (`fe001e3` + `aa42be8` — thanks!), this PR now contains **only the follow-up you don't have yet**:

**`fix: skip redundant pty resizes — boot banner no longer stacks in scrollback`**

`tryFit()` previously called `resizePty` on every fit, even when cols/rows hadn't changed. ConPTY treats *any* resize as "redraw everything", so each agent switch re-emitted the boot banner into scrollback — switch back and forth a few times and the history was full of stacked banners. Now we only forward the resize when the dimensions actually changed.

Diff is down to one small hunk in `PtyTerminalView.tsx`.
