### PR TITLE
fix(packaging): include Slack trigger helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build",
+    "build": "electron-vite build && npm run copy:main-assets",
+    "copy:main-assets": "node tools/copy-main-assets.cjs",
     "preview": "electron-vite preview",
     "postinstall": "electron-rebuild -f && node tools/ensure-pty-perms.cjs",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",

--- a/src/main/tunnelmole.d.ts
+++ b/src/main/tunnelmole.d.ts
@@ -1,0 +1,3 @@
+declare module 'tunnelmole' {
+  export function tunnelmole(options: { port: number | string; [key: string]: unknown }): Promise<string>;
+}

--- a/tools/copy-main-assets.cjs
+++ b/tools/copy-main-assets.cjs
@@ -1,0 +1,23 @@
+'use strict';
+
+const { copyFileSync, mkdirSync, statSync } = require('node:fs');
+const { dirname, join } = require('node:path');
+
+const ROOT = join(__dirname, '..');
+const MAIN_ASSETS = [
+  ['src/main/slack-trigger.cjs', 'out/main/slack-trigger.cjs'],
+];
+
+for (const [fromRel, toRel] of MAIN_ASSETS) {
+  const from = join(ROOT, fromRel);
+  const to = join(ROOT, toRel);
+
+  mkdirSync(dirname(to), { recursive: true });
+  copyFileSync(from, to);
+
+  const copied = statSync(to);
+  if (!copied.isFile() || copied.size === 0) {
+    throw new Error(`Failed to copy required main-process asset: ${fromRel} -> ${toRel}`);
+  }
+  console.log(`[copy-main-assets] ${fromRel} -> ${toRel}`);
+}


### PR DESCRIPTION
## Summary
- Fixes the packaged macOS app launch crash in `v0.2.5`: `Cannot find module './slack-trigger.cjs'`.
- Copies the required main-process CJS helper into `out/main` after `electron-vite build`, so `electron-builder` includes it in `app.asar`.
- Adds a small ambient `tunnelmole` declaration so the current main branch typechecks cleanly.

## What happened
`src/main/slack.ts` loads the pure Slack trigger logic with `require('./slack-trigger.cjs')`. The built `out/main/index.js` preserves that relative require.

The production package includes `out/**`, but `slack-trigger.cjs` stayed in `src/main`, so the released `app.asar` had `out/main/index.js` without the required `out/main/slack-trigger.cjs`. That makes the Electron main process crash before the app boots.

## Fix
- `npm run build` now runs `npm run copy:main-assets` after `electron-vite build`.
- `tools/copy-main-assets.cjs` copies `src/main/slack-trigger.cjs` to `out/main/slack-trigger.cjs` and fails if the copy is missing or empty.
- `src/main/tunnelmole.d.ts` covers the existing dynamic import used by Slack/webhook tunnel startup.

## Validation
- Confirmed the installed `v0.2.5` app had `/out/main/index.js` but no `/out/main/slack-trigger.cjs` in `/Applications/Munder Difflin.app/Contents/Resources/app.asar`.
- Applied a local hotfix by repacking `app.asar` with the missing helper; the installed app now launches successfully.
- `npm run build`
- `npm run typecheck`
- `node test/slack.test.cjs`
- Runtime smoke: `require('./out/main/slack-trigger.cjs')` exposes `shouldTrigger`.

No Slack runtime behavior changes are intended; this is packaging only, plus the type declaration needed to keep CI green.