### PR TITLE
feat: monitor tab gets a real context-window row - the budget meter was being misread

### DIFF
--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -475,14 +475,46 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                   background: 'var(--cth-paper-200)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)', color: 'var(--cth-ink-700)'
                 }}>{lastTool[a.id]}</span>
               )}
+              <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 10, color: 'var(--cth-ink-300)', flexShrink: 0 }}>budget</span>
               <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-900)', width: 56, textAlign: 'right' }}>{fmtTokens(tokens)}</span>
               <div
-                title={`${tokens.toLocaleString()} of ${denom.toLocaleString()} tokens${agentCap ? ' (agent limit)' : ' (floor budget)'}`}
+                title={`CUMULATIVE session usage: ${tokens.toLocaleString()} of ${denom.toLocaleString()} tokens${agentCap ? ' (agent limit)' : ' (floor budget)'} — not the context window`}
                 style={{ width: 96, height: 8, background: 'var(--cth-cream-200)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)', flexShrink: 0 }}
               >
                 <div style={{ width: `${pct}%`, height: '100%', background: meterColor }} />
               </div>
               <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-500)', width: 30, textAlign: 'right' }}>{pct}%</span>
+            </div>
+            {/* Context window — the SAME exact statusLine-fed numbers as the
+                avatar-card gauge (tokens currently in the window vs the real
+                200k/1M size). Distinct from the cumulative budget meter above,
+                which keeps growing forever and pins at 100% — that one is
+                spend, this one is headroom before compaction. */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ flex: 1 }} />
+              <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 10, color: 'var(--cth-ink-300)', flexShrink: 0 }}>ctx</span>
+              {a.contextTokens !== undefined && a.contextLimit ? (() => {
+                const cpct = Math.min(100, Math.round((a.contextTokens! / a.contextLimit!) * 100));
+                const ccolor = cpct >= 88 ? 'var(--cth-coral)' : cpct >= 75 ? 'var(--cth-lemon)' : `var(--cth-${a.accent})`;
+                return (
+                  <>
+                    <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-900)', width: 56, textAlign: 'right' }}>
+                      {fmtTokens(a.contextTokens!)}
+                    </span>
+                    <div
+                      title={`Context window: ${a.contextTokens!.toLocaleString()} of ${a.contextLimit!.toLocaleString()} tokens (${cpct}%)`}
+                      style={{ width: 96, height: 8, background: 'var(--cth-cream-200)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)', flexShrink: 0 }}
+                    >
+                      <div style={{ width: `${cpct}%`, height: '100%', background: ccolor }} />
+                    </div>
+                    <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-500)', width: 30, textAlign: 'right' }}>{cpct}%</span>
+                  </>
+                );
+              })() : (
+                <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-300)' }}>
+                  no status tick yet
+                </span>
+              )}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <Select


### PR DESCRIPTION
Follow-up to the just-merged #12, prompted by the human reading the monitor tab: its only per-agent meter is the CUMULATIVE token-budget bar, which grows forever and pins at 100% once an agent passes the default 1M budget - trivially misread as a context gauge showing nonsense (3M / 100% red while the actual window sat at a comfortable 24%).

Each agent row now carries a second, clearly-labeled **ctx** row fed by the SAME exact statusLine numbers as the avatar-card gauge (current window tokens vs the real 200k/1M size, same color thresholds: accent / lemon at 75% / coral at 88%), with a no-status-tick-yet placeholder before the first response. The budget meter is labeled **budget** and its tooltip now says spend-not-headroom in as many words.

Renderer-only, one component; typecheck + build clean.