### PR TITLE
feat: delete button for scheduled missions

### DIFF
--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -229,6 +229,10 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
   };
   const toggleMission = (id: string) =>
     persistMissions(missions.map((m) => (m.id === id ? { ...m, enabled: !m.enabled } : m)));
+  // The backend merge in missions:save keeps only the missions the renderer
+  // sends back, so deletion is just "save the list without it".
+  const deleteMission = (id: string) =>
+    persistMissions(missions.filter((m) => m.id !== id));
   const addMission = () => {
     if (!mLabel.trim() || !mBody.trim()) return;
     const next: ScheduledMission = {
@@ -422,6 +426,16 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                 fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-ink-900)'
               }}
             >{m.enabled ? 'on' : 'off'}</button>
+            <button
+              onClick={() => deleteMission(m.id)}
+              title="Delete this scheduled mission"
+              style={{
+                padding: '2px 6px 1px', border: 'none', cursor: 'pointer', flexShrink: 0,
+                background: 'var(--cth-cream-200)',
+                boxShadow: 'inset 0 0 0 1px var(--cth-ink-700)',
+                fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-coral)'
+              }}
+            >✕</button>
           </div>
         ))}
         <div style={{ display: 'flex', gap: 6, marginTop: 6, marginBottom: 6 }}>


### PR DESCRIPTION
## What

The SCHEDULES section in Michael's command center can create missions and toggle them on/off — but there is no way to **remove** one. A stale mission stays in `config.json` forever unless the user closes the app and hand-edits the file.

## Change

A small per-row ✕ button next to the on/off toggle. No backend change needed: the `missions:save` handler already keeps only the missions the renderer sends back (it merges by id over the *incoming* array), so deletion is simply saving the list without the entry — `lastFiredAt` stamps on the remaining missions are preserved by the existing merge.

## Testing

- `npm run typecheck` passes.
- Verified on Windows 11: deleting a mission removes it from `config.json` on the spot, the scheduler timer is cleared by the existing `syncMissions()` call in the save handler, and the remaining mission's `lastFiredAt` survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
