### PR TITLE
release: v0.2.6 — terminal boot-fit, dev sidecar (#67), Slack host-pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.2.6] — 2026-06-10
+
+A polish + reliability patch: the agent terminal renders correctly the moment it opens,
+`npm run dev` no longer crashes on a missing sidecar, a Windows ConPTY crash is guarded,
+the wall clock becomes a clickable closing-time control, the ASK ME board reads in the
+memory font, and the Slack file download is host-pinned.
+
+### Added
+- **The office clock is interactive (#64).** The clock on the wall reads the real time, and clicking it opens the closing-time (graceful shutdown) flow.
+
+### Fixed
+- **Terminal no longer renders oversized/clipped when an agent boots.** xterm used to fit before its container had a real size and cached the character-cell metrics from before the web font (VT323) loaded, so the welcome banner overflowed and was clipped until you manually resized. The view now waits for a real size, re-measures and re-rasters the WebGL glyph atlas after the font loads, and lets the `ResizeObserver` drive the first fit — so it fits immediately on boot.
+- **`npm run dev` no longer crashes on the missing Slack-trigger sidecar (#67).** The `.cjs` sidecar copy now runs as a vite `writeBundle` plugin, so both `dev` and `build` emit `out/main/slack-trigger.cjs` from one place. (v0.2.5 fixed only the packaged-build path, so a fresh clone's `npm run dev` still died at boot.)
+- **Windows: node-pty ConPTY `AttachConsole` crash guarded (#65).** Companion to the Antigravity provider work — the main process no longer crashes when ConPTY fails to attach a console.
+- **ASK ME reads in the memory font (#63).** The ASK ME board now uses VT323 instead of the chunky Pixelify Sans, matching the rest of the memory surfaces.
+
+### Security
+- **`downloadSlackFile()` host-pinned to Slack.** The Slack bot token is now only ever sent to `slack.com` / `*.slack.com` hosts — a defense-in-depth guard before the `Authorization: Bearer` header is attached (the URL is already Slack-issued + HMAC-verified, so this hardens against a future redirect/parsing change).
+
 ## [0.2.5] — 2026-06-10
 
 A reliability + reach patch: a Windows-terminal regression fix, an agent-lifecycle

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Munder Difflin v0.2.4
+# Munder Difflin v0.2.6
 
 **A local hive of Claude Code, Antigravity & Codex agents that run themselves** — messaging,
 routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-first and open source.
@@ -7,18 +7,29 @@ routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-f
 
 ---
 
-## What's new in 0.2.4 — *Codex gets full hive parity*
+## What's new in 0.2.6 — *Polish & reliability*
 
-Three CLIs, one hive. v0.2.4 promotes **Codex** to a first-class, hive-aware participant
-and polishes the orchestrator's first impression:
+A focused patch that fixes the first thing you see and the first thing that can break:
 
-- **Codex lifecycle-hook bridge — full hive parity** — Codex now joins the floor as a fully hive-aware provider. A native lifecycle-hook bridge maps Codex's events into the existing hook pipeline (live status + inbox-drain + outbox routing), discovered through Codex's `config.toml [hooks]` surface, with agy/codex dispatch unified behind one path. Verified running hive-aware in bypass-permissions mode. (#47, #54)
-- **God opens to its Terminal by default** — selecting the orchestrator no longer reopens a stale "ASK ME" tab; the command center mounts to its terminal, with ASK ME one click away.
-- **Multi-provider landing & launch** — the site now presents Claude Code, Antigravity (Gemini), and OpenAI Codex as equal first-class providers (one-line mobile badge), with a fresh v0.2.4 launch post + technical walkthrough.
-- **Resilience fixes** — the heartbeat re-engages the god the moment actionable mail lands (not only on a quiet floor), and the Slack done-summary no longer retries forever on a terminal error (e.g. a bot token missing `chat:write`) — it records + logs once instead of flooding the console.
+- **The agent terminal renders correctly the moment it opens.** It used to fit before its
+  pane had a real size — and cache the character-cell metrics from before the `VT323` font
+  loaded — so the welcome banner came up oversized and clipped until you manually resized.
+  The view now waits for a real size, re-measures and re-rasters once the font is ready, and
+  lets a `ResizeObserver` drive the first fit. It just fits.
+- **`npm run dev` no longer crashes on a fresh clone (#67).** The boot-time Slack-trigger
+  `.cjs` sidecar is now copied by a vite `writeBundle` plugin, so **both** `dev` and `build`
+  emit it from one place (the packaged-build fix in v0.2.5 didn't cover the dev path).
+- **Windows: node-pty ConPTY crash guarded (#65).** The main process no longer dies when
+  ConPTY fails to attach a console — a companion hardening to the Antigravity provider work.
+- **The wall clock is interactive (#64).** The office clock shows the real time, and clicking
+  it opens the closing-time (graceful shutdown) flow.
+- **ASK ME reads in the memory font (#63).** The ASK ME board now uses `VT323` to match the
+  rest of the memory surfaces, instead of the chunky Pixelify Sans.
+- **Security — Slack download host-pinned.** The Slack bot token is only ever sent to
+  `*.slack.com`, a defense-in-depth guard added before the `Authorization` header is attached.
 
-Everything from **v0.2.3** (first-class Antigravity, Codex inbox support, Schedules tab,
-terminal work-orders, tunnelmole ingress) and earlier is included.
+Everything from **v0.2.5** (the packaging crash fix, autonomous Slack-request protocol, the
+delegate toggle) and earlier is included.
 See the [CHANGELOG](https://github.com/chaitanyagiri/munder-difflin/blob/main/CHANGELOG.md) for full detail.
 
 ---
@@ -31,22 +42,22 @@ Apple Silicon and Intel.
 ### 🍎 macOS
 | Build | File |
 |---|---|
-| Universal (Apple Silicon + Intel) | [`Munder-Difflin-0.2.4-mac-universal.dmg`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.4-mac-universal.dmg) |
+| Universal (Apple Silicon + Intel) | [`Munder-Difflin-0.2.6-mac-universal.dmg`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.6-mac-universal.dmg) |
 
 ### 🪟 Windows
 | Build | File |
 |---|---|
-| Installer (x64) — *recommended* | [`Munder-Difflin-0.2.4-win-x64-setup.exe`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.4-win-x64-setup.exe) |
-| Portable (x64, no install) | [`Munder-Difflin-0.2.4-win-x64-portable.exe`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.4-win-x64-portable.exe) |
+| Installer (x64) — *recommended* | [`Munder-Difflin-0.2.6-win-x64-setup.exe`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.6-win-x64-setup.exe) |
+| Portable (x64, no install) | [`Munder-Difflin-0.2.6-win-x64-portable.exe`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.6-win-x64-portable.exe) |
 
 ### 🐧 Linux
 | Build | File |
 |---|---|
-| AppImage (x86_64) | [`Munder-Difflin-0.2.4-linux-x86_64.AppImage`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.4-linux-x86_64.AppImage) |
+| AppImage (x86_64) | [`Munder-Difflin-0.2.6-linux-x86_64.AppImage`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/Munder-Difflin-0.2.6-linux-x86_64.AppImage) |
 
 ### 📦 Source
-[Source code (zip)](https://github.com/chaitanyagiri/munder-difflin/archive/refs/tags/v0.2.4.zip) ·
-[Source code (tar.gz)](https://github.com/chaitanyagiri/munder-difflin/archive/refs/tags/v0.2.4.tar.gz)
+[Source code (zip)](https://github.com/chaitanyagiri/munder-difflin/archive/refs/tags/v0.2.6.zip) ·
+[Source code (tar.gz)](https://github.com/chaitanyagiri/munder-difflin/archive/refs/tags/v0.2.6.tar.gz)
 
 > **Verify your download:** [`SHA256SUMS.txt`](https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/SHA256SUMS.txt) — then `shasum -a 256 -c SHA256SUMS.txt` (macOS/Linux) or `Get-FileHash` (Windows).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
   "url": "https://munderdiffl.in/",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "macOS, Windows, Linux",
-  "softwareVersion": "0.2.5",
+  "softwareVersion": "0.2.6",
   "downloadUrl": "https://github.com/chaitanyagiri/munder-difflin/releases/latest",
   "softwareHelp": "https://github.com/chaitanyagiri/munder-difflin#readme",
   "license": "https://github.com/chaitanyagiri/munder-difflin/blob/main/LICENSE",
@@ -588,7 +588,7 @@
 <!-- ===================== HERO ===================== -->
 <header class="hero">
   <div class="wrap">
-    <div class="chip reveal">⚡ <b>v0.2.5</b> · Multi-provider · Open source · macOS · Windows</div>
+    <div class="chip reveal">⚡ <b>v0.2.6</b> · Multi-provider · Open source · macOS · Windows</div>
     <h1 class="hero-title reveal">
       Run a virtual <span style="color:var(--sky)">office of AI agents</span> on any computer.
     </h1>
@@ -1051,7 +1051,7 @@
 <!-- ===================== FINAL CTA ===================== -->
 <section class="final">
   <div class="wrap">
-    <div class="eyebrow reveal">v0.2.5 · Free &amp; open source</div>
+    <div class="eyebrow reveal">v0.2.6 · Free &amp; open source</div>
     <h2 class="reveal">Your virtual office is <span class="sky">one download away.</span></h2>
     <p class="reveal">A full hive of AI agents — Claude Code, Antigravity, and Codex — running 24/7, for you.
       Free, local, and MIT-licensed. Download for macOS, Windows, or Linux — or clone and run in two commands.</p>
@@ -1105,7 +1105,7 @@
   // download picker — pick macOS / Windows / Linux, click starts the download
   (function () {
     var REPO = 'chaitanyagiri/munder-difflin';
-    var REL = '0.2.5'; // fallback version; live links are resolved from the GitHub API below
+    var REL = '0.2.6'; // fallback version; live links are resolved from the GitHub API below
     var BASE = 'https://github.com/' + REPO + '/releases/latest/download/';
     var PLATFORMS = [
       { key: 'mac',   icon: '🍎', os: 'macOS',   sub: 'Universal · Apple Silicon + Intel', match: 'mac-universal.dmg',     file: 'Munder-Difflin-' + REL + '-mac-universal.dmg' },

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,15 +1,42 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { readFileSync, copyFileSync, mkdirSync, statSync } from 'node:fs';
 
 // Single source of truth for the displayed app version: package.json.
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
 const define = { __APP_VERSION__: JSON.stringify(pkg.version) };
 
+// Copy raw .cjs main-process sidecars into out/main after the main bundle is
+// written. electron-vite/rollup neither bundles nor copies require()'d .cjs
+// sidecars, so without this the boot-time `require('./slack-trigger.cjs')` is
+// missing from out/main — which crashed the packaged app (#66) AND `npm run
+// dev` (#67). A writeBundle hook runs after the main build in BOTH dev and
+// build, so the sidecar is emitted from a single place for every path.
+function copyMainSidecars() {
+  const ASSETS: Array<[string, string]> = [
+    ['src/main/slack-trigger.cjs', 'out/main/slack-trigger.cjs']
+  ];
+  return {
+    name: 'copy-main-cjs-sidecars',
+    writeBundle() {
+      for (const [fromRel, toRel] of ASSETS) {
+        const from = resolve(__dirname, fromRel);
+        const to = resolve(__dirname, toRel);
+        mkdirSync(dirname(to), { recursive: true });
+        copyFileSync(from, to);
+        const copied = statSync(to);
+        if (!copied.isFile() || copied.size === 0) {
+          throw new Error(`Failed to copy main-process sidecar: ${fromRel} -> ${toRel}`);
+        }
+      }
+    }
+  };
+}
+
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin(), copyMainSidecars()],
     define,
     build: {
       rollupOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munder-difflin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munder-difflin",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munder-difflin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "Local multi-agent harness for Claude Code: autonomous agents that message, route, and remember — coordinated by a GOD orchestrator and visualized as avatars at work.",
   "main": "out/main/index.js",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -712,6 +712,13 @@ function downloadSlackFile(
       return;
     }
     if (urlObj.protocol !== 'https:') { resolve(null); return; }
+    // Defense-in-depth: only ever send the Slack bot token to Slack hosts.
+    // url_private comes from a Slack-issued (HMAC-verified) event and node's
+    // https client doesn't auto-follow redirects, so the Bearer token reaches
+    // Slack today — but pin the host so a future redirect/parsing change can
+    // never leak the token to a third party.
+    const host = urlObj.hostname.toLowerCase();
+    if (host !== 'slack.com' && !host.endsWith('.slack.com')) { resolve(null); return; }
 
     const req = httpsRequest(
       { hostname: urlObj.hostname, path: urlObj.pathname + urlObj.search, method: 'GET',

--- a/src/renderer/src/components/PtyTerminalView.tsx
+++ b/src/renderer/src/components/PtyTerminalView.tsx
@@ -159,7 +159,17 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
     // the pooled terminal resets its viewport to the top otherwise. Later
     // resize-driven fits pass false so they don't yank a user who has scrolled
     // up to read history back down to the bottom.
+    // Tracks the first fit that actually ran against a real (non-zero) host, so
+    // the ResizeObserver below can snap to the bottom on the FIRST effective fit
+    // even when the initial rAF/timeout fits no-op (terminal mounted under an
+    // inactive tab whose host has no size yet).
+    let initialFitDone = false;
     const tryFit = (scrollToEnd = false) => {
+      // Never fit while the host has no real size. Fitting a 0×0 host makes
+      // xterm propose a tiny grid and resize the pty to it, so the boot banner
+      // renders oversized/clipped and only "fixes" on a later manual resize.
+      // Wait for real dimensions — the ResizeObserver drives the first fit.
+      if (!container.clientWidth || !container.clientHeight) return;
       try {
         const before = { cols: entry.term.cols, rows: entry.term.rows };
         entry.fit.fit();
@@ -172,6 +182,7 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
           window.cth.resizePty(ptyId, entry.term.cols, entry.term.rows);
         }
         entry.term.refresh(0, Math.max(0, entry.term.rows - 1));
+        initialFitDone = true;
       } catch { /* host may not be sized yet */ }
       if (scrollToEnd) {
         try {
@@ -195,14 +206,36 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
       }
     };
     // Fit once layout has settled and again once the web font has loaded —
-    // these are the initial-attach fits, so snap to the bottom.
+    // these are the initial-attach fits, so snap to the bottom. They no-op
+    // until the host has a real size, so a terminal mounted under an inactive
+    // tab simply waits for the ResizeObserver below to fire the first fit.
     requestAnimationFrame(() => requestAnimationFrame(() => tryFit(true)));
     const retries = [setTimeout(() => tryFit(true), 60), setTimeout(() => tryFit(true), 240)];
     if (typeof document !== 'undefined' && document.fonts?.ready) {
-      document.fonts.ready.then(() => tryFit(true)).catch(() => { /* noop */ });
+      document.fonts.ready
+        .then(() => {
+          // xterm measures the character cell ONCE at open(); if VT323 hadn't
+          // loaded yet, that cached cell is the fallback font's size, so every
+          // fit() proposes the wrong column count and the WebGL glyph atlas is
+          // rastered at the wrong metrics — the banner renders oversized until a
+          // manual resize. Re-applying the font + clearing the texture atlas
+          // forces a re-measure / re-raster with the real font, then we refit.
+          try {
+            const fam = entry.term.options.fontFamily;
+            entry.term.options.fontFamily = fam;
+            entry.term.options.fontSize = fontSizeRef.current;
+            entry.term.clearTextureAtlas?.();
+          } catch { /* noop */ }
+          tryFit(true);
+        })
+        .catch(() => { /* noop */ });
     }
 
-    const ro = new ResizeObserver(() => tryFit(false));
+    // The ResizeObserver is the authoritative trigger: it fires when the host
+    // first gets a real size (e.g. its tab becomes visible) and on every later
+    // resize. Snap to the bottom on the first effective fit, then never again
+    // (so a user who scrolled up to read history isn't yanked back down).
+    const ro = new ResizeObserver(() => tryFit(!initialFitDone));
     ro.observe(container);
     const onWinResize = () => tryFit(false);
     window.addEventListener('resize', onWinResize);


### PR DESCRIPTION
## v0.2.6 — polish & reliability

Cuts **v0.2.6** off `main` (which already has #63/#64/#65/#66). Adds three new fixes + the release packaging.

### New in this PR
- **Terminal renders correctly on agent boot.** xterm used to `fit()` before its pane had a real size, and cached the character-cell metrics from before `VT323` loaded — so the welcome banner came up oversized/clipped until a manual resize. Now: guard `fit()` against a 0×0 host, re-measure + `clearTextureAtlas()` after the web font loads, and let the `ResizeObserver` drive the first effective fit. _(`src/renderer/src/components/PtyTerminalView.tsx`)_
- **Fix #67 — `npm run dev` boot crash.** The `slack-trigger.cjs` sidecar copy now runs as a vite `writeBundle` plugin, so **both** `dev` and `build` emit `out/main/slack-trigger.cjs` from one place. (v0.2.5/#66 fixed only the packaged-build path, so a fresh clone's `npm run dev` still died at boot.) Verified: running `electron-vite build` alone (no post-script) emits the sidecar. _(`electron.vite.config.ts`)_
- **Security — Slack download host-pin.** `downloadSlackFile()` rejects any non-`*.slack.com` host before attaching the `Authorization: Bearer` token (defense-in-depth). _(`src/main/index.ts`)_

### Packaging
- Bump `0.2.5` → `0.2.6` (package.json + lock), CHANGELOG `[0.2.6]`, **RELEASE.md rewritten** (was stale at v0.2.4 — it is the GitHub release body via `body_path`), landing `softwareVersion`/chips/`REL` → 0.2.6.

### Also in v0.2.6 (already merged to main)
- #63 ASK ME reads in the memory font (VT323) · #64 interactive wall clock → closing time · #65 Windows node-pty ConPTY crash guard.

### Verification
- `npm run typecheck` (node + web) ✅ · `npm run build` (876 modules) ✅ · vite plugin emits sidecar standalone ✅
- ⚠️ The **terminal boot-fit** change is the one piece not verifiable headlessly — needs a live GUI eyeball (`git checkout release/v0.2.6 && npm run dev`, watch an agent terminal boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
