### PR TITLE
[codex] Update Codex model options

### DIFF
--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -77,7 +77,7 @@ Return EXACTLY this shape (omit optional fields you don't need; keep the spec st
 }
 
 Rules:
-- "provider" MUST be one of: claude | codex | antigravity. "model" must be a real model id for that provider (e.g. claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
+- "provider" MUST be one of: claude | codex | antigravity. "model" must be a real model id for that provider (e.g. claude-opus-4-8[1m], gpt-5.5, "Gemini 3.1 Pro (High)").
 - Do NOT include shell commands or any flags beyond these fields.
 - Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
 

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -126,17 +126,15 @@ export const AGENT_MODELS: ModelOption[] = [
 ];
 
 /** Models offered when an agent runs on the OpenAI Codex CLI (`codex`). Codex's
- *  `--model` takes a model slug (e.g. `codex --model o4-mini`). These are the
+ *  `--model` takes a model slug (e.g. `codex --model gpt-5.5`). These are the
  *  curated suggestions surfaced in the picker — the command field stays editable,
- *  and `codex --model <id>` is the source of truth. // TODO-verify the exact live
- *  slug list once the codex CLI can be installed to confirm. */
+ *  and `codex --model <id>` is the source of truth. */
 export const CODEX_MODELS: ModelOption[] = [
   { id: undefined, label: 'default' },
-  { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
-  { id: 'gpt-5', label: 'GPT-5' },
-  { id: 'gpt-5-mini', label: 'GPT-5 Mini' },
-  { id: 'o4-mini', label: 'o4-mini' },
-  { id: 'o3', label: 'o3' }
+  { id: 'gpt-5.5', label: 'GPT-5.5' },
+  { id: 'gpt-5.4', label: 'GPT-5.4' },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+  { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' }
 ];
 
 /** Models offered when an agent runs on the Antigravity CLI (`agy`). agy's

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -171,9 +171,8 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     // inbox-wake nudge remains as a harmless fallback for an idle worker).
     canReceiveInbox: true,
     initialPromptFlag: undefined,
-    // Codex's long-context coding model for the orchestrator role. // TODO-verify
-    // the exact codex CLI model id (couldn't install the codex CLI to confirm).
-    recommendedOrchestratorModel: 'gpt-5-codex',
+    // Codex's long-context coding model for the orchestrator role.
+    recommendedOrchestratorModel: 'gpt-5.5',
     // Codex has no stable session-resume CLI flag in the curated reference; spawn
     // fresh on respawn (the protocol is re-injected as the initial prompt anyway).
     resumeFlag: undefined,

--- a/src/shared/codexCommands.ts
+++ b/src/shared/codexCommands.ts
@@ -57,7 +57,7 @@ export const CODEX_COMMAND_GROUPS: CmdGroup[] = [
   {
     title: 'CONFIG',
     items: [
-      { cmd: 'codex --model <model>', kind: 'cli', desc: 'Choose the model (e.g. o4-mini, o3).', usage: 'codex --model o4-mini' },
+      { cmd: 'codex --model <model>', kind: 'cli', desc: 'Choose the model (e.g. gpt-5.5).', usage: 'codex --model gpt-5.5' },
       { cmd: 'codex --provider <provider>', kind: 'cli', desc: 'Select the API provider (openai, azure, anthropic…).', usage: 'codex --provider openai' }
     ]
   }


### PR DESCRIPTION
## Summary

Updates the Codex provider model suggestions to match the currently available Codex CLI model choices surfaced in the picker:

- `gpt-5.5`
- `gpt-5.4`
- `gpt-5.4-mini`
- `gpt-5.3-codex-spark`

Also updates the Codex recommended orchestrator default and nearby help/generated-hire examples so the UI does not keep suggesting stale `gpt-5-codex`, `o4-mini`, or `o3` model choices.

## Why

The Add Agent engine step was showing stale Codex model presets. Selecting those can produce unsupported-model startup failures for current Codex accounts. This keeps the model picker and generated model guidance aligned with the current Codex model menu while leaving the command field editable.

## Validation

- `npm run typecheck`
- `npm run build`
