### PR TITLE
fix(windows): guard node-pty ConPTY AttachConsole crash (companion to #54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
-    "postinstall": "electron-rebuild -f && node tools/ensure-pty-perms.cjs",
+    "postinstall": "electron-rebuild -f && node tools/ensure-pty-perms.cjs && node tools/patch-node-pty-conpty.cjs",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,19 @@ import {
 } from '../shared/agentProvider';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
+
+// Keep the hive alive through transient faults. The floor is a long-running
+// multi-agent supervisor — a single stray throw (e.g. node-pty's ConPTY console
+// helper choking when a fast-exiting agent CLI's console is already gone) must
+// NOT take the whole app and every running agent down with it. Log and continue
+// rather than letting the default handler exit the process.
+process.on('uncaughtException', (err) => {
+  console.error('[main] uncaughtException (kept alive):', err);
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('[main] unhandledRejection (kept alive):', reason);
+});
+
 const ptyManager = new PtyManager();
 /** Live PTY id → its hive agent id, recorded at spawn. The pty:kill handler only
  *  gets the PTY id, so this lets a closed tab archive the right registry agent. */

--- a/tools/patch-node-pty-conpty.cjs
+++ b/tools/patch-node-pty-conpty.cjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Windows-only node-pty crash guard, re-applied on every install (postinstall,
+ * after electron-rebuild). No-op on non-Windows and when already patched.
+ *
+ * node-pty forks `conpty_console_list_agent.js` to enumerate console processes
+ * when a pty is killed/exits. For a child whose console is already gone — e.g.
+ * an agent CLI that manages its own console and exits fast (Antigravity's `agy`)
+ * — `getConsoleProcessList(shellPid)` throws "AttachConsole failed" UNCAUGHT in
+ * that forked helper, which cascades into a whole-app crash (exit 255). Wrap it
+ * so it degrades to an empty list instead.
+ */
+const { readFileSync, writeFileSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+if (process.platform !== 'win32') process.exit(0);
+
+const agent = join(__dirname, '..', 'node_modules', 'node-pty', 'lib', 'conpty_console_list_agent.js');
+if (!existsSync(agent)) process.exit(0);
+
+const src = readFileSync(agent, 'utf8');
+// Idempotent: only patch the original unguarded form.
+if (!src.includes('var consoleProcessList = getConsoleProcessList(shellPid);')) process.exit(0);
+
+const guarded =
+  'var consoleProcessList = [];\n' +
+  '// PATCHED: AttachConsole can fail when the shell console is already gone (e.g.\n' +
+  "// a fast-exiting agent CLI that owns its console). Don't let the uncaught throw\n" +
+  '// crash this forked helper and cascade into a whole-app crash.\n' +
+  'try { consoleProcessList = getConsoleProcessList(shellPid); } catch (e) { consoleProcessList = []; }';
+
+let out = src.replace('var consoleProcessList = getConsoleProcessList(shellPid);', guarded);
+out = out.replace(
+  'process.send({ consoleProcessList: consoleProcessList });',
+  'try { process.send({ consoleProcessList: consoleProcessList }); } catch (e) { /* parent gone */ }'
+);
+if (out !== src) {
+  writeFileSync(agent, out, 'utf8');
+  console.log('[patch-node-pty-conpty] guarded conpty_console_list_agent against AttachConsole crash');
+}


### PR DESCRIPTION
Closes #60. Companion to #54 (Antigravity provider).

Now that agy workers can be spawned, on **Windows** a worker exiting could crash the whole app: node-pty forks `conpty_console_list_agent.js` to enumerate console processes when a pty dies, and `getConsoleProcessList(shellPid)` throws **`AttachConsole failed`** uncaught (the `agy` Go binary manages its own console, already gone), cascading to exit 255.

- **`tools/patch-node-pty-conpty.cjs`** — a Windows-only, idempotent, best-effort postinstall patcher (runs after `electron-rebuild`, alongside `ensure-pty-perms.cjs`) that wraps the helper's `getConsoleProcessList` in try/catch → degrades to an empty list instead of throwing.
- **main-process `uncaughtException` / `unhandledRejection` guards** that log and keep running — a long-running multi-agent supervisor shouldn't die from a stray throw in a forked helper.

Additive only (new tool + one postinstall entry + the guards). The patcher is a no-op on non-Windows and when already patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
