### PR TITLE
Auto-compact: dedicated persistent maintenance schedule + warning UI (maint-1)

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -27,7 +27,7 @@ export interface ScheduledMission {
    *  e.g. the ops standup). 'heartbeat' (Lane A #1) is a context-aware beat: it
    *  observes live floor state, re-engages a quiet god, and ticks the circuit
    *  breaker — armed with an adaptive cadence, not a fixed setInterval. */
-  kind?: 'dispatch' | 'heartbeat';
+  kind?: 'dispatch' | 'heartbeat' | 'compact';
   /** Heartbeat only: a floor is "quiet" when no tracked signal (log.jsonl mtime,
    *  inbox/outbox mtimes, any PTY output) has moved in this many ms. Default
    *  ~5 min. NOT derived from registry.status (which never transitions in main). */
@@ -77,6 +77,25 @@ export const HEARTBEAT_MISSION: ScheduledMission = {
   enabled: false,
   kind: 'heartbeat',
   quietThresholdMs: 300_000
+};
+
+/** The dedicated auto-compact MAINTENANCE schedule (maint-1). DECOUPLED from the
+ *  ops standup so editing/replacing a standup can never silently disable
+ *  compaction again (the bug this fixes). It fires ONLY the auto-compact signal —
+ *  `kind:'compact'` makes syncMissions skip the hive.send dispatch (empty to/body).
+ *  Shipped ENABLED: auto-compact is REQUIRED for long-running agents — without it
+ *  each agent's terminal context grows until it overflows and the agent fails. It
+ *  is the SINGLE source of truth for compaction (migration drops autoCompact off
+ *  other missions), and it's persistent: deleting it makes it reappear DISABLED. */
+export const COMPACT_MAINTENANCE_MISSION: ScheduledMission = {
+  id: 'compact-maintenance',
+  label: 'Auto-compact (maintenance)',
+  intervalMs: 3_600_000,
+  to: '',
+  body: '',
+  enabled: true,
+  autoCompact: true,
+  kind: 'compact'
 };
 
 /** Circuit-breaker thresholds (Lane A #6.6b). The breaker runs inside the
@@ -156,6 +175,11 @@ export interface HarnessConfig {
   /** One-time guard for the built-in heartbeat mission (mirrors opsStandupSeeded
    *  so a user who deletes the heartbeat doesn't get it re-added every boot). */
   heartbeatSeeded?: boolean;
+  /** maint-1 guard for the dedicated auto-compact maintenance mission. UNLIKE the
+   *  two above, this does NOT suppress re-add forever: once seeded (flag set), a
+   *  later delete makes the mission reappear DISABLED on next boot (compaction is
+   *  required, so it's never silently lost — only user-disabled). */
+  compactMaintenanceSeeded?: boolean;
   /** Hard dollar ceiling across all active agents before the circuit breaker
    *  trips. UNSET by default (Lane A #6.6b decision): the breaker trips on
    *  behavioral signals; the $-cap is purely opt-in. Legacy — the UI now sets a

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,7 +7,7 @@ import { request as httpsRequest } from 'node:https';
 import { PtyManager, type SpawnOptions } from './pty';
 import {
   readConfig, writeConfig, resetConfig, ensureHarnessHome, ensureClaudePermissionsAccepted,
-  modelForRole, OPS_STANDUP_MISSION, HEARTBEAT_MISSION, type HarnessConfig, type ScheduledMission
+  modelForRole, OPS_STANDUP_MISSION, HEARTBEAT_MISSION, COMPACT_MAINTENANCE_MISSION, type HarnessConfig, type ScheduledMission
 } from './config';
 import { listDir, readFileText, writeFileText } from './fs';
 import {
@@ -458,14 +458,16 @@ function syncMissions(): void {
     if (m.kind === 'heartbeat') { armHeartbeat(m); continue; }
     const fire = (): void => {
       try {
-        if (hive.enabled()) {
+        // A 'compact' maintenance mission (maint-1) is compaction-ONLY: it carries
+        // no dispatch body/target, so skip the hive.send and just fire auto-compact.
+        if (m.kind !== 'compact' && m.body && hive.enabled()) {
           hive.send({ to: m.to, act: 'request', subject: m.label, body: m.body }, 'scheduler');
         }
         // Auto-compact: do NOT jam /compact into busy terminals. Hand it to the
         // renderer, which queues a /compact per agent (deduped — never two at
         // once) and delivers it only when that agent goes idle (its drain loop),
         // so a working agent compacts between steps, never mid-step.
-        if (m.autoCompact) {
+        if (m.autoCompact || m.kind === 'compact') {
           try { liveWebContents()?.send('mission:autoCompact'); } catch { /* window gone */ }
         }
         const current = readConfig().missions ?? [];
@@ -545,6 +547,34 @@ function ensureDefaultMissions(): void {
     writeConfig({
       missions: has ? missions : [...missions, { ...HEARTBEAT_MISSION, lastFiredAt: Date.now() }],
       heartbeatSeeded: true
+    });
+  }
+
+  // maint-1: the dedicated auto-compact maintenance mission. Auto-compact USED to
+  // ride solely on the ops standup's autoCompact flag, so replacing the standup
+  // silently disabled compaction for all long-running agents. This makes it a
+  // first-class, persistent schedule:
+  //   • FIRST seed (flag unset): add it ENABLED + MIGRATE — drop autoCompact from
+  //     every OTHER mission so this is the single source of truth (no double
+  //     /compact whether compaction rode the standup or a stopgapped custom mission).
+  //   • PERSISTENT (flag set): if the user later deletes it, it reappears DISABLED
+  //     next boot — never silently lost (only user-disabled, with a UI warning).
+  const cfg3 = readConfig();
+  const missions3 = cfg3.missions ?? [];
+  const hasCompact = missions3.some((m) => m.id === COMPACT_MAINTENANCE_MISSION.id);
+  if (!cfg3.compactMaintenanceSeeded) {
+    const migrated = missions3.map((m) =>
+      m.id === COMPACT_MAINTENANCE_MISSION.id ? m : { ...m, autoCompact: false }
+    );
+    writeConfig({
+      missions: hasCompact
+        ? migrated
+        : [...migrated, { ...COMPACT_MAINTENANCE_MISSION, lastFiredAt: Date.now() }],
+      compactMaintenanceSeeded: true
+    });
+  } else if (!hasCompact) {
+    writeConfig({
+      missions: [...missions3, { ...COMPACT_MAINTENANCE_MISSION, enabled: false, lastFiredAt: Date.now() }]
     });
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -460,7 +460,10 @@ function syncMissions(): void {
       try {
         // A 'compact' maintenance mission (maint-1) is compaction-ONLY: it carries
         // no dispatch body/target, so skip the hive.send and just fire auto-compact.
-        if (m.kind !== 'compact' && m.body && hive.enabled()) {
+        // Gate on `kind!=='compact'` ALONE — that already excludes the compact mission;
+        // we deliberately do NOT add `&& m.body`, so other (dispatch) missions keep
+        // their prior behaviour, including the historical empty-body send (Pam N1).
+        if (m.kind !== 'compact' && hive.enabled()) {
           hive.send({ to: m.to, act: 'request', subject: m.label, body: m.body }, 'scheduler');
         }
         // Auto-compact: do NOT jam /compact into busy terminals. Hand it to the

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -142,7 +142,7 @@ export interface ScheduledMission {
   autoCompact?: boolean;
   lastFiredAt?: number;
   /** Mission flavor; 'heartbeat' (Lane A #1) is a context-aware adaptive beat. */
-  kind?: 'dispatch' | 'heartbeat';
+  kind?: 'dispatch' | 'heartbeat' | 'compact';
   /** Heartbeat only: floor-quiet threshold in ms. */
   quietThresholdMs?: number;
 }

--- a/src/renderer/src/components/SchedulesTab.tsx
+++ b/src/renderer/src/components/SchedulesTab.tsx
@@ -17,7 +17,7 @@ interface ScheduledMission {
   enabled: boolean;
   autoCompact?: boolean;
   lastFiredAt?: number;
-  kind?: 'dispatch' | 'heartbeat';
+  kind?: 'dispatch' | 'heartbeat' | 'compact';
   quietThresholdMs?: number;
 }
 
@@ -74,6 +74,8 @@ export function SchedulesTab() {
   };
   const toggleMission = (id: string) =>
     persistMissions(missions.map((m) => (m.id === id ? { ...m, enabled: !m.enabled } : m)));
+  const updateInterval = (id: string, intervalMs: number) =>
+    persistMissions(missions.map((m) => (m.id === id ? { ...m, intervalMs } : m)));
   // The backend merge in missions:save keeps only the missions the renderer
   // sends back, so deletion is just "save the list without it".
   const deleteMission = (id: string) =>
@@ -104,27 +106,42 @@ export function SchedulesTab() {
       )}
       {missions.map((m) => {
         const hb = m.kind === 'heartbeat';
+        const isCompact = m.kind === 'compact' || m.id === 'compact-maintenance';
         const fired = m.lastFiredAt ? `fired ${relTime(Date.now() - m.lastFiredAt)}` : 'not yet fired';
         const next = m.enabled && m.lastFiredAt
           ? ` · next ${relTime(Date.now() - (m.lastFiredAt + m.intervalMs))}` : '';
         return (
-        <div key={m.id} style={{
+        <div key={m.id} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <div style={{
           display: 'flex', alignItems: 'center', gap: 6, padding: 6,
-          background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)'
+          background: 'var(--cth-paper-100)',
+          boxShadow: `inset 0 0 0 1px ${isCompact && !m.enabled ? 'var(--cth-coral)' : 'var(--cth-ink-300)'}`
         }}>
           <span style={{
             fontFamily: 'var(--cth-font-display)', fontSize: 9, padding: '2px 5px 1px',
-            background: hb ? 'var(--cth-lemon)' : 'var(--cth-cream-200)',
-            boxShadow: `inset 0 0 0 1px ${hb ? 'var(--cth-ink-900)' : 'var(--cth-ink-700)'}`,
+            background: hb || isCompact ? 'var(--cth-lemon)' : 'var(--cth-cream-200)',
+            boxShadow: `inset 0 0 0 1px ${hb || isCompact ? 'var(--cth-ink-900)' : 'var(--cth-ink-700)'}`,
             color: 'var(--cth-ink-900)', flexShrink: 0
-          }}>{hb ? '♥ beat' : intervalLabel(m.intervalMs)}</span>
+          }}>{isCompact ? '⚙ compact' : hb ? '♥ beat' : intervalLabel(m.intervalMs)}</span>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 13, color: 'var(--cth-ink-900)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{m.label}</div>
             <div style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>
-              → {targetName(m.to)}{hb ? ` · adaptive ~${intervalLabel(m.intervalMs)} · auto digest` : ''}
+              {isCompact
+                ? `every ${intervalLabel(m.intervalMs)} · keeps every agent's terminal context lean`
+                : <>→ {targetName(m.to)}{hb ? ` · adaptive ~${intervalLabel(m.intervalMs)} · auto digest` : ''}</>}
             </div>
             <div style={{ fontSize: 10, color: 'var(--cth-ink-500)' }}>{fired}{next}</div>
           </div>
+          {isCompact && (
+            <select
+              value={String(m.intervalMs)}
+              onChange={(e) => updateInterval(m.id, Number(e.target.value))}
+              title="How often to compact every agent"
+              style={selectStyle}
+            >
+              {INTERVAL_OPTS.map((o) => <option key={o.ms} value={String(o.ms)}>{o.label}</option>)}
+            </select>
+          )}
           <button
             onClick={() => toggleMission(m.id)}
             style={{
@@ -136,7 +153,7 @@ export function SchedulesTab() {
           >{m.enabled ? 'on' : 'off'}</button>
           <button
             onClick={() => deleteMission(m.id)}
-            title="Delete this scheduled mission"
+            title={isCompact ? 'Delete (it reappears disabled on next launch — auto-compact is required)' : 'Delete this scheduled mission'}
             style={{
               padding: '2px 6px 1px', border: 'none', cursor: 'pointer', flexShrink: 0,
               background: 'var(--cth-cream-200)',
@@ -144,6 +161,18 @@ export function SchedulesTab() {
               fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-coral)'
             }}
           >✕</button>
+        </div>
+        {isCompact && !m.enabled && (
+          <div style={{
+            fontSize: 11, lineHeight: '15px', color: 'var(--cth-ink-900)',
+            padding: '6px 8px', background: 'var(--cth-coral-light, #f7dcd6)',
+            boxShadow: 'inset 0 0 0 1px var(--cth-coral)'
+          }}>
+            ⚠ Auto-compact is OFF. Long-running agents need this — without it each
+            agent's terminal context grows until it overflows and the agent fails.
+            Turn it back on unless you're compacting another way.
+          </div>
+        )}
         </div>
         );
       })}

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -26,7 +26,7 @@ export interface ScheduledMission {
   enabled: boolean;
   autoCompact?: boolean;
   lastFiredAt?: number;
-  kind?: 'dispatch' | 'heartbeat';
+  kind?: 'dispatch' | 'heartbeat' | 'compact';
   quietThresholdMs?: number;
 }
 


### PR DESCRIPTION
## Auto-compact becomes a first-class, persistent, configurable schedule

**Operational bug + feature** (human-flagged, root-caused by god). Terminal `/compact` only ever fired as a *side-effect* of a mission carrying `autoCompact:true` — and that flag lived **solely on the built-in ops standup**. When the human replaced the standup with a custom mission, compaction **silently stopped** for every long-running agent (whose terminal context then grows until it overflows and the agent fails), with no UI to restore it.

This decouples auto-compact into its own dedicated schedule.

### What changed (4 parts)
1. **Dedicated mission** (`config.ts`) — `COMPACT_MAINTENANCE_MISSION` (`kind:'compact'`, `autoCompact`, ~1h, default **enabled**, empty to/body). `syncMissions` fires a `kind:'compact'` mission's auto-compact signal **only** (skips the dispatch hive.send). Compaction can never again be coupled to a standup.
2. **Persistent / effectively undeletable** (`ensureDefaultMissions`) — once seeded, deleting it makes it **reappear DISABLED** on next boot (never silently lost; only user-disabled). Unlike the standup/heartbeat one-time-seed-then-suppress guards.
3. **Warning UI** (`SchedulesTab`) — the maintenance schedule shows a "⚙ compact" badge, a **configurable interval** (1h/6h/24h/weekly), an enable/disable toggle, and a prominent **coral warning when disabled** (long-running agents need auto-compact or they overflow).
4. **Migration** — on first launch the mission is seeded **enabled** and `autoCompact` is **dropped from every other mission** (single source of truth → no double `/compact`), covering installs where compaction rode the standup *or* a stopgapped custom mission.

### Notes
- Separate branch off `main` (not `feat/realtime-michael` / PR #96).
- `'compact'` threaded through the `ScheduledMission.kind` union in all three hand-mirrored type copies (main/preload/renderer).
- typecheck node+web + build GREEN.
- The ops-standup body still *mentions* compaction in prose (now handled by the dedicated mission) — left as-is to keep the diff focused; can trim in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)