### PR TITLE
[codex] Add Codex provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
 
 | Area | What works today |
 |---|---|
-| **Real terminals** | Spawn any command (default: `claude`) in a `node-pty` PTY. Full read/write/resize/kill, live streaming over IPC, multi-agent. |
+| **Real terminals** | Spawn Claude Code, Codex, or a custom command in a `node-pty` PTY. Full read/write/resize/kill, live streaming over IPC, multi-agent. |
 | **The hive** | On-disk multi-agent layer: per-agent identity + long-term memory, atomic-file mailboxes, a shared blackboard, append-only event log, single-committer git. |
 | **GOD orchestrator** | An always-on supervisor agent that adjudicates traffic, routes tasks, scribes the blackboard, and escalates only critical items to you. |
 | **Memory layer** | Markdown-first long-term memory per agent, mined into a shared semantic palace for instant recall; searchable from the UI. Degrades gracefully when the index isn't installed. |
@@ -138,7 +138,9 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
   xcode-select --install
   ```
 - **[Claude Code](https://claude.com/claude-code)** on your `PATH` so agents can run `claude`
-  (the default command). Any other command works too.
+  (the default command). Add Agent also includes a Codex preset that runs `codex`
+  without Claude-only flags; initial Codex support is terminal spawning with shared
+  workspace/env, not Claude telemetry or hook parity.
 - *Optional:* the semantic memory index for instant cross-session recall (the app works without it —
   markdown memory still functions).
 

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -536,12 +536,20 @@ export class HiveManager {
     const resolveTo = (to: string): string => (to === 'human' || to === 'god' ? godId : to);
     const targets = msg.to === 'broadcast'
       // The roster for fan-out is the ACTIVE registry: skip the send-only prep
-      // assistant and any archived agent (closed tab) so mail never piles into a
-      // dead inbox no one will read.
-      ? Object.keys(reg.agents).filter((a) => a !== msg.from && !reg.agents[a]?.isAssistant && !reg.agents[a]?.archived)
+      // assistant, non-Claude providers without hook/protocol support, and any
+      // archived agent (closed tab) so mail never piles into a dead inbox no one
+      // will read.
+      ? Object.keys(reg.agents).filter((a) => {
+        const agent = reg.agents[a];
+        return a !== msg.from
+          && !agent?.isAssistant
+          && !agent?.archived
+          && isClaudeProvider(agent?.provider ?? 'claude');
+      })
       // Never deliver to self — guards a god → "human" message looping back to god.
       : [resolveTo(msg.to)].filter((t) => t !== msg.from);
     for (const t of targets) {
+      const target = reg.agents[t];
       // Enforce the assistant's send-only contract AT THE ROUTER: it has no
       // composer, is excluded from the inbox-wake nudge, and never reads an
       // inbox — yet direct mail used to be delivered there anyway, where it
@@ -549,11 +557,19 @@ export class HiveManager {
       // reprimand about the unread inbox, both unread for hours). Bounce such
       // mail to god instead, so the sender's intent surfaces immediately and
       // nothing is silently lost.
-      if (reg.agents[t]?.isAssistant) {
+      if (target?.isAssistant) {
         this.deliver({
           ...msg,
           to: godId,
           subject: `[bounced — "${t}" is the send-only prep assistant; route work to a real agent] ${msg.subject}`
+        }, godId);
+        continue;
+      }
+      if (target && !isClaudeProvider(target.provider ?? 'claude')) {
+        this.deliver({
+          ...msg,
+          to: godId,
+          subject: `[bounced — "${t}" uses ${target.provider ?? 'custom'}; route via its terminal, not hive inbox] ${msg.subject}`
         }, godId);
         continue;
       }

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -26,6 +26,7 @@ import { spawnSync } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentUsageSample } from './usage';
 import { COMMAND_GROUPS } from '../shared/claudeCommands';
+import { isClaudeProvider, type AgentProvider } from '../shared/agentProvider';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -60,6 +61,7 @@ export interface HiveTask {
 export interface AgentMeta {
   id: string;
   name: string;
+  provider?: AgentProvider;
   role?: string;
   capabilities?: string[];
   cwd: string;
@@ -88,7 +90,7 @@ export interface Registry {
   agents: Record<string, RegistryAgent>;
 }
 
-/** Build env + extra spawn args that make a `claude` process hive-aware. */
+/** Build env + extra spawn args that make an agent process hive-aware. */
 export interface SpawnInjection {
   args: string[];
   env: Record<string, string>;
@@ -238,7 +240,7 @@ export class HiveManager {
 
   /**
    * Ensure an agent's workspace + registry entry, returning the spawn injection
-   * (extra `claude` args + env) that makes the process hive-aware.
+   * (provider-specific args + env) that makes the process hive-aware.
    */
   ensureAgent(meta: AgentMeta, opts: { semanticMemory?: boolean; theme?: 'light' | 'dark' } = {}): SpawnInjection {
     const root = this.root();
@@ -284,14 +286,13 @@ export class HiveManager {
       AGENT_DIR: dir
     };
 
+    const claudeProvider = isClaudeProvider(meta.provider ?? 'claude');
+
     // Stage 7A — first-party Claude Code telemetry → the embedded loopback OTLP
     // collector (telemetry.ts). Pure env, no --settings change. Only injected
-    // once the collector is up (otelEndpoint set), so telemetry-off installs and
-    // tests spawn exactly as before. http/json (no protobuf dep). The resource
-    // attrs are the agent↔event join key the collector reads. NOTE: Claude Code
-    // reads these at process start, so they apply only to NEW spawns — an agent
-    // already running won't emit until respawned.
-    if (this._otelEndpoint) {
+    // for Claude Code once the collector is up (otelEndpoint set), so telemetry-
+    // off installs and non-Claude providers spawn exactly as before.
+    if (claudeProvider && this._otelEndpoint) {
       env.CLAUDE_CODE_ENABLE_TELEMETRY = '1';
       env.OTEL_METRICS_EXPORTER = 'otlp';
       env.OTEL_LOGS_EXPORTER = 'otlp';
@@ -301,7 +302,10 @@ export class HiveManager {
       env.OTEL_LOGS_EXPORT_INTERVAL = '2000';
       env.OTEL_RESOURCE_ATTRIBUTES = `agent.id=${meta.id},agent.name=${meta.name}`;
     }
-    const args = ['--append-system-prompt', this.injectedPrompt(meta, dir, root, opts.semanticMemory ?? false)];
+    const args: string[] = [];
+    if (!claudeProvider) return { args, env };
+
+    args.push('--append-system-prompt', this.injectedPrompt(meta, dir, root, opts.semanticMemory ?? false));
 
     // Phase 1 — autonomy: attach lifecycle hooks via --settings (no edits to the
     // user's repo) so the agent reports activity and drains its inbox on Stop.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import { listIssues, listCIRuns } from './github';
 import { SlackWebhookServer } from './slack';
 import { TelemetryCollector } from './telemetry';
 import { ControlRegistry } from './control';
+import { inferAgentProvider, isClaudeProvider, type AgentProvider } from '../shared/agentProvider';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
 const ptyManager = new PtyManager();
@@ -637,10 +638,13 @@ function createWindow(): void {
 }
 
 // ─── IPC: pty lifecycle ─────────────────────────────────────────────────────
-ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean }) => {
+ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean; provider?: AgentProvider }) => {
   if (!opts || typeof opts.id !== 'string' || typeof opts.cwd !== 'string' || typeof opts.command !== 'string') {
     return { ok: false, error: 'invalid SpawnOptions' };
   }
+  const provider = inferAgentProvider(opts.command, opts.provider ?? opts.hive?.provider);
+  opts.provider = provider;
+  if (opts.hive) opts.hive = { ...opts.hive, provider };
   // Git isolation: when requested and the cwd is a real repo, give this agent
   // its own worktree on an `agent/<id>` branch so it can't clobber other agents'
   // (or the user's) working tree. Best-effort — a failure falls back to the
@@ -673,12 +677,13 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
       console.error('[worktree] isolation failed:', e);
     }
   }
-  // If the agent carries hive metadata, provision its workspace and inject the
-  // identity + protocol (extra --append-system-prompt args + AGENT_* env).
+  // If the agent carries hive metadata, provision its workspace and add
+  // provider-specific spawn injection. Non-Claude providers get shared AGENT_*
+  // env only; Claude Code also gets prompt/settings hook args.
   if (opts.hive && hive.enabled()) {
     try {
       const inj = hive.ensureAgent(
-        { ...opts.hive, cwd: opts.cwd },
+        { ...opts.hive, cwd: opts.cwd, provider },
         { semanticMemory: memory.active(), theme: readConfig().terminalTheme ?? 'light' }
       );
       opts.args = [...(opts.args ?? []), ...inj.args];
@@ -691,7 +696,7 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
   }
   // Long-run guardrails + tiering (Lane A #6.4/#6.6). All additive to the args
   // already assembled (incl. the hive injection); an explicit choice always wins.
-  if (opts.hive) {
+  if (opts.hive && isClaudeProvider(provider)) {
     const cfg = readConfig();
     const args = opts.args ?? [];
     // Model precedence: an explicit per-agent --model (from the renderer) wins;
@@ -718,7 +723,9 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
   // Pre-accept Claude Code's bypass-mode warning + folder-trust dialog so the
   // agent (spawned with --permission-mode bypassPermissions) doesn't stall on an
   // interactive prompt it can't answer and exit code 1. Best-effort, never blocks.
-  try { ensureClaudePermissionsAccepted(opts.cwd); } catch { /* never block spawn */ }
+  if (isClaudeProvider(provider)) {
+    try { ensureClaudePermissionsAccepted(opts.cwd); } catch { /* never block spawn */ }
+  }
   const res = ptyManager.spawn(opts);
   syncKeepAwake(); // arm the power-save blocker while ≥1 agent PTY is alive (#18)
   return res;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,8 +1,10 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import type { AgentProvider } from '../shared/agentProvider';
 
 export interface HiveAgentMeta {
   id: string;
   name: string;
+  provider?: AgentProvider;
   role?: string;
   capabilities?: string[];
   cwd: string;
@@ -62,6 +64,7 @@ export interface SpawnPtyOptions {
   id: string;
   cwd: string;
   command: string;
+  provider?: AgentProvider;
   args?: string[];
   cols?: number;
   rows?: number;

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -6,7 +6,15 @@ import { Icon } from './Icon';
 import { useStore, type Agent } from '@/store/store';
 import { OFFICE_CAST, DEFAULT_CHARACTER, type OfficeCharacterName } from '@/scene/office/cast';
 import { type AccentColorName } from '@/design/tokens';
-import { type HarnessConfig, buildSpawnCommand, AGENT_MODELS } from '@/store/config';
+import {
+  type AgentProvider,
+  type HarnessConfig,
+  AGENT_MODELS,
+  AGENT_PROVIDER_PRESETS,
+  buildSpawnCommand,
+  inferAgentProvider,
+  isClaudeProvider
+} from '@/store/config';
 
 const ACCENTS: AccentColorName[] = ['coral', 'mint', 'sky', 'lemon', 'lilac', 'peach'];
 
@@ -25,20 +33,34 @@ export interface AddAgentModalProps {
 
 export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
   const addAgent = useStore(s => s.addAgent);
+  const initialProvider = inferAgentProvider(config.defaultCommand);
+  const initialModel = isClaudeProvider(initialProvider) ? config.defaultModel : undefined;
 
   const [name, setName] = useState('Jim');
   const [character, setCharacter] = useState<OfficeCharacterName>(DEFAULT_CHARACTER);
   const [accent, setAccent] = useState<AccentColorName>('sky');
   const [cwd, setCwd] = useState<string>(config.registeredRepos[0] ?? '');
-  const [model, setModel] = useState<string | undefined>(config.defaultModel);
-  const [command, setCommand] = useState(buildSpawnCommand(config, config.defaultModel));
+  const [provider, setProvider] = useState<AgentProvider>(initialProvider);
+  const [model, setModel] = useState<string | undefined>(initialModel);
+  const [command, setCommand] = useState(buildSpawnCommand(config, initialModel, initialProvider));
   const [description, setDescription] = useState('a fresh harness');
 
   // Picking a model rebuilds the command; the command field stays editable for
   // power users (it's the source of truth for the actual spawn).
   const pickModel = (id?: string) => {
     setModel(id);
-    setCommand(buildSpawnCommand(config, id));
+    setCommand(buildSpawnCommand(config, id, provider));
+  };
+
+  const pickProvider = (id: AgentProvider) => {
+    setProvider(id);
+    const nextModel = isClaudeProvider(id) ? config.defaultModel : undefined;
+    setModel(nextModel);
+    if (id === 'custom') {
+      setCommand(command.trim() || config.defaultCommand || '');
+      return;
+    }
+    setCommand(buildSpawnCommand(config, nextModel, id));
   };
   const [goal, setGoal] = useState('');
   const [isolate, setIsolate] = useState(false);
@@ -61,13 +83,13 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
     setBusy(true);
     const id = uniqueId(name);
     const ptyId = `pty-${id}`;
-    // The command field contains `claude --permission-mode bypassPermissions`
-    // for auto mode. Split into argv-style for node-pty.
+    // Split the editable command field into argv-style pieces for node-pty.
     const [exe, ...args] = command.trim().split(/\s+/);
     const spawnRes = await window.cth.spawnPty({
       id: ptyId,
       cwd,
       command: exe,
+      provider,
       args,
       cols: 100,
       rows: 30,
@@ -77,6 +99,7 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
       hive: {
         id,
         name: name.trim(),
+        provider,
         cwd,
         role: description.trim() || undefined
       }
@@ -103,6 +126,7 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
       currentStation: 'desk',
       ptyId,
       command: command.trim(),
+      provider,
       model,
       recentTextTs: Date.now()
     };
@@ -178,7 +202,33 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
               </div>
             </Row>
 
-            <Row label="Model">
+            <Row label="Provider">
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {AGENT_PROVIDER_PRESETS.map((p) => {
+                  const active = provider === p.id;
+                  return (
+                    <button
+                      key={p.id}
+                      onClick={() => pickProvider(p.id)}
+                      title={p.id === 'codex' ? 'Spawn codex without Claude-only flags' : p.label}
+                      style={{
+                        padding: '3px 8px 1px',
+                        background: active ? `var(--cth-${accent}-light)` : 'var(--cth-cream-100)',
+                        boxShadow: active
+                          ? 'inset 0 0 0 2px var(--cth-ink-900)'
+                          : 'inset 0 0 0 1px var(--cth-ink-700)',
+                        fontFamily: 'var(--cth-font-ui)', fontSize: 13,
+                        color: 'var(--cth-ink-900)', cursor: 'pointer', border: 'none'
+                      }}
+                    >
+                      {p.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </Row>
+
+            {isClaudeProvider(provider) && <Row label="Model">
               <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                 {AGENT_MODELS.map((m) => {
                   const active = (model ?? '') === (m.id ?? '');
@@ -202,13 +252,13 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
                   );
                 })}
               </div>
-            </Row>
+            </Row>}
 
             <Row label={config.autoMode ? 'Command (auto mode on)' : 'Command'}>
               <input
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}
-                placeholder="claude"
+                placeholder={provider === 'codex' ? 'codex' : provider === 'custom' ? 'your-agent-cli' : 'claude'}
                 style={{ ...inputStyle, fontFamily: 'var(--cth-font-mono)' }}
               />
             </Row>

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -254,7 +254,7 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
               </div>
             </Row>}
 
-            <Row label={config.autoMode ? 'Command (auto mode on)' : 'Command'}>
+            <Row label={config.autoMode && isClaudeProvider(provider) ? 'Command (auto mode on)' : 'Command'}>
               <input
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -3,7 +3,7 @@ import { AgentCard } from './AgentCard';
 import { PixelButton } from './PixelButton';
 import { Icon } from './Icon';
 import { useStore, type Agent } from '@/store/store';
-import { buildSpawnCommand, type HarnessConfig } from '@/store/config';
+import { buildSpawnCommand, inferAgentProvider, type HarnessConfig } from '@/store/config';
 
 export interface AgentStripProps {
   /** Needed to rebuild a spawn command when a restorable agent predates the
@@ -28,7 +28,8 @@ export function AgentStrip({ config }: AgentStripProps) {
     const prevSel = useStore.getState().selectedId;
     try {
       for (const a of [...restorableAgents]) {
-        const command = (a.command ?? '').trim() || (config ? buildSpawnCommand(config, a.model) : '');
+        const provider = inferAgentProvider(a.command, a.provider);
+        const command = (a.command ?? '').trim() || (config ? buildSpawnCommand(config, a.model, provider) : '');
         if (!command || !a.cwd) { useStore.getState().removeRestorableAgent(a.id); continue; }
         const [exe, ...args] = command.split(/\s+/);
         const ptyId = a.ptyId ?? `pty-${a.id}`;
@@ -36,17 +37,19 @@ export function AgentStrip({ config }: AgentStripProps) {
           id: ptyId,
           cwd: a.cwd,
           command: exe,
+          provider,
           args,
           cols: 100,
           rows: 30,
           // Re-request isolation if the agent ran in its own worktree before —
           // the old worktree was torn down on exit, so a fresh one is created.
           isolate: !!a.worktreePath,
-          hive: { id: a.id, name: a.name, cwd: a.cwd, role: a.description }
+          hive: { id: a.id, name: a.name, provider, cwd: a.cwd, role: a.description }
         });
         if (res.ok) {
           useStore.getState().addAgent({
             ...a,
+            provider,
             ptyId,
             archived: false,
             status: 'idle',

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -13,7 +13,7 @@ import { useFleetTelemetry } from '@/hooks/useTelemetry';
 import { COMMAND_GROUPS } from '@shared/claudeCommands';
 import { useStore, type Agent } from '@/store/store';
 import { usePtyParser } from '@/hooks/usePtyParser';
-import { buildSpawnCommand, AGENT_MODELS } from '@/store/config';
+import { buildSpawnCommand, AGENT_MODELS, inferAgentProvider, isClaudeProvider } from '@/store/config';
 
 /** Michael's control surface. Shown instead of the plain terminal/files panel
  *  when the god agent is selected: terminal + queue, the floor roster (with
@@ -294,15 +294,16 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
       const cfg = await window.cth.getConfig();
       await window.cth.killPty(a.ptyId);
       disposeTerminal(a.ptyId);
-      const command = buildSpawnCommand(cfg, model);
+      const provider = inferAgentProvider(a.command, a.provider);
+      const command = buildSpawnCommand(cfg, model, provider);
       const [exe, ...args] = command.trim().split(/\s+/);
       const hive = a.isGod
-        ? { id: a.id, name: a.name, cwd: a.cwd, isGod: true, role: 'orchestrator (god)' }
+        ? { id: a.id, name: a.name, provider, cwd: a.cwd, isGod: true, role: 'orchestrator (god)' }
         : a.isAssistant
-        ? { id: a.id, name: a.name, cwd: a.cwd, isAssistant: true, role: "Michael's prep assistant" }
-        : { id: a.id, name: a.name, cwd: a.cwd, role: a.description };
-      const res = await window.cth.spawnPty({ id: a.ptyId, cwd: a.cwd, command: exe, args, cols: 100, rows: 30, hive });
-      if (res.ok) updateAgent(a.id, { command: command.trim(), model, status: 'idle', action: 'restarting…' });
+        ? { id: a.id, name: a.name, provider, cwd: a.cwd, isAssistant: true, role: "Michael's prep assistant" }
+        : { id: a.id, name: a.name, provider, cwd: a.cwd, role: a.description };
+      const res = await window.cth.spawnPty({ id: a.ptyId, cwd: a.cwd, command: exe, provider, args, cols: 100, rows: 30, hive });
+      if (res.ok) updateAgent(a.id, { command: command.trim(), provider, model, status: 'idle', action: 'restarting…' });
     } catch { /* noop */ } finally {
       setRestarting(null);
     }
@@ -484,7 +485,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
               </div>
               <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-500)', width: 30, textAlign: 'right' }}>{pct}%</span>
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            {isClaudeProvider(inferAgentProvider(a.command, a.provider)) ? <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <Select
                 value={a.model ?? ''}
                 disabled={restarting === a.id}
@@ -497,7 +498,11 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
               <span style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>
                 {restarting === a.id ? 'restarting…' : 'model (restarts agent)'}
               </span>
-            </div>
+            </div> : (
+              <div style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>
+                provider: {inferAgentProvider(a.command, a.provider)}
+              </div>
+            )}
           </div>
           );
         })}

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -1,6 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { useStore, type Agent, type StationKind, type ToolKind } from '@/store/store';
-import { buildSpawnCommand, ASSISTANT_MODEL, type HarnessConfig } from '@/store/config';
+import {
+  buildSpawnCommand,
+  ASSISTANT_MODEL,
+  inferAgentProvider,
+  isClaudeProvider,
+  type HarnessConfig
+} from '@/store/config';
 
 const GOD_ID = 'god';
 const GOD_PTY = `pty-${GOD_ID}`;
@@ -521,6 +527,7 @@ export function useHive(config: HarnessConfig | null): void {
       const { agents, messageQueues, enqueueMessage } = useStore.getState();
       for (const a of agents) {
         if (!a.ptyId) continue;
+        if (!isClaudeProvider(inferAgentProvider(a.command, a.provider))) continue;
         const queued = messageQueues[a.id] ?? [];
         if (queued.some((m) => m.text.trimStart().startsWith('/compact'))) continue;
         enqueueMessage(a.id, COMPACT_CMD);

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -159,16 +159,17 @@ export function useHive(config: HarnessConfig | null): void {
       godSpawning.current = true;
       useStore.getState().removeAgent(GOD_ID); // clear any stale restored entry
 
-      const command = buildSpawnCommand(config, config.defaultModel);
+      const command = buildSpawnCommand(config, config.defaultModel, 'claude');
       const [exe, ...args] = command.trim().split(/\s+/);
       const res = await window.cth.spawnPty({
         id: GOD_PTY,
         cwd: config.harnessHome!,
         command: exe,
+        provider: 'claude',
         args,
         cols: 100,
         rows: 30,
-        hive: { id: GOD_ID, name: 'Michael', cwd: config.harnessHome!, isGod: true, role: 'orchestrator (god)' }
+        hive: { id: GOD_ID, name: 'Michael', provider: 'claude', cwd: config.harnessHome!, isGod: true, role: 'orchestrator (god)' }
       });
       if (cancelled) { godSpawning.current = false; return; }
       if (!res.ok) { godSpawning.current = false; useStore.getState().setGodStatus('failed'); return; }
@@ -187,6 +188,7 @@ export function useHive(config: HarnessConfig | null): void {
         currentStation: 'desk',
         ptyId: GOD_PTY,
         command: command.trim(),
+        provider: 'claude',
         model: config.defaultModel,
         isGod: true,
         recentTextTs: Date.now()
@@ -228,16 +230,17 @@ export function useHive(config: HarnessConfig | null): void {
       assistantSpawning.current = true;
       useStore.getState().removeAgent(ASSISTANT_ID); // clear any stale restored entry
 
-      const command = buildSpawnCommand(config, ASSISTANT_MODEL);
+      const command = buildSpawnCommand(config, ASSISTANT_MODEL, 'claude');
       const [exe, ...args] = command.trim().split(/\s+/);
       const res = await window.cth.spawnPty({
         id: ASSISTANT_PTY,
         cwd: config.harnessHome!,
         command: exe,
+        provider: 'claude',
         args,
         cols: 100,
         rows: 30,
-        hive: { id: ASSISTANT_ID, name: 'Dwight', cwd: config.harnessHome!, isAssistant: true, role: "Michael's prep assistant" }
+        hive: { id: ASSISTANT_ID, name: 'Dwight', provider: 'claude', cwd: config.harnessHome!, isAssistant: true, role: "Michael's prep assistant" }
       });
       if (cancelled || !res.ok) { assistantSpawning.current = false; return; }
       const assistant: Agent = {
@@ -255,6 +258,7 @@ export function useHive(config: HarnessConfig | null): void {
         currentStation: 'desk',
         ptyId: ASSISTANT_PTY,
         command: command.trim(),
+        provider: 'claude',
         model: ASSISTANT_MODEL,
         isAssistant: true,
         recentTextTs: Date.now()

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -1,5 +1,19 @@
 // Mirrors src/main/config.ts. Kept as a renderer-side type-only module
 // so we don't have to reach into the preload package to type-check.
+import {
+  AGENT_PROVIDER_PRESETS,
+  defaultCommandForProvider,
+  inferAgentProvider,
+  isClaudeProvider,
+  type AgentProvider
+} from '@shared/agentProvider';
+
+export {
+  AGENT_PROVIDER_PRESETS,
+  inferAgentProvider,
+  isClaudeProvider,
+  type AgentProvider
+};
 
 /** A recurring auto-dispatched mission (mirrors src/main/config.ts). */
 export interface ScheduledMission {
@@ -79,9 +93,12 @@ export const AGENT_MODELS: ModelOption[] = [
  *  optional per-agent model override (injected as `--model <model>`). */
 export function buildSpawnCommand(
   config: Pick<HarnessConfig, 'defaultCommand' | 'autoMode'>,
-  model?: string
+  model?: string,
+  provider: AgentProvider = inferAgentProvider(config.defaultCommand)
 ): string {
-  const base = config.defaultCommand || 'claude';
-  const withModel = model ? `${base} --model ${model}` : base;
-  return config.autoMode ? `${withModel} --permission-mode bypassPermissions` : withModel;
+  const base = isClaudeProvider(provider)
+    ? config.defaultCommand || defaultCommandForProvider(provider)
+    : defaultCommandForProvider(provider, config.defaultCommand || '') || config.defaultCommand || '';
+  const withModel = isClaudeProvider(provider) && model ? `${base} --model ${model}` : base;
+  return isClaudeProvider(provider) && config.autoMode ? `${withModel} --permission-mode bypassPermissions` : withModel;
 }

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { AccentColorName } from '@/design/tokens';
 import type { OfficeCharacterName } from '@/scene/office/cast';
 import type { StatusKind } from '@/components/PixelBadge';
+import type { AgentProvider } from '@shared/agentProvider';
 
 export type ToolKind =
   | 'Read' | 'Edit' | 'Write' | 'Bash' | 'WebFetch' | 'WebSearch'
@@ -50,6 +51,8 @@ export interface Agent {
   ptyId?: string;
   /** the command being run in the PTY (e.g. 'claude') */
   command?: string;
+  /** which agent CLI preset owns this PTY recipe */
+  provider?: AgentProvider;
   /** the model this agent runs on (e.g. 'claude-sonnet-4-6[1m]'); drives the
    *  model selector + the --model arg used when (re)spawning the agent */
   model?: string;

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -1,0 +1,46 @@
+export type AgentProvider = 'claude' | 'codex' | 'custom';
+
+export interface AgentProviderPreset {
+  id: AgentProvider;
+  label: string;
+  defaultCommand: string;
+  supportsModels: boolean;
+}
+
+export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
+  { id: 'claude', label: 'Claude Code', defaultCommand: 'claude', supportsModels: true },
+  { id: 'codex', label: 'Codex', defaultCommand: 'codex', supportsModels: false },
+  { id: 'custom', label: 'Custom', defaultCommand: '', supportsModels: false }
+];
+
+export function isAgentProvider(value: unknown): value is AgentProvider {
+  return value === 'claude' || value === 'codex' || value === 'custom';
+}
+
+export function normalizeAgentProvider(value: unknown): AgentProvider | undefined {
+  return isAgentProvider(value) ? value : undefined;
+}
+
+export function isClaudeProvider(provider: AgentProvider | undefined): boolean {
+  return provider === 'claude';
+}
+
+function commandBinary(command: string | undefined): string {
+  const first = (command ?? '').trim().split(/\s+/)[0] ?? '';
+  const base = first.split(/[\\/]/).pop() ?? first;
+  return base.replace(/\.(cmd|exe)$/i, '').toLowerCase();
+}
+
+export function inferAgentProvider(command: string | undefined, explicit?: unknown): AgentProvider {
+  const normalized = normalizeAgentProvider(explicit);
+  if (normalized) return normalized;
+  const bin = commandBinary(command);
+  if (bin === 'codex') return 'codex';
+  if (bin === 'claude' || !bin) return 'claude';
+  return 'custom';
+}
+
+export function defaultCommandForProvider(provider: AgentProvider, fallback = ''): string {
+  if (provider === 'custom') return fallback;
+  return AGENT_PROVIDER_PRESETS.find((p) => p.id === provider)?.defaultCommand ?? fallback;
+}

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -4,13 +4,12 @@ export interface AgentProviderPreset {
   id: AgentProvider;
   label: string;
   defaultCommand: string;
-  supportsModels: boolean;
 }
 
 export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
-  { id: 'claude', label: 'Claude Code', defaultCommand: 'claude', supportsModels: true },
-  { id: 'codex', label: 'Codex', defaultCommand: 'codex', supportsModels: false },
-  { id: 'custom', label: 'Custom', defaultCommand: '', supportsModels: false }
+  { id: 'claude', label: 'Claude Code', defaultCommand: 'claude' },
+  { id: 'codex', label: 'Codex', defaultCommand: 'codex' },
+  { id: 'custom', label: 'Custom', defaultCommand: '' }
 ];
 
 export function isAgentProvider(value: unknown): value is AgentProvider {


### PR DESCRIPTION
## What changed

- Added a small shared provider preset model for `claude`, `codex`, and `custom`.
- Added a Codex option in Add Agent that defaults the command to `codex`.
- Carries the provider through spawn, restore, and restart flows.
- Gates Claude-only setup so Codex/custom agents do not receive Claude Code flags, settings, telemetry env, model args, resume args, or permission pre-accept writes.
- Documents the initial Codex support boundary.

## Why

This starts the provider layer discussed in #21 without trying to build full Codex parity. Codex support here is intentionally limited to terminal spawning plus shared workspace/env so Claude Code and Codex can coexist in the harness.

## Validation

- `npm run typecheck`

Note: dependency install for validation used `npm ci --ignore-scripts` because the local Node 26 environment cannot build `better-sqlite3@11.10.0` native bindings.
