### PR TITLE
fix(windows): usage meter read 0/0 - transcript dir encoding

### DIFF
--- a/src/main/transcript.ts
+++ b/src/main/transcript.ts
@@ -6,9 +6,14 @@ import { estimateCostUsd, normalizeModel } from './pricing';
 /** Resolve the Claude Code transcript directory for a given working directory.
  *  Claude Code stores per-project transcripts under ~/.claude/projects, keying
  *  each project by its absolute cwd with the leading slash dropped and every
- *  remaining slash turned into a dash (e.g. /Users/me/app → Users-me-app). */
+ *  remaining slash turned into a dash (e.g. /Users/me/app → Users-me-app). On
+ *  Windows EVERY non-alphanumeric character is dashed (drive colon and
+ *  backslashes included): C:\Users\me\app → C--Users-me-app. */
 export function projectDir(cwd: string): string {
-  return path.join(os.homedir(), '.claude/projects', cwd.replace(/^\//, '').replaceAll('/', '-'));
+  const key = process.platform === 'win32'
+    ? cwd.replace(/[^a-zA-Z0-9]/g, '-')
+    : cwd.replace(/^\//, '').replaceAll('/', '-');
+  return path.join(os.homedir(), '.claude/projects', key);
 }
 
 export interface AgentUsage {


### PR DESCRIPTION
Fixes #10.

On Windows the usage meter always read 0 tokens / $0.00. The transcript reconciler builds the per-project directory name with the POSIX rule (`cwd.replace(/^\//,'').replaceAll('/','-')`), but Claude Code on Windows encodes **every non-alphanumeric character** — including the drive colon and backslashes — as `-`:

```
C:\Users\me\dev\app  →  C--Users-me-dev-app     (Claude Code, win32)
C:\Users\me\dev\app  →  C:\Users\me\dev\app-…   (current code → no such dir)
```

So the reconciler looked for a directory that never exists and summed zero transcripts.

The fix mirrors Claude Code's actual win32 encoding (`cwd.replace(/[^a-zA-Z0-9]/g, '-')`) on `process.platform === 'win32'`, POSIX path untouched. One small function, verified against real `~/.claude/projects` directories on Windows 11.

(Found while running the harness on Windows — same family as the path issues fixed in v0.1.9, this one is in the cost/usage path. Rebased onto v0.2.1; note the OTel live path in v0.2.0 doesn't replace this — the reconciler/fallback path still reads transcripts.)
