### PR TITLE
fix: deliver multi-line messages via bracketed paste (fixes #24)

### DIFF
--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -24,16 +24,22 @@ const INITIAL_GOD_PROMPT = [
 ].join('\n');
 
 /**
- * Type a line into an agent's Claude Code TUI and actually submit it.
+ * Type a message into an agent's Claude Code TUI and actually submit it.
  *
- * Writing the text and the carriage return in a single chunk makes the TUI
- * treat the whole thing as a paste, so the "\r" lands as a newline inside the
- * input box instead of submitting — the command just sits there as text. We
- * send the text first, then the Enter as a separate keystroke a tick later so
- * the prompt is registered and executed. Idle autonomous agents thus act on a
- * dispatched instruction on their own. */
+ * The text is wrapped in bracketed-paste markers (ESC[200~ … ESC[201~) so the
+ * TUI treats it as ONE paste: embedded newlines land as literal newlines
+ * inside the input box. Without the markers, every "\n" in a multi-line
+ * message acted as Enter — the message was submitted line by line in
+ * fragments, and the agent effectively only saw the last chunk. This affected
+ * every harness delivery: queued composer messages, inbox-wake nudges, the
+ * god agent's own multi-line boot orientation prompt, and enrich tasks.
+ *
+ * The closing Enter is still sent as a separate keystroke a tick later: inside
+ * the paste it would also just be a newline, so the prompt would sit there
+ * unsubmitted. Idle autonomous agents thus act on a dispatched instruction on
+ * their own. */
 async function submitToPty(ptyId: string, text: string): Promise<void> {
-  await window.cth.writePty(ptyId, text);
+  await window.cth.writePty(ptyId, `\x1b[200~${text}\x1b[201~`);
   await new Promise((r) => setTimeout(r, 140));
   await window.cth.writePty(ptyId, '\r');
 }


### PR DESCRIPTION
## What

Fixes #24 — multi-line messages typed into agent TUIs arrived chopped: every embedded `\n` acted as Enter, so the agent received the message as line-by-line fragments (and effectively only saw the last chunk). Affected every harness delivery — queued composer messages, inbox-wake nudges, the god agent's own 5-line boot orientation prompt, and enrich tasks.

## Change

One function (`submitToPty`): wrap the text in **bracketed-paste markers** (`ESC[200~ … ESC[201~`) — exactly what real terminals send when pasting — so the TUI treats it as one paste with literal newlines. The separate Enter keystroke 140 ms later submits the complete message, as before (inside the paste it would just be another newline).

## Testing

- `npm run typecheck` passes.
- Verified on Windows 11: a 6-line queued message lands as one block in the agent's input box and is submitted whole; the god boot prompt arrives intact for the first time; single-line deliveries unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
