### PR TITLE
feat(debug): add local control endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
+    "test:debug-control": "node test/debug-control.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/src/main/closingTime.ts
+++ b/src/main/closingTime.ts
@@ -37,6 +37,10 @@ export interface ClosingTimeEvent {
   total: number;
 }
 
+export interface ClosingTimeSnapshot extends ClosingTimeEvent {
+  active: boolean;
+}
+
 /** Subject markers. Deliberately forgiving (case, -/_/space) — agents write
  *  these by hand, so "Closing Time Ack" must count as well as the canonical
  *  CLOSING-TIME-ACK the brief asks for. */
@@ -76,6 +80,15 @@ export class ClosingTimeController {
 
   isActive(): boolean {
     return this.active;
+  }
+
+  snapshot(): ClosingTimeSnapshot {
+    return {
+      active: this.active,
+      phase: this.active ? 'progress' : 'cancelled',
+      acked: this.acked.size,
+      total: this.workers.size
+    };
   }
 
   /** Kick off the protocol. Returns an error string when the floor cannot run

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -162,6 +162,11 @@ export interface HarnessConfig {
   /** Local HTTP port the generic webhook server binds to (default 3849). */
   webhookPort?: number;
 
+  /** Local-only debug/test control plane. Also enabled by MUNDER_DEBUG_CONTROL=1. */
+  debugControlEnabled?: boolean;
+  /** Optional fixed debug control port; default 0 lets the OS choose. */
+  debugControlPort?: number;
+
   // ─── Memory reflection (the janitor's condense half) ───────────────────────
   /** Master toggle for the in-process MemoryReflector. Default on. */
   reflectEnabled?: boolean;
@@ -197,6 +202,8 @@ const DEFAULTS: HarnessConfig = {
   webhookEnabled: false,
   webhookSecret: undefined,
   webhookPort: undefined,
+  debugControlEnabled: false,
+  debugControlPort: undefined,
   // Memory reflection — preventive; nobody is over threshold today, so it sits
   // dark until an agent's memory crosses one of these (the verify gate is the
   // safety for the LLM step). Thresholds DECIDED by god 2026-06-06.

--- a/src/main/debugControl.ts
+++ b/src/main/debugControl.ts
@@ -1,0 +1,209 @@
+/**
+ * Local debug control endpoint.
+ *
+ * Loopback-only, token-gated control plane for tests and local MCP clients.
+ * It deliberately opens no public tunnel and never exposes terminal buffers,
+ * memory files, or secrets.
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+
+export const DEBUG_CONTROL_ENDPOINT_VERSION = 1;
+
+export interface DebugControlServerOptions {
+  port: number;
+  token: string;
+  handlers: DebugControlHandlers;
+}
+
+export interface DebugControlHandlers {
+  health: () => unknown;
+  snapshot: () => unknown;
+  workOrder: (payload: unknown) => unknown;
+  startClosingTime: () => unknown;
+  control: (agentId: string, action: 'steer' | 'halt' | 'resume', payload: unknown) => unknown;
+  killPty: (ptyId: string) => unknown;
+  quitNow: (payload: unknown) => unknown;
+}
+
+export interface DebugControlStartResult {
+  ok: boolean;
+  port?: number;
+  url?: string;
+  error?: string;
+}
+
+const MAX_BODY_BYTES = 1024 * 1024;
+
+export class DebugControlServer {
+  private server: Server | null = null;
+  private port = 0;
+
+  constructor(private readonly opts: DebugControlServerOptions) {}
+
+  async start(): Promise<DebugControlStartResult> {
+    if (this.server) return { ok: false, error: 'already running' };
+    if (!this.opts.token) return { ok: false, error: 'missing token' };
+
+    return new Promise((resolve) => {
+      const server = createServer((req, res) => {
+        void this.handleRequest(req, res);
+      });
+      server.once('error', (e) => {
+        try { server.close(); } catch { /* noop */ }
+        this.server = null;
+        resolve({ ok: false, error: errMsg(e) });
+      });
+      server.listen(this.opts.port, '127.0.0.1', () => {
+        const addr = server.address();
+        const port = typeof addr === 'object' && addr ? addr.port : this.opts.port;
+        this.server = server;
+        this.port = port;
+        resolve({ ok: true, port, url: `http://127.0.0.1:${port}` });
+      });
+    });
+  }
+
+  stop(): void {
+    try { this.server?.close(); } catch { /* noop */ }
+    this.server = null;
+    this.port = 0;
+  }
+
+  currentPort(): number {
+    return this.port;
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!isLoopback(req.socket.remoteAddress)) {
+      json(res, 403, { ok: false, error: 'loopback only' });
+      return;
+    }
+    if (!this.authorized(req)) {
+      json(res, 401, { ok: false, error: 'unauthorized' });
+      return;
+    }
+
+    const method = req.method ?? '';
+    let url: URL;
+    try {
+      url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    } catch {
+      json(res, 400, { ok: false, error: 'bad url' });
+      return;
+    }
+
+    try {
+      if (method === 'GET') {
+        this.handleGet(url.pathname, res);
+        return;
+      }
+      if (method === 'POST') {
+        const payload = await readJson(req);
+        this.handlePost(url.pathname, payload, res);
+        return;
+      }
+      res.writeHead(405);
+      res.end();
+    } catch (e) {
+      const msg = errMsg(e);
+      json(res, msg === 'bad json' ? 400 : 500, { ok: false, error: msg });
+    }
+  }
+
+  private handleGet(path: string, res: ServerResponse): void {
+    if (path === '/health') {
+      json(res, 200, this.opts.handlers.health());
+      return;
+    }
+    if (path === '/snapshot') {
+      json(res, 200, this.opts.handlers.snapshot());
+      return;
+    }
+    json(res, 404, { ok: false, error: 'not found' });
+  }
+
+  private handlePost(path: string, payload: unknown, res: ServerResponse): void {
+    if (path === '/work-order') {
+      json(res, 200, this.opts.handlers.workOrder(payload));
+      return;
+    }
+    if (path === '/closing-time/start') {
+      json(res, 200, this.opts.handlers.startClosingTime());
+      return;
+    }
+    if (path === '/app/quit-now') {
+      json(res, 200, this.opts.handlers.quitNow(payload));
+      return;
+    }
+
+    const control = path.match(/^\/control\/([^/]+)\/(steer|halt|resume)$/);
+    if (control) {
+      json(res, 200, this.opts.handlers.control(
+        decodeURIComponent(control[1]),
+        control[2] as 'steer' | 'halt' | 'resume',
+        payload
+      ));
+      return;
+    }
+
+    const kill = path.match(/^\/pty\/([^/]+)\/kill$/);
+    if (kill) {
+      json(res, 200, this.opts.handlers.killPty(decodeURIComponent(kill[1])));
+      return;
+    }
+
+    json(res, 404, { ok: false, error: 'not found' });
+  }
+
+  private authorized(req: IncomingMessage): boolean {
+    const provided = tokenFromRequest(req);
+    if (!provided) return false;
+    const a = Buffer.from(provided);
+    const b = Buffer.from(this.opts.token);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  }
+}
+
+function tokenFromRequest(req: IncomingMessage): string {
+  const header = req.headers.authorization;
+  if (typeof header === 'string') {
+    const m = header.match(/^Bearer\s+(.+)$/i);
+    if (m) return m[1].trim();
+  }
+  const debugHeader = req.headers['x-munder-debug-token'];
+  return typeof debugHeader === 'string' ? debugHeader.trim() : '';
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buf.length;
+    if (size > MAX_BODY_BYTES) throw new Error('body too large');
+    chunks.push(buf);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error('bad json');
+  }
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function isLoopback(addr: string | undefined): boolean {
+  if (!addr) return false;
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, clipboard, dialog, ipcMain, powerSaveBlocker, screen, shell, Notification } from 'electron';
 import { spawn } from 'node:child_process';
-import { rmSync, existsSync, readFileSync, readdirSync, statSync, cpSync, writeFileSync, unlinkSync, mkdirSync, createWriteStream } from 'node:fs';
+import { rmSync, existsSync, readFileSync, readdirSync, statSync, cpSync, writeFileSync, unlinkSync, mkdirSync, createWriteStream, chmodSync } from 'node:fs';
 import { randomBytes, createHash, timingSafeEqual } from 'node:crypto';
 import { join, resolve, sep, basename } from 'node:path';
 import { request as httpsRequest } from 'node:https';
@@ -28,6 +28,7 @@ import { WebhookServer, type WebhookInbound, type WebhookTaskStatus } from './we
 import { TelemetryCollector } from './telemetry';
 import { ControlRegistry } from './control';
 import { ClosingTimeController } from './closingTime';
+import { DEBUG_CONTROL_ENDPOINT_VERSION, DebugControlServer } from './debugControl';
 import {
   inferAgentProvider,
   isClaudeProvider,
@@ -126,6 +127,7 @@ const reflector = new MemoryReflector(
 // net-new command history. Opened in whenReady, closed in the teardown blocks.
 const persist = new PersistStore();
 let mainWindow: BrowserWindow | null = null;
+let debugControlServer: DebugControlServer | null = null;
 
 /** When true, skip the quit interceptor (user already confirmed). */
 let allowQuit = false;
@@ -590,6 +592,185 @@ function armHeartbeat(m: ScheduledMission): void {
 function liveWebContents(): Electron.WebContents | null {
   const wc = mainWindow?.webContents;
   return wc && !wc.isDestroyed() ? wc : null;
+}
+
+// ─── Local debug control endpoint (loopback only, opt-in) ───────────────────
+function debugControlDiscoveryPath(): string {
+  return join(app.getPath('userData'), 'debug-control.json');
+}
+
+function debugControlEnabled(cfg = readConfig()): boolean {
+  return process.env.MUNDER_DEBUG_CONTROL === '1' || cfg.debugControlEnabled === true;
+}
+
+function debugControlPort(cfg = readConfig()): number {
+  const raw = process.env.MUNDER_DEBUG_CONTROL_PORT;
+  const envPort = raw ? Number(raw) : NaN;
+  if (Number.isInteger(envPort) && envPort >= 0 && envPort <= 65535) return envPort;
+  return Number.isInteger(cfg.debugControlPort) && (cfg.debugControlPort ?? -1) >= 0
+    ? cfg.debugControlPort ?? 0
+    : 0;
+}
+
+function readOrCreateDebugControlToken(): string {
+  const p = debugControlDiscoveryPath();
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf8')) as { token?: unknown };
+    if (typeof parsed.token === 'string' && parsed.token.length >= 32) return parsed.token;
+  } catch { /* stale/missing discovery is normal */ }
+  return randomBytes(32).toString('hex');
+}
+
+function writeDebugControlDiscovery(url: string, port: number, token: string): void {
+  const p = debugControlDiscoveryPath();
+  const body = {
+    endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION,
+    url,
+    port,
+    token,
+    pid: process.pid,
+    updatedAt: new Date().toISOString()
+  };
+  writeFileSync(p, JSON.stringify(body, null, 2), 'utf8');
+  try { chmodSync(p, 0o600); } catch { /* best-effort on platforms without chmod */ }
+}
+
+function removeDebugControlDiscovery(): void {
+  try { unlinkSync(debugControlDiscoveryPath()); } catch { /* missing is fine */ }
+}
+
+function buildDebugControlSnapshot(): unknown {
+  const now = Date.now();
+  const reg = hive.enabled() ? hive.registry() : { godId: null, agents: {} };
+  const agents = Object.entries(reg.agents).map(([id, a]) => ({
+    id,
+    name: a.name,
+    provider: a.provider ?? 'claude',
+    role: a.role,
+    status: a.status,
+    archived: a.archived === true,
+    isGod: a.isGod === true,
+    isAssistant: a.isAssistant === true,
+    inboxCount: hive.enabled() ? hive.inbox(id).length : 0,
+    hasLivePty: ptyForAgent(id) !== undefined
+  }));
+  const ptys = ptyManager.list().map((p) => ({
+    id: p.id,
+    agentId: ptyToAgent.get(p.id) ?? null,
+    command: basename(p.command),
+    pid: p.pid,
+    lastOutputAt: p.lastOutputAt,
+    idleMs: Math.max(0, now - p.lastOutputAt)
+  }));
+  return {
+    ok: true,
+    endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION,
+    appVersion: app.getVersion(),
+    ts: now,
+    harnessConfigured: !!readConfig().harnessHome,
+    hive: { enabled: hive.enabled(), godId: reg.godId, agents },
+    ptys,
+    closingTime: closingTime.snapshot(),
+    recentLog: hive.enabled() ? hive.logTail(25).map(sanitizeDebugLogEvent) : []
+  };
+}
+
+function sanitizeDebugLogEvent(event: unknown): Record<string, unknown> {
+  const e = (event && typeof event === 'object') ? event as Record<string, unknown> : {};
+  const out: Record<string, unknown> = {};
+  for (const key of ['ts', 'kind', 'id', 'from', 'to', 'act', 'subject', 'agentId', 'targetId', 'delivered', 'phase', 'reason']) {
+    if (key in e) out[key] = e[key];
+  }
+  if (Array.isArray(e.targets)) out.targets = e.targets.filter((x) => typeof x === 'string');
+  return out;
+}
+
+function startDebugControlServer(): void {
+  const cfg = readConfig();
+  if (!debugControlEnabled(cfg)) {
+    removeDebugControlDiscovery();
+    return;
+  }
+  if (debugControlServer) return;
+  const token = readOrCreateDebugControlToken();
+  debugControlServer = new DebugControlServer({
+    port: debugControlPort(cfg),
+    token,
+    handlers: {
+      health: () => ({
+        ok: true,
+        endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION,
+        appVersion: app.getVersion(),
+        ts: Date.now(),
+        harnessConfigured: !!readConfig().harnessHome
+      }),
+      snapshot: buildDebugControlSnapshot,
+      workOrder: handleDebugWorkOrder,
+      startClosingTime: () => closingTime.start(),
+      control: handleDebugControl,
+      killPty: (ptyId) => {
+        const res = ptyManager.kill(ptyId);
+        teardownPty(ptyId);
+        return res;
+      },
+      quitNow: () => {
+        setTimeout(() => teardownAndQuit(), 50);
+        return { ok: true };
+      }
+    }
+  });
+  void debugControlServer.start().then((res) => {
+    if (!res.ok || !res.url || typeof res.port !== 'number') {
+      debugControlServer = null;
+      removeDebugControlDiscovery();
+      console.error('[debug-control] failed to start:', res.error);
+      return;
+    }
+    writeDebugControlDiscovery(res.url, res.port, token);
+    console.log(`[debug-control] listening on ${res.url}`);
+  });
+}
+
+function stopDebugControlServer(): void {
+  try { debugControlServer?.stop(); } catch { /* best-effort */ }
+  debugControlServer = null;
+  removeDebugControlDiscovery();
+}
+
+function handleDebugWorkOrder(payload: unknown): unknown {
+  if (!hive.enabled()) return { ok: false, error: 'hive not configured' };
+  const p = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+  const body = typeof p.body === 'string' ? p.body.trim() : '';
+  if (!body) return { ok: false, error: 'body required' };
+  const act = isHiveAct(p.act) ? p.act : 'request';
+  const msg = hive.send({
+    to: typeof p.to === 'string' && p.to.trim() ? p.to.trim() : 'god',
+    act,
+    subject: typeof p.subject === 'string' && p.subject.trim() ? p.subject.trim() : 'Debug control work order',
+    body,
+    requires_reply: p.requiresReply === true
+  }, typeof p.from === 'string' && p.from.trim() ? p.from.trim() : 'debug-control');
+  return { ok: true, id: msg.id, to: msg.to, subject: msg.subject };
+}
+
+function handleDebugControl(agentId: string, action: 'steer' | 'halt' | 'resume', payload: unknown): unknown {
+  if (!agentId) return { ok: false, error: 'agent id required' };
+  if (action === 'steer') {
+    const p = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+    const text = typeof p.text === 'string' ? p.text.trim() : '';
+    if (!text) return { ok: false, error: 'text required' };
+    control.steer(agentId, text);
+  } else if (action === 'halt') {
+    control.halt(agentId);
+  } else {
+    control.resume(agentId);
+  }
+  return { ok: true, control: control.snapshot(agentId) };
+}
+
+function isHiveAct(v: unknown): v is HiveMessage['act'] {
+  return v === 'request' || v === 'inform' || v === 'propose' || v === 'query'
+    || v === 'agree' || v === 'refuse' || v === 'done';
 }
 
 // ─── Slack webhook server (Slack message → Michael's queue) ──────────────────
@@ -1552,6 +1733,7 @@ function teardownAndQuit(): void {
   allowQuit = true;
   // Each teardown step is best-effort: a throw here (e.g. a dying child or a
   // half-torn-down socket) must never abort the quit or pop a crash dialog.
+  try { stopDebugControlServer(); } catch (e) { console.error('[quit] debugControl.stop:', e); }
   try { clearMissionTimers(); } catch (e) { console.error('[quit] clearMissionTimers:', e); }
   try { hive.stopRouter(); } catch (e) { console.error('[quit] stopRouter:', e); }
   try { hookServer.stop(); } catch (e) { console.error('[quit] hookServer.stop:', e); }
@@ -1595,6 +1777,7 @@ ipcMain.handle('app:cancelClosingTime', () => closingTime.cancel());
 ipcMain.handle('app:resetAll', () => {
   allowQuit = true;
   // Tear everything down first so nothing writes back into the dirs we wipe.
+  try { stopDebugControlServer(); } catch (e) { console.error('[reset] debugControl.stop:', e); }
   try { clearMissionTimers(); } catch (e) { console.error('[reset] clearMissionTimers:', e); }
   try { hive.stopRouter(); } catch (e) { console.error('[reset] stopRouter:', e); }
   try { hookServer.stop(); } catch (e) { console.error('[reset] hookServer.stop:', e); }
@@ -1865,6 +2048,7 @@ app.whenReady().then(() => {
   // Bootstrap the hive (if harnessHome is configured) and start the message router.
   bootstrapHiveServices();
   createWindow();
+  startDebugControlServer();
   // Auto-start the Slack webhook server when configured. Best-effort: a tunnel
   // failure (offline) is logged, not fatal. The tunnel URL is ephemeral and
   // changes per restart, so the user re-pastes it via Settings → Start.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -162,6 +162,8 @@ export interface HarnessConfig {
   webhookEnabled?: boolean;
   webhookSecret?: string;
   webhookPort?: number;
+  debugControlEnabled?: boolean;
+  debugControlPort?: number;
   costCapUsd?: number;
   costCapTokens?: number;
   agentTokenCaps?: Record<string, number>;

--- a/test/debug-control.test.cjs
+++ b/test/debug-control.test.cjs
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('assert');
+const { mkdtempSync, rmSync } = require('fs');
+const { tmpdir } = require('os');
+const { join } = require('path');
+const { spawnSync } = require('child_process');
+
+let failures = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.log(`  ✗ ${name}\n     ${err.message}`);
+  }
+}
+
+function compileDebugControl() {
+  const out = mkdtempSync(join(tmpdir(), 'munder-debug-control-test-'));
+  const tsc = spawnSync('./node_modules/.bin/tsc', [
+    'src/main/debugControl.ts',
+    '--target', 'ES2022',
+    '--module', 'CommonJS',
+    '--moduleResolution', 'node',
+    '--esModuleInterop',
+    '--skipLibCheck',
+    '--outDir', out,
+  ], { encoding: 'utf8' });
+  if (tsc.status !== 0) {
+    rmSync(out, { recursive: true, force: true });
+    throw new Error(`tsc failed\n${tsc.stdout}\n${tsc.stderr}`);
+  }
+  return out;
+}
+
+async function readJson(res) {
+  return JSON.parse(await res.text());
+}
+
+(async () => {
+  console.log('debug control endpoint tests');
+  const out = compileDebugControl();
+  const { DebugControlServer, DEBUG_CONTROL_ENDPOINT_VERSION } = require(join(out, 'debugControl.js'));
+  const calls = [];
+  const server = new DebugControlServer({
+    port: 0,
+    token: 'test-token',
+    handlers: {
+      health: () => ({ ok: true, endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION, harnessConfigured: true }),
+      snapshot: () => ({ ok: true, hive: { agents: [] }, ptys: [], recentLog: [] }),
+      workOrder: (payload) => { calls.push(['workOrder', payload]); return { ok: true, id: 'msg-1' }; },
+      startClosingTime: () => ({ ok: true }),
+      control: (agentId, action, payload) => { calls.push(['control', agentId, action, payload]); return { ok: true }; },
+      killPty: (ptyId) => { calls.push(['killPty', ptyId]); return { ok: true }; },
+      quitNow: () => ({ ok: true }),
+    },
+  });
+  const started = await server.start();
+  assert.strictEqual(started.ok, true, started.error);
+  const base = started.url;
+
+  await test('requires a debug token', async () => {
+    const res = await fetch(`${base}/health`);
+    assert.strictEqual(res.status, 401);
+  });
+
+  await test('accepts bearer token and returns health', async () => {
+    const res = await fetch(`${base}/health`, { headers: { authorization: 'Bearer test-token' } });
+    assert.strictEqual(res.status, 200);
+    const body = await readJson(res);
+    assert.strictEqual(body.ok, true);
+    assert.strictEqual(body.endpointVersion, 1);
+  });
+
+  await test('accepts x-munder-debug-token and returns snapshot', async () => {
+    const res = await fetch(`${base}/snapshot`, { headers: { 'x-munder-debug-token': 'test-token' } });
+    assert.strictEqual(res.status, 200);
+    const body = await readJson(res);
+    assert.deepStrictEqual(body.ptys, []);
+    assert.deepStrictEqual(body.recentLog, []);
+  });
+
+  await test('rejects malformed JSON', async () => {
+    const res = await fetch(`${base}/work-order`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token' },
+      body: '{bad',
+    });
+    assert.strictEqual(res.status, 400);
+  });
+
+  await test('dispatches work order payload', async () => {
+    const res = await fetch(`${base}/work-order`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token', 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'god', body: 'hello' }),
+    });
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await readJson(res), { ok: true, id: 'msg-1' });
+    assert.deepStrictEqual(calls[0], ['workOrder', { to: 'god', body: 'hello' }]);
+  });
+
+  await test('routes control and kill actions', async () => {
+    await fetch(`${base}/control/agent-1/steer`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token', 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'pause soon' }),
+    });
+    await fetch(`${base}/pty/pty-1/kill`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token' },
+    });
+    assert.deepStrictEqual(calls[1], ['control', 'agent-1', 'steer', { text: 'pause soon' }]);
+    assert.deepStrictEqual(calls[2], ['killPty', 'pty-1']);
+  });
+
+  server.stop();
+  rmSync(out, { recursive: true, force: true });
+  if (failures > 0) process.exit(1);
+  console.log('all passed');
+})();


### PR DESCRIPTION
## Summary
Adds an opt-in local debug control endpoint for Munder Difflin. This is the first small bridge toward reliable agent-driven debugging and future MCP control, without turning it into a public automation API.

## Why
The UI is not a reliable enough control surface for debugging orchestration by itself. We need a small local control plane that agents and tests can use to inspect app state, send bounded work orders, and exercise shutdown/control paths repeatably.

## What changed
- Adds a `DebugControlServer` in the Electron main process.
- Binds only to `127.0.0.1`.
- Stays disabled by default unless `MUNDER_DEBUG_CONTROL=1` or `debugControlEnabled` config is set.
- Generates a local token and writes a discovery file under app `userData`.
- Adds token-gated endpoints for:
  - `GET /health`
  - `GET /snapshot`
  - `POST /work-order`
  - `POST /closing-time/start`
  - `POST /control/:agentId/steer|halt|resume`
  - `POST /pty/:ptyId/kill`
  - `POST /app/quit-now`
- Reuses existing main-process primitives: hive routing, PTY management, control registry, closing-time controller, and fleet state.
- Keeps snapshots intentionally sanitized: no terminal buffers, no secrets, no full memory files.
- Adds focused unit coverage for auth, request validation, endpoint shape, and dispatch behavior.

## Stack
This is PR 1/3 in a stacked debugging/MCP sequence:

1. **This PR:** local debug control endpoint.
2. **Next PR:** `tools/munder-mcp`, a stdio MCP wrapper over this endpoint.
3. **Final PR:** reliable headless smoke harness with fake agents, so orchestration can be tested without clicking the UI or calling real models.

The point of splitting this is to keep each reviewable: endpoint first, MCP client second, smoke harness third.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run test:debug-control`
- `node test/slack.test.cjs`
