### PR TITLE
feat: schedules get their own Command-Center tab + a boss-room calendar

### DIFF
--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -6,6 +6,7 @@ import { SpritePortrait } from './SpritePortrait';
 import { PtyTerminalView } from './PtyTerminalView';
 import { MessageQueueComposer } from './MessageQueueComposer';
 import { TasksKanban } from './TasksKanban';
+import { SchedulesTab } from './SchedulesTab';
 import { disposeTerminal } from './terminalPool';
 import { Icon } from './Icon';
 import { MemoryGraphPanel } from './MemoryGraphPanel';
@@ -20,46 +21,12 @@ import { buildSpawnCommand, AGENT_MODELS } from '@/store/config';
  *  per-agent model + dispatch + assistant access), a memory view, and a live
  *  activity feed / board / usage meter. */
 
-type CCTab = 'terminal' | 'floor' | 'tasks' | 'memory' | 'graph' | 'activity' | 'handbook';
-
-/** A recurring auto-dispatched mission (mirrors the main-process config type). */
-interface ScheduledMission {
-  id: string;
-  label: string;
-  intervalMs: number;
-  to: string;
-  body: string;
-  enabled: boolean;
-  autoCompact?: boolean;
-  lastFiredAt?: number;
-  /** 'heartbeat' (Lane A #1) is a context-aware adaptive beat, not a plain dispatch. */
-  kind?: 'dispatch' | 'heartbeat';
-  quietThresholdMs?: number;
-}
-
-/** Compact relative time, e.g. "4m ago" / "in 2m" / "just now". A positive ms is
- *  in the past, negative in the future. */
-function relTime(ms: number): string {
-  const past = ms >= 0;
-  const a = Math.abs(ms);
-  if (a < 45_000) return 'just now';
-  const mins = Math.round(a / 60_000);
-  const unit = mins < 60 ? `${mins}m` : mins < 1440 ? `${Math.round(mins / 60)}h` : `${Math.round(mins / 1440)}d`;
-  return past ? `${unit} ago` : `in ${unit}`;
-}
+type CCTab = 'terminal' | 'floor' | 'tasks' | 'schedules' | 'memory' | 'graph' | 'activity' | 'handbook';
 
 /** Fallback denominator for the per-agent token meter when no floor token budget
  *  is configured — so the bar reads as a budget estimate (filled + remaining)
  *  rather than being pinned to 100% for whichever agent burns the most tokens. */
 const DEFAULT_TOKEN_CAP = 1_000_000;
-
-/** Interval presets offered in the SCHEDULES form / shown as badges. */
-const INTERVAL_OPTS: { ms: number; label: string }[] = [
-  { ms: 3600000, label: '1h' },
-  { ms: 21600000, label: '6h' },
-  { ms: 86400000, label: '24h' },
-  { ms: 604800000, label: 'weekly' }
-];
 
 /** A GitHub issue as returned by `window.cth.githubIssues` (labels/assignees flattened). */
 interface GHIssue {
@@ -75,6 +42,7 @@ const TABS: { key: CCTab; label: string; icon: Parameters<typeof Icon>[0]['name'
   { key: 'terminal', label: 'terminal', icon: 'terminal' },
   { key: 'floor', label: 'monitor', icon: 'mcp' },
   { key: 'tasks', label: 'tasks', icon: 'check' },
+  { key: 'schedules', label: 'schedules', icon: 'clock' },
   { key: 'memory', label: 'memory', icon: 'sparkle' },
   { key: 'graph', label: 'graph', icon: 'web' },
   { key: 'activity', label: 'activity', icon: 'bell' },
@@ -83,6 +51,14 @@ const TABS: { key: CCTab; label: string; icon: Parameters<typeof Icon>[0]['name'
 
 export function CommandCenterPanel({ agent }: { agent: Agent }) {
   const [tab, setTab] = useState<CCTab>('terminal');
+  // External tab requests (e.g. the boss-room calendar → 'schedules'). seq-keyed
+  // so clicking the prop again re-opens the tab even if it was already current.
+  const ccTabRequest = useStore((s) => s.ccTabRequest);
+  useEffect(() => {
+    if (ccTabRequest && TABS.some((t) => t.key === ccTabRequest.tab)) {
+      setTab(ccTabRequest.tab as CCTab);
+    }
+  }, [ccTabRequest]);
   // A task-card "assign" pre-fills the Floor dispatch box and jumps to it. The
   // counter bumps so re-assigning the same card re-seeds the textarea (the seed
   // string alone wouldn't change). { seq } makes every assign distinct.
@@ -184,6 +160,7 @@ export function CommandCenterPanel({ agent }: { agent: Agent }) {
           )
         )}
         {tab === 'floor' && <FloorTab seed={dispatchSeed} />}
+        {tab === 'schedules' && <SchedulesTab />}
         {tab === 'tasks' && (
           <TasksKanban
             onAssign={(prefill) => {
@@ -236,25 +213,12 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
   const [issuesLoading, setIssuesLoading] = useState(false);
   const [issuesError, setIssuesError] = useState<string | null>(null);
 
-  // ── Scheduled missions (recurring auto-dispatch) ──
-  const [missions, setMissions] = useState<ScheduledMission[]>([]);
-  const [mLabel, setMLabel] = useState('');
-  const [mInterval, setMInterval] = useState<string>(String(INTERVAL_OPTS[0].ms));
-  const [mTo, setMTo] = useState<string>('god');
-  const [mBody, setMBody] = useState('');
-
   useEffect(() => {
     window.cth.getConfig().then((c) => {
       setRepos(c.registeredRepos ?? []);
       setTokenCap(c.costCapTokens);
       setAgentTokenCaps(c.agentTokenCaps ?? {});
     }).catch(() => { /* noop */ });
-    window.cth.listMissions().then(setMissions).catch(() => { /* noop */ });
-    // Refresh "last fired" when the scheduler stamps a beat/dispatch (#2.3).
-    const off = window.cth.onMissionsUpdated(() => {
-      window.cth.listMissions().then(setMissions).catch(() => { /* noop */ });
-    });
-    return off;
   }, []);
 
   // Seed the dispatch box from a task-card "assign" (keyed on seq so repeat
@@ -262,33 +226,6 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
   useEffect(() => {
     if (seed.seq > 0) setDispatchText(seed.text);
   }, [seed.seq, seed.text]);
-
-  const persistMissions = async (next: ScheduledMission[]) => {
-    setMissions(next);
-    await window.cth.saveMissions(next).catch(() => { /* noop */ });
-  };
-  const toggleMission = (id: string) =>
-    persistMissions(missions.map((m) => (m.id === id ? { ...m, enabled: !m.enabled } : m)));
-  // The backend merge in missions:save keeps only the missions the renderer
-  // sends back, so deletion is just "save the list without it".
-  const deleteMission = (id: string) =>
-    persistMissions(missions.filter((m) => m.id !== id));
-  const addMission = () => {
-    if (!mLabel.trim() || !mBody.trim()) return;
-    const next: ScheduledMission = {
-      id: `m_${Date.now().toString(36)}`,
-      label: mLabel.trim(),
-      intervalMs: Number(mInterval),
-      to: mTo,
-      body: mBody.trim(),
-      enabled: true
-    };
-    persistMissions([...missions, next]);
-    setMLabel(''); setMBody('');
-  };
-  const targetName = (to: string) =>
-    to === 'broadcast' ? 'everyone' : to === 'god' ? 'Michael' : agents.find((a) => a.id === to)?.name ?? to;
-  const intervalLabel = (ms: number) => INTERVAL_OPTS.find((o) => o.ms === ms)?.label ?? `${Math.round(ms / 3600000)}h`;
 
   const restartWithModel = async (a: Agent, model: string | undefined) => {
     if (!a.ptyId) return;
@@ -569,85 +506,6 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
               fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-ink-900)'
             }}
           ><Icon name="sparkle" /> enrich {enrichEnabled ? 'on' : 'off'}</button>
-        </div>
-      </Section>
-
-      <Section title="SCHEDULES">
-        {missions.length === 0 && <Muted>No scheduled missions.</Muted>}
-        {missions.map((m) => {
-          const hb = m.kind === 'heartbeat';
-          const fired = m.lastFiredAt ? `fired ${relTime(Date.now() - m.lastFiredAt)}` : 'not yet fired';
-          const next = m.enabled && m.lastFiredAt
-            ? ` · next ${relTime(Date.now() - (m.lastFiredAt + m.intervalMs))}` : '';
-          return (
-          <div key={m.id} style={{
-            display: 'flex', alignItems: 'center', gap: 6, padding: 6, marginBottom: 6,
-            background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)'
-          }}>
-            <span style={{
-              fontFamily: 'var(--cth-font-display)', fontSize: 9, padding: '2px 5px 1px',
-              background: hb ? 'var(--cth-lemon)' : 'var(--cth-cream-200)',
-              boxShadow: `inset 0 0 0 1px ${hb ? 'var(--cth-ink-900)' : 'var(--cth-ink-700)'}`,
-              color: 'var(--cth-ink-900)', flexShrink: 0
-            }}>{hb ? '♥ beat' : intervalLabel(m.intervalMs)}</span>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 13, color: 'var(--cth-ink-900)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{m.label}</div>
-              <div style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>
-                → {targetName(m.to)}{hb ? ` · adaptive ~${intervalLabel(m.intervalMs)} · auto digest` : ''}
-              </div>
-              <div style={{ fontSize: 10, color: 'var(--cth-ink-500)' }}>{fired}{next}</div>
-            </div>
-            <button
-              onClick={() => toggleMission(m.id)}
-              style={{
-                padding: '2px 8px 1px', border: 'none', cursor: 'pointer', flexShrink: 0,
-                background: m.enabled ? 'var(--cth-lemon)' : 'var(--cth-cream-200)',
-                boxShadow: `inset 0 0 0 1px ${m.enabled ? 'var(--cth-ink-900)' : 'var(--cth-ink-700)'}`,
-                fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-ink-900)'
-              }}
-            >{m.enabled ? 'on' : 'off'}</button>
-            <button
-              onClick={() => deleteMission(m.id)}
-              title="Delete this scheduled mission"
-              style={{
-                padding: '2px 6px 1px', border: 'none', cursor: 'pointer', flexShrink: 0,
-                background: 'var(--cth-cream-200)',
-                boxShadow: 'inset 0 0 0 1px var(--cth-ink-700)',
-                fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-coral)'
-              }}
-            >✕</button>
-          </div>
-          );
-        })}
-        <div style={{ display: 'flex', gap: 6, marginTop: 6, marginBottom: 6 }}>
-          <input
-            value={mLabel}
-            onChange={(e) => setMLabel(e.target.value)}
-            placeholder="mission label"
-            style={{ ...textareaStyle, flex: 1, fontFamily: 'var(--cth-font-ui)' }}
-          />
-          <Select value={mInterval} onChange={setMInterval}>
-            {INTERVAL_OPTS.map((o) => <option key={o.ms} value={String(o.ms)}>{o.label}</option>)}
-          </Select>
-          <Select value={mTo} onChange={setMTo}>
-            <option value="broadcast">everyone</option>
-            <option value="god">Michael</option>
-            {agents.filter((a) => !a.isGod).map((a) => (
-              <option key={a.id} value={a.id}>{a.name}</option>
-            ))}
-          </Select>
-        </div>
-        <textarea
-          value={mBody}
-          onChange={(e) => setMBody(e.target.value)}
-          rows={2}
-          placeholder="Recurring task body… (dispatched on each interval)"
-          style={textareaStyle}
-        />
-        <div style={{ marginTop: 6 }}>
-          <PixelButton variant="primary" size="sm" onClick={addMission} disabled={!mLabel.trim() || !mBody.trim()}>
-            add mission
-          </PixelButton>
         </div>
       </Section>
 

--- a/src/renderer/src/components/Icon.tsx
+++ b/src/renderer/src/components/Icon.tsx
@@ -6,7 +6,7 @@ import { CSSProperties } from 'react';
 export type IconName =
   | 'gear' | 'plus' | 'x' | 'check' | 'arrow-right' | 'pause' | 'play'
   | 'bell' | 'folder' | 'terminal' | 'code' | 'web' | 'mcp' | 'sparkle'
-  | 'expand' | 'minimize';
+  | 'clock' | 'expand' | 'minimize';
 
 interface IconDef {
   ink: string;     // primary color path d
@@ -41,6 +41,11 @@ const paths: Record<IconName, IconDef> = {
   pause: {
     accentColor: 'var(--cth-lemon)',
     ink:   'M4 3h3v10H4V3zm5 0h3v10H9V3z'
+  },
+  // Clock face: a ring (outer square minus inner hole, evenodd) with two hands.
+  clock: {
+    accentColor: 'var(--cth-sky)',
+    ink:   'M5 1h6v2h2v2h2v6h-2v2h-2v2H5v-2H3v-2H1V5h2V3h2V1zM5 3v2H3v6h2v2h6v-2h2V5h-2V3H5zM7 5h2v3h2v2H7V5z'
   },
   play: {
     accentColor: 'var(--cth-mint)',

--- a/src/renderer/src/components/SchedulesTab.tsx
+++ b/src/renderer/src/components/SchedulesTab.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from 'react';
+import { PixelButton } from './PixelButton';
+import { useStore } from '@/store/store';
+
+/**
+ * SCHEDULES — recurring auto-dispatched missions, as their own Command-Center
+ * tab (they used to be buried in the monitor tab's long scroll). Also the
+ * landing spot for the calendar hanging in the boss's office.
+ */
+
+interface ScheduledMission {
+  id: string;
+  label: string;
+  intervalMs: number;
+  to: string;
+  body: string;
+  enabled: boolean;
+  autoCompact?: boolean;
+  lastFiredAt?: number;
+  kind?: 'dispatch' | 'heartbeat';
+  quietThresholdMs?: number;
+}
+
+const INTERVAL_OPTS: { ms: number; label: string }[] = [
+  { ms: 3600000, label: '1h' },
+  { ms: 21600000, label: '6h' },
+  { ms: 86400000, label: '24h' },
+  { ms: 604800000, label: 'weekly' }
+];
+
+function relTime(ms: number): string {
+  const past = ms >= 0;
+  const a = Math.abs(ms);
+  if (a < 45_000) return 'just now';
+  const mins = Math.round(a / 60_000);
+  const unit = mins < 60 ? `${mins}m` : mins < 1440 ? `${Math.round(mins / 60)}h` : `${Math.round(mins / 1440)}d`;
+  return past ? `${unit} ago` : `in ${unit}`;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box', padding: '6px 8px', resize: 'vertical',
+  background: 'var(--cth-paper-100)', border: 'none',
+  boxShadow: 'inset 0 0 0 1px var(--cth-ink-700)',
+  fontFamily: 'var(--cth-font-mono)', fontSize: 12, lineHeight: '17px',
+  color: 'var(--cth-ink-900)', outline: 'none'
+};
+
+const selectStyle: React.CSSProperties = {
+  padding: '4px 6px', background: 'var(--cth-paper-100)', border: 'none',
+  boxShadow: 'inset 0 0 0 1px var(--cth-ink-700)', fontFamily: 'var(--cth-font-ui)',
+  fontSize: 12, color: 'var(--cth-ink-900)', cursor: 'pointer'
+};
+
+export function SchedulesTab() {
+  const agents = useStore((s) => s.agents);
+  const [missions, setMissions] = useState<ScheduledMission[]>([]);
+  const [mLabel, setMLabel] = useState('');
+  const [mInterval, setMInterval] = useState<string>(String(INTERVAL_OPTS[0].ms));
+  const [mTo, setMTo] = useState<string>('god');
+  const [mBody, setMBody] = useState('');
+
+  useEffect(() => {
+    window.cth.listMissions().then(setMissions).catch(() => { /* noop */ });
+    // Refresh "last fired" when the scheduler stamps a beat/dispatch (#2.3).
+    const off = window.cth.onMissionsUpdated(() => {
+      window.cth.listMissions().then(setMissions).catch(() => { /* noop */ });
+    });
+    return off;
+  }, []);
+
+  const persistMissions = async (next: ScheduledMission[]) => {
+    setMissions(next);
+    await window.cth.saveMissions(next).catch(() => { /* noop */ });
+  };
+  const toggleMission = (id: string) =>
+    persistMissions(missions.map((m) => (m.id === id ? { ...m, enabled: !m.enabled } : m)));
+  // The backend merge in missions:save keeps only the missions the renderer
+  // sends back, so deletion is just "save the list without it".
+  const deleteMission = (id: string) =>
+    persistMissions(missions.filter((m) => m.id !== id));
+  const addMission = () => {
+    if (!mLabel.trim() || !mBody.trim()) return;
+    const next: ScheduledMission = {
+      id: `m_${Date.now().toString(36)}`,
+      label: mLabel.trim(),
+      intervalMs: Number(mInterval),
+      to: mTo,
+      body: mBody.trim(),
+      enabled: true
+    };
+    persistMissions([...missions, next]);
+    setMLabel(''); setMBody('');
+  };
+  const targetName = (to: string) =>
+    to === 'broadcast' ? 'everyone' : to === 'god' ? 'Michael' : agents.find((a) => a.id === to)?.name ?? to;
+  const intervalLabel = (ms: number) => INTERVAL_OPTS.find((o) => o.ms === ms)?.label ?? `${Math.round(ms / 3600000)}h`;
+
+  return (
+    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--cth-paper-200)', padding: 10, display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {missions.length === 0 && (
+        <div style={{ fontSize: 12, color: 'var(--cth-ink-300)', textAlign: 'center', padding: '12px 0' }}>
+          No scheduled missions.
+        </div>
+      )}
+      {missions.map((m) => {
+        const hb = m.kind === 'heartbeat';
+        const fired = m.lastFiredAt ? `fired ${relTime(Date.now() - m.lastFiredAt)}` : 'not yet fired';
+        const next = m.enabled && m.lastFiredAt
+          ? ` · next ${relTime(Date.now() - (m.lastFiredAt + m.intervalMs))}` : '';
+        return (
+        <div key={m.id} style={{
+          display: 'flex', alignItems: 'center', gap: 6, padding: 6,
+          background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)'
+        }}>
+          <span style={{
+            fontFamily: 'var(--cth-font-display)', fontSize: 9, padding: '2px 5px 1px',
+            background: hb ? 'var(--cth-lemon)' : 'var(--cth-cream-200)',
+            boxShadow: `inset 0 0 0 1px ${hb ? 'var(--cth-ink-900)' : 'var(--cth-ink-700)'}`,
+            color: 'var(--cth-ink-900)', flexShrink: 0
+          }}>{hb ? '♥ beat' : intervalLabel(m.intervalMs)}</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, color: 'var(--cth-ink-900)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{m.label}</div>
+            <div style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>
+              → {targetName(m.to)}{hb ? ` · adaptive ~${intervalLabel(m.intervalMs)} · auto digest` : ''}
+            </div>
+            <div style={{ fontSize: 10, color: 'var(--cth-ink-500)' }}>{fired}{next}</div>
+          </div>
+          <button
+            onClick={() => toggleMission(m.id)}
+            style={{
+              padding: '2px 8px 1px', border: 'none', cursor: 'pointer', flexShrink: 0,
+              background: m.enabled ? 'var(--cth-lemon)' : 'var(--cth-cream-200)',
+              boxShadow: `inset 0 0 0 1px ${m.enabled ? 'var(--cth-ink-900)' : 'var(--cth-ink-700)'}`,
+              fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-ink-900)'
+            }}
+          >{m.enabled ? 'on' : 'off'}</button>
+          <button
+            onClick={() => deleteMission(m.id)}
+            title="Delete this scheduled mission"
+            style={{
+              padding: '2px 6px 1px', border: 'none', cursor: 'pointer', flexShrink: 0,
+              background: 'var(--cth-cream-200)',
+              boxShadow: 'inset 0 0 0 1px var(--cth-ink-700)',
+              fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-coral)'
+            }}
+          >✕</button>
+        </div>
+        );
+      })}
+
+      <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+        <input
+          value={mLabel}
+          onChange={(e) => setMLabel(e.target.value)}
+          placeholder="mission label"
+          style={{ ...inputStyle, flex: 1, fontFamily: 'var(--cth-font-ui)' }}
+        />
+        <select value={mInterval} onChange={(e) => setMInterval(e.target.value)} style={selectStyle}>
+          {INTERVAL_OPTS.map((o) => <option key={o.ms} value={String(o.ms)}>{o.label}</option>)}
+        </select>
+        <select value={mTo} onChange={(e) => setMTo(e.target.value)} style={selectStyle}>
+          <option value="broadcast">everyone</option>
+          <option value="god">Michael</option>
+          {agents.filter((a) => !a.isGod).map((a) => (
+            <option key={a.id} value={a.id}>{a.name}</option>
+          ))}
+        </select>
+      </div>
+      <textarea
+        value={mBody}
+        onChange={(e) => setMBody(e.target.value)}
+        rows={2}
+        placeholder="Recurring task body… (dispatched on each interval)"
+        style={inputStyle}
+      />
+      <div>
+        <PixelButton variant="primary" size="sm" onClick={addMission} disabled={!mLabel.trim() || !mBody.trim()}>
+          add mission
+        </PixelButton>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/scene/office/OfficeFloor.tsx
+++ b/src/renderer/src/scene/office/OfficeFloor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Application, Container, Ticker, Texture } from 'pixi.js';
+import { Application, Container, Graphics, Ticker, Texture } from 'pixi.js';
 // PixiJS uses new Function() internally, blocked by Electron CSP — this patches it.
 import 'pixi.js/unsafe-eval';
 import { useStore, type Agent } from '@/store/store';
@@ -176,6 +176,38 @@ export function OfficeFloor() {
       camera.setMapSize(mapRenderer.width * mapRenderer.tileSize, mapRenderer.height * mapRenderer.tileSize);
       camera.setViewSize(app.screen.width, app.screen.height);
       camera.fitToScreen();
+
+      // ─── The boss's wall calendar → SCHEDULES ──────────────────────────────
+      // A little tear-off month page hangs on the CEO office wall. Clicking it
+      // selects Michael (the god) and opens the Command Center's SCHEDULES tab —
+      // recurring missions are what's written on the boss's calendar.
+      const calTs = mapRenderer.tileSize;
+      const calG = new Graphics();
+      calG.eventMode = 'static';
+      calG.cursor = 'pointer';
+      calG.position.set(4 * calTs + 8, 1 * calTs + 5);
+      calG.zIndex = 3 * calTs;
+      calG.on('pointertap', (ev) => {
+        ev.stopPropagation();
+        const st = useStore.getState();
+        const god = st.agents.find((a) => a.isGod);
+        if (god) st.select(god.id);
+        st.requestCommandCenterTab('schedules');
+      });
+      // nail + ring binding above a white page with a red month header
+      calG.rect(7, -2, 2, 2).fill(0x4a3b52);                  // nail
+      calG.rect(0, 0, 16, 20).fill(0x4a3b52);                 // frame/shadow
+      calG.rect(1, 1, 14, 18).fill(0xf2ead8);                 // the page
+      calG.rect(1, 1, 14, 4).fill(0xc94f4f);                  // month banner
+      calG.rect(4, 0, 1, 2).fill(0xd8d3c4);                   // binding rings
+      calG.rect(11, 0, 1, 2).fill(0xd8d3c4);
+      for (let r = 0; r < 3; r++) {
+        for (let c = 0; c < 5; c++) {
+          calG.rect(2 + c * 3, 7 + r * 4, 2, 2).fill(0xb8ab90); // day grid
+        }
+      }
+      calG.rect(8, 11, 2, 2).fill(0xc94f4f);                  // today, circled red
+      charLayer.addChild(calG);
 
       // Build the ordered seat list once: PC desks + named desks first, then
       // conference-room chairs as overflow. Each agent claims one and stays there;

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -115,6 +115,10 @@ interface State {
   selectedId: string | null;
   feeds: Record<string, string[]>;
   addAgentOpen: boolean;
+  /** One-shot request to switch the Command Center to a tab (e.g. the boss-room
+   *  calendar → 'schedules'). seq-keyed so a repeat click re-fires. */
+  ccTabRequest: { tab: string; seq: number } | null;
+  requestCommandCenterTab: (tab: string) => void;
   fullscreenAgentId: string | null;
   fullscreenFilePath: string | null;
   sidebarWidth: number;
@@ -348,6 +352,9 @@ export const useStore = create<State>((set) => ({
   selectedId: initialSelectedId,
   feeds: {},
   addAgentOpen: false,
+  ccTabRequest: null,
+  requestCommandCenterTab: (tab) =>
+    set((s) => ({ ccTabRequest: { tab, seq: (s.ccTabRequest?.seq ?? 0) + 1 } })),
   fullscreenAgentId: null,
   fullscreenFilePath: null,
   sidebarWidth: initialSidebarWidth,


### PR DESCRIPTION
Closes #49.

Scheduled missions used to live at the very bottom of the **monitor** tab — you scrolled past DISPATCH, the whole AGENTS roster, and ASSISTANT to reach them. This gives schedules a home of their own, and a physical way in from the office floor.

## What changed

- **New `SCHEDULES` Command-Center tab** (`SchedulesTab.tsx`) — the mission list + add-form, lifted verbatim out of the monitor scroll into a self-contained tab (clock icon, between `tasks` and `memory`). On/off toggle, delete, add-mission form, and the live "fired … / next …" line via `onMissionsUpdated`. The monitor tab (`FloorTab`) loses ~150 lines and its mission state/handlers.
- **A wall calendar in the CEO office** (`OfficeFloor.tsx`) — a tear-off month page (red banner, 5×3 day grid, today circled red, nail + binding rings) hanging on the wall at tile (4–5, 1). `pointertap` selects the god (Michael) and requests the SCHEDULES tab.
- **`requestCommandCenterTab(tab)` / `ccTabRequest`** — a small seq-keyed store one-shot so the floor prop can drive the panel's active tab (seq-keyed so clicking the calendar again re-opens it even if already current). The panel consumes it in an effect.
- **A `clock` pixel icon** for the tab.

## Notes

- Pure UI/UX reorg — the scheduler, mission config shape, and `missions:*` IPC are untouched.
- `requestCommandCenterTab` is intentionally generic; it's a natural hook for other "jump to a CC tab from elsewhere" affordances later.

## Verification

- `tsc --noEmit` clean on both `tsconfig.web.json` and `tsconfig.node.json`.
- `npm run build` green (renderer + main).
- Manual: calendar click selects Michael and opens SCHEDULES; missions list/toggle/delete/add all work from the new tab; live "next fired" still updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
