### PR TITLE
fix(hive): quote cth-hook path so Codex hooks work under paths with spaces

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1132,8 +1132,11 @@ export class HiveManager {
       // over) and append a `[[hooks.<Event>]]` group per event, each pointing at the
       // SAME cth-hook shim — reused verbatim (Codex's hook payload + response are
       // already Claude-shaped, so HookServer/drainForStop run unchanged). Regenerated
-      // each spawn (idempotent). A single-quoted TOML literal avoids path escaping
-      // (hive roots are space/quote-free). NOTE: hooks fire in INTERACTIVE codex
+      // each spawn (idempotent). The command is a single-quoted TOML literal; the
+      // shim path is double-quoted INSIDE it so a hive root containing spaces (e.g.
+      // an iCloud "Mobile Documents" path) isn't word-split when Codex runs the
+      // command through a shell — otherwise `node` is handed a truncated path and
+      // exits 1 on every hook event. NOTE: hooks fire in INTERACTIVE codex
       // sessions (how hive workers run), not in headless `codex exec`.
       const shim = this.shimPath();
       let config = existsSync(join(userHome, 'config.toml'))
@@ -1143,7 +1146,7 @@ export class HiveManager {
           'SessionStart', 'UserPromptSubmit', 'PreCompact', 'PostCompact'];
         config += '\n# --- munder-hive lifecycle hooks (auto-generated; do not edit) ---\n';
         for (const ev of events) {
-          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = 'node ${shim}'\ntimeout = 0\n`;
+          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = 'node "${shim}"'\ntimeout = 0\n`;
         }
       }
       writeFileSync(join(home, 'config.toml'), config, 'utf8');


### PR DESCRIPTION
## Problem

`installCodexHooks` (`src/main/hive.ts`) generates the per-agent `config.toml` lifecycle hooks with the shim path **unquoted**:

```toml
command = 'node /Users/.../Mobile Documents/.../hive/bin/cth-hook.cjs'
```

When the hive root contains a space — e.g. a project living under an iCloud Drive **`Mobile Documents`** path — Codex runs the command through a shell, which word-splits the unquoted path. `node` is handed a truncated path (`/Users/<user>/Library/Mobile`), fails with `MODULE_NOT_FOUND`, and exits 1.

The result is that **every** Codex lifecycle hook fails, on every event:

```
• SessionStart hook (failed)   error: hook exited with code 1
• PreToolUse hook (failed)     error: hook exited with code 1
• PostToolUse hook (failed)    error: hook exited with code 1
• Stop hook (failed)           error: hook exited with code 1
...
```

No hook ever reaches the UDS server, so Codex agents are invisible to fleet tracking and message delivery. (`cth-hook.cjs` itself has no `exit(1)` path — confirming `node` dies before the script runs.)

## Fix

Double-quote the shim path inside the single-quoted TOML literal:

```toml
command = 'node "/Users/.../Mobile Documents/.../cth-hook.cjs"'
```

The Claude `settings.json` path already quotes the shim; this brings the Codex generator in line. One line, plus the now-stale comment (which asserted *"hive roots are space/quote-free"* — the assumption that caused the bug).

## Verification

Reproduced the shell word-split directly:

```console
$ sh -c "node /Users/.../Mobile Documents/.../cth-hook.cjs <<< '{}'"
Error: Cannot find module '/Users/.../Library/Mobile'   → exit 1

$ sh -c 'node "/Users/.../Mobile Documents/.../cth-hook.cjs" <<< "{}"'
   → exit 0
```

After applying the fix to a live agent's generated `config.toml`, all 8 hook events exit 0 and the `hook exited with code 1` spam is gone.