### PR TITLE
fix: composer drafts survive agent switches + visible caret on dark-mode OS (fixes #25)

### DIFF
--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -1,4 +1,4 @@
-import { useState, KeyboardEvent } from 'react';
+import { KeyboardEvent } from 'react';
 import { PixelButton } from './PixelButton';
 import { Icon } from './Icon';
 import { useStore, type Agent, type QueuedMessage } from '@/store/store';
@@ -26,7 +26,11 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   const enrichEnabled = useStore((s) => s.enrichEnabled);
   const setEnrichEnabled = useStore((s) => s.setEnrichEnabled);
 
-  const [text, setText] = useState('');
+  // Draft lives in the store, keyed by agent — switching agents remounts this
+  // component, and component-local state would silently eat the typed text.
+  const text = useStore((s) => s.drafts[agent.id] ?? '');
+  const setDraft = useStore((s) => s.setDraft);
+  const setText = (t: string) => setDraft(agent.id, t);
 
   // The enrich toggle governs Michael's queue (it routes through the assistant).
   const showEnrichToggle = !!agent.isGod;

--- a/src/renderer/src/design/global.css
+++ b/src/renderer/src/design/global.css
@@ -2,6 +2,11 @@
 
 *, *::before, *::after { box-sizing: border-box; }
 
+/* The app is a fixed cream/light design. Without declaring it, Chromium on a
+   dark-mode OS styles form controls with the DARK UA scheme — most visibly a
+   white text caret on our cream textareas (invisible cursor). */
+:root { color-scheme: light; }
+
 html, body, #root {
   margin: 0;
   height: 100%;
@@ -28,6 +33,9 @@ button, input, textarea, select {
   font-size: inherit;
   color: inherit;
 }
+
+/* Belt + suspenders for the caret: follow the ink, never the UA scheme. */
+input, textarea { caret-color: var(--cth-ink-900); }
 
 /* Pixel-snapping for any rasterised content */
 canvas, img, svg { image-rendering: pixelated; image-rendering: crisp-edges; }

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -134,6 +134,10 @@ interface State {
   /** Permanently forget an archived agent (drops the renderer entry only; the
    *  hive registry keeps its record). */
   removeArchivedAgent: (id: string) => void;
+  /** Unsent composer drafts, per agent — so switching agents (which remounts
+   *  the composer) doesn't eat what the user was typing. */
+  drafts: Record<string, string>;
+  setDraft: (agentId: string, text: string) => void;
   /** Park a message for an agent. Returns nothing; the flush loop delivers it. */
   enqueueMessage: (agentId: string, text: string) => void;
   /** Drop a single queued message (user removed it, or it was just delivered). */
@@ -372,6 +376,9 @@ export const useStore = create<State>((set) => ({
       persistArchived(archivedAgents);
       return { archivedAgents };
     }),
+  drafts: {},
+  setDraft: (agentId, text) =>
+    set((s) => ({ drafts: { ...s.drafts, [agentId]: text } })),
   enqueueMessage: (agentId, text) =>
     set((s) => {
       const trimmed = text.trim();


### PR DESCRIPTION
## What

Fixes #25 — two composer/input papercuts.

## Changes

1. **Drafts survive agent switches.** The composer's text moves from component-local state into the store, keyed by agent id (`drafts` + `setDraft`). Switching agents remounts the composer, which previously ate the typed text; now each agent keeps its own unsent draft, cleared on send.
2. **Caret visible on dark-mode systems.** Declare `:root { color-scheme: light }` for the fixed cream design — without it, Chromium on a dark-mode OS styles form controls with the dark UA scheme, most visibly a white (invisible) text caret on the cream textareas; scrollbars and select popups also normalize. `caret-color: var(--cth-ink-900)` pins it explicitly as belt and suspenders.

## Testing

- `npm run typecheck` passes.
- Verified on Windows 11 (dark mode): type for one agent → switch → switch back → draft intact; caret clearly visible in composer, dispatch box and mission inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
