### PR TITLE
feat(compact): only auto-compact when context is ≥30% of the model's window

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -12,8 +12,10 @@ export interface ScheduledMission {
   to: string;
   body: string;
   enabled: boolean;
-  /** When true, the scheduler also sends `/compact` to every live terminal when
-   *  this mission fires — keeping each agent's context lean on a cadence. */
+  /** When true, the scheduler asks the renderer to `/compact` live terminals when
+   *  this mission fires — but only agents whose context has filled past a
+   *  threshold (~30% of their model's window) are compacted, so small/idle
+   *  sessions are left alone instead of compacting on every tick. */
   autoCompact?: boolean;
   lastFiredAt?: number;
   /** Mission flavor. Absent ⇒ 'dispatch' (the classic interval-dispatch mission,

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -42,6 +42,14 @@ const COMPACT_CMD =
   '/compact Summarise exactly what you are currently working on and the next step, ' +
   'so you can resume from the same point — then continue that work after compacting.';
 
+// Auto-compact only fires once an agent's live context has filled to at least
+// this fraction of its model's window. It's a FRACTION of contextLimit (which is
+// per-agent/per-model), so a 200k session and a 1M session both compact at the
+// same 30% relative fill — not at a fixed token count. Agents below this, or with
+// no context telemetry yet, are left alone — so the hourly standup no longer
+// compacts every terminal unconditionally.
+const COMPACT_CONTEXT_THRESHOLD = 0.3;
+
 // Per-pty submission chain. Every submitToPty for a given pty is appended here so
 // two callers (e.g. the boot sequence's /remote-control and the inbox-wake nudge)
 // can NEVER interleave their text + Enter — which jammed them onto one line and
@@ -619,6 +627,13 @@ export function useHive(config: HarnessConfig | null): void {
         // /compact is a Claude Code slash command — non-Claude CLIs (agy, codex)
         // would just receive it as literal prompt text. Skip them.
         if (!isClaudeProvider(inferAgentProvider(a.command, a.provider))) continue;
+        // Only compact agents whose context has actually filled past the
+        // threshold. contextLimit is per-model (200k vs the 1M window), so this
+        // gate scales to each agent's own window instead of a fixed token count.
+        // Unknown telemetry (limit not polled yet) ⇒ skip — never compact blind.
+        const limit = a.contextLimit ?? 0;
+        const used = a.contextTokens ?? 0;
+        if (limit <= 0 || used / limit < COMPACT_CONTEXT_THRESHOLD) continue;
         const queued = messageQueues[a.id] ?? [];
         if (queued.some((m) => m.text.trimStart().startsWith('/compact'))) continue;
         enqueueMessage(a.id, COMPACT_CMD);


### PR DESCRIPTION
## What

Auto-compaction (the hourly ops standup's `autoCompact`) now only fires for an agent when its **live context has filled to ≥30% of that agent's context window** — instead of compacting **every** live Claude terminal on every tick.

## Why

The standup queued `/compact` for all live Claude agents each hour regardless of how full they were, so small or barely-used sessions got compacted needlessly (losing detail for no benefit). Compaction should be driven by actual context pressure, not a fixed cadence.

## How

In the `onAutoCompact` handler (`useHive.ts`), gate each agent on `contextTokens / contextLimit >= 0.30`:

- `contextLimit` is **per-model**, so a **200k** session and a **1M** session both compact at the same **30% relative fill** rather than a fixed token count — this matters because users run both window sizes.
- Agents with **no context telemetry yet** (`contextLimit` not polled) are skipped — never compact blind.
- Threshold is a single named constant `COMPACT_CONTEXT_THRESHOLD = 0.3`.

The existing dedupe (no second `/compact` if one is already queued) and idle-only delivery (never interrupts a working terminal mid-step) are unchanged. Config doc comment for `autoCompact` updated to match.

## Test

`npm run typecheck` passes (node + web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)