### PR TITLE
fix: text-select mouse cursor invisible on cream - inked I-beam with halo

### DIFF
--- a/src/renderer/src/design/global.css
+++ b/src/renderer/src/design/global.css
@@ -37,6 +37,16 @@ button, input, textarea, select {
 /* Belt + suspenders for the caret: follow the ink, never the UA scheme. */
 input, textarea { caret-color: var(--cth-ink-900); }
 
+/* The MOUSE text-select pointer (the I-beam) is a different beast from the
+   caret: it comes from the OS cursor scheme, which `color-scheme` can't touch.
+   On Windows several schemes (and HiDPI variants) draw it white with a hairline
+   outline — invisible hovering over our cream inputs. Replace it with our own
+   inked I-beam wearing a cream halo, so it reads on cream AND on the dark
+   terminal. Falls back to the UA `text` cursor if SVG cursors are unavailable. */
+input, textarea, [contenteditable='true'] {
+  cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='17' height='18'><g fill='none' stroke='%23fdf6e3' stroke-width='4' stroke-linecap='round'><path d='M5 2.5h7M8.5 3v12M5 15.5h7'/></g><g fill='none' stroke='%23261d31' stroke-width='1.6' stroke-linecap='round'><path d='M5 2.5h7M8.5 3v12M5 15.5h7'/></g></svg>") 8 9, text;
+}
+
 /* Command Center tab bar scrolls horizontally when it overflows a narrow
    sidebar; hide the scrollbar (overlay on mac, hidden elsewhere) — scroll with
    trackpad / Shift+wheel, like a browser tab strip. */


### PR DESCRIPTION
Follow-up to the caret fix that landed in v0.2.0: `color-scheme: light` + `caret-color` fixed the BLINKING caret, but the hovering **I-beam** (the mouse text-select pointer) is an OS cursor that CSS color hints cannot touch - several Windows cursor schemes (incl. HiDPI variants) draw it white with a hairline outline, so it disappears over the cream composer.

One CSS rule: text fields get a custom SVG I-beam drawn in ink wearing a cream halo, readable on the cream inputs and the dark terminal alike. Hotspot centered on the stem; falls back to the UA `text` cursor where SVG cursors are unsupported.