### PR TITLE
feat(terminal): drag-and-drop a file onto the terminal to inject its path

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import { contextBridge, ipcRenderer, webUtils, type IpcRendererEvent } from 'electron';
 import type { AgentProvider } from '../shared/agentProvider';
 
 // Injected at build time from package.json (see electron.vite.config.ts).
@@ -310,6 +310,13 @@ const api = {
     ipcRenderer.invoke('pty:spawn', opts),
   writePty: (id: string, data: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('pty:write', id, data),
+  /** Resolve the absolute filesystem path of a dropped/selected File. Electron 32
+   *  removed `File.path`; `webUtils.getPathForFile` is the supported replacement
+   *  and must run in the preload (it isn't on `window`). Returns '' if unknown
+   *  (e.g. a synthetic File that never came from disk). */
+  getFilePath: (file: File): string => {
+    try { return webUtils.getPathForFile(file) || ''; } catch { return ''; }
+  },
   resizePty: (id: string, cols: number, rows: number): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('pty:resize', id, cols, rows),
   killPty: (id: string): Promise<{ ok: boolean; error?: string }> =>

--- a/src/renderer/src/components/PtyTerminalView.tsx
+++ b/src/renderer/src/components/PtyTerminalView.tsx
@@ -269,6 +269,34 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
     } catch { /* host may not be sized yet */ }
   }, [fontSize, ptyId]);
 
+  // Drag-and-drop a file (image, etc.) onto the terminal → inject its absolute
+  // path into the pty, exactly like a native terminal's drag-drop. Claude Code
+  // detects an image path in the prompt and attaches it. Without this, Electron
+  // would treat the drop as navigation and load the file:// URL over the app.
+  const onDragOver = (e: React.DragEvent) => {
+    // Must preventDefault on dragover too — otherwise `drop` never fires and the
+    // window navigates to the dropped file. Only claim it when files are present
+    // so text/selection drags fall through to xterm's own handling.
+    if (e.dataTransfer?.types?.includes('Files')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    }
+  };
+  const onDrop = (e: React.DragEvent) => {
+    const files = Array.from(e.dataTransfer?.files ?? []);
+    if (files.length === 0) return; // not a file drop — let xterm handle it
+    e.preventDefault();
+    const paths = files
+      .map((f) => window.cth.getFilePath(f))
+      .filter(Boolean)
+      // Backslash-escape whitespace/quotes so each path lands as a single token,
+      // matching what a real terminal emits on drag-drop.
+      .map((p) => p.replace(/(["'\\ \t])/g, '\\$1'));
+    if (paths.length === 0) return;
+    // Trailing space separates consecutive drops and lets the user keep typing.
+    void window.cth.writePty(ptyId, paths.join(' ') + ' ');
+  };
+
   const zoom = (delta: number) =>
     setFontSize((s) => Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, s + delta)));
   const resetZoom = () => setFontSize(DEFAULT_FONT_SIZE);
@@ -360,7 +388,7 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
           )}
         </div>
       </div>
-      <div ref={hostRef} style={{
+      <div ref={hostRef} onDragOver={onDragOver} onDrop={onDrop} style={{
         flex: 1, minHeight: 0,
         padding: embedded ? '0 8px 8px' : 0
       }} />


### PR DESCRIPTION
## What

Drag-and-drop a file (image, etc.) onto a PTY terminal and its **absolute, shell-escaped path** is written into the session — exactly like a native terminal's drag-drop. Claude Code then detects the image path in the prompt and attaches it.

## Why

Previously, dropping a file onto the terminal made Electron treat it as navigation and load the `file://` URL over the app. This makes the common "drop an image into the agent" flow work in-app.

## Changes

- **`preload/index.ts`** — expose `getFilePath` backed by `webUtils.getPathForFile`. Electron 32 removed `File.path`; `getPathForFile` is the supported replacement and must run in the preload (it isn't on `window`). Returns `''` for synthetic files.
- **`PtyTerminalView.tsx`** — `onDragOver`/`onDrop` handlers that:
  - `preventDefault` only when files are present (text/selection drags still fall through to xterm),
  - resolve each dropped file's path,
  - backslash-escape whitespace/quotes so each path lands as a single token,
  - write them space-separated with a trailing space so the user can keep typing.

## Notes

Branched off `main` and scoped to **only** these two files — independent of the session-resume work in #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)