### PR TITLE
feat: one-click restore of last session's workers after a restart (closes #15)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -228,7 +228,7 @@ export function App() {
         </div>
       </div>
 
-      <AgentStrip />
+      <AgentStrip config={config} />
 
       {addAgentOpen && (
         <AddAgentModal onClose={() => setAddAgentOpen(false)} config={config} />

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -1,13 +1,72 @@
+import { useState } from 'react';
 import { AgentCard } from './AgentCard';
 import { PixelButton } from './PixelButton';
 import { Icon } from './Icon';
-import { useStore } from '@/store/store';
+import { useStore, type Agent } from '@/store/store';
+import { buildSpawnCommand, type HarnessConfig } from '@/store/config';
 
-export function AgentStrip() {
+export interface AgentStripProps {
+  /** Needed to rebuild a spawn command when a restorable agent predates the
+   *  persisted `command` field. Optional so the strip renders without config. */
+  config?: HarnessConfig | null;
+}
+
+export function AgentStrip({ config }: AgentStripProps) {
   const agents = useStore(s => s.agents);
+  const restorableAgents = useStore(s => s.restorableAgents);
   const selectedId = useStore(s => s.selectedId);
   const select = useStore(s => s.select);
   const setAddAgentOpen = useStore(s => s.setAddAgentOpen);
+  const [restoring, setRestoring] = useState(false);
+
+  /** Respawn every worker from the previous session with its ORIGINAL agent id,
+   *  cwd, model and command — the hive workspace (memory.md, inbox, registry
+   *  entry) reattaches by itself, no memory transplant needed. */
+  const restoreTeam = async () => {
+    if (restoring) return;
+    setRestoring(true);
+    const prevSel = useStore.getState().selectedId;
+    try {
+      for (const a of [...restorableAgents]) {
+        const command = (a.command ?? '').trim() || (config ? buildSpawnCommand(config, a.model) : '');
+        if (!command || !a.cwd) { useStore.getState().removeRestorableAgent(a.id); continue; }
+        const [exe, ...args] = command.split(/\s+/);
+        const ptyId = a.ptyId ?? `pty-${a.id}`;
+        const res = await window.cth.spawnPty({
+          id: ptyId,
+          cwd: a.cwd,
+          command: exe,
+          args,
+          cols: 100,
+          rows: 30,
+          // Re-request isolation if the agent ran in its own worktree before —
+          // the old worktree was torn down on exit, so a fresh one is created.
+          isolate: !!a.worktreePath,
+          hive: { id: a.id, name: a.name, cwd: a.cwd, role: a.description }
+        });
+        if (res.ok) {
+          useStore.getState().addAgent({
+            ...a,
+            ptyId,
+            archived: false,
+            status: 'idle',
+            action: 'starting up',
+            carrying: undefined,
+            currentStation: 'desk',
+            recentTextTs: Date.now()
+          });
+        } else {
+          // Leave it restorable so the user can retry; don't block the rest.
+          console.error('[restore] spawn failed for', a.id, res.error);
+        }
+      }
+    } finally {
+      // addAgent auto-selects each spawn; put the user back where they were.
+      const sel = useStore.getState();
+      if (prevSel && sel.agents.some((x) => x.id === prevSel)) sel.select(prevSel);
+      setRestoring(false);
+    }
+  };
 
   return (
     <div style={{
@@ -38,6 +97,23 @@ export function AgentStrip() {
           onClick={() => select(a.id)}
         />
       ))}
+      {restorableAgents.length > 0 && (
+        <span
+          style={{ alignSelf: 'center', flexShrink: 0 }}
+          title={`Respawn from last session: ${restorableAgents.map((a: Agent) => a.name).join(', ')} — same ids, memory and inboxes reattach automatically`}
+        >
+          <PixelButton
+            variant="primary"
+            size="lg"
+            onClick={restoreTeam}
+            disabled={restoring}
+          >
+            <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+              <Icon name="play" /> {restoring ? 'restoring…' : `restore team (${restorableAgents.length})`}
+            </span>
+          </PixelButton>
+        </span>
+      )}
       <PixelButton
         variant="secondary"
         size="lg"

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -101,6 +101,12 @@ interface State {
    *  roster/floor. The hive registry retains them durably; this mirrors them for
    *  the renderer's "Archived" view. */
   archivedAgents: Agent[];
+  /** Workers from the previous session whose terminal died with the app (quit /
+   *  crash). Kept with their full spawn recipe (id, cwd, model, command) so the
+   *  user can one-click respawn them with the SAME agent id — memory, inbox and
+   *  registry entry reattach by themselves. God/assistant are excluded (they
+   *  auto-respawn). */
+  restorableAgents: Agent[];
   selectedId: string | null;
   feeds: Record<string, string[]>;
   addAgentOpen: boolean;
@@ -134,6 +140,8 @@ interface State {
   /** Permanently forget an archived agent (drops the renderer entry only; the
    *  hive registry keeps its record). */
   removeArchivedAgent: (id: string) => void;
+  /** Drop one agent from the restorable list (it was respawned or dismissed). */
+  removeRestorableAgent: (id: string) => void;
   /** Park a message for an agent. Returns nothing; the flush loop delivers it. */
   enqueueMessage: (agentId: string, text: string) => void;
   /** Drop a single queued message (user removed it, or it was just delivered). */
@@ -155,6 +163,7 @@ const LS_SIDEBAR_WIDTH = 'cth.sidebarWidth';
 const LS_SIDEBAR_TAB = 'cth.sidebarTab';
 const LS_AGENTS = 'cth.agents';
 const LS_ARCHIVED = 'cth.archivedAgents';
+const LS_RESTORABLE = 'cth.restorableAgents';
 const LS_SELECTED = 'cth.selectedId';
 const LS_QUEUES = 'cth.messageQueues';
 const LS_ENRICH = 'cth.enrichEnabled';
@@ -223,6 +232,34 @@ function loadPersistedArchived(): Agent[] {
   }
 }
 
+function persistRestorable(restorable: Agent[]): void {
+  try {
+    const slim: PersistedAgent[] = restorable.map(({ recentAssistantText, recentTextTs, blockReason, ...rest }) => {
+      void recentAssistantText; void recentTextTs; void blockReason;
+      return rest;
+    });
+    window.localStorage.setItem(LS_RESTORABLE, JSON.stringify(slim));
+  } catch { /* noop */ }
+}
+
+function loadPersistedRestorable(): Agent[] {
+  try {
+    const raw = window.localStorage.getItem(LS_RESTORABLE);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as PersistedAgent[];
+    if (!Array.isArray(parsed)) return [];
+    // No live process — clear run-state; the spawn recipe fields are what matter.
+    return parsed.map((a) => ({
+      ...a,
+      status: 'idle',
+      carrying: undefined,
+      currentStation: undefined
+    }));
+  } catch {
+    return [];
+  }
+}
+
 function persistQueues(queues: Record<string, QueuedMessage[]>): void {
   try {
     // Only keep non-empty queues so the key stays small.
@@ -277,6 +314,7 @@ const initialSidebarTab: SidebarTab = (() => {
 
 const initialAgents = loadPersistedAgents();
 const initialArchivedAgents = loadPersistedArchived();
+const initialRestorableAgents = loadPersistedRestorable();
 const initialSelectedId = loadPersistedSelectedId(initialAgents);
 const initialQueues = loadPersistedQueues();
 const initialEnrichEnabled: boolean = (() => {
@@ -294,6 +332,7 @@ function newQueuedId(): string {
 export const useStore = create<State>((set) => ({
   agents: initialAgents,
   archivedAgents: initialArchivedAgents,
+  restorableAgents: initialRestorableAgents,
   selectedId: initialSelectedId,
   feeds: {},
   addAgentOpen: false,
@@ -322,11 +361,15 @@ export const useStore = create<State>((set) => ({
       const agents = [...s.agents, agent];
       // Re-spawning an archived agent un-archives it: an id is active xor archived.
       const archivedAgents = s.archivedAgents.filter((a) => a.id !== agent.id);
+      // A live (re)spawn also consumes any restorable entry for the same id.
+      const restorableAgents = s.restorableAgents.filter((a) => a.id !== agent.id);
       persistAgents(agents, agent.id);
       persistArchived(archivedAgents);
+      if (restorableAgents.length !== s.restorableAgents.length) persistRestorable(restorableAgents);
       return {
         agents,
         archivedAgents,
+        restorableAgents,
         selectedId: agent.id,
         feeds: { ...s.feeds, [agent.id]: s.feeds[agent.id] ?? [] }
       };
@@ -372,6 +415,13 @@ export const useStore = create<State>((set) => ({
       persistArchived(archivedAgents);
       return { archivedAgents };
     }),
+  removeRestorableAgent: (id) =>
+    set((s) => {
+      if (!s.restorableAgents.some((a) => a.id === id)) return s;
+      const restorableAgents = s.restorableAgents.filter((a) => a.id !== id);
+      persistRestorable(restorableAgents);
+      return { restorableAgents };
+    }),
   enqueueMessage: (agentId, text) =>
     set((s) => {
       const trimmed = text.trim();
@@ -403,13 +453,24 @@ export const useStore = create<State>((set) => ({
       // Keep agents with no PTY (synthetic) or whose PTY is still alive.
       const agents = s.agents.filter((a) => !a.ptyId || live.has(a.ptyId));
       if (agents.length === s.agents.length) return s;
+      // Workers whose terminal died with the previous session become restorable
+      // (full spawn recipe retained) instead of silently vanishing. God and the
+      // assistant are excluded — they auto-respawn at boot.
+      const dead = s.agents.filter(
+        (a) => a.ptyId && !live.has(a.ptyId) && !a.isGod && !a.isAssistant
+      );
+      const restorableAgents = [
+        ...s.restorableAgents.filter((r) => !dead.some((d) => d.id === r.id)),
+        ...dead
+      ];
       const feeds: Record<string, string[]> = {};
       for (const a of agents) feeds[a.id] = s.feeds[a.id] ?? [];
       const selectedId = agents.some((a) => a.id === s.selectedId)
         ? s.selectedId
         : (agents[0]?.id ?? null);
       persistAgents(agents, selectedId);
-      return { agents, feeds, selectedId };
+      persistRestorable(restorableAgents);
+      return { agents, feeds, selectedId, restorableAgents };
     }),
   setAddAgentOpen: (open) => set({ addAgentOpen: open }),
   setFullscreen: (id) => set({ fullscreenAgentId: id }),


### PR DESCRIPTION
## What

Closes #15 — after a harness restart, workers from the previous session can be respawned with **one click**, keeping their original agent ids so their hive `memory.md`, inbox and registry entry reattach automatically. No more re-adding agents and hand-transplanting memories after every restart.

## How

- **`reconcileWithLivePtys`** (store): dead-pty workers are moved into a new persisted `restorableAgents` list (full spawn recipe: id, cwd, model, command, worktree flag) instead of being silently dropped. God/assistant excluded — they auto-respawn at boot.
- **`AgentStrip`**: shows a `▶ restore team (N)` button while that list is non-empty. Clicking it respawns each worker sequentially with its **original agent id** — `ensureAgent()` already treats a same-id spawn as a live respawn (clears `archived`), so the hive workspace reattaches by itself. Worktree-isolated agents respawn with `isolate` set (the old worktree was torn down on exit; a fresh one is created). Selection is restored afterwards so the spawns don't yank focus.
- **`addAgent`** consumes any restorable entry with the same id, so a manual re-add and a restore can't duplicate.
- Failures leave the entry restorable (retry-able) and don't block the rest of the team.

Deliberately **no auto-respawn on boot**: starting N claude sessions is a billing decision, so it stays behind an explicit click.

## Testing

- `npm run typecheck` passes.
- Verified on Windows 11 with a 6-agent hive: quit → relaunch → button shows `restore team (4)` → all four workers respawn with their old ids, read their `memory.md`/inboxes and resume; the button disappears; a second restart restores the restored set again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
