### PR TITLE
Fix Windows agent spawn (error 193): route .cmd/script shims through …

### DIFF
--- a/src/main/assistant.ts
+++ b/src/main/assistant.ts
@@ -123,7 +123,17 @@ export function enrichMessage(req: EnrichRequest): Promise<EnrichResult> {
 
     let child;
     try {
-      child = spawn(exe, args, {
+      // Windows: route the npm `.cmd`/extensionless `claude` shim through cmd.exe;
+      // CreateProcess can't exec it directly (EINVAL on modern Node / error 193).
+      // The prompt rides in `args`; cmd leaves quoted args intact aside from %VAR%
+      // expansion (a follow-up could pass the prompt via stdin to avoid even that).
+      let spawnFile = exe;
+      let spawnArgs = args;
+      if (process.platform === 'win32' && !/\.(exe|com)$/i.test(exe)) {
+        spawnFile = process.env.ComSpec || 'cmd.exe';
+        spawnArgs = ['/c', exe, ...args];
+      }
+      child = spawn(spawnFile, spawnArgs, {
         cwd: req.cwd,
         env: {
           ...process.env,

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -130,7 +130,18 @@ export class PtyManager {
         }
       })();
 
-      const proc = pty.spawn(resolved, opts.args ?? [], {
+      // Windows: node-pty's CreateProcess can't run the npm `.cmd`/extensionless
+      // `claude` shim directly (ERROR_BAD_EXE_FORMAT, error 193). Route non-.exe
+      // targets through cmd.exe so PATHEXT resolves the shim. This also covers the
+      // auto-spawned GOD agent's hardcoded command. A real claude.exe (WinGet)
+      // matches the .exe guard and still launches directly.
+      let file = resolved;
+      let spawnArgs = opts.args ?? [];
+      if (process.platform === 'win32' && !/\.(exe|com)$/i.test(resolved)) {
+        file = process.env.ComSpec || 'cmd.exe';
+        spawnArgs = ['/c', opts.command, ...(opts.args ?? [])];
+      }
+      const proc = pty.spawn(file, spawnArgs, {
         name: 'xterm-256color',
         cols: opts.cols ?? 100,
         rows: opts.rows ?? 30,

--- a/src/main/reflect.ts
+++ b/src/main/reflect.ts
@@ -291,7 +291,17 @@ export class MemoryReflector {
 
       let child;
       try {
-        child = spawn(exe, args, {
+        // Windows: route the npm `.cmd`/extensionless `claude` shim through cmd.exe;
+        // CreateProcess can't exec it directly (EINVAL on modern Node / error 193).
+        // The prompt rides in `args`; cmd leaves quoted args intact aside from %VAR%
+        // expansion (a follow-up could pass the prompt via stdin to avoid even that).
+        let spawnFile = exe;
+        let spawnArgs = args;
+        if (process.platform === 'win32' && !/\.(exe|com)$/i.test(exe)) {
+          spawnFile = process.env.ComSpec || 'cmd.exe';
+          spawnArgs = ['/c', exe, ...args];
+        }
+        child = spawn(spawnFile, spawnArgs, {
           cwd: home,
           env: { ...process.env, PATH: userShellPath(), ...this.getMemoryEnv() } as Record<string, string>,
           stdio: ['ignore', 'pipe', 'pipe']


### PR DESCRIPTION
## Fix Windows agent spawn (error 193) — route `.cmd`/script shims through cmd.exe

Closes #22.

### Problem
On Windows, spawning any agent — including the auto-created GOD agent (Michael) — fails with `Cannot create process, error code: 193` (`ERROR_BAD_EXE_FORMAT`) when Claude Code is installed via **npm**.

### Root cause
`node-pty` (and `child_process`) launch via `CreateProcess`, which only runs real `.exe`/`.com` binaries and ignores `PATHEXT`. `npm i -g @anthropic-ai/claude-code` installs an **extensionless** `claude` shell script alongside `claude.cmd` (no `.exe`). `resolveCommand()` takes the first `where claude` hit — the extensionless script — and hands it to `node-pty`, which can't execute it → error 193. `cmd /c claude …` works because cmd honors `PATHEXT`. WinGet installs ship a real `claude.exe`, so they don't hit this. (Same root cause as generalaction/emdash#1703.)

### Fix
When the resolved target on Windows isn't a real executable, launch it through `cmd.exe /c`. Applied at every spawn site:
- `src/main/pty.ts` — agent terminals. This is what fixes the GOD agent + manually-added agents; it sits in `PtyManager.spawn`, so it also covers the GOD agent's hardcoded command.
- - `src/main/assistant.ts` and `src/main/reflect.ts` — the headless `claude -p` calls (enrichment / memory condense).
A real `claude.exe` (WinGet) matches the `.exe` guard and still launches directly. macOS/Linux are untouched.

### Verification
Patched into the compiled 0.2.2 build and verified end-to-end on Windows 11 (Claude Code via npm, Node v24.13.0): **Michael now clocks in and stays, and manually-added agents spawn with no error 193.** The two headless paths use the same wrapper; note they pass the prompt in `args`, so `cmd.exe` leaves quoted args intact except for `%VAR%` expansion — a follow-up could pass the prompt via stdin to remove even that edge case.