### PR TITLE
feat: terminal theme toggle (per-session Claude theme) + Unicode 11 emoji widths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@lezer/highlight": "^1.2.3",
         "@uiw/react-codemirror": "^4.25.10",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^5.5.0",
         "better-sqlite3": "^11.10.0",
@@ -2492,6 +2493,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/addon-webgl": {
       "version": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@lezer/highlight": "^1.2.3",
     "@uiw/react-codemirror": "^4.25.10",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^5.5.0",
     "better-sqlite3": "^11.10.0",

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -137,6 +137,10 @@ export interface HarnessConfig {
   circuitBreaker?: CircuitBreakerConfig;
   /** Fire native desktop notifications on agent lifecycle events (idle finish / waiting for input). */
   notifications?: boolean;
+  /** Terminal theme — mirrored into each agent's per-session Claude settings
+   *  ("theme" key) at spawn so the TUI's truecolor palette matches. Scoped to
+   *  harness agents only; the user's global Claude theme is never touched. */
+  terminalTheme?: 'light' | 'dark';
   /** Master toggle for the Slack → Michael's-queue integration. */
   slackEnabled?: boolean;
   /** Slack app signing secret (Basic Information → Signing Secret). Never logged. */

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -240,7 +240,7 @@ export class HiveManager {
    * Ensure an agent's workspace + registry entry, returning the spawn injection
    * (extra `claude` args + env) that makes the process hive-aware.
    */
-  ensureAgent(meta: AgentMeta, opts: { semanticMemory?: boolean } = {}): SpawnInjection {
+  ensureAgent(meta: AgentMeta, opts: { semanticMemory?: boolean; theme?: 'light' | 'dark' } = {}): SpawnInjection {
     const root = this.root();
     if (!root) return { args: [], env: {} };
     this.ensureHive();
@@ -310,7 +310,7 @@ export class HiveManager {
     if (sock && shim) {
       env.HIVE_SOCK = sock;
       const settingsPath = join(dir, 'settings.json');
-      this.writeJson(settingsPath, this.hookSettings(shim));
+      this.writeJson(settingsPath, this.hookSettings(shim, opts.theme));
       args.push('--settings', settingsPath);
     }
     return { args, env };
@@ -366,13 +366,17 @@ export class HiveManager {
   }
 
   /** Claude Code settings that route every relevant hook through the shim. */
-  private hookSettings(shim: string): unknown {
+  private hookSettings(shim: string, theme?: 'light' | 'dark'): unknown {
     const cmd = `node "${shim}"`;
     const entry = (matcher?: string) => ({
       ...(matcher ? { matcher } : {}),
       hooks: [{ type: 'command', command: cmd }]
     });
     return {
+      // Match the TUI's truecolor palette to the harness terminal theme —
+      // PER SESSION, so the user's global Claude theme (their own terminals
+      // outside the app) is never touched.
+      ...(theme ? { theme } : {}),
       hooks: {
         Stop: [entry()],
         SubagentStop: [entry()],

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -677,7 +677,10 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
   // identity + protocol (extra --append-system-prompt args + AGENT_* env).
   if (opts.hive && hive.enabled()) {
     try {
-      const inj = hive.ensureAgent({ ...opts.hive, cwd: opts.cwd }, { semanticMemory: memory.active() });
+      const inj = hive.ensureAgent(
+        { ...opts.hive, cwd: opts.cwd },
+        { semanticMemory: memory.active(), theme: readConfig().terminalTheme ?? 'light' }
+      );
       opts.args = [...(opts.args ?? []), ...inj.args];
       // Point the agent's mempalace CLI at the shared palace (no-op if inactive).
       opts.env = { ...(opts.env ?? {}), ...inj.env, ...memory.env() };
@@ -748,6 +751,10 @@ ipcMain.handle('app:copyToClipboard', (_evt, text: unknown) => {
 ipcMain.handle('app:readClipboard', () => {
   try { return clipboard.readText(); } catch { return ''; }
 });
+// NOTE: the terminal theme is mirrored into each agent's per-session Claude
+// settings at spawn (hive.ensureAgent theme option) — deliberately NOT via
+// `claude config set -g theme`, which would also restyle the user's own
+// Claude sessions outside the app.
 
 // ─── IPC: folder picker ─────────────────────────────────────────────────────
 ipcMain.handle('dialog:chooseFolder', async (evt) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -121,6 +121,8 @@ export interface HarnessConfig {
   agentTokenCaps?: Record<string, number>;
   maxTurns?: number;
   circuitBreaker?: CircuitBreakerConfig;
+  /** Terminal theme, mirrored into each agent's per-session Claude settings. */
+  terminalTheme?: 'light' | 'dark';
 }
 
 export interface MemoryStatus {

--- a/src/renderer/src/components/PtyTerminalView.tsx
+++ b/src/renderer/src/components/PtyTerminalView.tsx
@@ -26,6 +26,9 @@ function loadTheme(): PtyTheme {
     const v = window.localStorage.getItem(LS_THEME);
     if (v === 'dark' || v === 'light') return v;
   } catch { /* noop */ }
+  // Cream by default — safe because each agent's per-session Claude settings
+  // mirror the terminal theme, so the TUI paints the matching truecolor
+  // palette (light on cream, dark on ink).
   return 'light';
 }
 
@@ -272,8 +275,20 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
         live · pty {ptyId}
         <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 2 }}>
           <button
-            onClick={() => setPtyTheme((t) => (t === 'dark' ? 'light' : 'dark'))}
-            title={ptyTheme === 'dark' ? 'Switch to light terminal' : 'Switch to dark terminal'}
+            onClick={() => {
+              const next: PtyTheme = ptyTheme === 'dark' ? 'light' : 'dark';
+              setPtyTheme(next);
+              // Mirror into the harness config: every agent (re)spawned from
+              // now on gets the matching `theme` in its per-session Claude
+              // settings, so the TUI's truecolor palette fits the terminal.
+              // Scoped to harness agents — the user's global Claude theme
+              // (their own terminals) is never touched. Running sessions keep
+              // their palette until they restart.
+              void window.cth.updateConfig({ terminalTheme: next });
+            }}
+            title={ptyTheme === 'dark'
+              ? 'Switch terminal + agent sessions to the light theme'
+              : 'Switch terminal + agent sessions to the dark theme'}
             style={{ ...zoomBtnStyle, width: 22, marginRight: 4 }}
           >{ptyTheme === 'dark' ? '☀' : '☾'}</button>
           <button

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -16,6 +16,7 @@
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
 import '@xterm/xterm/css/xterm.css';
 
 export interface TerminalEntry {
@@ -68,6 +69,12 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
   });
   const fit = new FitAddon();
   term.loadAddon(fit);
+  // Unicode 11 width tables: xterm's default (Unicode 6) counts most emoji as
+  // ONE cell wide, but Claude Code positions text with modern widths (emoji =
+  // two cells) — the glyph then overflows its single cell and merges with the
+  // following text (e.g. "✅FIX-…"). Match the app's idea of character width.
+  term.loadAddon(new Unicode11Addon());
+  term.unicode.activeVersion = '11';
   // NOTE: don't open() yet — xterm needs its host connected to the document to
   // measure correctly. We open on first attach (see attachTerminal).
 


### PR DESCRIPTION
Rebased onto v0.2.1 — and happily, most of this PR is no longer needed: the WebGL renderer, copy/paste wiring and `minimumContrastRatio` all landed in your v0.2.0 work (your 4.5 ratio is the better pick). 🎉

What remains here are the two pieces main doesn't have yet:

1. **Terminal theme toggle with per-session Claude theme mirroring** — a dark/cream toggle on the terminal panel, persisted as `terminalTheme` in the harness config. The interesting bit: each agent's generated `--settings` file gets a scoped `"theme"` key, so the *Claude Code TUI itself* (syntax colors, diff colors) matches the terminal theme — without touching the user's global `claude config`, so terminals outside the app are unaffected. Cream stays the default.
2. **Unicode 11 width tables** (`@xterm/addon-unicode11`) — xterm's default measures emoji like ✅/⚠️ as width 1, so the glyph painted over the following character ("✅Done" rendered merged). Claude Code's own renderer uses Unicode 11 widths; with the addon the TUI's column math and xterm's agree and emoji get their proper two cells.

Diff is now 8 files / ~50 lines.
