### PR TITLE
fix: enforce the assistant's send-only contract at the router (fixes #32)

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -527,7 +527,24 @@ export class HiveManager {
       ? Object.keys(reg.agents).filter((a) => a !== msg.from && !reg.agents[a]?.isAssistant && !reg.agents[a]?.archived)
       // Never deliver to self — guards a god → "human" message looping back to god.
       : [resolveTo(msg.to)].filter((t) => t !== msg.from);
-    for (const t of targets) this.deliver(msg, t);
+    for (const t of targets) {
+      // Enforce the assistant's send-only contract AT THE ROUTER: it has no
+      // composer, is excluded from the inbox-wake nudge, and never reads an
+      // inbox — yet direct mail used to be delivered there anyway, where it
+      // rotted unread (observed live: a task brief plus the follow-up
+      // reprimand about the unread inbox, both unread for hours). Bounce such
+      // mail to god instead, so the sender's intent surfaces immediately and
+      // nothing is silently lost.
+      if (reg.agents[t]?.isAssistant) {
+        this.deliver({
+          ...msg,
+          to: godId,
+          subject: `[bounced — "${t}" is the send-only prep assistant; route work to a real agent] ${msg.subject}`
+        }, godId);
+        continue;
+      }
+      this.deliver(msg, t);
+    }
     this.appendLog({ kind: 'message', from: msg.from, to: msg.to, act: msg.act, subject: msg.subject, id: msg.id });
     this.emitMessage(msg, targets);
   }


### PR DESCRIPTION
## What

Fixes #32 â€” direct mail to the send-only prep assistant black-holed in an inbox nothing ever reads.

## Change

One spot in `HiveManager.route()`: when a resolved target is an `isAssistant` agent, the message is **bounced to god** instead of delivered, with the subject prefixed `[bounced â€” "<id>" is the send-only prep assistant; route work to a real agent]`. The sender (usually the orchestrator) learns immediately that it addressed the wrong agent and can reroute â€” instead of waiting on an agent that will never answer.

Considered and rejected: making the assistant read its inbox (including it in the inbox-wake nudge). That fixes the rot but erodes the role â€” the assistant is deliberately a stateless prompt-enricher with no composer; the right place to enforce a routing contract is the router.

Broadcast behavior is unchanged (already filtered). `requires_reply`/conversation fields ride along on the bounce, so god sees the full original intent.

## Testing

- `npm run typecheck` passes.
- Verified in a live hive: god â†’ assistant direct mail arrives in god's own inbox with the bounce prefix within one router tick; the assistant's inbox stays empty; the enrich flow (assistant â†’ god) is unaffected.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
