### PR TITLE
feat: first-class Antigravity (Gemini / agy) agent provider + native hook bridge

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -26,6 +26,7 @@ import { spawnSync } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentUsageSample } from './usage';
 import { COMMAND_GROUPS } from '../shared/claudeCommands';
+import { isHiveAwareProvider, type AgentProvider } from '../shared/agentProvider';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -60,6 +61,8 @@ export interface HiveTask {
 export interface AgentMeta {
   id: string;
   name: string;
+  /** Which CLI this agent runs on. Defaults to 'claude' when unset (legacy). */
+  provider?: AgentProvider;
   role?: string;
   capabilities?: string[];
   cwd: string;
@@ -283,6 +286,15 @@ export class HiveManager {
       HIVE_ROOT: root,
       AGENT_DIR: dir
     };
+
+    // Non-Claude providers (e.g. Antigravity's `agy`) don't understand Claude
+    // Code's flags or hook protocol. They still get a hive workspace + the
+    // shared AGENT_* env above, but no telemetry/prompt/settings injection —
+    // and direct hive mail to them bounces to the god (router). This is what
+    // makes the floor runnable without Claude installed at all.
+    if (!isHiveAwareProvider(meta.provider)) {
+      return { args: [], env };
+    }
 
     // Stage 7A — first-party Claude Code telemetry → the embedded loopback OTLP
     // collector (telemetry.ts). Pure env, no --settings change. Only injected
@@ -550,6 +562,19 @@ export class HiveManager {
           ...msg,
           to: godId,
           subject: `[bounced — "${t}" is the send-only prep assistant; route work to a real agent] ${msg.subject}`
+        }, godId);
+        continue;
+      }
+      // Non-Claude workers (e.g. Antigravity's `agy`) don't run the hive's Stop
+      // hook, so they never drain their inbox — direct mail would rot unread.
+      // Bounce it to the god (the same way assistant mail bounces) so the
+      // orchestrator relays it as a live prompt instead. God himself is exempt
+      // (he may legitimately run on any provider and is the bounce target).
+      if (t !== godId && !isHiveAwareProvider(reg.agents[t]?.provider)) {
+        this.deliver({
+          ...msg,
+          to: godId,
+          subject: `[bounced — "${t}" runs ${reg.agents[t]?.provider ?? 'a non-Claude CLI'} and can't read its hive inbox; relay this to it] ${msg.subject}`
         }, godId);
         continue;
       }

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -27,7 +27,7 @@ import { spawnSync } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentUsageSample } from './usage';
 import { COMMAND_GROUPS } from '../shared/claudeCommands';
-import { isHiveAwareProvider, providerPreset, type AgentProvider } from '../shared/agentProvider';
+import { isHiveAwareProvider, canReceiveInbox, providerPreset, type AgentProvider } from '../shared/agentProvider';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -560,15 +560,15 @@ export class HiveManager {
     const resolveTo = (to: string): string => (to === 'human' || to === 'god' ? godId : to);
     const targets = msg.to === 'broadcast'
       // The roster for fan-out is the ACTIVE registry: skip the send-only prep
-      // assistant, any archived agent (closed tab), and non-hive-aware providers
-      // (e.g. Antigravity's agy — they never drain an inbox) so mail never piles
-      // into a dead inbox no one will read. A broadcast just skips them; their
-      // god relays anything they actually need (direct mail to them bounces).
+      // assistant, any archived agent (closed tab), and providers that can't
+      // drain an inbox (hookless custom commands) so mail never piles into a dead
+      // inbox no one reads. Claude AND Antigravity workers ARE included — agy
+      // drains its inbox via the agy-hook Stop→drain bridge.
       ? Object.keys(reg.agents).filter((a) =>
           a !== msg.from
           && !reg.agents[a]?.isAssistant
           && !reg.agents[a]?.archived
-          && isHiveAwareProvider(reg.agents[a]?.provider))
+          && canReceiveInbox(reg.agents[a]?.provider))
       // Never deliver to self — guards a god → "human" message looping back to god.
       : [resolveTo(msg.to)].filter((t) => t !== msg.from);
     for (const t of targets) {
@@ -587,16 +587,15 @@ export class HiveManager {
         }, godId);
         continue;
       }
-      // Non-Claude workers (e.g. Antigravity's `agy`) don't run the hive's Stop
-      // hook, so they never drain their inbox — direct mail would rot unread.
-      // Bounce it to the god (the same way assistant mail bounces) so the
-      // orchestrator relays it as a live prompt instead. God himself is exempt
-      // (he may legitimately run on any provider and is the bounce target).
-      if (t !== godId && !isHiveAwareProvider(reg.agents[t]?.provider)) {
+      // A provider with no way to drain its inbox (a hookless custom command)
+      // would let direct mail rot unread — bounce it to the god to relay as a
+      // live prompt. Claude + Antigravity drain their inbox (Stop hook / agy-hook
+      // bridge), so they receive directly. God is exempt (the bounce target).
+      if (t !== godId && !canReceiveInbox(reg.agents[t]?.provider)) {
         this.deliver({
           ...msg,
           to: godId,
-          subject: `[bounced — "${t}" runs ${reg.agents[t]?.provider ?? 'a non-Claude CLI'} and can't read its hive inbox; relay this to it] ${msg.subject}`
+          subject: `[bounced — "${t}" runs ${reg.agents[t]?.provider ?? 'a hookless CLI'} and can't drain its hive inbox; relay this to it] ${msg.subject}`
         }, godId);
         continue;
       }

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1062,8 +1062,11 @@ process.stdin.on('end', () => {
   };
   let resp = '';
   const done = () => {
-    // Translate the HookServer's Claude-shaped reply into agy's contract.
-    let out = {};
+    // Translate the HookServer's Claude-shaped reply into agy's contract. CRITICAL:
+    // agy treats ANY object written to stdout as a decision and FAIL-CLOSES (an
+    // empty/decision-less object = DENY). So emit JSON ONLY when there's a real
+    // directive (deny/block/steer); otherwise write NOTHING — no output = allow.
+    let out = null;
     try {
       const r = JSON.parse(resp || '{}');
       if (r.decision === 'block') out = { decision: 'block', reason: r.reason, stopReason: r.reason, systemMessage: r.reason };
@@ -1071,7 +1074,7 @@ process.stdin.on('end', () => {
       else if (r.continue === false) out = { decision: 'block', stopReason: r.stopReason };
       else if (r.hookSpecificOutput && r.hookSpecificOutput.additionalContext) out = { systemMessage: r.hookSpecificOutput.additionalContext };
     } catch (_) {}
-    try { process.stdout.write(JSON.stringify(out)); } catch (_) {}
+    if (out) { try { process.stdout.write(JSON.stringify(out)); } catch (_) {} }
     process.exit(0);
   };
   try {

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -544,9 +544,15 @@ export class HiveManager {
     const resolveTo = (to: string): string => (to === 'human' || to === 'god' ? godId : to);
     const targets = msg.to === 'broadcast'
       // The roster for fan-out is the ACTIVE registry: skip the send-only prep
-      // assistant and any archived agent (closed tab) so mail never piles into a
-      // dead inbox no one will read.
-      ? Object.keys(reg.agents).filter((a) => a !== msg.from && !reg.agents[a]?.isAssistant && !reg.agents[a]?.archived)
+      // assistant, any archived agent (closed tab), and non-hive-aware providers
+      // (e.g. Antigravity's agy — they never drain an inbox) so mail never piles
+      // into a dead inbox no one will read. A broadcast just skips them; their
+      // god relays anything they actually need (direct mail to them bounces).
+      ? Object.keys(reg.agents).filter((a) =>
+          a !== msg.from
+          && !reg.agents[a]?.isAssistant
+          && !reg.agents[a]?.archived
+          && isHiveAwareProvider(reg.agents[a]?.provider))
       // Never deliver to self — guards a god → "human" message looping back to god.
       : [resolveTo(msg.to)].filter((t) => t !== msg.from);
     for (const t of targets) {

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -21,7 +21,8 @@ import {
   existsSync, mkdirSync, readFileSync, writeFileSync, renameSync,
   readdirSync, statSync, rmSync, appendFileSync
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentUsageSample } from './usage';
@@ -297,6 +298,15 @@ export class HiveManager {
     if (!isHiveAwareProvider(meta.provider)) {
       const flag = providerPreset(meta.provider ?? 'claude').initialPromptFlag;
       if (flag) {
+        // agy DOES expose lifecycle hooks (PreToolUse/PostToolUse/Stop/…), just
+        // with its own payload shape and config file. Install the bridge so a
+        // Gemini worker gets the SAME live status + inbox-drain Claude does — on
+        // the subscription, no SDK/API-key. The shim reads HIVE_SOCK + AGENT_ID.
+        const sock = this.sockPath();
+        if (sock) {
+          env.HIVE_SOCK = sock;
+          try { this.installAgyHooks(); } catch (e) { console.error('[hive] installAgyHooks failed:', e); }
+        }
         return { args: [flag, this.injectedPrompt(meta, dir, root, opts.semanticMemory ?? false)], env };
       }
       return { args: [], env };
@@ -693,6 +703,52 @@ export class HiveManager {
     if (!existsSync(dir)) return 0;
     try { return readdirSync(dir).filter((f) => f.endsWith('.json')).length; } catch { return 0; }
   }
+  /** Install the Antigravity (`agy`) lifecycle-hook bridge: write the normalizer
+   *  shim and merge a `munder-hive` hook group into agy's global hooks.json so a
+   *  Gemini worker reports PreToolUse/PostToolUse/Stop/PreInvocation/PostInvocation
+   *  to this HookServer (live status + inbox-drain), reusing the Claude pipeline.
+   *
+   *  Two agy-isms handled: (1) antigravity-cli#49 — agy LOADS hooks from
+   *  `~/.gemini/antigravity-cli/hooks.json` but TRIGGERS from `~/.gemini/config/
+   *  hooks.json`, so we write BOTH; (2) commands go to cmd.exe and agy mangles
+   *  embedded quotes, so the shim path must be space-free (hive roots are).
+   *  Runtime-scoped by AGENT_ID (the shim no-ops for non-hive agy sessions), so
+   *  this global config never disturbs the user's own `agy` usage. Best-effort,
+   *  idempotent (only our own group is overwritten). */
+  private installAgyHooks(): void {
+    const root = this.root();
+    if (!root) return;
+    const shim = join(root, 'bin', 'agy-hook.cjs');
+    mkdirSync(join(root, 'bin'), { recursive: true });
+    writeFileSync(shim, AGY_HOOK_SHIM, 'utf8');
+    const tool = (event: string) => ({
+      matcher: '*',
+      hooks: [{ type: 'command', command: `node ${shim} ${event}`, timeout: 0 }]
+    });
+    const plain = (event: string) => ({
+      hooks: [{ type: 'command', command: `node ${shim} ${event}`, timeout: 0 }]
+    });
+    const group = {
+      PreToolUse: [tool('PreToolUse')],
+      PostToolUse: [tool('PostToolUse')],
+      PreInvocation: [plain('PreInvocation')],
+      PostInvocation: [plain('PostInvocation')],
+      Stop: [plain('Stop')]
+    };
+    const gem = join(homedir(), '.gemini');
+    for (const p of [join(gem, 'config', 'hooks.json'), join(gem, 'antigravity-cli', 'hooks.json')]) {
+      try {
+        mkdirSync(dirname(p), { recursive: true });
+        let existing: Record<string, unknown> = {};
+        if (existsSync(p)) {
+          try { existing = JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>; } catch { existing = {}; }
+        }
+        existing['munder-hive'] = group;
+        writeFileSync(p, JSON.stringify(existing, null, 2), 'utf8');
+      } catch { /* best-effort per file */ }
+    }
+  }
+
   /** Write the live fleet snapshot Michael reads (`fleet.json`, gitignored).
    *  Best-effort — called from a timer, must never throw. */
   writeFleetSnapshot(snapshot: unknown): void {
@@ -965,5 +1021,66 @@ process.stdin.on('end', () => {
   c.on('end', () => done(0));
   c.on('error', () => process.exit(0));
   setTimeout(() => process.exit(0), 5000).unref();
+});
+`;
+
+// ─── agy-hook shim (written to <hive>/bin/agy-hook.cjs) ──────────────────────
+// Antigravity's `agy` CLI fires lifecycle hooks (PreToolUse/PostToolUse/Stop/
+// PreInvocation/PostInvocation) but with a DIFFERENT stdin shape than Claude
+// (conversationId / toolCall{name,args} / workspacePaths, and no hook_event_name
+// — the event arrives as argv from the hooks.json command). This shim normalizes
+// that into the same HookPayload the HookServer already consumes, so status,
+// inbox-drain-on-Stop, and tool gating are reused UNCHANGED, then translates the
+// server's Claude-shaped response back into agy's stdout contract (decision:
+// allow|deny|block + a message). Scoped by AGENT_ID: a personal agy session
+// (no AGENT_ID in env) is a no-op, so the global hooks.json never disturbs the
+// user's own agy usage — only hive workers (spawned with AGENT_ID set) bridge.
+// NOTE (agy bug, antigravity-cli#49): the loader reads ~/.gemini/antigravity-cli/
+// hooks.json but the trigger reads ~/.gemini/config/hooks.json — we write BOTH.
+const AGY_HOOK_SHIM = `#!/usr/bin/env node
+'use strict';
+const net = require('net');
+const event = process.argv[2] || 'Unknown';
+const agentId = process.env.AGENT_ID || null;
+let data = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (d) => { data += d; });
+process.stdin.on('end', () => {
+  const sock = process.env.HIVE_SOCK;
+  if (!agentId || !sock) { process.exit(0); } // not a hive worker → ignore
+  let agy = {};
+  try { agy = JSON.parse(data || '{}'); } catch (_) {}
+  const tc = agy.toolCall || {};
+  const payload = {
+    hook_event_name: event,
+    agent_id: agentId,
+    session_id: agy.conversationId,
+    transcript_path: agy.transcriptPath,
+    cwd: Array.isArray(agy.workspacePaths) ? agy.workspacePaths[0] : undefined,
+    tool_name: tc.name,
+    tool_input: tc.args
+  };
+  let resp = '';
+  const done = () => {
+    // Translate the HookServer's Claude-shaped reply into agy's contract.
+    let out = {};
+    try {
+      const r = JSON.parse(resp || '{}');
+      if (r.decision === 'block') out = { decision: 'block', reason: r.reason, stopReason: r.reason, systemMessage: r.reason };
+      else if (r.hookSpecificOutput && r.hookSpecificOutput.permissionDecision === 'deny') out = { decision: 'deny', reason: r.hookSpecificOutput.permissionDecisionReason };
+      else if (r.continue === false) out = { decision: 'block', stopReason: r.stopReason };
+      else if (r.hookSpecificOutput && r.hookSpecificOutput.additionalContext) out = { systemMessage: r.hookSpecificOutput.additionalContext };
+    } catch (_) {}
+    try { process.stdout.write(JSON.stringify(out)); } catch (_) {}
+    process.exit(0);
+  };
+  try {
+    const c = net.createConnection(sock, () => c.write(JSON.stringify(payload) + '\\n'));
+    c.setEncoding('utf8');
+    c.on('data', (d) => { resp += d; });
+    c.on('end', done);
+    c.on('error', () => process.exit(0));
+    setTimeout(() => process.exit(0), 5000).unref();
+  } catch (_) { process.exit(0); }
 });
 `;

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -26,7 +26,7 @@ import { spawnSync } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentUsageSample } from './usage';
 import { COMMAND_GROUPS } from '../shared/claudeCommands';
-import { isHiveAwareProvider, type AgentProvider } from '../shared/agentProvider';
+import { isHiveAwareProvider, providerPreset, type AgentProvider } from '../shared/agentProvider';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -288,11 +288,17 @@ export class HiveManager {
     };
 
     // Non-Claude providers (e.g. Antigravity's `agy`) don't understand Claude
-    // Code's flags or hook protocol. They still get a hive workspace + the
-    // shared AGENT_* env above, but no telemetry/prompt/settings injection —
-    // and direct hive mail to them bounces to the god (router). This is what
-    // makes the floor runnable without Claude installed at all.
+    // Code's flags or hook protocol — no telemetry, no `--settings` hooks, and
+    // direct hive mail to them bounces to the god (router). But where the CLI
+    // takes an INITIAL prompt (agy's `-i`), we still orient the session with the
+    // same hive identity+protocol — the closest thing to `--append-system-prompt`
+    // these CLIs offer (it's the first turn, then the session continues). This is
+    // what makes a Gemini worker hive-aware without Claude installed at all.
     if (!isHiveAwareProvider(meta.provider)) {
+      const flag = providerPreset(meta.provider ?? 'claude').initialPromptFlag;
+      if (flag) {
+        return { args: [flag, this.injectedPrompt(meta, dir, root, opts.semanticMemory ?? false)], env };
+      }
       return { args: [], env };
     }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,7 +25,7 @@ import { listIssues, listCIRuns } from './github';
 import { SlackWebhookServer } from './slack';
 import { TelemetryCollector } from './telemetry';
 import { ControlRegistry } from './control';
-import { inferAgentProvider, isClaudeProvider, type AgentProvider } from '../shared/agentProvider';
+import { inferAgentProvider, isClaudeProvider, providerPreset, type AgentProvider } from '../shared/agentProvider';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
 const ptyManager = new PtyManager();
@@ -711,13 +711,20 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
     if (typeof cfg.maxTurns === 'number' && cfg.maxTurns > 0 && !args.includes('--max-turns')) {
       args.push('--max-turns', String(cfg.maxTurns));
     }
-    // Idempotent resume (#6.6a): only when explicitly requested and we have a
-    // prior session id for this agent.
-    if (opts.resume === true) {
-      const sid = hive.lastSession(opts.hive.id);
-      if (sid && !args.includes('--resume')) args.push('--resume', sid);
-    }
     opts.args = args;
+  }
+  // Idempotent session resume on respawn (#6.6a) — provider-aware: Claude
+  // `--resume <sid>`, Antigravity `--conversation <id>`. The recorded session id
+  // comes from hook payloads (agy's conversationId flows through the bridge), so
+  // a restored worker continues its prior CLI session. Only when requested AND a
+  // prior id exists for this agent.
+  if (opts.hive && opts.resume === true) {
+    const rf = providerPreset(provider).resumeFlag;
+    const sid = hive.lastSession(opts.hive.id);
+    if (rf && sid) {
+      const args = opts.args ?? [];
+      if (!args.includes(rf)) { args.push(rf, sid); opts.args = args; }
+    }
   }
   // Remember which agent owns this PTY so closing the tab can archive it. A
   // live terminal means active — ensureAgent above already cleared `archived`.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import { listIssues, listCIRuns } from './github';
 import { SlackWebhookServer } from './slack';
 import { TelemetryCollector } from './telemetry';
 import { ControlRegistry } from './control';
+import { inferAgentProvider, isClaudeProvider, type AgentProvider } from '../shared/agentProvider';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
 const ptyManager = new PtyManager();
@@ -637,10 +638,14 @@ function createWindow(): void {
 }
 
 // ─── IPC: pty lifecycle ─────────────────────────────────────────────────────
-ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean }) => {
+ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean; provider?: AgentProvider }) => {
   if (!opts || typeof opts.id !== 'string' || typeof opts.cwd !== 'string' || typeof opts.command !== 'string') {
     return { ok: false, error: 'invalid SpawnOptions' };
   }
+  // Which CLI is this? Explicit wins; else inferred from the binary (claude/agy).
+  // Non-Claude providers skip every Claude-only spawn step below.
+  const provider = inferAgentProvider(opts.command, opts.provider ?? opts.hive?.provider);
+  const claudeProvider = isClaudeProvider(provider);
   // Git isolation: when requested and the cwd is a real repo, give this agent
   // its own worktree on an `agent/<id>` branch so it can't clobber other agents'
   // (or the user's) working tree. Best-effort — a failure falls back to the
@@ -678,7 +683,7 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
   if (opts.hive && hive.enabled()) {
     try {
       const inj = hive.ensureAgent(
-        { ...opts.hive, cwd: opts.cwd },
+        { ...opts.hive, cwd: opts.cwd, provider },
         { semanticMemory: memory.active(), theme: readConfig().terminalTheme ?? 'light' }
       );
       opts.args = [...(opts.args ?? []), ...inj.args];
@@ -691,7 +696,9 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
   }
   // Long-run guardrails + tiering (Lane A #6.4/#6.6). All additive to the args
   // already assembled (incl. the hive injection); an explicit choice always wins.
-  if (opts.hive) {
+  // Claude-only — these are Claude Code flags; other CLIs carry their own flags
+  // in the command string the renderer already built.
+  if (opts.hive && claudeProvider) {
     const cfg = readConfig();
     const args = opts.args ?? [];
     // Model precedence: an explicit per-agent --model (from the renderer) wins;
@@ -718,7 +725,10 @@ ipcMain.handle('pty:spawn', async (_evt, opts: SpawnOptions & { hive?: AgentMeta
   // Pre-accept Claude Code's bypass-mode warning + folder-trust dialog so the
   // agent (spawned with --permission-mode bypassPermissions) doesn't stall on an
   // interactive prompt it can't answer and exit code 1. Best-effort, never blocks.
-  try { ensureClaudePermissionsAccepted(opts.cwd); } catch { /* never block spawn */ }
+  // Claude-only — other CLIs handle their own permission UX.
+  if (claudeProvider) {
+    try { ensureClaudePermissionsAccepted(opts.cwd); } catch { /* never block spawn */ }
+  }
   const res = ptyManager.spawn(opts);
   syncKeepAwake(); // arm the power-save blocker while ≥1 agent PTY is alive (#18)
   return res;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,8 +1,11 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import type { AgentProvider } from '../shared/agentProvider';
 
 export interface HiveAgentMeta {
   id: string;
   name: string;
+  /** Which CLI this agent runs on (claude/antigravity/custom); defaults claude. */
+  provider?: AgentProvider;
   role?: string;
   capabilities?: string[];
   cwd: string;
@@ -62,6 +65,8 @@ export interface SpawnPtyOptions {
   id: string;
   cwd: string;
   command: string;
+  /** Which CLI to spawn; usually inferred from `command` in the main process. */
+  provider?: AgentProvider;
   args?: string[];
   cols?: number;
   rows?: number;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -74,6 +74,9 @@ export interface SpawnPtyOptions {
   hive?: HiveAgentMeta;
   /** When true (and cwd is a git repo), spawn the agent in its own git worktree. */
   isolate?: boolean;
+  /** When true, continue the agent's prior CLI session if one was recorded
+   *  (provider-aware: Claude `--resume`, Antigravity `--conversation`). */
+  resume?: boolean;
 }
 
 export interface PtyExit { exitCode: number; signal?: number | undefined }

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -10,6 +10,7 @@ import {
   type HarnessConfig,
   type AgentProvider,
   buildSpawnCommand,
+  tokenizeCommand,
   modelsForProvider,
   inferAgentProvider,
   providerPreset,
@@ -87,8 +88,9 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
     const id = uniqueId(name);
     const ptyId = `pty-${id}`;
     // The command field contains `claude --permission-mode bypassPermissions`
-    // for auto mode. Split into argv-style for node-pty.
-    const [exe, ...args] = command.trim().split(/\s+/);
+    // for auto mode. Split into argv-style for node-pty (quote-aware so an agy
+    // model label like "Gemini 3.1 Pro (High)" stays one argument).
+    const [exe, ...args] = tokenizeCommand(command.trim());
     const spawnRes = await window.cth.spawnPty({
       id: ptyId,
       cwd,

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -6,7 +6,16 @@ import { Icon } from './Icon';
 import { useStore, type Agent } from '@/store/store';
 import { OFFICE_CAST, DEFAULT_CHARACTER, type OfficeCharacterName } from '@/scene/office/cast';
 import { type AccentColorName } from '@/design/tokens';
-import { type HarnessConfig, buildSpawnCommand, AGENT_MODELS } from '@/store/config';
+import {
+  type HarnessConfig,
+  type AgentProvider,
+  buildSpawnCommand,
+  modelsForProvider,
+  inferAgentProvider,
+  providerPreset,
+  isClaudeProvider
+} from '@/store/config';
+import { AGENT_PROVIDER_PRESETS } from '@shared/agentProvider';
 
 const ACCENTS: AccentColorName[] = ['coral', 'mint', 'sky', 'lemon', 'lilac', 'peach'];
 
@@ -26,20 +35,36 @@ export interface AddAgentModalProps {
 export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
   const addAgent = useStore(s => s.addAgent);
 
+  // Default provider follows whatever the global default command is (claude
+  // unless the user reconfigured it); the model only carries over for Claude.
+  const initialProvider = inferAgentProvider(config.defaultCommand);
+  const initialModel = isClaudeProvider(initialProvider) ? config.defaultModel : undefined;
+
   const [name, setName] = useState('Jim');
   const [character, setCharacter] = useState<OfficeCharacterName>(DEFAULT_CHARACTER);
   const [accent, setAccent] = useState<AccentColorName>('sky');
   const [cwd, setCwd] = useState<string>(config.registeredRepos[0] ?? '');
-  const [model, setModel] = useState<string | undefined>(config.defaultModel);
-  const [command, setCommand] = useState(buildSpawnCommand(config, config.defaultModel));
+  const [provider, setProvider] = useState<AgentProvider>(initialProvider);
+  const [model, setModel] = useState<string | undefined>(initialModel);
+  const [command, setCommand] = useState(buildSpawnCommand(config, initialModel, initialProvider));
   const [description, setDescription] = useState('a fresh harness');
 
   // Picking a model rebuilds the command; the command field stays editable for
   // power users (it's the source of truth for the actual spawn).
   const pickModel = (id?: string) => {
     setModel(id);
-    setCommand(buildSpawnCommand(config, id));
+    setCommand(buildSpawnCommand(config, id, provider));
   };
+  // Switching provider resets the model to that CLI's default and rebuilds the
+  // command from the provider's preset binary (so Antigravity spawns `agy`, not
+  // the configured `claude`).
+  const pickProvider = (id: AgentProvider) => {
+    setProvider(id);
+    const nextModel = isClaudeProvider(id) ? config.defaultModel : undefined;
+    setModel(nextModel);
+    setCommand(buildSpawnCommand(config, nextModel, id));
+  };
+  const preset = providerPreset(provider);
   const [goal, setGoal] = useState('');
   const [isolate, setIsolate] = useState(false);
   const [error, setError] = useState<string | undefined>();
@@ -69,6 +94,7 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
       cwd,
       command: exe,
       args,
+      provider,
       cols: 100,
       rows: 30,
       // When set, the main process spawns this agent in its own git worktree.
@@ -78,6 +104,7 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
         id,
         name: name.trim(),
         cwd,
+        provider,
         role: description.trim() || undefined
       }
     });
@@ -103,6 +130,7 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
       currentStation: 'desk',
       ptyId,
       command: command.trim(),
+      provider,
       model,
       recentTextTs: Date.now()
     };
@@ -178,9 +206,41 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
               </div>
             </Row>
 
-            <Row label="Model">
+            <Row label="Provider">
               <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                {AGENT_MODELS.map((m) => {
+                {AGENT_PROVIDER_PRESETS.map((p) => {
+                  const active = provider === p.id;
+                  return (
+                    <button
+                      key={p.id}
+                      onClick={() => pickProvider(p.id)}
+                      title={
+                        p.id === 'antigravity'
+                          ? 'Spawn the Antigravity CLI (agy) with a Gemini model'
+                          : p.id === 'custom'
+                            ? 'Run any command — no Claude-only flags'
+                            : p.label
+                      }
+                      style={{
+                        padding: '3px 8px 1px',
+                        background: active ? `var(--cth-${accent}-light)` : 'var(--cth-cream-100)',
+                        boxShadow: active
+                          ? 'inset 0 0 0 2px var(--cth-ink-900)'
+                          : 'inset 0 0 0 1px var(--cth-ink-700)',
+                        fontFamily: 'var(--cth-font-ui)', fontSize: 13,
+                        color: 'var(--cth-ink-900)', cursor: 'pointer', border: 'none'
+                      }}
+                    >
+                      {p.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </Row>
+
+            {preset.supportsModel && <Row label="Model">
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {modelsForProvider(provider).map((m) => {
                   const active = (model ?? '') === (m.id ?? '');
                   return (
                     <button
@@ -202,13 +262,13 @@ export function AddAgentModal({ onClose, config }: AddAgentModalProps) {
                   );
                 })}
               </div>
-            </Row>
+            </Row>}
 
-            <Row label={config.autoMode ? 'Command (auto mode on)' : 'Command'}>
+            <Row label={config.autoMode && preset.autoFlag ? 'Command (auto mode on)' : 'Command'}>
               <input
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}
-                placeholder="claude"
+                placeholder={provider === 'antigravity' ? 'agy' : provider === 'custom' ? 'your-agent-cli' : 'claude'}
                 style={{ ...inputStyle, fontFamily: 'var(--cth-font-mono)' }}
               />
             </Row>

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -39,6 +39,10 @@ export function AgentStrip({ config }: AgentStripProps) {
           args,
           cols: 100,
           rows: 30,
+          // Continue the worker's prior CLI session if one was recorded — the
+          // main process picks the provider's resume flag (Claude --resume,
+          // agy --conversation). No-op when there's no recorded session id.
+          resume: true,
           // Re-request isolation if the agent ran in its own worktree before —
           // the old worktree was torn down on exit, so a fresh one is created.
           isolate: !!a.worktreePath,

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -3,7 +3,7 @@ import { AgentCard } from './AgentCard';
 import { PixelButton } from './PixelButton';
 import { Icon } from './Icon';
 import { useStore, type Agent } from '@/store/store';
-import { buildSpawnCommand, type HarnessConfig } from '@/store/config';
+import { buildSpawnCommand, tokenizeCommand, type HarnessConfig } from '@/store/config';
 
 export interface AgentStripProps {
   /** Needed to rebuild a spawn command when a restorable agent predates the
@@ -30,7 +30,7 @@ export function AgentStrip({ config }: AgentStripProps) {
       for (const a of [...restorableAgents]) {
         const command = (a.command ?? '').trim() || (config ? buildSpawnCommand(config, a.model) : '');
         if (!command || !a.cwd) { useStore.getState().removeRestorableAgent(a.id); continue; }
-        const [exe, ...args] = command.split(/\s+/);
+        const [exe, ...args] = tokenizeCommand(command);
         const ptyId = a.ptyId ?? `pty-${a.id}`;
         const res = await window.cth.spawnPty({
           id: ptyId,

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -13,7 +13,7 @@ import { useFleetTelemetry } from '@/hooks/useTelemetry';
 import { COMMAND_GROUPS } from '@shared/claudeCommands';
 import { useStore, type Agent } from '@/store/store';
 import { usePtyParser } from '@/hooks/usePtyParser';
-import { buildSpawnCommand, AGENT_MODELS, modelsForProvider, inferAgentProvider, isClaudeProvider } from '@/store/config';
+import { buildSpawnCommand, AGENT_MODELS, modelsForProvider, tokenizeCommand, inferAgentProvider, isClaudeProvider } from '@/store/config';
 
 /** Michael's control surface. Shown instead of the plain terminal/files panel
  *  when the god agent is selected: terminal + queue, the floor roster (with
@@ -301,7 +301,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
       // command if not explicitly tagged) so an Antigravity worker stays `agy`.
       const provider = inferAgentProvider(a.command, a.provider);
       const command = buildSpawnCommand(cfg, model, provider);
-      const [exe, ...args] = command.trim().split(/\s+/);
+      const [exe, ...args] = tokenizeCommand(command.trim());
       const hive = a.isGod
         ? { id: a.id, name: a.name, cwd: a.cwd, provider, isGod: true, role: 'orchestrator (god)' }
         : a.isAssistant

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -13,7 +13,7 @@ import { useFleetTelemetry } from '@/hooks/useTelemetry';
 import { COMMAND_GROUPS } from '@shared/claudeCommands';
 import { useStore, type Agent } from '@/store/store';
 import { usePtyParser } from '@/hooks/usePtyParser';
-import { buildSpawnCommand, AGENT_MODELS } from '@/store/config';
+import { buildSpawnCommand, AGENT_MODELS, modelsForProvider, inferAgentProvider, isClaudeProvider } from '@/store/config';
 
 /** Michael's control surface. Shown instead of the plain terminal/files panel
  *  when the god agent is selected: terminal + queue, the floor roster (with
@@ -297,15 +297,18 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
       const cfg = await window.cth.getConfig();
       await window.cth.killPty(a.ptyId);
       disposeTerminal(a.ptyId);
-      const command = buildSpawnCommand(cfg, model);
+      // Respawn on the same CLI this agent already runs on (inferred from its
+      // command if not explicitly tagged) so an Antigravity worker stays `agy`.
+      const provider = inferAgentProvider(a.command, a.provider);
+      const command = buildSpawnCommand(cfg, model, provider);
       const [exe, ...args] = command.trim().split(/\s+/);
       const hive = a.isGod
-        ? { id: a.id, name: a.name, cwd: a.cwd, isGod: true, role: 'orchestrator (god)' }
+        ? { id: a.id, name: a.name, cwd: a.cwd, provider, isGod: true, role: 'orchestrator (god)' }
         : a.isAssistant
-        ? { id: a.id, name: a.name, cwd: a.cwd, isAssistant: true, role: "Michael's prep assistant" }
-        : { id: a.id, name: a.name, cwd: a.cwd, role: a.description };
-      const res = await window.cth.spawnPty({ id: a.ptyId, cwd: a.cwd, command: exe, args, cols: 100, rows: 30, hive });
-      if (res.ok) updateAgent(a.id, { command: command.trim(), model, status: 'idle', action: 'restarting…' });
+        ? { id: a.id, name: a.name, cwd: a.cwd, provider, isAssistant: true, role: "Michael's prep assistant" }
+        : { id: a.id, name: a.name, cwd: a.cwd, provider, role: a.description };
+      const res = await window.cth.spawnPty({ id: a.ptyId, cwd: a.cwd, command: exe, args, provider, cols: 100, rows: 30, hive });
+      if (res.ok) updateAgent(a.id, { command: command.trim(), provider, model, status: 'idle', action: 'restarting…' });
     } catch { /* noop */ } finally {
       setRestarting(null);
     }
@@ -525,12 +528,16 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                 disabled={restarting === a.id}
                 onChange={(v) => restartWithModel(a, v || undefined)}
               >
-                {AGENT_MODELS.map((m) => (
+                {modelsForProvider(inferAgentProvider(a.command, a.provider)).map((m) => (
                   <option key={m.label} value={m.id ?? ''}>{m.label}</option>
                 ))}
               </Select>
               <span style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>
-                {restarting === a.id ? 'restarting…' : 'model (restarts agent)'}
+                {restarting === a.id
+                  ? 'restarting…'
+                  : isClaudeProvider(inferAgentProvider(a.command, a.provider))
+                    ? 'model (restarts agent)'
+                    : `${inferAgentProvider(a.command, a.provider)} · model (restarts agent)`}
               </span>
             </div>
           </div>

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -303,6 +303,15 @@ export function useHive(config: HarnessConfig | null): void {
         // A turn is in progress (prompt submitted / tool just finished) — keep
         // it working so it doesn't flicker idle between tool calls.
         if (!breakerArmed) updateAgent(e.agentId, { status: 'working' });
+      } else if (e.event === 'PreInvocation') {
+        // Antigravity (agy): the model is being called — it's thinking/working.
+        if (!breakerArmed) updateAgent(e.agentId, { status: 'working', action: 'thinking' });
+      } else if (e.event === 'PostInvocation') {
+        // agy's per-turn boundary. Unlike Claude, agy's Stop fires only on process
+        // EXIT, so without this an agy worker would never register as idle and the
+        // inbox-wake nudge (idle-only) could never reach it — its mail would sit
+        // undrained. Treat it as idle; a follow-up tool/turn re-sets working.
+        if (!breakerArmed) updateAgent(e.agentId, { status: 'idle', action: 'idle', carrying: undefined });
       } else if (e.event === 'Stop' || e.event === 'SubagentStop') {
         // A blocked Stop means the agent is being re-engaged to process its
         // inbox — it's NOT idle, so keep it working until it genuinely stops.

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -104,8 +104,17 @@ const TOOL_STATION: Record<string, { station: StationKind; carry?: ToolKind }> =
  *  the MCP station (previously these silently sat at the desk, #5A gap); anything
  *  else → the desk. */
 function stationForTool(tool: string): { station: StationKind; carry?: ToolKind } {
-  return TOOL_STATION[tool]
-    ?? (tool.startsWith('mcp__') ? { station: 'mcp', carry: 'MCP' } : { station: 'desk' });
+  if (TOOL_STATION[tool]) return TOOL_STATION[tool];
+  if (tool.startsWith('mcp__')) return { station: 'mcp', carry: 'MCP' };
+  // Heuristic fallback for non-Claude tool names (Antigravity sends run_command,
+  // ListDir, write_file, … — its hook names differ from Claude's exact tags).
+  // Match write/edit BEFORE read so "write_file" → desk, not shelf.
+  const t = tool.toLowerCase();
+  if (/command|bash|shell|exec|terminal|run_/.test(t)) return { station: 'terminal', carry: 'Bash' };
+  if (/web|fetch|browser|http|url/.test(t)) return { station: 'web', carry: 'WebFetch' };
+  if (/write|edit|create|patch|replace|apply/.test(t)) return { station: 'desk', carry: 'Write' };
+  if (/read|list|view|dir|glob|grep|search|find|file|cat|\bls\b/.test(t)) return { station: 'shelf', carry: 'Read' };
+  return { station: 'desk' };
 }
 
 /**

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -65,7 +65,12 @@ const writeChains = new Map<string, Promise<void>>();
 function submitToPty(ptyId: string, text: string, settleMs = 250): Promise<void> {
   const prev = writeChains.get(ptyId) ?? Promise.resolve();
   const next = prev.catch(() => { /* a failed prior write must not stall the chain */ }).then(async () => {
-    await window.cth.writePty(ptyId, `\x1b[200~${text}\x1b[201~`);
+    // Bracketed paste (ESC[200~ … ESC[201~) only matters for MULTI-LINE text, so a
+    // stray "\n" doesn't submit early (#24). Single-line text (nudges, slash
+    // commands) is sent raw — some TUIs (Antigravity's agy) treat the paste
+    // markers as literal input and never submit, so skipping them is more robust.
+    const payload = text.includes('\n') ? `\x1b[200~${text}\x1b[201~` : text;
+    await window.cth.writePty(ptyId, payload);
     await new Promise((r) => setTimeout(r, 140));
     await window.cth.writePty(ptyId, '\r');
     await new Promise((r) => setTimeout(r, settleMs));

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useStore, type Agent, type StationKind, type ToolKind } from '@/store/store';
-import { buildSpawnCommand, ASSISTANT_MODEL, type HarnessConfig } from '@/store/config';
+import { buildSpawnCommand, ASSISTANT_MODEL, inferAgentProvider, isClaudeProvider, type HarnessConfig } from '@/store/config';
 
 const GOD_ID = 'god';
 const GOD_PTY = `pty-${GOD_ID}`;
@@ -517,6 +517,9 @@ export function useHive(config: HarnessConfig | null): void {
       const { agents, messageQueues, enqueueMessage } = useStore.getState();
       for (const a of agents) {
         if (!a.ptyId) continue;
+        // /compact is a Claude Code slash command — non-Claude CLIs (agy) would
+        // just receive it as literal prompt text. Skip them.
+        if (!isClaudeProvider(inferAgentProvider(a.command, a.provider))) continue;
         const queued = messageQueues[a.id] ?? [];
         if (queued.some((m) => m.text.trimStart().startsWith('/compact'))) continue;
         enqueueMessage(a.id, COMPACT_CMD);

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -91,16 +91,34 @@ export const AGENT_MODELS: ModelOption[] = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' }
 ];
 
-/** Gemini models offered when an agent runs on the Antigravity CLI (`agy`).
- *  `--model` is free-form, so these are presets — the command field stays
- *  editable. Run `agy models` (once logged in) for the live list. */
+/** Models offered when an agent runs on the Antigravity CLI (`agy`). agy's
+ *  `--model` takes the DISPLAY-NAME LABEL exactly as `agy models` prints it
+ *  (verified: agy logs `Propagating selected model override … label="…"`), not a
+ *  slug — so these ids ARE the labels (spaces/parens included; buildSpawnCommand
+ *  quotes them and the command tokenizer keeps them whole). The command field
+ *  stays editable; `agy models` is the source of truth for the live list. */
 export const ANTIGRAVITY_MODELS: ModelOption[] = [
   { id: undefined, label: 'default' },
-  { id: 'gemini-3-pro', label: 'Gemini 3 Pro' },
-  { id: 'gemini-3-flash', label: 'Gemini 3 Flash' },
-  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' }
+  { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro · High' },
+  { id: 'Gemini 3.1 Pro (Low)', label: 'Gemini 3.1 Pro · Low' },
+  { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash · High' },
+  { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash · Med' },
+  { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash · Low' },
+  { id: 'Claude Sonnet 4.6 (Thinking)', label: 'Claude Sonnet 4.6' },
+  { id: 'Claude Opus 4.6 (Thinking)', label: 'Claude Opus 4.6' },
+  { id: 'GPT-OSS 120B (Medium)', label: 'GPT-OSS 120B' }
 ];
+
+/** Split a command string into argv, respecting double/single quotes so a model
+ *  value with spaces (agy's `--model "Gemini 3.1 Pro (High)"`) stays one token.
+ *  Quotes are stripped from the result. */
+export function tokenizeCommand(command: string): string[] {
+  const out: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(command)) !== null) out.push(m[1] ?? m[2] ?? m[3]);
+  return out;
+}
 
 /** The model preset list for a given provider's picker. */
 export function modelsForProvider(provider: AgentProvider): ModelOption[] {
@@ -124,7 +142,12 @@ export function buildSpawnCommand(
         ? config.defaultCommand || ''
         : preset.defaultCommand;
   let cmd = base;
-  if (preset.supportsModel && model && preset.modelFlag) cmd = `${cmd} ${preset.modelFlag} ${model}`;
+  if (preset.supportsModel && model && preset.modelFlag) {
+    // Quote model values that contain whitespace (agy labels like
+    // "Gemini 3.1 Pro (High)") so the command tokenizer keeps them one arg.
+    const m = /\s/.test(model) ? `"${model}"` : model;
+    cmd = `${cmd} ${preset.modelFlag} ${m}`;
+  }
   if (config.autoMode && preset.autoFlag) cmd = `${cmd} ${preset.autoFlag}`;
   return cmd;
 }

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -1,6 +1,22 @@
 // Mirrors src/main/config.ts. Kept as a renderer-side type-only module
 // so we don't have to reach into the preload package to type-check.
 
+import {
+  AGENT_PROVIDER_PRESETS,
+  providerPreset,
+  inferAgentProvider,
+  isClaudeProvider,
+  type AgentProvider
+} from '@shared/agentProvider';
+
+export {
+  AGENT_PROVIDER_PRESETS,
+  providerPreset,
+  inferAgentProvider,
+  isClaudeProvider,
+  type AgentProvider
+};
+
 /** A recurring auto-dispatched mission (mirrors src/main/config.ts). */
 export interface ScheduledMission {
   id: string;
@@ -75,13 +91,40 @@ export const AGENT_MODELS: ModelOption[] = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' }
 ];
 
-/** Build the command line to feed into spawnPty, honoring autoMode and an
- *  optional per-agent model override (injected as `--model <model>`). */
+/** Gemini models offered when an agent runs on the Antigravity CLI (`agy`).
+ *  `--model` is free-form, so these are presets — the command field stays
+ *  editable. Run `agy models` (once logged in) for the live list. */
+export const ANTIGRAVITY_MODELS: ModelOption[] = [
+  { id: undefined, label: 'default' },
+  { id: 'gemini-3-pro', label: 'Gemini 3 Pro' },
+  { id: 'gemini-3-flash', label: 'Gemini 3 Flash' },
+  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' }
+];
+
+/** The model preset list for a given provider's picker. */
+export function modelsForProvider(provider: AgentProvider): ModelOption[] {
+  return provider === 'antigravity' ? ANTIGRAVITY_MODELS : AGENT_MODELS;
+}
+
+/** Build the command line to feed into spawnPty, honoring the provider's flags,
+ *  autoMode, and an optional per-agent model override. Claude keeps the user's
+ *  configured `defaultCommand`; other providers use their preset binary so the
+ *  app works without Claude installed. */
 export function buildSpawnCommand(
   config: Pick<HarnessConfig, 'defaultCommand' | 'autoMode'>,
-  model?: string
+  model?: string,
+  provider: AgentProvider = inferAgentProvider(config.defaultCommand)
 ): string {
-  const base = config.defaultCommand || 'claude';
-  const withModel = model ? `${base} --model ${model}` : base;
-  return config.autoMode ? `${withModel} --permission-mode bypassPermissions` : withModel;
+  const preset = providerPreset(provider);
+  const base =
+    provider === 'claude'
+      ? config.defaultCommand || preset.defaultCommand
+      : provider === 'custom'
+        ? config.defaultCommand || ''
+        : preset.defaultCommand;
+  let cmd = base;
+  if (preset.supportsModel && model && preset.modelFlag) cmd = `${cmd} ${preset.modelFlag} ${model}`;
+  if (config.autoMode && preset.autoFlag) cmd = `${cmd} ${preset.autoFlag}`;
+  return cmd;
 }

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { AccentColorName } from '@/design/tokens';
 import type { OfficeCharacterName } from '@/scene/office/cast';
 import type { StatusKind } from '@/components/PixelBadge';
+import type { AgentProvider } from '@shared/agentProvider';
 
 export type ToolKind =
   | 'Read' | 'Edit' | 'Write' | 'Bash' | 'WebFetch' | 'WebSearch'
@@ -48,10 +49,13 @@ export interface Agent {
   blockReason?: BlockReason;
   /** present iff this agent has a real PTY in the main process */
   ptyId?: string;
-  /** the command being run in the PTY (e.g. 'claude') */
+  /** the command being run in the PTY (e.g. 'claude' or 'agy') */
   command?: string;
-  /** the model this agent runs on (e.g. 'claude-sonnet-4-6[1m]'); drives the
-   *  model selector + the --model arg used when (re)spawning the agent */
+  /** which CLI this agent runs on; drives the model picker + spawn flags.
+   *  Defaults to 'claude' when unset (legacy agents / inferred from command). */
+  provider?: AgentProvider;
+  /** the model this agent runs on (e.g. 'claude-sonnet-4-6[1m]' or 'gemini-3-pro');
+   *  drives the model selector + the --model arg used when (re)spawning the agent */
   model?: string;
   /** the last prompt the user submitted to this agent in Claude Code —
    *  shown on the floor as a card above the seated avatar */

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -27,6 +27,11 @@ export interface AgentProviderPreset {
    *  + hook `--settings`). Other CLIs don't — they spawn with the shared AGENT_*
    *  env only, and direct hive mail to them bounces to the god. */
   hiveAware: boolean;
+  /** For non-hive-aware CLIs that still take an INITIAL prompt to orient the
+   *  session (Antigravity's `agy -i "<prompt>"`), the flag to pass it under. The
+   *  hive identity+protocol rides in as the first turn — the closest thing to
+   *  Claude's `--append-system-prompt` these CLIs offer. undefined = no way in. */
+  initialPromptFlag?: string;
 }
 
 export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
@@ -46,7 +51,8 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     supportsModel: true,
     modelFlag: '--model',
     autoFlag: '--dangerously-skip-permissions',
-    hiveAware: false
+    hiveAware: false,
+    initialPromptFlag: '-i' // agy --prompt-interactive: orient the session, then continue
   },
   {
     id: 'custom',

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -25,8 +25,15 @@ export interface AgentProviderPreset {
   autoFlag?: string;
   /** Claude Code accepts the hive identity injection (`--append-system-prompt`
    *  + hook `--settings`). Other CLIs don't — they spawn with the shared AGENT_*
-   *  env only, and direct hive mail to them bounces to the god. */
+   *  env only. Gates the Claude-specific spawn injection in hive.ensureAgent. */
   hiveAware: boolean;
+  /** Whether the router may DELIVER inbox mail to this provider (vs bouncing it
+   *  to the god). Requires a way for the agent to actually drain its inbox: Claude
+   *  via its Stop hook, Antigravity via the agy-hook bridge's Stop→drain. A
+   *  provider with no hook surface (custom) can't, so its mail still bounces.
+   *  Distinct from hiveAware: agy is NOT hiveAware (no Claude injection) but CAN
+   *  receive inbox (it has the bridged Stop-drain hook). */
+  canReceiveInbox: boolean;
   /** For non-hive-aware CLIs that still take an INITIAL prompt to orient the
    *  session (Antigravity's `agy -i "<prompt>"`), the flag to pass it under. The
    *  hive identity+protocol rides in as the first turn — the closest thing to
@@ -42,7 +49,8 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     supportsModel: true,
     modelFlag: '--model',
     autoFlag: '--permission-mode bypassPermissions',
-    hiveAware: true
+    hiveAware: true,
+    canReceiveInbox: true
   },
   {
     id: 'antigravity',
@@ -52,6 +60,7 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     modelFlag: '--model',
     autoFlag: '--dangerously-skip-permissions',
     hiveAware: false,
+    canReceiveInbox: true, // via the agy-hook bridge (Stop→drain); verified agy honors hook decisions
     initialPromptFlag: '-i' // agy --prompt-interactive: orient the session, then continue
   },
   {
@@ -59,7 +68,8 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     label: 'Custom',
     defaultCommand: '',
     supportsModel: false,
-    hiveAware: false
+    hiveAware: false,
+    canReceiveInbox: false // no hook surface to drain an inbox → mail bounces to the god
   }
 ];
 
@@ -82,6 +92,14 @@ export function isClaudeProvider(provider: AgentProvider | undefined): boolean {
 /** Whether this provider takes the hive's Claude-only identity injection. */
 export function isHiveAwareProvider(provider: AgentProvider | undefined): boolean {
   return providerPreset(provider ?? 'claude').hiveAware;
+}
+
+/** Whether the router may deliver inbox mail to this provider (else bounce to
+ *  the god). True for any provider that can actually drain its inbox — Claude
+ *  and Antigravity (via the agy-hook Stop→drain bridge); false for hookless
+ *  custom commands. */
+export function canReceiveInbox(provider: AgentProvider | undefined): boolean {
+  return providerPreset(provider ?? 'claude').canReceiveInbox;
 }
 
 /** The bare executable from a command string ('agy --model x' → 'agy'). */

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -39,6 +39,10 @@ export interface AgentProviderPreset {
    *  hive identity+protocol rides in as the first turn — the closest thing to
    *  Claude's `--append-system-prompt` these CLIs offer. undefined = no way in. */
   initialPromptFlag?: string;
+  /** Flag to resume a prior session on respawn, given the recorded session id
+   *  (Claude `--resume <sid>`, Antigravity `--conversation <id>`). undefined = no
+   *  resume support, spawn fresh. */
+  resumeFlag?: string;
 }
 
 export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
@@ -50,7 +54,8 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     modelFlag: '--model',
     autoFlag: '--permission-mode bypassPermissions',
     hiveAware: true,
-    canReceiveInbox: true
+    canReceiveInbox: true,
+    resumeFlag: '--resume'
   },
   {
     id: 'antigravity',
@@ -61,7 +66,8 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     autoFlag: '--dangerously-skip-permissions',
     hiveAware: false,
     canReceiveInbox: true, // via the agy-hook bridge (Stop→drain); verified agy honors hook decisions
-    initialPromptFlag: '-i' // agy --prompt-interactive: orient the session, then continue
+    initialPromptFlag: '-i', // agy --prompt-interactive: orient the session, then continue
+    resumeFlag: '--conversation' // agy: resume a previous conversation by ID
   },
   {
     id: 'custom',

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -1,0 +1,102 @@
+/**
+ * Agent providers — the CLI a worker runs on. The app is no longer Claude-only:
+ * a worker can run Claude Code or the Antigravity CLI (`agy`, Gemini models), or
+ * any custom command. Each provider declares how to build its spawn command
+ * (model flag, auto-mode flag) and whether it accepts the hive's Claude-specific
+ * identity injection (`--append-system-prompt` + `--settings`).
+ *
+ * Shared between main and renderer; keep it dependency-free (no electron, no UI).
+ * Mirrors the shape of the upstream provider-preset work (PR #47 / issue #21) so
+ * the two reconcile cleanly — this build adds the `antigravity` preset.
+ */
+
+export type AgentProvider = 'claude' | 'antigravity' | 'custom';
+
+export interface AgentProviderPreset {
+  id: AgentProvider;
+  label: string;
+  /** The binary spawned when the user hasn't typed a custom command. */
+  defaultCommand: string;
+  /** Show a model picker and splice the model into the command. */
+  supportsModel: boolean;
+  /** Flag that selects the session model, e.g. `--model`. */
+  modelFlag?: string;
+  /** Flag appended when the floor is in auto (skip-permissions) mode. */
+  autoFlag?: string;
+  /** Claude Code accepts the hive identity injection (`--append-system-prompt`
+   *  + hook `--settings`). Other CLIs don't — they spawn with the shared AGENT_*
+   *  env only, and direct hive mail to them bounces to the god. */
+  hiveAware: boolean;
+}
+
+export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
+  {
+    id: 'claude',
+    label: 'Claude Code',
+    defaultCommand: 'claude',
+    supportsModel: true,
+    modelFlag: '--model',
+    autoFlag: '--permission-mode bypassPermissions',
+    hiveAware: true
+  },
+  {
+    id: 'antigravity',
+    label: 'Antigravity · Gemini',
+    defaultCommand: 'agy',
+    supportsModel: true,
+    modelFlag: '--model',
+    autoFlag: '--dangerously-skip-permissions',
+    hiveAware: false
+  },
+  {
+    id: 'custom',
+    label: 'Custom',
+    defaultCommand: '',
+    supportsModel: false,
+    hiveAware: false
+  }
+];
+
+export function isAgentProvider(value: unknown): value is AgentProvider {
+  return value === 'claude' || value === 'antigravity' || value === 'custom';
+}
+
+export function normalizeAgentProvider(value: unknown): AgentProvider | undefined {
+  return isAgentProvider(value) ? value : undefined;
+}
+
+export function providerPreset(provider: AgentProvider): AgentProviderPreset {
+  return AGENT_PROVIDER_PRESETS.find((p) => p.id === provider) ?? AGENT_PROVIDER_PRESETS[0];
+}
+
+export function isClaudeProvider(provider: AgentProvider | undefined): boolean {
+  return provider === 'claude';
+}
+
+/** Whether this provider takes the hive's Claude-only identity injection. */
+export function isHiveAwareProvider(provider: AgentProvider | undefined): boolean {
+  return providerPreset(provider ?? 'claude').hiveAware;
+}
+
+/** The bare executable from a command string ('agy --model x' → 'agy'). */
+function commandBinary(command: string | undefined): string {
+  const first = (command ?? '').trim().split(/\s+/)[0] ?? '';
+  // strip a path + extension so 'C:\...\agy.exe' and '/usr/bin/claude' both map
+  const leaf = first.split(/[\\/]/).pop() ?? first;
+  return leaf.replace(/\.(exe|cmd|bat|ps1)$/i, '').toLowerCase();
+}
+
+/** Infer the provider from a command (or honor an explicit override). */
+export function inferAgentProvider(command: string | undefined, explicit?: unknown): AgentProvider {
+  const normalized = normalizeAgentProvider(explicit);
+  if (normalized) return normalized;
+  const bin = commandBinary(command);
+  if (bin === 'agy' || bin === 'antigravity') return 'antigravity';
+  if (bin === 'claude' || !bin) return 'claude';
+  return 'custom';
+}
+
+export function defaultCommandForProvider(provider: AgentProvider, fallback = ''): string {
+  if (provider === 'custom') return fallback;
+  return providerPreset(provider).defaultCommand || fallback;
+}


### PR DESCRIPTION
Implements #52. Adds **Antigravity CLI (`agy`)** as a first-class agent provider — Gemini (and Claude/GPT) models on the user's Antigravity **OAuth subscription**, with a bridge that maps agy's native lifecycle hooks into the existing `HookServer`.

Builds on the provider-preset direction of #47 / #21 — see "Relationship to #47" below.

## What's here

- **Provider abstraction** (`src/shared/agentProvider.ts`): `claude | antigravity | custom` presets with per-provider model/auto/resume flags, `hiveAware`, `canReceiveInbox`, `initialPromptFlag`; `inferAgentProvider` (from the command binary), `isClaudeProvider`, `canReceiveInbox`. Threaded through `SpawnOptions`/`AgentMeta`/`Agent`.
- **Add Agent → provider picker**; per-provider model list (agy uses display-name **labels** — `Gemini 3.1 Pro (High)` — since `agy --model` takes the label, not a slug) + a quote-aware command tokenizer so a spaced label survives as one arg.
- **System prompt**: agy has no `--append-system-prompt`, so the hive identity+protocol is injected as the session's first turn via `agy -i "<prompt>"`.
- **Native hook bridge** (`AGY_HOOK_SHIM` → `<hive>/bin/agy-hook.cjs`, written by `installAgyHooks`): agy's hooks are Claude-protocol-compatible but with a different payload shape (`conversationId` / `toolCall{name,args}` / `workspacePaths`, event via argv). The shim normalizes that into the existing `HookPayload`, forwards to the same `HookServer` (so status, inbox-drain, and tool gating are reused unchanged), and translates the reply back into agy's `{decision}` contract. Scoped by `AGENT_ID` (personal agy sessions no-op).
- **Two-way hive messaging**: `canReceiveInbox` lets the router deliver to agy directly (and include it in broadcasts), since it drains its inbox via the bridge — Claude + agy true; hookless `custom` still bounces to the god.
- **Provider-aware resume**: Claude `--resume <sid>`, agy `--conversation <id>` (its `conversationId` flows through the bridge as the session id); wired into restore-team.
- **Status/stations**: maps agy's `PreInvocation`/`PostInvocation` (its per-turn boundary — agy's `Stop` fires only on *exit*) to working/idle, and a tool-name→station heuristic (`run_command`→terminal, `write_file`→desk, `ListDir`→shelf, …).
- Single-line PTY submits go raw (agy's TUI treats bracketed-paste markers as literal input); multi-line keeps bracketed paste.

## Why CLI, not SDK
The `agy` CLI is OAuth (the user's subscription, no extra cost). The Antigravity SDK requires an API key and blocks reusing the CLI's OAuth token → separate billing. So the integration is CLI-only.

## Known gaps (documented in #52)
- No token/cost telemetry (agy emits no OTel; its hook payload has no usage) → Gemini rows show 0 in the fleet meter.
- No context-window gauge (no statusLine equivalent).
- `-i` is a first-turn prompt, not a persistent system prompt (low-risk: agy doesn't auto-compact).
- No auto-compaction.

## Notable agy quirks handled (full notes in #52, filed upstream at antigravity-cli#49)
- **antigravity-cli#49**: agy *loads* hooks from `~/.gemini/antigravity-cli/hooks.json` but *triggers* from `~/.gemini/config/hooks.json` → `installAgyHooks` writes **both**.
- Hook commands go to `cmd.exe`; escaped quotes break it (keep space-free/unquoted), and an empty/decision-less stdout object reads as **deny** (so the shim stays silent to allow).
- agy passes env to hook subprocesses (verified) → `AGENT_ID` scoping works.

## Relationship to #47 (Codex provider)
Both add `src/shared/agentProvider.ts` with provider presets — they will conflict. This PR uses the same shape, enriched (per-provider flags, `canReceiveInbox`, the hook bridge). Happy to **rebase onto #47** so the abstraction lands once, or land independently — your call.

## Not included (separable)
The node-pty ConPTY `AttachConsole` crash-guard (a Windows node-pty robustness fix triggered when an `agy` worker exits) is intentionally left out — it lives in local Windows build tooling and isn't agy-specific.

## Verification
`tsc --noEmit` (web + node) and `npm run build` green on a clean branch off `main`; diff is 10 files, agy-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
