### PR TITLE
feat(mcp): add Munder MCP wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
 | **Scheduled missions & heartbeat** | Recurring auto-dispatch missions with label, interval, target agent, and body — plus a scheduler heartbeat that re-engages the floor when it goes quiet. Missions now live in their own Schedules tab with last/next-fired times. |
 | **Terminal work-order handoff** | Providers without an inbox-drain hook receive hive mail as a `WORK ORDER FROM HIVE` typed into their terminal; if the renderer is unavailable, the message bounces to the GOD agent instead of disappearing. |
 | **Slack/webhook ingress** | Slack and generic webhook ingress expose local endpoints through tunnelmole, so POSTs pass straight through and failed tunnels surface a real error instead of a silent broken URL. |
+| **Local debug/MCP control** | Opt-in loopback debug control plus `tools/munder-mcp` let local agents and smoke tests inspect the floor, send work orders, and start closing time without clicking through the UI. |
 | **GitHub ingestion** | Pull open issues from any registered repo via the `gh` CLI and assign them to agents with one click from the Command Center. |
 | **CI status watcher** | Live pass/fail/in-progress status for GitHub Actions runs, visible in the Activity tab for every registered repo. |
 | **Threaded chat** | Every hive message is grouped by conversation and rendered as a reply chain in each agent's Messages tab — readable, replyable, auditable. |

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "test:debug-control": "node test/debug-control.test.cjs",
+    "test:munder-mcp": "node test/munder-mcp.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
+    "test:debug-control": "node test/debug-control.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/src/main/closingTime.ts
+++ b/src/main/closingTime.ts
@@ -37,6 +37,10 @@ export interface ClosingTimeEvent {
   total: number;
 }
 
+export interface ClosingTimeSnapshot extends ClosingTimeEvent {
+  active: boolean;
+}
+
 /** Subject markers. Deliberately forgiving (case, -/_/space) — agents write
  *  these by hand, so "Closing Time Ack" must count as well as the canonical
  *  CLOSING-TIME-ACK the brief asks for. */
@@ -76,6 +80,15 @@ export class ClosingTimeController {
 
   isActive(): boolean {
     return this.active;
+  }
+
+  snapshot(): ClosingTimeSnapshot {
+    return {
+      active: this.active,
+      phase: this.active ? 'progress' : 'cancelled',
+      acked: this.acked.size,
+      total: this.workers.size
+    };
   }
 
   /** Kick off the protocol. Returns an error string when the floor cannot run

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -162,6 +162,11 @@ export interface HarnessConfig {
   /** Local HTTP port the generic webhook server binds to (default 3849). */
   webhookPort?: number;
 
+  /** Local-only debug/test control plane. Also enabled by MUNDER_DEBUG_CONTROL=1. */
+  debugControlEnabled?: boolean;
+  /** Optional fixed debug control port; default 0 lets the OS choose. */
+  debugControlPort?: number;
+
   // ─── Memory reflection (the janitor's condense half) ───────────────────────
   /** Master toggle for the in-process MemoryReflector. Default on. */
   reflectEnabled?: boolean;
@@ -197,6 +202,8 @@ const DEFAULTS: HarnessConfig = {
   webhookEnabled: false,
   webhookSecret: undefined,
   webhookPort: undefined,
+  debugControlEnabled: false,
+  debugControlPort: undefined,
   // Memory reflection — preventive; nobody is over threshold today, so it sits
   // dark until an agent's memory crosses one of these (the verify gate is the
   // safety for the LLM step). Thresholds DECIDED by god 2026-06-06.

--- a/src/main/debugControl.ts
+++ b/src/main/debugControl.ts
@@ -1,0 +1,209 @@
+/**
+ * Local debug control endpoint.
+ *
+ * Loopback-only, token-gated control plane for tests and local MCP clients.
+ * It deliberately opens no public tunnel and never exposes terminal buffers,
+ * memory files, or secrets.
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+
+export const DEBUG_CONTROL_ENDPOINT_VERSION = 1;
+
+export interface DebugControlServerOptions {
+  port: number;
+  token: string;
+  handlers: DebugControlHandlers;
+}
+
+export interface DebugControlHandlers {
+  health: () => unknown;
+  snapshot: () => unknown;
+  workOrder: (payload: unknown) => unknown;
+  startClosingTime: () => unknown;
+  control: (agentId: string, action: 'steer' | 'halt' | 'resume', payload: unknown) => unknown;
+  killPty: (ptyId: string) => unknown;
+  quitNow: (payload: unknown) => unknown;
+}
+
+export interface DebugControlStartResult {
+  ok: boolean;
+  port?: number;
+  url?: string;
+  error?: string;
+}
+
+const MAX_BODY_BYTES = 1024 * 1024;
+
+export class DebugControlServer {
+  private server: Server | null = null;
+  private port = 0;
+
+  constructor(private readonly opts: DebugControlServerOptions) {}
+
+  async start(): Promise<DebugControlStartResult> {
+    if (this.server) return { ok: false, error: 'already running' };
+    if (!this.opts.token) return { ok: false, error: 'missing token' };
+
+    return new Promise((resolve) => {
+      const server = createServer((req, res) => {
+        void this.handleRequest(req, res);
+      });
+      server.once('error', (e) => {
+        try { server.close(); } catch { /* noop */ }
+        this.server = null;
+        resolve({ ok: false, error: errMsg(e) });
+      });
+      server.listen(this.opts.port, '127.0.0.1', () => {
+        const addr = server.address();
+        const port = typeof addr === 'object' && addr ? addr.port : this.opts.port;
+        this.server = server;
+        this.port = port;
+        resolve({ ok: true, port, url: `http://127.0.0.1:${port}` });
+      });
+    });
+  }
+
+  stop(): void {
+    try { this.server?.close(); } catch { /* noop */ }
+    this.server = null;
+    this.port = 0;
+  }
+
+  currentPort(): number {
+    return this.port;
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!isLoopback(req.socket.remoteAddress)) {
+      json(res, 403, { ok: false, error: 'loopback only' });
+      return;
+    }
+    if (!this.authorized(req)) {
+      json(res, 401, { ok: false, error: 'unauthorized' });
+      return;
+    }
+
+    const method = req.method ?? '';
+    let url: URL;
+    try {
+      url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    } catch {
+      json(res, 400, { ok: false, error: 'bad url' });
+      return;
+    }
+
+    try {
+      if (method === 'GET') {
+        this.handleGet(url.pathname, res);
+        return;
+      }
+      if (method === 'POST') {
+        const payload = await readJson(req);
+        this.handlePost(url.pathname, payload, res);
+        return;
+      }
+      res.writeHead(405);
+      res.end();
+    } catch (e) {
+      const msg = errMsg(e);
+      json(res, msg === 'bad json' ? 400 : 500, { ok: false, error: msg });
+    }
+  }
+
+  private handleGet(path: string, res: ServerResponse): void {
+    if (path === '/health') {
+      json(res, 200, this.opts.handlers.health());
+      return;
+    }
+    if (path === '/snapshot') {
+      json(res, 200, this.opts.handlers.snapshot());
+      return;
+    }
+    json(res, 404, { ok: false, error: 'not found' });
+  }
+
+  private handlePost(path: string, payload: unknown, res: ServerResponse): void {
+    if (path === '/work-order') {
+      json(res, 200, this.opts.handlers.workOrder(payload));
+      return;
+    }
+    if (path === '/closing-time/start') {
+      json(res, 200, this.opts.handlers.startClosingTime());
+      return;
+    }
+    if (path === '/app/quit-now') {
+      json(res, 200, this.opts.handlers.quitNow(payload));
+      return;
+    }
+
+    const control = path.match(/^\/control\/([^/]+)\/(steer|halt|resume)$/);
+    if (control) {
+      json(res, 200, this.opts.handlers.control(
+        decodeURIComponent(control[1]),
+        control[2] as 'steer' | 'halt' | 'resume',
+        payload
+      ));
+      return;
+    }
+
+    const kill = path.match(/^\/pty\/([^/]+)\/kill$/);
+    if (kill) {
+      json(res, 200, this.opts.handlers.killPty(decodeURIComponent(kill[1])));
+      return;
+    }
+
+    json(res, 404, { ok: false, error: 'not found' });
+  }
+
+  private authorized(req: IncomingMessage): boolean {
+    const provided = tokenFromRequest(req);
+    if (!provided) return false;
+    const a = Buffer.from(provided);
+    const b = Buffer.from(this.opts.token);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  }
+}
+
+function tokenFromRequest(req: IncomingMessage): string {
+  const header = req.headers.authorization;
+  if (typeof header === 'string') {
+    const m = header.match(/^Bearer\s+(.+)$/i);
+    if (m) return m[1].trim();
+  }
+  const debugHeader = req.headers['x-munder-debug-token'];
+  return typeof debugHeader === 'string' ? debugHeader.trim() : '';
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buf.length;
+    if (size > MAX_BODY_BYTES) throw new Error('body too large');
+    chunks.push(buf);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error('bad json');
+  }
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function isLoopback(addr: string | undefined): boolean {
+  if (!addr) return false;
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, clipboard, dialog, ipcMain, powerSaveBlocker, screen, shell, Notification } from 'electron';
 import { spawn } from 'node:child_process';
-import { rmSync, existsSync, readFileSync, readdirSync, statSync, cpSync, writeFileSync, unlinkSync, mkdirSync, createWriteStream } from 'node:fs';
+import { rmSync, existsSync, readFileSync, readdirSync, statSync, cpSync, writeFileSync, unlinkSync, mkdirSync, createWriteStream, chmodSync } from 'node:fs';
 import { randomBytes, createHash, timingSafeEqual } from 'node:crypto';
 import { join, resolve, sep, basename } from 'node:path';
 import { request as httpsRequest } from 'node:https';
@@ -28,6 +28,7 @@ import { WebhookServer, type WebhookInbound, type WebhookTaskStatus } from './we
 import { TelemetryCollector } from './telemetry';
 import { ControlRegistry } from './control';
 import { ClosingTimeController } from './closingTime';
+import { DEBUG_CONTROL_ENDPOINT_VERSION, DebugControlServer } from './debugControl';
 import {
   inferAgentProvider,
   isClaudeProvider,
@@ -126,6 +127,7 @@ const reflector = new MemoryReflector(
 // net-new command history. Opened in whenReady, closed in the teardown blocks.
 const persist = new PersistStore();
 let mainWindow: BrowserWindow | null = null;
+let debugControlServer: DebugControlServer | null = null;
 
 /** When true, skip the quit interceptor (user already confirmed). */
 let allowQuit = false;
@@ -590,6 +592,185 @@ function armHeartbeat(m: ScheduledMission): void {
 function liveWebContents(): Electron.WebContents | null {
   const wc = mainWindow?.webContents;
   return wc && !wc.isDestroyed() ? wc : null;
+}
+
+// ─── Local debug control endpoint (loopback only, opt-in) ───────────────────
+function debugControlDiscoveryPath(): string {
+  return join(app.getPath('userData'), 'debug-control.json');
+}
+
+function debugControlEnabled(cfg = readConfig()): boolean {
+  return process.env.MUNDER_DEBUG_CONTROL === '1' || cfg.debugControlEnabled === true;
+}
+
+function debugControlPort(cfg = readConfig()): number {
+  const raw = process.env.MUNDER_DEBUG_CONTROL_PORT;
+  const envPort = raw ? Number(raw) : NaN;
+  if (Number.isInteger(envPort) && envPort >= 0 && envPort <= 65535) return envPort;
+  return Number.isInteger(cfg.debugControlPort) && (cfg.debugControlPort ?? -1) >= 0
+    ? cfg.debugControlPort ?? 0
+    : 0;
+}
+
+function readOrCreateDebugControlToken(): string {
+  const p = debugControlDiscoveryPath();
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf8')) as { token?: unknown };
+    if (typeof parsed.token === 'string' && parsed.token.length >= 32) return parsed.token;
+  } catch { /* stale/missing discovery is normal */ }
+  return randomBytes(32).toString('hex');
+}
+
+function writeDebugControlDiscovery(url: string, port: number, token: string): void {
+  const p = debugControlDiscoveryPath();
+  const body = {
+    endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION,
+    url,
+    port,
+    token,
+    pid: process.pid,
+    updatedAt: new Date().toISOString()
+  };
+  writeFileSync(p, JSON.stringify(body, null, 2), 'utf8');
+  try { chmodSync(p, 0o600); } catch { /* best-effort on platforms without chmod */ }
+}
+
+function removeDebugControlDiscovery(): void {
+  try { unlinkSync(debugControlDiscoveryPath()); } catch { /* missing is fine */ }
+}
+
+function buildDebugControlSnapshot(): unknown {
+  const now = Date.now();
+  const reg = hive.enabled() ? hive.registry() : { godId: null, agents: {} };
+  const agents = Object.entries(reg.agents).map(([id, a]) => ({
+    id,
+    name: a.name,
+    provider: a.provider ?? 'claude',
+    role: a.role,
+    status: a.status,
+    archived: a.archived === true,
+    isGod: a.isGod === true,
+    isAssistant: a.isAssistant === true,
+    inboxCount: hive.enabled() ? hive.inbox(id).length : 0,
+    hasLivePty: ptyForAgent(id) !== undefined
+  }));
+  const ptys = ptyManager.list().map((p) => ({
+    id: p.id,
+    agentId: ptyToAgent.get(p.id) ?? null,
+    command: basename(p.command),
+    pid: p.pid,
+    lastOutputAt: p.lastOutputAt,
+    idleMs: Math.max(0, now - p.lastOutputAt)
+  }));
+  return {
+    ok: true,
+    endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION,
+    appVersion: app.getVersion(),
+    ts: now,
+    harnessConfigured: !!readConfig().harnessHome,
+    hive: { enabled: hive.enabled(), godId: reg.godId, agents },
+    ptys,
+    closingTime: closingTime.snapshot(),
+    recentLog: hive.enabled() ? hive.logTail(25).map(sanitizeDebugLogEvent) : []
+  };
+}
+
+function sanitizeDebugLogEvent(event: unknown): Record<string, unknown> {
+  const e = (event && typeof event === 'object') ? event as Record<string, unknown> : {};
+  const out: Record<string, unknown> = {};
+  for (const key of ['ts', 'kind', 'id', 'from', 'to', 'act', 'subject', 'agentId', 'targetId', 'delivered', 'phase', 'reason']) {
+    if (key in e) out[key] = e[key];
+  }
+  if (Array.isArray(e.targets)) out.targets = e.targets.filter((x) => typeof x === 'string');
+  return out;
+}
+
+function startDebugControlServer(): void {
+  const cfg = readConfig();
+  if (!debugControlEnabled(cfg)) {
+    removeDebugControlDiscovery();
+    return;
+  }
+  if (debugControlServer) return;
+  const token = readOrCreateDebugControlToken();
+  debugControlServer = new DebugControlServer({
+    port: debugControlPort(cfg),
+    token,
+    handlers: {
+      health: () => ({
+        ok: true,
+        endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION,
+        appVersion: app.getVersion(),
+        ts: Date.now(),
+        harnessConfigured: !!readConfig().harnessHome
+      }),
+      snapshot: buildDebugControlSnapshot,
+      workOrder: handleDebugWorkOrder,
+      startClosingTime: () => closingTime.start(),
+      control: handleDebugControl,
+      killPty: (ptyId) => {
+        const res = ptyManager.kill(ptyId);
+        teardownPty(ptyId);
+        return res;
+      },
+      quitNow: () => {
+        setTimeout(() => teardownAndQuit(), 50);
+        return { ok: true };
+      }
+    }
+  });
+  void debugControlServer.start().then((res) => {
+    if (!res.ok || !res.url || typeof res.port !== 'number') {
+      debugControlServer = null;
+      removeDebugControlDiscovery();
+      console.error('[debug-control] failed to start:', res.error);
+      return;
+    }
+    writeDebugControlDiscovery(res.url, res.port, token);
+    console.log(`[debug-control] listening on ${res.url}`);
+  });
+}
+
+function stopDebugControlServer(): void {
+  try { debugControlServer?.stop(); } catch { /* best-effort */ }
+  debugControlServer = null;
+  removeDebugControlDiscovery();
+}
+
+function handleDebugWorkOrder(payload: unknown): unknown {
+  if (!hive.enabled()) return { ok: false, error: 'hive not configured' };
+  const p = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+  const body = typeof p.body === 'string' ? p.body.trim() : '';
+  if (!body) return { ok: false, error: 'body required' };
+  const act = isHiveAct(p.act) ? p.act : 'request';
+  const msg = hive.send({
+    to: typeof p.to === 'string' && p.to.trim() ? p.to.trim() : 'god',
+    act,
+    subject: typeof p.subject === 'string' && p.subject.trim() ? p.subject.trim() : 'Debug control work order',
+    body,
+    requires_reply: p.requiresReply === true
+  }, typeof p.from === 'string' && p.from.trim() ? p.from.trim() : 'debug-control');
+  return { ok: true, id: msg.id, to: msg.to, subject: msg.subject };
+}
+
+function handleDebugControl(agentId: string, action: 'steer' | 'halt' | 'resume', payload: unknown): unknown {
+  if (!agentId) return { ok: false, error: 'agent id required' };
+  if (action === 'steer') {
+    const p = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+    const text = typeof p.text === 'string' ? p.text.trim() : '';
+    if (!text) return { ok: false, error: 'text required' };
+    control.steer(agentId, text);
+  } else if (action === 'halt') {
+    control.halt(agentId);
+  } else {
+    control.resume(agentId);
+  }
+  return { ok: true, control: control.snapshot(agentId) };
+}
+
+function isHiveAct(v: unknown): v is HiveMessage['act'] {
+  return v === 'request' || v === 'inform' || v === 'propose' || v === 'query'
+    || v === 'agree' || v === 'refuse' || v === 'done';
 }
 
 // ─── Slack webhook server (Slack message → Michael's queue) ──────────────────
@@ -1552,6 +1733,7 @@ function teardownAndQuit(): void {
   allowQuit = true;
   // Each teardown step is best-effort: a throw here (e.g. a dying child or a
   // half-torn-down socket) must never abort the quit or pop a crash dialog.
+  try { stopDebugControlServer(); } catch (e) { console.error('[quit] debugControl.stop:', e); }
   try { clearMissionTimers(); } catch (e) { console.error('[quit] clearMissionTimers:', e); }
   try { hive.stopRouter(); } catch (e) { console.error('[quit] stopRouter:', e); }
   try { hookServer.stop(); } catch (e) { console.error('[quit] hookServer.stop:', e); }
@@ -1595,6 +1777,7 @@ ipcMain.handle('app:cancelClosingTime', () => closingTime.cancel());
 ipcMain.handle('app:resetAll', () => {
   allowQuit = true;
   // Tear everything down first so nothing writes back into the dirs we wipe.
+  try { stopDebugControlServer(); } catch (e) { console.error('[reset] debugControl.stop:', e); }
   try { clearMissionTimers(); } catch (e) { console.error('[reset] clearMissionTimers:', e); }
   try { hive.stopRouter(); } catch (e) { console.error('[reset] stopRouter:', e); }
   try { hookServer.stop(); } catch (e) { console.error('[reset] hookServer.stop:', e); }
@@ -1865,6 +2048,7 @@ app.whenReady().then(() => {
   // Bootstrap the hive (if harnessHome is configured) and start the message router.
   bootstrapHiveServices();
   createWindow();
+  startDebugControlServer();
   // Auto-start the Slack webhook server when configured. Best-effort: a tunnel
   // failure (offline) is logged, not fatal. The tunnel URL is ephemeral and
   // changes per restart, so the user re-pastes it via Settings → Start.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -162,6 +162,8 @@ export interface HarnessConfig {
   webhookEnabled?: boolean;
   webhookSecret?: string;
   webhookPort?: number;
+  debugControlEnabled?: boolean;
+  debugControlPort?: number;
   costCapUsd?: number;
   costCapTokens?: number;
   agentTokenCaps?: Record<string, number>;

--- a/test/debug-control.test.cjs
+++ b/test/debug-control.test.cjs
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('assert');
+const { mkdtempSync, rmSync } = require('fs');
+const { tmpdir } = require('os');
+const { join } = require('path');
+const { spawnSync } = require('child_process');
+
+let failures = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.log(`  ✗ ${name}\n     ${err.message}`);
+  }
+}
+
+function compileDebugControl() {
+  const out = mkdtempSync(join(tmpdir(), 'munder-debug-control-test-'));
+  const tsc = spawnSync('./node_modules/.bin/tsc', [
+    'src/main/debugControl.ts',
+    '--target', 'ES2022',
+    '--module', 'CommonJS',
+    '--moduleResolution', 'node',
+    '--esModuleInterop',
+    '--skipLibCheck',
+    '--outDir', out,
+  ], { encoding: 'utf8' });
+  if (tsc.status !== 0) {
+    rmSync(out, { recursive: true, force: true });
+    throw new Error(`tsc failed\n${tsc.stdout}\n${tsc.stderr}`);
+  }
+  return out;
+}
+
+async function readJson(res) {
+  return JSON.parse(await res.text());
+}
+
+(async () => {
+  console.log('debug control endpoint tests');
+  const out = compileDebugControl();
+  const { DebugControlServer, DEBUG_CONTROL_ENDPOINT_VERSION } = require(join(out, 'debugControl.js'));
+  const calls = [];
+  const server = new DebugControlServer({
+    port: 0,
+    token: 'test-token',
+    handlers: {
+      health: () => ({ ok: true, endpointVersion: DEBUG_CONTROL_ENDPOINT_VERSION, harnessConfigured: true }),
+      snapshot: () => ({ ok: true, hive: { agents: [] }, ptys: [], recentLog: [] }),
+      workOrder: (payload) => { calls.push(['workOrder', payload]); return { ok: true, id: 'msg-1' }; },
+      startClosingTime: () => ({ ok: true }),
+      control: (agentId, action, payload) => { calls.push(['control', agentId, action, payload]); return { ok: true }; },
+      killPty: (ptyId) => { calls.push(['killPty', ptyId]); return { ok: true }; },
+      quitNow: () => ({ ok: true }),
+    },
+  });
+  const started = await server.start();
+  assert.strictEqual(started.ok, true, started.error);
+  const base = started.url;
+
+  await test('requires a debug token', async () => {
+    const res = await fetch(`${base}/health`);
+    assert.strictEqual(res.status, 401);
+  });
+
+  await test('accepts bearer token and returns health', async () => {
+    const res = await fetch(`${base}/health`, { headers: { authorization: 'Bearer test-token' } });
+    assert.strictEqual(res.status, 200);
+    const body = await readJson(res);
+    assert.strictEqual(body.ok, true);
+    assert.strictEqual(body.endpointVersion, 1);
+  });
+
+  await test('accepts x-munder-debug-token and returns snapshot', async () => {
+    const res = await fetch(`${base}/snapshot`, { headers: { 'x-munder-debug-token': 'test-token' } });
+    assert.strictEqual(res.status, 200);
+    const body = await readJson(res);
+    assert.deepStrictEqual(body.ptys, []);
+    assert.deepStrictEqual(body.recentLog, []);
+  });
+
+  await test('rejects malformed JSON', async () => {
+    const res = await fetch(`${base}/work-order`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token' },
+      body: '{bad',
+    });
+    assert.strictEqual(res.status, 400);
+  });
+
+  await test('dispatches work order payload', async () => {
+    const res = await fetch(`${base}/work-order`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token', 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'god', body: 'hello' }),
+    });
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await readJson(res), { ok: true, id: 'msg-1' });
+    assert.deepStrictEqual(calls[0], ['workOrder', { to: 'god', body: 'hello' }]);
+  });
+
+  await test('routes control and kill actions', async () => {
+    await fetch(`${base}/control/agent-1/steer`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token', 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'pause soon' }),
+    });
+    await fetch(`${base}/pty/pty-1/kill`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token' },
+    });
+    assert.deepStrictEqual(calls[1], ['control', 'agent-1', 'steer', { text: 'pause soon' }]);
+    assert.deepStrictEqual(calls[2], ['killPty', 'pty-1']);
+  });
+
+  server.stop();
+  rmSync(out, { recursive: true, force: true });
+  if (failures > 0) process.exit(1);
+  console.log('all passed');
+})();

--- a/test/munder-mcp.test.cjs
+++ b/test/munder-mcp.test.cjs
@@ -1,0 +1,109 @@
+'use strict';
+
+const assert = require('assert');
+const { createServer } = require('http');
+const { handleToolCall, TOOLS } = require('../tools/munder-mcp/index.cjs');
+
+let failures = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.log(`  ✗ ${name}\n     ${err.message}`);
+  }
+}
+
+function fakeClient() {
+  const calls = [];
+  return {
+    calls,
+    health: async () => ({ ok: true }),
+    snapshot: async () => ({
+      ok: true,
+      hive: { agents: [{ id: 'god', name: 'Michael' }] },
+      ptys: [{ id: 'pty-1', agentId: 'god', idleMs: 5000 }],
+      recentLog: [{ subject: 'hello from hive' }],
+    }),
+    workOrder: async (payload) => { calls.push(['workOrder', payload]); return { ok: true, id: 'm1' }; },
+    startClosingTime: async () => ({ ok: true }),
+    steer: async (agentId, text) => { calls.push(['steer', agentId, text]); return { ok: true }; },
+    halt: async (agentId) => { calls.push(['halt', agentId]); return { ok: true }; },
+    kill: async (ptyId) => { calls.push(['kill', ptyId]); return { ok: true }; },
+  };
+}
+
+(async () => {
+  console.log('munder MCP wrapper tests');
+
+  await test('exposes expected tool names', () => {
+    const names = TOOLS.map((t) => t.name);
+    for (const name of [
+      'munder_health',
+      'munder_snapshot',
+      'munder_list_agents',
+      'munder_send_work_order',
+      'munder_wait_for_idle',
+      'munder_wait_for_text',
+      'munder_start_closing_time',
+      'munder_steer_agent',
+      'munder_halt_agent',
+      'munder_kill_agent',
+    ]) {
+      assert.ok(names.includes(name), `${name} missing`);
+    }
+  });
+
+  await test('maps health and list agents', async () => {
+    const client = fakeClient();
+    assert.deepStrictEqual(await handleToolCall('munder_health', {}, client), { ok: true });
+    assert.deepStrictEqual(await handleToolCall('munder_list_agents', {}, client), {
+      ok: true,
+      agents: [{ id: 'god', name: 'Michael' }],
+    });
+  });
+
+  await test('maps work order, steer, halt, and kill', async () => {
+    const client = fakeClient();
+    await handleToolCall('munder_send_work_order', { to: 'god', body: 'do it' }, client);
+    await handleToolCall('munder_steer_agent', { agentId: 'god', text: 'wrap up' }, client);
+    await handleToolCall('munder_halt_agent', { agentId: 'god' }, client);
+    await handleToolCall('munder_kill_agent', { ptyId: 'pty-1' }, client);
+    assert.deepStrictEqual(client.calls, [
+      ['workOrder', { to: 'god', body: 'do it' }],
+      ['steer', 'god', 'wrap up'],
+      ['halt', 'god'],
+      ['kill', 'pty-1'],
+    ]);
+  });
+
+  await test('wait tools poll sanitized snapshot metadata', async () => {
+    const client = fakeClient();
+    assert.strictEqual((await handleToolCall('munder_wait_for_idle', { agentId: 'god', idleMs: 1000 }, client)).state, 'idle');
+    assert.deepStrictEqual(await handleToolCall('munder_wait_for_text', { text: 'hello from hive' }, client), {
+      ok: true,
+      text: 'hello from hive',
+    });
+  });
+
+  await test('client reports endpoint auth errors clearly', async () => {
+    const server = createServer((req, res) => {
+      assert.strictEqual(req.headers.authorization, 'Bearer token');
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, error: 'unauthorized' }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = server.address().port;
+    process.env.MUNDER_DEBUG_URL = `http://127.0.0.1:${port}`;
+    process.env.MUNDER_DEBUG_TOKEN = 'token';
+    const { createMunderClient } = require('../tools/munder-mcp/index.cjs');
+    await assert.rejects(() => createMunderClient().health(), /401: unauthorized/);
+    delete process.env.MUNDER_DEBUG_URL;
+    delete process.env.MUNDER_DEBUG_TOKEN;
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  if (failures > 0) process.exit(1);
+  console.log('all passed');
+})();

--- a/tools/munder-mcp/README.md
+++ b/tools/munder-mcp/README.md
@@ -1,0 +1,27 @@
+# munder-mcp
+
+`munder-mcp` is a local stdio MCP wrapper around Munder Difflin's debug control
+endpoint. It is a client of the running Electron app, not a second orchestrator.
+
+Start Munder with the local debug endpoint enabled:
+
+```bash
+MUNDER_DEBUG_CONTROL=1 open -a "Munder Difflin"
+```
+
+Register the MCP server with a client that supports stdio MCP:
+
+```bash
+node /path/to/munder-difflin/tools/munder-mcp/index.cjs
+```
+
+The server reads the discovery file written by Munder. Override it with
+`MUNDER_DEBUG_DISCOVERY=/path/to/debug-control.json`, or set
+`MUNDER_DEBUG_URL` and `MUNDER_DEBUG_TOKEN` directly for tests.
+
+Example flow:
+
+1. Call `munder_health`.
+2. Call `munder_list_agents` and pick a target agent id.
+3. Call `munder_send_work_order` with `{ "to": "<agent-id>", "body": "..." }`.
+4. Call `munder_wait_for_idle` for that agent.

--- a/tools/munder-mcp/index.cjs
+++ b/tools/munder-mcp/index.cjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+'use strict';
+
+const { existsSync, readFileSync } = require('node:fs');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+
+const SERVER_NAME = 'munder-mcp';
+const SERVER_VERSION = '0.1.0';
+const MIN_ENDPOINT_VERSION = 1;
+
+const TOOLS = [
+  {
+    name: 'munder_health',
+    description: 'Check whether the local Munder Difflin debug control endpoint is available.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'munder_snapshot',
+    description: 'Return the current sanitized Munder snapshot: agents, PTYs, closing-time state, and recent metadata log.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'munder_list_agents',
+    description: 'List known Munder hive agents from the sanitized debug snapshot.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'munder_send_work_order',
+    description: 'Route a work order through Munder hive mail to god or a named agent.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'Target hive agent id. Defaults to god.' },
+        subject: { type: 'string' },
+        body: { type: 'string' },
+        act: { type: 'string', enum: ['request', 'inform', 'propose', 'query', 'agree', 'refuse', 'done'] },
+        requiresReply: { type: 'boolean' },
+      },
+      required: ['body'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'munder_wait_for_idle',
+    description: 'Poll the snapshot until a PTY or agent has produced no output for the requested idle window.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentId: { type: 'string' },
+        ptyId: { type: 'string' },
+        idleMs: { type: 'number', default: 2000 },
+        timeoutMs: { type: 'number', default: 60000 },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'munder_wait_for_text',
+    description: 'Poll sanitized snapshot metadata until its JSON contains the given text.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string' },
+        timeoutMs: { type: 'number', default: 60000 },
+      },
+      required: ['text'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'munder_start_closing_time',
+    description: 'Start Munder closing-time graceful shutdown protocol.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'munder_steer_agent',
+    description: 'Inject a steer note for an agent at its next hook boundary.',
+    inputSchema: {
+      type: 'object',
+      properties: { agentId: { type: 'string' }, text: { type: 'string' } },
+      required: ['agentId', 'text'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'munder_halt_agent',
+    description: 'Request a graceful halt for an agent at its next hook boundary.',
+    inputSchema: {
+      type: 'object',
+      properties: { agentId: { type: 'string' } },
+      required: ['agentId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'munder_kill_agent',
+    description: 'Kill a live Munder PTY by id. Destructive: use only when graceful stop failed.',
+    inputSchema: {
+      type: 'object',
+      properties: { ptyId: { type: 'string' } },
+      required: ['ptyId'],
+      additionalProperties: false,
+    },
+  },
+];
+
+function defaultDiscoveryPath() {
+  if (process.env.MUNDER_DEBUG_DISCOVERY) return process.env.MUNDER_DEBUG_DISCOVERY;
+  if (process.platform === 'darwin') return join(homedir(), 'Library', 'Application Support', 'munder-difflin', 'debug-control.json');
+  if (process.platform === 'win32') return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'munder-difflin', 'debug-control.json');
+  return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'munder-difflin', 'debug-control.json');
+}
+
+function readDiscovery() {
+  if (process.env.MUNDER_DEBUG_URL && process.env.MUNDER_DEBUG_TOKEN) {
+    return {
+      url: process.env.MUNDER_DEBUG_URL,
+      token: process.env.MUNDER_DEBUG_TOKEN,
+      endpointVersion: Number(process.env.MUNDER_DEBUG_ENDPOINT_VERSION || MIN_ENDPOINT_VERSION),
+    };
+  }
+  const path = defaultDiscoveryPath();
+  if (!existsSync(path)) {
+    throw new Error(`Munder debug discovery file not found: ${path}. Start Munder with MUNDER_DEBUG_CONTROL=1.`);
+  }
+  const parsed = JSON.parse(readFileSync(path, 'utf8'));
+  if (!parsed || typeof parsed.url !== 'string' || typeof parsed.token !== 'string') {
+    throw new Error(`Invalid Munder debug discovery file: ${path}`);
+  }
+  if (Number(parsed.endpointVersion || 0) < MIN_ENDPOINT_VERSION) {
+    throw new Error(`Unsupported Munder debug endpoint version: ${parsed.endpointVersion}`);
+  }
+  return parsed;
+}
+
+function createMunderClient(discovery = readDiscovery()) {
+  async function request(path, opts = {}) {
+    const res = await fetch(`${discovery.url}${path}`, {
+      method: opts.method || 'GET',
+      headers: {
+        authorization: `Bearer ${discovery.token}`,
+        ...(opts.body ? { 'content-type': 'application/json' } : {}),
+      },
+      body: opts.body ? JSON.stringify(opts.body) : undefined,
+    });
+    const text = await res.text();
+    let body;
+    try { body = text ? JSON.parse(text) : null; }
+    catch { body = { raw: text }; }
+    if (!res.ok) {
+      throw new Error(`Munder debug endpoint ${res.status}: ${body?.error || text || res.statusText}`);
+    }
+    return body;
+  }
+  return {
+    health: () => request('/health'),
+    snapshot: () => request('/snapshot'),
+    workOrder: (payload) => request('/work-order', { method: 'POST', body: payload }),
+    startClosingTime: () => request('/closing-time/start', { method: 'POST', body: {} }),
+    steer: (agentId, text) => request(`/control/${encodeURIComponent(agentId)}/steer`, { method: 'POST', body: { text } }),
+    halt: (agentId) => request(`/control/${encodeURIComponent(agentId)}/halt`, { method: 'POST', body: {} }),
+    kill: (ptyId) => request(`/pty/${encodeURIComponent(ptyId)}/kill`, { method: 'POST', body: {} }),
+  };
+}
+
+async function handleToolCall(name, args = {}, client = createMunderClient()) {
+  switch (name) {
+    case 'munder_health':
+      return client.health();
+    case 'munder_snapshot':
+      return client.snapshot();
+    case 'munder_list_agents': {
+      const snap = await client.snapshot();
+      return { ok: true, agents: snap?.hive?.agents || [] };
+    }
+    case 'munder_send_work_order':
+      if (!args.body || typeof args.body !== 'string') throw new Error('body is required');
+      return client.workOrder(args);
+    case 'munder_wait_for_idle':
+      return waitForIdle(args, client);
+    case 'munder_wait_for_text':
+      return waitForText(args, client);
+    case 'munder_start_closing_time':
+      return client.startClosingTime();
+    case 'munder_steer_agent':
+      if (!args.agentId || !args.text) throw new Error('agentId and text are required');
+      return client.steer(args.agentId, args.text);
+    case 'munder_halt_agent':
+      if (!args.agentId) throw new Error('agentId is required');
+      return client.halt(args.agentId);
+    case 'munder_kill_agent':
+      if (!args.ptyId) throw new Error('ptyId is required');
+      return client.kill(args.ptyId);
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+async function waitForIdle(args, client) {
+  const timeoutMs = numberOr(args.timeoutMs, 60000);
+  const idleMs = numberOr(args.idleMs, 2000);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    const snap = await client.snapshot();
+    const ptys = Array.isArray(snap.ptys) ? snap.ptys : [];
+    const pty = args.ptyId
+      ? ptys.find((p) => p.id === args.ptyId)
+      : args.agentId
+        ? ptys.find((p) => p.agentId === args.agentId)
+        : null;
+    if (!pty) return { ok: true, state: 'no-live-pty' };
+    if (typeof pty.idleMs === 'number' && pty.idleMs >= idleMs) {
+      return { ok: true, state: 'idle', pty };
+    }
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for idle after ${timeoutMs}ms`);
+}
+
+async function waitForText(args, client) {
+  if (!args.text || typeof args.text !== 'string') throw new Error('text is required');
+  const timeoutMs = numberOr(args.timeoutMs, 60000);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    const snap = await client.snapshot();
+    if (JSON.stringify(snap).includes(args.text)) {
+      return { ok: true, text: args.text };
+    }
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for text: ${args.text}`);
+}
+
+function numberOr(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function writeMessage(msg) {
+  const body = Buffer.from(JSON.stringify(msg), 'utf8');
+  process.stdout.write(`Content-Length: ${body.length}\r\n\r\n`);
+  process.stdout.write(body);
+}
+
+async function handleRpc(msg) {
+  if (msg.method === 'notifications/initialized') return;
+  try {
+    if (msg.method === 'initialize') {
+      writeMessage({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          protocolVersion: msg.params?.protocolVersion || '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+        },
+      });
+      return;
+    }
+    if (msg.method === 'tools/list') {
+      writeMessage({ jsonrpc: '2.0', id: msg.id, result: { tools: TOOLS } });
+      return;
+    }
+    if (msg.method === 'tools/call') {
+      const result = await handleToolCall(msg.params?.name, msg.params?.arguments || {});
+      writeMessage({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] },
+      });
+      return;
+    }
+    writeMessage({ jsonrpc: '2.0', id: msg.id, error: { code: -32601, message: `Method not found: ${msg.method}` } });
+  } catch (e) {
+    writeMessage({ jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: e instanceof Error ? e.message : String(e) } });
+  }
+}
+
+function startStdioServer() {
+  let buffer = Buffer.alloc(0);
+  process.stdin.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (true) {
+      const sep = buffer.indexOf('\r\n\r\n');
+      if (sep === -1) return;
+      const headers = buffer.slice(0, sep).toString('utf8');
+      const m = headers.match(/Content-Length:\s*(\d+)/i);
+      if (!m) throw new Error('Missing Content-Length header');
+      const length = Number(m[1]);
+      const start = sep + 4;
+      if (buffer.length < start + length) return;
+      const body = buffer.slice(start, start + length).toString('utf8');
+      buffer = buffer.slice(start + length);
+      void handleRpc(JSON.parse(body));
+    }
+  });
+}
+
+if (require.main === module) startStdioServer();
+
+module.exports = {
+  TOOLS,
+  createMunderClient,
+  defaultDiscoveryPath,
+  handleToolCall,
+  readDiscovery,
+  startStdioServer,
+};


### PR DESCRIPTION
## Summary
Adds `tools/munder-mcp`, a small stdio MCP wrapper over the local debug control endpoint introduced in #75.

This lets Codex, Claude, and other MCP-capable agents control and inspect a running local Munder Difflin instance through a stable tool surface instead of clicking the UI.

## Stack
This is PR 2/3 in the debugging/MCP stack.

- Depends on #75.
- Please review after #75 lands, or review only the PR2-specific files listed below.
- Until #75 merges, GitHub may show the endpoint commit in this PR because this branch is stacked locally.

PR sequence:

1. #75 — local debug control endpoint.
2. **This PR** — stdio MCP wrapper over that endpoint.
3. Next — reliable headless smoke harness using fake agents.

## What changed
- Adds `tools/munder-mcp/index.cjs`, a dependency-light stdio MCP server.
- Reads the Munder debug discovery file or explicit `MUNDER_DEBUG_URL` / `MUNDER_DEBUG_TOKEN`.
- Fails clearly when Munder is not running, debug control is disabled, the discovery file is missing, or the endpoint version is incompatible.
- Exposes MCP tools:
  - `munder_health`
  - `munder_snapshot`
  - `munder_list_agents`
  - `munder_send_work_order`
  - `munder_wait_for_idle`
  - `munder_wait_for_text`
  - `munder_start_closing_time`
  - `munder_steer_agent`
  - `munder_halt_agent`
  - `munder_kill_agent`
- Keeps MCP as a client of Munder, not a second orchestrator.
- Adds README guidance for registering the server with Codex/Claude and sending a work order.
- Adds unit coverage with a fake HTTP server for tool schemas, endpoint calls, wait helpers, and error mapping.

## Review focus
- `tools/munder-mcp/index.cjs`
- `tools/munder-mcp/README.md`
- `test/munder-mcp.test.cjs`
- Root README/package script additions

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run test:debug-control`
- `npm run test:munder-mcp`
- `node test/slack.test.cjs`
