### PR TITLE
fix(windows): keep the hive running behind the lock screen (fixes #17)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, clipboard, dialog, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, clipboard, dialog, ipcMain, powerSaveBlocker, shell } from 'electron';
 import { spawn } from 'node:child_process';
 import { rmSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
@@ -79,9 +79,29 @@ function teardownPty(id: string): void {
       .then(r => { if (!r.ok) console.error('[worktree] removeWorktree failed:', r.error); })
       .catch(e => console.error('[worktree] removeWorktree threw:', e));
   }
+  syncKeepAwake();
 }
 // A natural PTY exit must run the same teardown as an explicit kill.
 ptyManager.setExitHandler(teardownPty);
+
+/** Keep the system from suspending the harness while agents are running.
+ *  Windows Modern Standby suspends desktop apps (and their child `claude`
+ *  processes!) shortly after the display sleeps/locks — the whole hive froze
+ *  mid-turn until unlock. `prevent-app-suspension` blocks exactly that while
+ *  still letting the display turn off and the session lock. Held only while at
+ *  least one PTY is alive, so an idle harness doesn't pin a laptop awake. */
+let keepAwakeId: number | null = null;
+function syncKeepAwake(): void {
+  const live = ptyManager.list().length > 0;
+  if (live && keepAwakeId === null) {
+    keepAwakeId = powerSaveBlocker.start('prevent-app-suspension');
+    console.log('[power] keep-awake ON — agents running');
+  } else if (!live && keepAwakeId !== null) {
+    try { if (powerSaveBlocker.isStarted(keepAwakeId)) powerSaveBlocker.stop(keepAwakeId); } catch { /* noop */ }
+    keepAwakeId = null;
+    console.log('[power] keep-awake off — no agents');
+  }
+}
 
 /** A mission's live scheduler handles: the initial `setTimeout` that waits out
  *  the time remaining until its next due fire, and the steady `setInterval`
@@ -206,7 +226,12 @@ function createWindow(): void {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false,
       contextIsolation: true,
-      nodeIntegration: false
+      nodeIntegration: false,
+      // The renderer runs the hive's heartbeat loops (inbox nudge, message
+      // flush, telemetry polls). Chromium throttles timers in occluded windows
+      // — incl. behind the LOCK SCREEN — which silently stalls the hive while
+      // the user is away. Don't.
+      backgroundThrottling: false
     }
   });
 
@@ -297,7 +322,9 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
   // Remember which agent owns this PTY so closing the tab can archive it. A
   // live terminal means active — ensureAgent above already cleared `archived`.
   if (opts.hive?.id) ptyToAgent.set(opts.id, opts.hive.id);
-  return ptyManager.spawn(opts);
+  const res = ptyManager.spawn(opts);
+  syncKeepAwake();
+  return res;
 });
 ipcMain.handle('pty:write', (_evt, id: string, data: string) => {
   if (typeof id !== 'string' || typeof data !== 'string') return { ok: false, error: 'invalid args' };


### PR DESCRIPTION
## What

Fixes #17 â€” the hive freezing behind the Windows lock screen.

Two stacked causes: Windows Modern Standby suspends desktop apps (and their child `claude` processes) shortly after the display sleeps/locks, freezing every agent mid-turn until unlock; and Chromium throttles timers in occluded windows (the lock screen counts), stalling the renderer's heartbeat loops (inbox-wake nudge, message-queue flush, telemetry polls).

## Change

- **`powerSaveBlocker('prevent-app-suspension')`, PTY-gated:** started when the first agent terminal spawns, released when the last one exits (`syncKeepAwake()` called from the spawn handler and `teardownPty`). The display still sleeps and the session still locks â€” only idle-triggered process suspension is prevented. Explicit sleep (lid close, Start â†’ Sleep) is unaffected, and an idle harness doesn't pin a laptop awake.
- **`backgroundThrottling: false`** on the main window so the renderer loops keep full cadence while occluded.

## Trade-off

With agents running, a laptop on battery won't drift into standby â€” intended, but it's real battery use if the user walks away unplugged. The PTY-gated lifecycle keeps this scoped to "work is actually happening". If you'd prefer it user-configurable, happy to add a settings toggle.

## Testing

- `npm run typecheck` passes.
- Draft until verified on real hardware overnight: the mechanism is confirmed (agents demonstrably froze behind the lock screen on Windows 11 Modern Standby; `prevent-app-suspension` is Electron's documented counter for exactly this), and a lock-screen soak test on a live 6-agent hive is running next â€” will mark ready once the activity log shows work marching through a locked period.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
