### PR TITLE
feat(rc): name each agent's Remote Control session after the agent

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1971,6 +1971,17 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
         : cfg.defaultModel ?? modelForRole(opts.hive, cfg);
       if (m) args.push('--model', m);
     }
+    // Name the Remote Control session after the agent (Michael, Jim, Dev1…) so it
+    // is identifiable in claude.ai / the mobile app. Otherwise Claude defaults the
+    // prefix to the machine hostname (e.g. "vyapaks-macbook-pro-…"), which is
+    // opaque when several agents run at once — especially with remoteControlAtStartup
+    // on, where RC auto-enables for every session. Slugify the friendly name into a
+    // single safe token; Claude still appends its own random suffix for uniqueness.
+    if (!args.includes('--remote-control-session-name-prefix')) {
+      const label = (opts.hive.name || opts.hive.id || '')
+        .trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+      if (label) args.push('--remote-control-session-name-prefix', label);
+    }
     // Coarse runaway cap.
     if (typeof cfg.maxTurns === 'number' && cfg.maxTurns > 0 && !args.includes('--max-turns')) {
       args.push('--max-turns', String(cfg.maxTurns));

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -300,8 +300,11 @@ export function useHive(config: HarnessConfig | null): void {
       timers.push(setTimeout(() => {
         if (cancelled) return;
         // settleMs pauses the chain ~1.5s after /remote-control before the
-        // orientation prompt (fresh spawns only) is submitted next.
-        submitToPty(GOD_PTY, '/remote-control', REMOTE_CONTROL_SETTLE_MS).catch(() => { /* best-effort */ });
+        // orientation prompt (fresh spawns only) is submitted next. Name the RC
+        // session "Michael" so it's identifiable in claude.ai / the mobile app
+        // rather than the opaque hostname default (matches the per-agent
+        // --remote-control-session-name-prefix set at spawn in the main process).
+        submitToPty(GOD_PTY, '/remote-control Michael', REMOTE_CONTROL_SETTLE_MS).catch(() => { /* best-effort */ });
         if (!resumedGod) {
           // A type-into-tui god (Crush) can't ride its hive protocol on argv, so the
           // main process hands it back as seedPrompt — type it FIRST (identity), then


### PR DESCRIPTION
## What

Remote Control sessions now appear in claude.ai / the mobile app named after the **agent** (Michael, Jim, Dev1…) instead of the machine hostname.

## Why

Today an agent's RC session shows up as `<hostname>-<random>` (e.g. `vyapaks-macbook-pro-mighty-hare`) — Claude's default RC name prefix is the hostname. With several agents running it's impossible to tell which session is which. This is especially bad for users who have `remoteControlAtStartup` enabled, where Claude auto-enables RC for **every** session, so every agent lands in the mobile app under the same opaque hostname.

## How

- **`src/main/index.ts`** — in the Claude-only spawn-flag block, add `--remote-control-session-name-prefix "<agent name>"` for every hive agent. The friendly name (`opts.hive.name`, fallback id) is slugified to a single safe token `[A-Za-z0-9._-]`; Claude still appends its own random suffix for uniqueness. Placed alongside `--model`, so non-Claude providers (codex, agy) are untouched, and an explicit prefix already in args is never overridden.
- **`src/renderer/src/hooks/useHive.ts`** — Michael's boot-time `/remote-control` now passes his name (`/remote-control Michael`) so his session is named deterministically, matching the spawn-time prefix.

## Result

| Before | After |
|---|---|
| `vyapaks-macbook-pro-mighty-hare` | `Michael-<suffix>`, `Jim-<suffix>`, `Dev1-<suffix>` |

## Test

`npm run typecheck` passes (node + web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)