### PR TITLE
feat: per-agent environment variables (Claude Code profiles) (#105)

### DIFF
--- a/docs/superpowers/plans/2026-07-08-per-agent-env-vars.md
+++ b/docs/superpowers/plans/2026-07-08-per-agent-env-vars.md
@@ -1,0 +1,990 @@
+# Per-Agent Environment Variables (Issue #105) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users set env vars (e.g. `CLAUDE_CONFIG_DIR=~/.claude-personal`) per agent and globally, so separate Claude Code profiles work — including telemetry, resume, and permissions-acceptance following the override.
+
+**Architecture:** Env is plain `Record<string, string>` data riding the existing spawn path (renderer `spawnPty` → `spawnAgentCore` → `PtyManager.spawn`, whose `env` merge already exists). A dependency-free `src/shared/agentEnv.ts` owns validation/denylist/tilde-expansion/masking so main, renderer, and tests share one implementation. Merge order: `process.env` → `defaultAgentEnv` (Settings) → per-agent env → internal injections (hive/BYOK/broker always win).
+
+**Tech Stack:** Electron (main/preload/renderer), TypeScript, React, node-pty. Tests are framework-free `.cjs` scripts that transpile shared TS in-process (see `test/agent-provider.test.cjs`).
+
+**Spec:** `docs/superpowers/specs/2026-07-08-per-agent-env-vars-design.md`
+
+## Global Constraints
+
+- `npm run typecheck` (node + web) must stay green — it is the CI gate.
+- `src/shared/` files must stay dependency-free: no `electron`, no `node:*` imports, no UI imports.
+- New UI derives from design tokens (`var(--cth-…)` CSS vars, existing `PixelButton`/`Row`/`inputStyle` idioms). No ad-hoc colors/fonts.
+- Env denylist (exact): `PATH`, `NODE_OPTIONS`, `ELECTRON_RUN_AS_NODE`. Denylist prefixes: `DYLD_`, `LD_`, `AGENT_`, `HIVE_`, `CTH_`.
+- Env key regex: `/^[A-Za-z_][A-Za-z0-9_]*$/`.
+- A rejected key **fails the spawn** with a specific error — never a silent drop.
+- Hire manifests may NOT import env vars (warning surfaced when a manifest carries one).
+- Commit after every task with a conventional-commits message.
+
+---
+
+### Task 1: Shared env module `src/shared/agentEnv.ts` (TDD)
+
+**Files:**
+- Create: `src/shared/agentEnv.ts`
+- Create: `test/agent-env.test.cjs`
+
+**Interfaces (Produces — later tasks rely on these exact signatures):**
+```ts
+export const ENV_KEY_RE: RegExp;
+export type EnvValidation =
+  | { ok: true; env: Record<string, string> }
+  | { ok: false; error: string };
+export function envKeyIssue(key: string): string | null;
+export function expandTilde(value: string, home: string): string;
+export function validateAgentEnv(env: Record<string, string> | undefined, home: string): EnvValidation;
+export function mergeAgentEnv(defaults: Record<string, string>, perAgent: Record<string, string>): Record<string, string>;
+export function claudeConfigDirFrom(env: Record<string, string> | undefined, home: string): string | null;
+export function maskSensitiveEnv(env: Record<string, string>): Record<string, string>;
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/agent-env.test.cjs` (mirrors `test/agent-provider.test.cjs`'s transpile-and-require pattern):
+
+```js
+'use strict';
+/**
+ * Per-agent env (#105) tests. Self-contained, no test framework — run with
+ * `node test/agent-env.test.cjs` (mirrors test/agent-provider.test.cjs). The
+ * module under test is dependency-free TypeScript (src/shared/agentEnv.ts), so
+ * we transpile it with the bundled `typescript` compiler into a temp dir and
+ * require the result. Covers key validation, the denylist, merge precedence,
+ * tilde expansion, Claude config-dir resolution, and sensitive-value masking.
+ */
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const ts = require('typescript');
+
+const SHARED = path.join(__dirname, '..', 'src', 'shared');
+const out = fs.mkdtempSync(path.join(os.tmpdir(), 'agentenv-'));
+const src = fs.readFileSync(path.join(SHARED, 'agentEnv.ts'), 'utf8');
+const js = ts.transpileModule(src, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 }
+}).outputText;
+fs.writeFileSync(path.join(out, 'agentEnv.js'), js, 'utf8');
+const ae = require(path.join(out, 'agentEnv.js'));
+
+let failures = 0;
+function check(name, fn) {
+  try { fn(); console.log(`  ok  ${name}`); }
+  catch (e) { failures++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+const HOME = '/Users/tester';
+
+// ── key validation ───────────────────────────────────────────────────────────
+check('accepts a plain key', () => {
+  assert.strictEqual(ae.envKeyIssue('CLAUDE_CONFIG_DIR'), null);
+});
+check('rejects malformed keys', () => {
+  assert.ok(ae.envKeyIssue('9BAD'));
+  assert.ok(ae.envKeyIssue('has space'));
+  assert.ok(ae.envKeyIssue('has-dash'));
+  assert.ok(ae.envKeyIssue(''));
+});
+check('rejects exact denylisted keys', () => {
+  for (const k of ['PATH', 'NODE_OPTIONS', 'ELECTRON_RUN_AS_NODE']) {
+    assert.ok(ae.envKeyIssue(k), `${k} should be denied`);
+  }
+});
+check('rejects denylisted prefixes', () => {
+  for (const k of ['DYLD_INSERT_LIBRARIES', 'LD_PRELOAD', 'AGENT_ID', 'HIVE_ROOT', 'CTH_X']) {
+    assert.ok(ae.envKeyIssue(k), `${k} should be denied`);
+  }
+});
+check('denylist is case-insensitive on exact names', () => {
+  assert.ok(ae.envKeyIssue('Path'));
+  assert.ok(ae.envKeyIssue('node_options'));
+});
+
+// ── validateAgentEnv ─────────────────────────────────────────────────────────
+check('undefined/empty env validates to {}', () => {
+  assert.deepStrictEqual(ae.validateAgentEnv(undefined, HOME), { ok: true, env: {} });
+  assert.deepStrictEqual(ae.validateAgentEnv({}, HOME), { ok: true, env: {} });
+});
+check('valid env passes through with tilde expansion', () => {
+  const r = ae.validateAgentEnv({ CLAUDE_CONFIG_DIR: '~/.claude-personal', FOO: 'bar' }, HOME);
+  assert.strictEqual(r.ok, true);
+  assert.deepStrictEqual(r.env, { CLAUDE_CONFIG_DIR: `${HOME}/.claude-personal`, FOO: 'bar' });
+});
+check('a denylisted key fails validation with the key named', () => {
+  const r = ae.validateAgentEnv({ NODE_OPTIONS: '--require evil' }, HOME);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.error.includes('NODE_OPTIONS'));
+});
+check('a non-string value fails validation', () => {
+  const r = ae.validateAgentEnv({ FOO: 42 }, HOME);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.error.includes('FOO'));
+});
+
+// ── expandTilde ──────────────────────────────────────────────────────────────
+check('expands leading ~/ and bare ~', () => {
+  assert.strictEqual(ae.expandTilde('~/x/y', HOME), `${HOME}/x/y`);
+  assert.strictEqual(ae.expandTilde('~', HOME), HOME);
+});
+check('does not expand mid-string or ~user', () => {
+  assert.strictEqual(ae.expandTilde('a~b', HOME), 'a~b');
+  assert.strictEqual(ae.expandTilde('~other/x', HOME), '~other/x');
+});
+
+// ── mergeAgentEnv ────────────────────────────────────────────────────────────
+check('per-agent env overrides defaults', () => {
+  const merged = ae.mergeAgentEnv({ A: '1', B: '2' }, { B: '3', C: '4' });
+  assert.deepStrictEqual(merged, { A: '1', B: '3', C: '4' });
+});
+
+// ── claudeConfigDirFrom ──────────────────────────────────────────────────────
+check('returns expanded CLAUDE_CONFIG_DIR when set', () => {
+  assert.strictEqual(
+    ae.claudeConfigDirFrom({ CLAUDE_CONFIG_DIR: '~/.claude-personal' }, HOME),
+    `${HOME}/.claude-personal`
+  );
+});
+check('returns null when unset/empty/undefined env', () => {
+  assert.strictEqual(ae.claudeConfigDirFrom({}, HOME), null);
+  assert.strictEqual(ae.claudeConfigDirFrom({ CLAUDE_CONFIG_DIR: '' }, HOME), null);
+  assert.strictEqual(ae.claudeConfigDirFrom(undefined, HOME), null);
+});
+
+// ── maskSensitiveEnv ─────────────────────────────────────────────────────────
+check('masks values whose key looks secret, keeps the rest', () => {
+  const masked = ae.maskSensitiveEnv({
+    OPENAI_API_KEY: 'sk-abc', MY_TOKEN: 't', DB_SECRET: 's', PASSWORD: 'p',
+    CLAUDE_CONFIG_DIR: '/x'
+  });
+  assert.deepStrictEqual(masked, {
+    OPENAI_API_KEY: '•••', MY_TOKEN: '•••', DB_SECRET: '•••', PASSWORD: '•••',
+    CLAUDE_CONFIG_DIR: '/x'
+  });
+});
+
+process.exit(failures ? 1 : 0);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node test/agent-env.test.cjs`
+Expected: FAIL — `ENOENT ... src/shared/agentEnv.ts` (module doesn't exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/shared/agentEnv.ts`:
+
+```ts
+/**
+ * Per-agent environment variables (#105) — validation, merge, and display rules.
+ *
+ * Users can attach env vars to an agent (Add Agent modal) and set a global
+ * default (Settings). The headline use case is Claude Code profiles:
+ * CLAUDE_CONFIG_DIR=~/.claude-personal. Env is plain data end-to-end — there is
+ * NO shell in the spawn path, which is also why we expand a leading `~` here.
+ *
+ * Shared between main and renderer; keep it dependency-free (no electron, no
+ * node imports — `home` is always passed in) so tests can transpile it standalone.
+ */
+
+/** Valid env key: what a POSIX shell would accept as an identifier. */
+export const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Keys that can hijack the child process or break the harness's own plumbing.
+ *  Checked case-insensitively. PATH is owned by pty.ts (the resolved interactive
+ *  shell PATH); NODE_OPTIONS / ELECTRON_RUN_AS_NODE / DYLD_* / LD_* are
+ *  code-injection vectors; AGENT_* / HIVE_* / CTH_* are the hive's identity
+ *  namespace and must never be user-settable. */
+const DENY_EXACT = new Set(['PATH', 'NODE_OPTIONS', 'ELECTRON_RUN_AS_NODE']);
+const DENY_PREFIXES = ['DYLD_', 'LD_', 'AGENT_', 'HIVE_', 'CTH_'];
+
+/** Why this key is not allowed, or null if it's fine. */
+export function envKeyIssue(key: string): string | null {
+  if (!ENV_KEY_RE.test(key)) {
+    return `invalid env key "${key}" (letters, digits, underscore; can't start with a digit)`;
+  }
+  const upper = key.toUpperCase();
+  if (DENY_EXACT.has(upper)) return `env key "${key}" is reserved and can't be overridden`;
+  for (const p of DENY_PREFIXES) {
+    if (upper.startsWith(p)) return `env key "${key}" is reserved (${p}*) and can't be overridden`;
+  }
+  return null;
+}
+
+/** Expand a LEADING `~` (bare or `~/…`) to the home dir. No shell in the spawn
+ *  path means a literal `~` would reach the child unexpanded. `~user` forms are
+ *  left alone — resolving other users' homes is a shell feature we don't want. */
+export function expandTilde(value: string, home: string): string {
+  if (value === '~') return home;
+  if (value.startsWith('~/')) return home + value.slice(1);
+  return value;
+}
+
+export type EnvValidation =
+  | { ok: true; env: Record<string, string> }
+  | { ok: false; error: string };
+
+/** Validate user-supplied env and normalize values (tilde expansion). The main
+ *  process is the enforcing boundary — a bad key FAILS the spawn (never a silent
+ *  drop); the renderer reuses this for immediate inline feedback. */
+export function validateAgentEnv(
+  env: Record<string, string> | undefined,
+  home: string
+): EnvValidation {
+  if (!env) return { ok: true, env: {} };
+  const clean: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    const issue = envKeyIssue(key);
+    if (issue) return { ok: false, error: issue };
+    if (typeof value !== 'string') return { ok: false, error: `env value for "${key}" must be a string` };
+    clean[key] = expandTilde(value, home);
+  }
+  return { ok: true, env: clean };
+}
+
+/** Global default (Settings) → per-agent (Add Agent). Per-agent wins. Internal
+ *  injections (hive identity, BYOK, broker) are merged AFTER this by the spawn
+ *  path, so they always win over user env. */
+export function mergeAgentEnv(
+  defaults: Record<string, string>,
+  perAgent: Record<string, string>
+): Record<string, string> {
+  return { ...defaults, ...perAgent };
+}
+
+/** The effective Claude config dir an env implies: the tilde-expanded
+ *  CLAUDE_CONFIG_DIR, or null when unset (caller falls back to ~/.claude). */
+export function claudeConfigDirFrom(
+  env: Record<string, string> | undefined,
+  home: string
+): string | null {
+  const raw = env?.CLAUDE_CONFIG_DIR;
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  return expandTilde(raw.trim(), home);
+}
+
+/** Keys whose values must never appear on derived surfaces (fleet.json, roster
+ *  IPC, tools/agent-env.cjs). registry.json keeps values verbatim (same trust
+ *  level as config.json); everything derived from it masks. */
+const SENSITIVE_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/i;
+
+export function maskSensitiveEnv(env: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) out[k] = SENSITIVE_KEY_RE.test(k) ? '•••' : v;
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node test/agent-env.test.cjs`
+Expected: every line `ok`, exit code 0.
+
+- [ ] **Step 5: Typecheck and commit**
+
+Run: `npm run typecheck` — expected green.
+
+```bash
+git add src/shared/agentEnv.ts test/agent-env.test.cjs
+git commit -m "feat(env): shared per-agent env validation module (#105)"
+```
+
+---
+
+### Task 2: Main-process boundary — config field, preload type, spawn validate+merge
+
+**Files:**
+- Modify: `src/main/config.ts` (HarnessConfig, ~line 133)
+- Modify: `src/preload/index.ts` (SpawnPtyOptions, ~line 164)
+- Modify: `src/main/hive.ts` (AgentMeta, ~line 125)
+- Modify: `src/main/index.ts` (`spawnAgentCore`, ~line 1802)
+
+**Interfaces:**
+- Consumes: `validateAgentEnv`, `mergeAgentEnv` from `@shared/agentEnv` (Task 1). Note: main-process files import shared code via relative path (`../shared/agentEnv`) — match the file's existing import style for `agentProvider`.
+- Produces: `HarnessConfig.defaultAgentEnv?: Record<string, string>`; `SpawnPtyOptions.env?: Record<string, string>`; `AgentMeta.env?: Record<string, string>`; spawn fails with `{ ok: false, error }` on invalid env.
+
+- [ ] **Step 1: Add `defaultAgentEnv` to HarnessConfig**
+
+In `src/main/config.ts`, inside `interface HarnessConfig` (after `defaultModel?`, ~line 154), add:
+
+```ts
+  /** Env vars merged into EVERY agent spawn (incl. Michael/GOD), set in
+   *  Settings → General. Per-agent env (Add Agent) overrides these; internal
+   *  injections (hive identity, BYOK, broker) override both. Headline use case:
+   *  CLAUDE_CONFIG_DIR for separate Claude Code work/personal profiles (#105). */
+  defaultAgentEnv?: Record<string, string>;
+```
+
+- [ ] **Step 2: Expose `env` on the preload spawn type**
+
+In `src/preload/index.ts`, inside `interface SpawnPtyOptions` (after `args?`, ~line 170), add:
+
+```ts
+  /** Per-agent env vars (#105), validated + merged in the main process over the
+   *  global defaultAgentEnv. Human-entered only — hire manifests can't carry env. */
+  env?: Record<string, string>;
+```
+
+- [ ] **Step 3: Add `env` to AgentMeta**
+
+In `src/main/hive.ts`, inside `interface AgentMeta` (after `cwd`, ~line 132), add:
+
+```ts
+  /** Per-agent env vars the agent was spawned with (#105) — persisted on the
+   *  registry entry (values verbatim; derived surfaces mask sensitive ones) so
+   *  respawn paths and the roster agree on the agent's environment. */
+  env?: Record<string, string>;
+```
+
+`ensureAgent` spreads `...meta` into the registry entry (hive.ts ~line 452), so no other hive change is needed — the field persists automatically.
+
+- [ ] **Step 4: Validate + merge in `spawnAgentCore`**
+
+In `src/main/index.ts`, at the top of `spawnAgentCore` immediately after `if (opts.hive) opts.hive = { ...opts.hive, provider };` (~line 1810), insert:
+
+```ts
+  // ── Per-agent env vars (#105) — validate + merge BEFORE internal injections ──
+  // Order: defaultAgentEnv (Settings) → opts.env (per-agent). Every internal
+  // injection below spreads AFTER opts.env, so user env can never clobber
+  // AGENT_ID / HIVE_ROOT / broker tokens / BYOK keys — and the denylist rejects
+  // the dangerous rest (PATH, NODE_OPTIONS, DYLD_*, …) outright, FAILING the
+  // spawn with a named key instead of silently dropping it.
+  const envHome = homedir();
+  const defEnv = validateAgentEnv(readConfig().defaultAgentEnv, envHome);
+  if (!defEnv.ok) return { ok: false, error: `default agent env: ${defEnv.error}` };
+  const perEnv = validateAgentEnv(opts.env, envHome);
+  if (!perEnv.ok) return { ok: false, error: perEnv.error };
+  // Registry records the PER-AGENT env only (defaults are re-read from config on
+  // every spawn, so a Settings change applies to the next respawn automatically).
+  if (opts.hive && Object.keys(perEnv.env).length > 0) opts.hive = { ...opts.hive, env: perEnv.env };
+  opts.env = mergeAgentEnv(defEnv.env, perEnv.env);
+```
+
+Imports: add `validateAgentEnv, mergeAgentEnv` to the shared-env import (create `import { validateAgentEnv, mergeAgentEnv, claudeConfigDirFrom } from '../shared/agentEnv';` — `claudeConfigDirFrom` is used in Task 3). Ensure `homedir` is imported from `node:os` (check the file's existing imports; add `import { homedir } from 'node:os';` if absent).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: green (both projects).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/config.ts src/preload/index.ts src/main/hive.ts src/main/index.ts
+git commit -m "feat(env): validate + merge per-agent and default env at the spawn boundary (#105)"
+```
+
+---
+
+### Task 3: `CLAUDE_CONFIG_DIR` follow-through — transcripts, resume seeding, permissions
+
+**Files:**
+- Modify: `src/main/transcript.ts`
+- Modify: `src/main/config.ts` (`ensureClaudePermissionsAccepted`, ~line 490)
+- Modify: `src/main/index.ts` (spawn path ~lines 1970/2008; startup wiring)
+
+**Interfaces:**
+- Consumes: `claudeConfigDirFrom` from `../shared/agentEnv` (Task 1); `AgentMeta.env` (Task 2).
+- Produces:
+  - `transcript.ts`: `setExtraClaudeConfigDirs(provider: () => string[]): void`; `projectDir(cwd: string, configDir?: string): string`; `seedSessionTranscript(cwd: string, sessionId: string, configDir?: string): boolean`; `resolveSessionCwd` and `readAgentUsage` keep their signatures but scan all registered roots.
+  - `config.ts`: `ensureClaudePermissionsAccepted(cwd?: string, configDir?: string): void`.
+
+- [ ] **Step 1: Multi-root support in `transcript.ts`**
+
+Replace the top of `src/main/transcript.ts` (the `projectDir` function, lines 6–17) with:
+
+```ts
+/** Extra Claude config dirs (from per-agent / default CLAUDE_CONFIG_DIR env,
+ *  #105) beyond the default ~/.claude. Registered lazily by index.ts so this
+ *  module stays free of config/hive imports. */
+let extraConfigDirs: () => string[] = () => [];
+export function setExtraClaudeConfigDirs(provider: () => string[]): void {
+  extraConfigDirs = provider;
+}
+
+function defaultConfigDir(): string {
+  return path.join(os.homedir(), '.claude');
+}
+
+/** Every `projects/` root transcripts may live under: the default ~/.claude
+ *  plus any CLAUDE_CONFIG_DIR overrides. Deduped; order = default first. */
+function projectsRoots(): string[] {
+  const dirs = [defaultConfigDir()];
+  try { dirs.push(...extraConfigDirs()); } catch { /* provider never blocks a read */ }
+  return [...new Set(dirs)].map((d) => path.join(d, 'projects'));
+}
+
+/** The project-dir KEY Claude Code derives from a cwd (absolute path with the
+ *  leading slash dropped and every remaining slash dashed; on Windows every
+ *  non-alphanumeric char is dashed — drive colon and backslashes included). */
+function projectKey(cwd: string): string {
+  return process.platform === 'win32'
+    ? cwd.replace(/[^a-zA-Z0-9]/g, '-')
+    : cwd.replace(/^\//, '').replaceAll('/', '-');
+}
+
+/** Resolve the Claude Code transcript directory for a working directory, under
+ *  the given config dir (an agent's CLAUDE_CONFIG_DIR override) or ~/.claude. */
+export function projectDir(cwd: string, configDir?: string): string {
+  return path.join(configDir ?? defaultConfigDir(), 'projects', projectKey(cwd));
+}
+```
+
+- [ ] **Step 2: Root-aware `seedSessionTranscript`**
+
+Update its signature to `(cwd: string, sessionId: string, configDir?: string)`, and:
+- target: `const target = path.join(projectDir(cwd, configDir), `${sessionId}.jsonl`);` (unchanged apart from `configDir`)
+- search: replace the single `projectsRoot` block (lines 41–50) with a loop over every root:
+
+```ts
+    // Search EVERY known projects root (default + CLAUDE_CONFIG_DIR overrides,
+    // #105) — the session may have run under a different profile than the one
+    // this spawn uses.
+    const roots = projectsRoots();
+    const targetRoot = path.dirname(path.dirname(target));
+    if (!roots.includes(targetRoot)) roots.push(targetRoot);
+    for (const projectsRoot of roots) {
+      if (!existsSync(projectsRoot)) continue;
+      for (const dir of readdirSync(projectsRoot)) {
+        const candidate = path.join(projectsRoot, dir, `${sessionId}.jsonl`);
+        if (existsSync(candidate)) {
+          mkdirSync(path.dirname(target), { recursive: true });
+          cpSync(candidate, target);
+          return true;
+        }
+      }
+    }
+    return false;
+```
+
+- [ ] **Step 3: Root-aware `resolveSessionCwd` and `readAgentUsage`**
+
+In `resolveSessionCwd`, replace the single-root scan (lines 67–76) with the same outer loop:
+
+```ts
+    let best: { file: string; mtime: number } | null = null;
+    for (const projectsRoot of projectsRoots()) {
+      if (!existsSync(projectsRoot)) continue;
+      for (const dir of readdirSync(projectsRoot)) {
+        const candidate = path.join(projectsRoot, dir, `${sessionId}.jsonl`);
+        try {
+          const st = statSync(candidate);
+          if (!best || st.mtimeMs > best.mtime) best = { file: candidate, mtime: st.mtimeMs };
+        } catch { /* not present in this project dir */ }
+      }
+    }
+```
+
+In `readAgentUsage`, replace `const dir = projectDir(cwd); if (!existsSync(dir)) return usage; const files = readdirSync(dir)…` with a loop that accumulates across every root's project dir for this cwd (the per-file try/catch body is unchanged — wrap it):
+
+```ts
+    const key = projectKey(cwd);
+    let lastModel: string | undefined;
+    for (const root of projectsRoots()) {
+      const dir = path.join(root, key);
+      if (!existsSync(dir)) continue;
+      const files = readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
+      for (const file of files) {
+        // …existing per-file parsing/accumulation body, reading from
+        // path.join(dir, file), unchanged…
+      }
+    }
+    if (lastModel) usage.model = lastModel;
+    return usage;
+```
+
+(Move the existing `let lastModel` declaration out of the removed block so it wraps both loops.)
+
+- [ ] **Step 4: Config-dir-aware `ensureClaudePermissionsAccepted`**
+
+In `src/main/config.ts`, change the signature (~line 490) and the two hardcoded paths:
+
+```ts
+export function ensureClaudePermissionsAccepted(cwd?: string, configDir?: string): void {
+  const home = homedir();
+  if (!home) return;
+  // With CLAUDE_CONFIG_DIR set, Claude Code reads settings.json from INSIDE that
+  // dir and .claude.json from <dir>/.claude.json (instead of ~/.claude.json). (#105)
+  const dir = configDir ?? join(home, '.claude');
+  const claudeJsonPath = configDir ? join(configDir, '.claude.json') : join(home, '.claude.json');
+```
+
+Then in part 1 use `const p = join(dir, 'settings.json');` (delete the old `const dir = join(home, '.claude');`) and in part 2 use `const p = claudeJsonPath;` (delete the old `const p = join(home, '.claude.json');`). Everything else is unchanged.
+
+- [ ] **Step 5: Wire the spawn path and startup provider in `index.ts`**
+
+Compute the agent's effective config dir once, after the env merge from Task 2 Step 4:
+
+```ts
+  // The Claude config dir this agent will actually use (#105) — drives resume
+  // seeding + permissions-acceptance below. Null = default ~/.claude.
+  const agentClaudeConfigDir = claudeConfigDirFrom(opts.env, envHome);
+```
+
+Then:
+- ~line 1970: `if (seedSessionTranscript(opts.cwd, sid, agentClaudeConfigDir ?? undefined)) {`
+- ~line 2008: `try { ensureClaudePermissionsAccepted(opts.cwd, agentClaudeConfigDir ?? undefined); } catch { /* never block spawn */ }`
+
+At module scope (right after the `hive` instance is constructed — the provider is lazy, so top-level registration is safe), register the extra-roots provider:
+
+```ts
+// #105 — teach the transcript reader about every CLAUDE_CONFIG_DIR override in
+// play (global default + per-agent), so telemetry/resume see profile sessions.
+setExtraClaudeConfigDirs(() => {
+  const home = homedir();
+  const dirs: string[] = [];
+  const d = claudeConfigDirFrom(readConfig().defaultAgentEnv, home);
+  if (d) dirs.push(d);
+  try {
+    for (const a of Object.values(hive.registry().agents)) {
+      const ad = claudeConfigDirFrom(a.env, home);
+      if (ad) dirs.push(ad);
+    }
+  } catch { /* hive not ready yet — default root still works */ }
+  return dirs;
+});
+```
+
+Add `setExtraClaudeConfigDirs` to the existing `./transcript` import (line 25).
+
+- [ ] **Step 6: Typecheck and re-run tests**
+
+Run: `npm run typecheck && node test/agent-env.test.cjs`
+Expected: both green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/transcript.ts src/main/config.ts src/main/index.ts
+git commit -m "feat(env): telemetry, resume seeding and permissions follow CLAUDE_CONFIG_DIR (#105)"
+```
+
+---
+
+### Task 4: Mask env on derived surfaces (fleet.json + agent-env.cjs)
+
+**Files:**
+- Modify: `src/main/index.ts` (`writeFleetSnapshot`, ~line 775)
+- Modify: `tools/agent-env.cjs`
+
+**Interfaces:**
+- Consumes: `maskSensitiveEnv` from `../shared/agentEnv` (Task 1); `RegistryAgent.env` (Task 2).
+- Produces: fleet.json agent entries gain optional `env` (masked); `agent-env.cjs` records gain optional `env` (masked).
+
+- [ ] **Step 1: Fleet snapshot**
+
+In `writeFleetSnapshot`'s `.map(([id, a]) => { … return { … } })` (index.ts ~line 788), add after `cwd: a.cwd,`:
+
+```ts
+          // Per-agent env (#105) — masked (never raw key material) so Michael can
+          // see WHICH profile a worker runs without fleet.json leaking secrets.
+          env: a.env ? maskSensitiveEnv(a.env) : undefined,
+```
+
+Add `maskSensitiveEnv` to the shared-env import from Task 2.
+
+- [ ] **Step 2: agent-env.cjs**
+
+`tools/agent-env.cjs` is dependency-free CommonJS (it can't import the TS module), so add a local mask near `cwdState` (~line 52):
+
+```js
+/** Mask env values whose key looks like key material — this tool's output is
+ *  documented as non-sensitive (#105). Mirrors src/shared/agentEnv.ts. */
+const SENSITIVE_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/i;
+function maskEnv(env) {
+  if (!env || typeof env !== 'object') return undefined;
+  const out = {};
+  for (const [k, v] of Object.entries(env)) out[k] = SENSITIVE_KEY_RE.test(k) ? '•••' : v;
+  return Object.keys(out).length ? out : undefined;
+}
+```
+
+Find where the per-agent record object is assembled (it maps registry entries to `{ id, name, provider, role, status, cwd, cwdValid, sessionId, … }`) and add `env: maskEnv(a.env),` alongside the other registry-sourced fields. Update the tool's header comment ("no env, no key material") to say env is included masked.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run typecheck && node test/kg-core.test.cjs && node test/agent-provider.test.cjs`
+Expected: green (guards against accidental breakage in files the tests transpile).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/index.ts tools/agent-env.cjs
+git commit -m "feat(env): surface masked per-agent env in fleet.json and agent-env tool (#105)"
+```
+
+---
+
+### Task 5: Renderer — env row editor, Add Agent integration, respawn threading
+
+**Files:**
+- Create: `src/renderer/src/components/EnvVarsEditor.tsx`
+- Modify: `src/renderer/src/store/store.ts` (Agent interface, ~line 29)
+- Modify: `src/renderer/src/components/AddAgentModal.tsx`
+- Modify: `src/renderer/src/components/AgentStrip.tsx` (~line 78)
+- Modify: `src/renderer/src/hooks/useHive.ts` (~line 816)
+- Modify: `src/renderer/src/components/CommandCenterPanel.tsx` (~line 280)
+
+**Interfaces:**
+- Consumes: `envKeyIssue` from `@shared/agentEnv` (Task 1 — renderer imports shared code via the `@shared/` alias, same as `agentProvider`); `SpawnPtyOptions.env` (Task 2).
+- Produces: `Agent.env?: Record<string, string>`; `<EnvVarsEditor rows={EnvRow[]} onChange={(rows: EnvRow[]) => void} />` with `type EnvRow = { key: string; value: string }`; helper `rowsToEnv(rows: EnvRow[]): Record<string, string> | undefined`.
+
+- [ ] **Step 1: Add `env` to the renderer Agent type**
+
+In `src/renderer/src/store/store.ts`, inside `interface Agent` (after `worktreePath?`, ~line 76), add:
+
+```ts
+  /** Per-agent env vars the agent is spawned with (#105) — e.g. CLAUDE_CONFIG_DIR
+   *  for a separate Claude profile. Persisted (spawn recipe, like `command`) so
+   *  restore-team / revive / restart respawn with the same environment. */
+  env?: Record<string, string>;
+```
+
+It is NOT in the `PersistedAgent` omit list, so localStorage persistence is automatic.
+
+- [ ] **Step 2: Create `EnvVarsEditor.tsx`**
+
+```tsx
+import React from 'react';
+import { envKeyIssue } from '@shared/agentEnv';
+import { PixelButton } from './PixelButton';
+
+export type EnvRow = { key: string; value: string };
+
+/** Rows → the env record a spawn wants; empty/blank-key rows are dropped.
+ *  Returns undefined when nothing usable is set. */
+export function rowsToEnv(rows: EnvRow[]): Record<string, string> | undefined {
+  const env: Record<string, string> = {};
+  for (const r of rows) if (r.key.trim()) env[r.key.trim()] = r.value;
+  return Object.keys(env).length ? env : undefined;
+}
+
+/** First problem across the rows (mirrors the main-process rules for instant
+ *  feedback — main remains the enforcing boundary), or null when clean. */
+export function envRowsIssue(rows: EnvRow[]): string | null {
+  const seen = new Set<string>();
+  for (const r of rows) {
+    const key = r.key.trim();
+    if (!key) continue;
+    const issue = envKeyIssue(key);
+    if (issue) return issue;
+    if (seen.has(key)) return `duplicate env key "${key}"`;
+    seen.add(key);
+  }
+  return null;
+}
+
+const cellStyle: React.CSSProperties = {
+  padding: '5px 7px 3px',
+  background: 'var(--cth-paper-100)',
+  border: 'none',
+  boxShadow: 'inset 0 0 0 1px var(--cth-ink-700)',
+  fontFamily: 'var(--cth-font-mono)',
+  fontSize: 13,
+  color: 'var(--cth-ink-900)',
+  outline: 'none',
+  minWidth: 0
+};
+
+/** KEY=VALUE row editor for per-agent env vars (#105). Dumb component: owns no
+ *  state — parent holds the rows (Add Agent form state / Settings config). */
+export function EnvVarsEditor({ rows, onChange }: {
+  rows: EnvRow[];
+  onChange: (rows: EnvRow[]) => void;
+}) {
+  const issue = envRowsIssue(rows);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {rows.map((r, i) => (
+        <div key={i} style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <input
+            value={r.key}
+            onChange={(e) => onChange(rows.map((x, j) => (j === i ? { ...x, key: e.target.value } : x)))}
+            placeholder="CLAUDE_CONFIG_DIR"
+            spellCheck={false}
+            style={{ ...cellStyle, width: 200, flexShrink: 0 }}
+          />
+          <span style={{ color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-mono)', fontSize: 13 }}>=</span>
+          <input
+            value={r.value}
+            onChange={(e) => onChange(rows.map((x, j) => (j === i ? { ...x, value: e.target.value } : x)))}
+            placeholder="~/.claude-personal"
+            spellCheck={false}
+            style={{ ...cellStyle, flex: 1 }}
+          />
+          <PixelButton size="sm" variant="ghost" title="remove"
+            onClick={() => onChange(rows.filter((_, j) => j !== i))}>✕</PixelButton>
+        </div>
+      ))}
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <PixelButton size="sm" onClick={() => onChange([...rows, { key: '', value: '' }])}>
+          + env var
+        </PixelButton>
+        {issue && (
+          <span style={{ fontSize: 12, color: 'var(--cth-paprika-700, #b3502e)' }}>{issue}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+(If `PixelButton` has no `ghost` variant, use `secondary` — check `Variant` in `PixelButton.tsx` and use an existing one.)
+
+- [ ] **Step 3: Add Agent modal — state, UI, spawn, agent object**
+
+In `AddAgentModal.tsx`:
+
+a. State (next to the other `useState` fields, ~line 175):
+
+```tsx
+  // Per-agent env vars (#105) — e.g. CLAUDE_CONFIG_DIR for a personal profile.
+  const [envRows, setEnvRows] = useState<EnvRow[]>([]);
+```
+
+Import: `import { EnvVarsEditor, envRowsIssue, rowsToEnv, type EnvRow } from './EnvVarsEditor';`
+
+b. Submit guard (with the other validations in `submit()`, ~line 298):
+
+```tsx
+    const envIssue = envRowsIssue(envRows);
+    if (envIssue) { setError(envIssue); setSection('workspace'); return; }
+```
+
+c. Spawn call (~line 307) — add to the `spawnPty` options object:
+
+```tsx
+      // Per-agent env vars (#105); validated + merged over defaultAgentEnv in main.
+      env: rowsToEnv(envRows),
+```
+
+d. Agent object (~line 343) — add alongside `worktreePath`:
+
+```tsx
+      env: rowsToEnv(envRows),
+```
+
+e. UI — in the `section === 'workspace'` block, after the existing folder/isolation/resume rows, add:
+
+```tsx
+                    <Row label="Env vars">
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        <EnvVarsEditor rows={envRows} onChange={setEnvRows} />
+                        <span style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>
+                          set on this agent's process — e.g. CLAUDE_CONFIG_DIR=~/.claude-personal
+                          for a separate Claude account. ~ expands to your home folder.
+                        </span>
+                      </div>
+                    </Row>
+```
+
+Update the workspace section hint (~line 118) to `hint: 'folder · isolation · resume · env'`.
+
+- [ ] **Step 4: Thread `env` through the three respawn call sites**
+
+Each respawns an existing `Agent a` — pass its recorded env:
+
+- `AgentStrip.tsx` `restoreTeam` spawn (~line 78): add `env: a.env,` to the `spawnPty` options.
+- `useHive.ts` auto-revive spawn (~line 816): add `env: a.env,` to the `spawnPty` options.
+- `CommandCenterPanel.tsx` restart/change-engine spawn (~line 280): add `env: a.env,` to the options object literal.
+
+(The god spawn in `useHive.ts` ~line 234 needs NO change — Michael inherits `defaultAgentEnv` inside `spawnAgentCore`.)
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: green.
+
+- [ ] **Step 6: Visual check**
+
+Run: `npm run dev`. Open Add Agent → Workspace: add an env row, confirm inline error on a bad key (`9BAD`, `PATH`), confirm the pixel aesthetic matches neighboring fields. Screenshot for the PR.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/src/components/EnvVarsEditor.tsx src/renderer/src/store/store.ts \
+  src/renderer/src/components/AddAgentModal.tsx src/renderer/src/components/AgentStrip.tsx \
+  src/renderer/src/hooks/useHive.ts src/renderer/src/components/CommandCenterPanel.tsx
+git commit -m "feat(env): per-agent env vars in Add Agent + respawn paths (#105)"
+```
+
+---
+
+### Task 6: Settings → General — global "Agent environment" editor
+
+**Files:**
+- Modify: `src/renderer/src/components/SettingsModal.tsx` (General section, ~line 654)
+
+**Interfaces:**
+- Consumes: `EnvVarsEditor`, `EnvRow`, `rowsToEnv`, `envRowsIssue` (Task 5); `HarnessConfig.defaultAgentEnv` (Task 2); the modal's existing config read/update plumbing (`window.cth.updateConfig`).
+
+- [ ] **Step 1: Add state + persistence**
+
+Seed rows from config when the modal opens (next to the other config-derived state):
+
+```tsx
+  const [defaultEnvRows, setDefaultEnvRows] = useState<EnvRow[]>(
+    Object.entries(config.defaultAgentEnv ?? {}).map(([key, value]) => ({ key, value }))
+  );
+```
+
+Persist on change (matching how the modal's other General fields save — if fields save on blur/apply, follow that pattern; if they save immediately via `updateConfig`, do):
+
+```tsx
+  const saveDefaultEnv = (rows: EnvRow[]) => {
+    setDefaultEnvRows(rows);
+    if (envRowsIssue(rows)) return; // don't persist a bad key; editor shows why
+    void window.cth.updateConfig({ defaultAgentEnv: rowsToEnv(rows) ?? {} });
+  };
+```
+
+Import `EnvVarsEditor, envRowsIssue, rowsToEnv, type EnvRow` from `./EnvVarsEditor`.
+
+- [ ] **Step 2: Render in the General section**
+
+Inside the `activeSection === 'General'` block, after the default command/model fields, add a framed group consistent with its neighbors:
+
+```tsx
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        <span style={{ fontFamily: 'var(--cth-font-display)', fontSize: 10, textTransform: 'uppercase', color: 'var(--cth-ink-700)' }}>
+                          Agent environment
+                        </span>
+                        <EnvVarsEditor rows={defaultEnvRows} onChange={saveDefaultEnv} />
+                        <span style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>
+                          env vars for every agent — including Michael. Applies to newly
+                          spawned agents; live terminals keep the env they started with.
+                          Per-agent env vars (Add Agent) override these.
+                        </span>
+                      </div>
+```
+
+(Match the exact heading/label markup style used by the adjacent General-section groups — copy a sibling's wrapper markup rather than inventing a new one.)
+
+- [ ] **Step 3: Typecheck + visual check**
+
+Run: `npm run typecheck` — green. Then `npm run dev` → Settings → General: add `CLAUDE_CONFIG_DIR=~/.claude-personal`, close and reopen Settings, confirm it persisted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/src/components/SettingsModal.tsx
+git commit -m "feat(env): global default agent env in Settings → General (#105)"
+```
+
+---
+
+### Task 7: Hire manifests — env is not importable (warning)
+
+**Files:**
+- Modify: `src/shared/hire.ts` (`HireValidation` ~line 83, `validateHireManifest` ~line 169)
+- Modify: `src/main/hire.ts` (the `finish()` result plumbing, ~lines 208/247)
+- Modify: `src/preload/index.ts` (`importHireFile` return type, ~line 756)
+- Modify: `src/renderer/src/components/AddAgentModal.tsx` (import banner, ~line 432)
+
+**Interfaces:**
+- Produces: `HireValidation.warnings?: string[]`; `importHireFile(): Promise<{ ok: boolean; manifest?: HireManifest; warnings?: string[]; error?: string }>`.
+
+- [ ] **Step 1: Note on testing**
+
+Hire validation has no existing test file, and a dedicated hire-manifest suite is out of scope for this feature. This task's behavior is covered by typecheck plus the manual import check in Step 5.
+
+- [ ] **Step 2: `src/shared/hire.ts`**
+
+In `HireValidation` add:
+
+```ts
+  /** Non-fatal notices to surface in the import banner (e.g. a manifest carried
+   *  an `env` field — env vars are human-entered only, never imported, #105). */
+  warnings?: string[];
+```
+
+In `validateHireManifest`, next to the other field extractions, add:
+
+```ts
+  const warnings: string[] = [];
+  // #105 — env vars are code-execution-adjacent (NODE_OPTIONS, DYLD_*), so a
+  // manifest (untrusted input) can never carry them. Not an error — the rest of
+  // the hire imports fine — but the human is told the field was ignored.
+  if (o.env !== undefined) {
+    warnings.push('this hire declared env vars — env is not importable; set it by hand in Workspace → Env vars');
+  }
+```
+
+and include `...(warnings.length ? { warnings } : {})` in the returned validation object (both the success and the field-errors return, so the notice survives either way).
+
+- [ ] **Step 3: Plumb warnings through main + preload**
+
+In `src/main/hire.ts`, `finish()` builds the `{ ok, manifest, error }` result from a `HireValidation` — pass `warnings` through: add `warnings: v.warnings` to the returned object (check the actual shape of `finish` at ~line 200 and mirror its style). In `src/preload/index.ts` line 756, add `warnings?: string[];` to the `importHireFile` return type.
+
+- [ ] **Step 4: Show it in the Add Agent banner**
+
+In `AddAgentModal.tsx`: store warnings when importing (`importHire`, ~line 287):
+
+```tsx
+  const [hireWarnings, setHireWarnings] = useState<string[]>([]);
+  // in importHire():
+    if (res.ok && res.manifest) { applyManifest(res.manifest); setHireWarnings(res.warnings ?? []); }
+```
+
+Also check how deep-link imports set `pendingHire` — if warnings can't reach that path without store changes, banner warnings apply to file-imports only for v1 (deep-link manifests with env still have the field ignored; only the notice is missing). In the banner (next to the `commandFlags` warning block, ~line 432), add:
+
+```tsx
+                {hireWarnings.map((w) => (
+                  <span key={w} style={{ fontSize: 12, marginTop: 2 }}>⚠️ {w}</span>
+                ))}
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `npm run typecheck` — green. Manual: write a hire-manifest JSON containing an `env` field to a scratch file, import it via Add Agent → import hire, confirm the banner shows the ignored-env notice and the form has no env rows pre-filled.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/hire.ts src/main/hire.ts src/preload/index.ts src/renderer/src/components/AddAgentModal.tsx
+git commit -m "feat(env): hire manifests cannot import env vars; surface a notice (#105)"
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: All tests + typecheck + build**
+
+```bash
+npm run typecheck
+node test/agent-env.test.cjs
+node test/agent-provider.test.cjs
+node test/kg-core.test.cjs
+node test/slack.test.cjs
+node test/realtime-findcard.test.cjs
+node test/voice-messages.test.cjs
+npm run build
+```
+
+Expected: all green.
+
+- [ ] **Step 2: End-to-end profile check (the issue's exact scenario)**
+
+1. `npm run dev`.
+2. Add an agent with env row `CLAUDE_CONFIG_DIR` = `~/.claude-personal`.
+3. In its terminal run `/status` (or check the account line) — confirm it's the personal account.
+4. Confirm the Activity tab shows nonzero tokens for that agent after a turn (multi-root telemetry).
+5. Restart the app → Restore team → confirm the agent comes back on the personal profile (env persisted).
+6. Set the same var in Settings → General instead, spawn a fresh worker with no per-agent env, confirm it also uses the personal profile (global default reaches every spawn).
+
+- [ ] **Step 3: Denylist check**
+
+Add an agent with env row `NODE_OPTIONS=--require x` → spawn must FAIL with an error naming `NODE_OPTIONS` in the modal.
+
+- [ ] **Step 4: Wrap up**
+
+Report results. Then use superpowers:finishing-a-development-branch to decide merge/PR.

--- a/docs/superpowers/specs/2026-07-08-per-agent-env-vars-design.md
+++ b/docs/superpowers/specs/2026-07-08-per-agent-env-vars-design.md
@@ -121,7 +121,7 @@ Applies to both `defaultAgentEnv` and `opts.env` in `spawnAgentCore`:
 
 ## Testing
 
-- `test/agent-env-spawn.test.cjs` in the existing framework-free style
+- `test/agent-env.test.cjs` in the existing framework-free style
   (transpile `src/shared/agentEnv.ts` in-process): validation, denylist, merge
   precedence, tilde expansion, config-dir resolution.
 - `npm run typecheck` stays green (the CI gate).

--- a/docs/superpowers/specs/2026-07-08-per-agent-env-vars-design.md
+++ b/docs/superpowers/specs/2026-07-08-per-agent-env-vars-design.md
@@ -1,0 +1,130 @@
+# Per-agent environment variables (Claude Code profiles) — design
+
+**Issue:** [#105 — Support Claude Code Profiles](https://github.com/chaitanyagiri/munder-difflin/issues/105)
+**Date:** 2026-07-08
+**Status:** approved
+
+## Problem
+
+Users who run separate Claude Code accounts (e.g. work vs personal via
+`CLAUDE_CONFIG_DIR=~/.claude-personal claude`) cannot make MD spawn an agent
+with that profile:
+
+- Shell aliases (`claude-personal`) aren't visible — `resolveCommand` runs
+  `which <cmd>`, which for a zsh alias prints the alias definition, not a path,
+  so resolution falls through to ENOENT.
+- Env-prefix syntax in the command field (`CLAUDE_CONFIG_DIR=… claude`) fails —
+  the command is tokenized into `[exe, ...args]` and exec'd directly by
+  node-pty with no shell, so it tries to exec a binary literally named
+  `CLAUDE_CONFIG_DIR=…`.
+
+## Decision summary
+
+| Question | Decision |
+| --- | --- |
+| Feature shape | Per-agent env vars (KEY=VALUE), not shell/alias support, not named profiles |
+| Coverage | Per-agent rows in Add Agent **plus** a global `defaultAgentEnv` in Settings inherited by every spawn (including Michael/GOD); per-agent overrides global |
+| `CLAUDE_CONFIG_DIR` knock-ons | In scope: telemetry/transcripts, resume seeding, and permissions-acceptance follow the override |
+| Hire manifests (untrusted) | May **not** carry env; env is human-entered only |
+
+Named profiles (Approach 2) were considered and deferred — the global default +
+per-agent override covers the realistic use case; profiles can be layered on
+later without rework. Shell wrapping (Approach 3) was rejected: rc noise,
+broken provider inference from the binary name, no Windows equivalent.
+
+## Data model & spawn flow
+
+New fields (all optional, `Record<string, string>`):
+
+- `SpawnPtyOptions.env` — `src/preload/index.ts`. Main's `SpawnOptions` already
+  has `env`; this exposes it through the typed bridge.
+- `Agent.env` — renderer store, included in the persisted "slim" localStorage
+  fields so restore-team respawns carry it.
+- `AgentMeta.env` — `src/main/hive.ts`, persisted on the registry record so
+  restart-and-continue / god-triggered respawns and roster views agree.
+  `registry.json` stores values verbatim (local file, same trust level as
+  `config.json`); values whose key matches `*KEY*` / `*TOKEN*` / `*SECRET*`
+  are masked in derived surfaces — `fleet.json`, roster IPC, and
+  `tools/agent-env.cjs` output, which is documented as non-sensitive.
+- `HarnessConfig.defaultAgentEnv` — `src/main/config.ts`, edited from Settings.
+
+Merge order in `spawnAgentCore` (last write wins):
+
+```
+process.env + userShellPath      (existing base, pty.ts)
+→ defaultAgentEnv                (global, Settings)
+→ opts.env                       (per-agent, Add Agent)
+→ internal injections            (hive identity, memory/kg, BYOK, broker,
+                                  non-interactive flags)
+```
+
+User env can never clobber `AGENT_ID`, `HIVE_ROOT`, broker tokens, or BYOK
+keys — internal plumbing always wins.
+
+## Validation (main-process boundary)
+
+Applies to both `defaultAgentEnv` and `opts.env` in `spawnAgentCore`:
+
+- Keys must match `/^[A-Za-z_][A-Za-z0-9_]*$/`.
+- Denylist: `PATH`, `NODE_OPTIONS`, `ELECTRON_RUN_AS_NODE`, and any key
+  starting with `DYLD_`, `LD_`, `AGENT_`, `HIVE_`, `CTH_`.
+- A rejected key **fails the spawn** with a specific error (surfaced in the
+  Add Agent modal) — never a silent drop.
+- A leading `~/` in a user-supplied env *value* is expanded to the home
+  directory (no shell in the spawn path, so `~` would reach the child
+  literally).
+
+## UI
+
+- **Add Agent modal** (`AddAgentModal.tsx`): an "env vars" disclosure in the
+  workspace/engine fields opens a compact KEY/VALUE row editor (add/remove
+  rows), built from existing pixel primitives + DESIGN.md tokens. Inline
+  validation mirrors the main-process rules; main remains the enforcing
+  boundary. Hint text shows the headline case:
+  `CLAUDE_CONFIG_DIR=~/.claude-personal`.
+- **Settings modal**: an "Agent environment" group with the same row editor
+  bound to `defaultAgentEnv`, noting changes apply to newly spawned agents
+  only (live terminals keep their env; Michael picks it up on next restart).
+- **Hire import**: the manifest schema does not gain an env field. An `env`
+  key in imported JSON is ignored; the import banner notes "env not
+  importable — set it in the form" only when one was present.
+- No new roster/detail display surfaces in v1; `tools/agent-env.cjs` remains
+  the orchestrator-facing query path.
+
+## Shared helper module
+
+`src/shared/agentEnv.ts` — dependency-free (main + renderer + tests):
+
+- key validation + denylist
+- merge precedence
+- tilde expansion
+- `claudeConfigDirFrom(env)` → tilde-expanded `CLAUDE_CONFIG_DIR` value, or
+  `~/.claude` when unset
+
+## `CLAUDE_CONFIG_DIR` follow-through
+
+- `transcript.ts` (telemetry reads, `seedSessionTranscript`,
+  `resolveSessionCwd`): replace the single hardcoded `~/.claude/projects` root
+  with a deduped set of candidate roots — default `~/.claude` plus any
+  `CLAUDE_CONFIG_DIR` found in `defaultAgentEnv` or registry agents' env.
+  Existing behavior is the degenerate (single-root) case.
+- `ensureClaudePermissionsAccepted` (`config.ts`): takes the effective config
+  dir for the agent being spawned and targets that dir's `.claude.json`
+  instead of the home-dir default.
+- A `CLAUDE_CONFIG_DIR` pointing at a not-yet-existing directory is fine —
+  Claude Code creates it (fresh-profile flow).
+
+## Error handling
+
+- Malformed/denylisted key → spawn fails with a clear error in the modal.
+- Env vars are plain data end-to-end; no shell interpretation anywhere.
+
+## Testing
+
+- `test/agent-env-spawn.test.cjs` in the existing framework-free style
+  (transpile `src/shared/agentEnv.ts` in-process): validation, denylist, merge
+  precedence, tilde expansion, config-dir resolution.
+- `npm run typecheck` stays green (the CI gate).
+- Manual verification: spawn a worker with
+  `CLAUDE_CONFIG_DIR=~/.claude-personal`, confirm the session runs the
+  personal account and telemetry still reports tokens.

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -152,6 +152,11 @@ export interface HarnessConfig {
   defaultCommand: string;
   /** Default model for newly spawned agents (e.g. 'claude-sonnet-4-6[1m]'); unset = CLI default. */
   defaultModel?: string;
+  /** Env vars merged into EVERY agent spawn (incl. Michael/GOD), set in
+   *  Settings → General. Per-agent env (Add Agent) overrides these; internal
+   *  injections (hive identity, BYOK, broker) override both. Headline use case:
+   *  CLAUDE_CONFIG_DIR for separate Claude Code work/personal profiles (#105). */
+  defaultAgentEnv?: Record<string, string>;
   /** Which provider powers the GOD orchestrator ("Michael"). The persona is
    *  constant; only its engine is selectable. Default 'claude'. Eligible providers
    *  are those that can receive inbox (claude/codex/antigravity/qwen). */

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -492,12 +492,15 @@ export function ensureHarnessHome(path: string): { ok: boolean; error?: string }
  *      `skipAutoPermissionPrompt` — these gate the bypass-mode warning (global).
  *   2. `~/.claude.json` → `projects[cwd].hasTrustDialogAccepted` — the per-folder
  *      "do you trust the files in this folder?" dialog. */
-export function ensureClaudePermissionsAccepted(cwd?: string): void {
+export function ensureClaudePermissionsAccepted(cwd?: string, configDir?: string): void {
   const home = homedir();
   if (!home) return;
+  // With CLAUDE_CONFIG_DIR set, Claude Code reads settings.json from INSIDE that
+  // dir and .claude.json from <dir>/.claude.json (instead of ~/.claude.json). (#105)
+  const dir = configDir ?? join(home, '.claude');
+  const claudeJsonPath = configDir ? join(configDir, '.claude.json') : join(home, '.claude.json');
   // 1) Global bypass-mode warning gate.
   try {
-    const dir = join(home, '.claude');
     const p = join(dir, 'settings.json');
     let s: Record<string, unknown> = {};
     if (existsSync(p)) {
@@ -513,7 +516,7 @@ export function ensureClaudePermissionsAccepted(cwd?: string): void {
   // 2) Per-folder trust dialog gate (only when this cwd isn't already trusted).
   if (cwd) {
     try {
-      const p = join(home, '.claude.json');
+      const p = claudeJsonPath;
       let c: { projects?: Record<string, { hasTrustDialogAccepted?: boolean }> } = {};
       if (existsSync(p)) {
         try { c = JSON.parse(readFileSync(p, 'utf8')); } catch { c = {}; }

--- a/src/main/hire.ts
+++ b/src/main/hire.ts
@@ -16,10 +16,12 @@ import {
   type HireValidation
 } from '../shared/hire';
 
-export type HireResult = { ok: true; manifest: HireManifest } | { ok: false; error: string };
+export type HireResult =
+  | { ok: true; manifest: HireManifest; warnings?: string[] }
+  | { ok: false; error: string };
 
 function finish(v: HireValidation): HireResult {
-  if (v.ok && v.manifest) return { ok: true, manifest: v.manifest };
+  if (v.ok && v.manifest) return { ok: true, manifest: v.manifest, warnings: v.warnings };
   return { ok: false, error: `invalid hire manifest: ${v.errors.join('; ')}` };
 }
 

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -461,6 +461,13 @@ export class HiveManager {
       cwdValid: cwd.valid,
       // A (re)spawn always means a live terminal — clear any prior archived flag.
       archived: false,
+      // `...meta` above only overrides `env` when meta CARRIES the key at all —
+      // an env-less respawn (spawnAgentCore only sets opts.hive.env when the
+      // per-agent env is non-empty) has no `env` property on meta, so the spread
+      // leaves prev.env lingering and the roster keeps advertising an env the
+      // live process no longer has. Set it explicitly so meta.env === undefined
+      // (this spawn's real "no env" signal) always wins over prev.env.
+      env: meta.env,
       lastSeen: Date.now()
     };
     if (meta.isGod) reg.godId = meta.id;

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -130,6 +130,10 @@ export interface AgentMeta {
   role?: string;
   capabilities?: string[];
   cwd: string;
+  /** Per-agent env vars the agent was spawned with (#105) — persisted on the
+   *  registry entry (values verbatim; derived surfaces mask sensitive ones) so
+   *  respawn paths and the roster agree on the agent's environment. */
+  env?: Record<string, string>;
   isGod?: boolean;
   /** Michael's prep assistant — enriches prompts and forwards them to Michael.
    *  Send-only: excluded from broadcast fan-out so it never drains an inbox. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1839,6 +1839,11 @@ ipcMain.handle('pty:spawn', async (evt, opts: AgentSpawnOptions) => {
   if (!opts || typeof opts.id !== 'string' || typeof opts.cwd !== 'string' || typeof opts.command !== 'string') {
     return { ok: false, error: 'invalid SpawnOptions' };
   }
+  // agentEnvApplied / internalEnv are main-internal spawn controls (env-validation
+  // guard + the un-validated internal-injection channel). A renderer payload must
+  // never set them — doing so would bypass the per-agent env denylist (#105).
+  delete (opts as { agentEnvApplied?: unknown }).agentEnvApplied;
+  delete (opts as { internalEnv?: unknown }).internalEnv;
   // Record the spawning window as the PTY's owner so its output routes ONLY back
   // to that floor, then run the shared spawn core.
   const owner = BrowserWindow.fromWebContents(evt.sender)?.webContents ?? null;
@@ -2409,7 +2414,17 @@ ipcMain.handle('git:diff', (_evt, cwd: unknown, relPath: unknown) => {
 });
 
 // ─── IPC: hive (multi-agent coordination) ───────────────────────────────────
-ipcMain.handle('hive:registry', () => hive.registry());
+// Roster IPC (#105 spec) — mask sensitive per-agent env before it crosses to the
+// renderer. registry.json itself keeps values verbatim (same trust level as
+// config.json; the respawn recipe is re-read from there, never from this IPC's
+// result), but every DERIVED surface — this roster read included — masks.
+ipcMain.handle('hive:registry', () => {
+  const reg = hive.registry();
+  const agents = Object.fromEntries(
+    Object.entries(reg.agents).map(([id, a]) => [id, { ...a, env: a.env ? maskSensitiveEnv(a.env) : a.env }])
+  );
+  return { ...reg, agents };
+});
 ipcMain.handle('hive:board', () => hive.board());
 ipcMain.handle('hive:tasks', () => hive.tasks());
 ipcMain.handle('hive:log', (_evt, n: unknown) => hive.logTail(typeof n === 'number' ? n : 200));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, powerMonitor, pow
 import { spawn } from 'node:child_process';
 import { rmSync, existsSync, readFileSync, readdirSync, statSync, cpSync, writeFileSync, unlinkSync, mkdirSync, renameSync, createWriteStream } from 'node:fs';
 import { randomBytes, createHash, timingSafeEqual } from 'node:crypto';
+import { homedir } from 'node:os';
 import { join, resolve, sep, basename } from 'node:path';
 import { request as httpsRequest } from 'node:https';
 import { PtyManager, type SpawnOptions } from './pty';
@@ -48,6 +49,7 @@ import {
   type AgentProvider,
   type ProviderInstallInfo
 } from '../shared/agentProvider';
+import { validateAgentEnv, mergeAgentEnv, claudeConfigDirFrom } from '../shared/agentEnv';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
 
@@ -1829,6 +1831,21 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
   const claudeProvider = isClaudeProvider(provider);
   opts.provider = provider;
   if (opts.hive) opts.hive = { ...opts.hive, provider };
+  // ── Per-agent env vars (#105) — validate + merge BEFORE internal injections ──
+  // Order: defaultAgentEnv (Settings) → opts.env (per-agent). Every internal
+  // injection below spreads AFTER opts.env, so user env can never clobber
+  // AGENT_ID / HIVE_ROOT / broker tokens / BYOK keys — and the denylist rejects
+  // the dangerous rest (PATH, NODE_OPTIONS, DYLD_*, …) outright, FAILING the
+  // spawn with a named key instead of silently dropping it.
+  const envHome = homedir();
+  const defEnv = validateAgentEnv(readConfig().defaultAgentEnv, envHome);
+  if (!defEnv.ok) return { ok: false, error: `default agent env: ${defEnv.error}` };
+  const perEnv = validateAgentEnv(opts.env, envHome);
+  if (!perEnv.ok) return { ok: false, error: perEnv.error };
+  // Registry records the PER-AGENT env only (defaults are re-read from config on
+  // every spawn, so a Settings change applies to the next respawn automatically).
+  if (opts.hive && Object.keys(perEnv.env).length > 0) opts.hive = { ...opts.hive, env: perEnv.env };
+  opts.env = mergeAgentEnv(defEnv.env, perEnv.env);
   // ── Missing engine CLI → run its installer visibly (pre-spawn) ───────────────
   // If the agent's engine binary (claude/codex/…) isn't installed, spawning it
   // just dies with "— process exited (code 1) —" and the user has no idea why.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1804,7 +1804,18 @@ function buildMissingCliScript(bin: string, provider: AgentProvider): string {
 // ─── IPC: pty lifecycle ─────────────────────────────────────────────────────
 /** Spawn options shared by the `pty:spawn` IPC handler and the god-triggered
  *  ephemeral-worker watcher. */
-type AgentSpawnOptions = SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean; resumeSessionId?: string; provider?: AgentProvider; noAutoInstall?: boolean };
+type AgentSpawnOptions = SpawnOptions & {
+  hive?: AgentMeta; isolate?: boolean; resume?: boolean; resumeSessionId?: string; provider?: AgentProvider; noAutoInstall?: boolean;
+  /** Set by spawnAgentCore once the user-env pass (validate → record → merge
+   *  defaults) has run, so a re-entry with the SAME opts (missing-CLI install
+   *  relaunch re-invokes spawnAgentCore with the stored opts) doesn't re-classify
+   *  the merged result as per-agent env and persist defaults to the registry. */
+  agentEnvApplied?: boolean;
+  /** Internal env injections from internal callers (e.g. the ephemeral-worker
+   *  broker URL/token). NEVER validated, NEVER recorded to the registry, merged
+   *  AFTER user env so internal plumbing always wins. */
+  internalEnv?: Record<string, string>;
+};
 
 ipcMain.handle('pty:spawn', async (evt, opts: AgentSpawnOptions) => {
   if (!opts || typeof opts.id !== 'string' || typeof opts.cwd !== 'string' || typeof opts.command !== 'string') {
@@ -1837,15 +1848,26 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
   // AGENT_ID / HIVE_ROOT / broker tokens / BYOK keys — and the denylist rejects
   // the dangerous rest (PATH, NODE_OPTIONS, DYLD_*, …) outright, FAILING the
   // spawn with a named key instead of silently dropping it.
+  // Guarded by agentEnvApplied so a re-entry with the SAME opts (missing-CLI
+  // install relaunch, ~line 383/1866, re-invokes this function with the already
+  // merged opts) never re-classifies the merged blend as fresh per-agent input
+  // and persists Settings-level defaults into the registry.
   const envHome = homedir();
-  const defEnv = validateAgentEnv(readConfig().defaultAgentEnv, envHome);
-  if (!defEnv.ok) return { ok: false, error: `default agent env: ${defEnv.error}` };
-  const perEnv = validateAgentEnv(opts.env, envHome);
-  if (!perEnv.ok) return { ok: false, error: perEnv.error };
-  // Registry records the PER-AGENT env only (defaults are re-read from config on
-  // every spawn, so a Settings change applies to the next respawn automatically).
-  if (opts.hive && Object.keys(perEnv.env).length > 0) opts.hive = { ...opts.hive, env: perEnv.env };
-  opts.env = mergeAgentEnv(defEnv.env, perEnv.env);
+  if (!opts.agentEnvApplied) {
+    const defEnv = validateAgentEnv(readConfig().defaultAgentEnv, envHome);
+    if (!defEnv.ok) return { ok: false, error: `default agent env: ${defEnv.error}` };
+    const perEnv = validateAgentEnv(opts.env, envHome);
+    if (!perEnv.ok) return { ok: false, error: perEnv.error };
+    // Registry records the PER-AGENT env only (defaults are re-read from config on
+    // every spawn, so a Settings change applies to the next respawn automatically).
+    if (opts.hive && Object.keys(perEnv.env).length > 0) opts.hive = { ...opts.hive, env: perEnv.env };
+    opts.env = mergeAgentEnv(defEnv.env, perEnv.env);
+    opts.agentEnvApplied = true;
+  }
+  // Internal injections from internal callers (broker handle for ephemeral
+  // workers) — folded AFTER the user-env pass so they win, and never validated
+  // or recorded as per-agent env. Idempotent on install-relaunch re-entry.
+  if (opts.internalEnv) opts.env = { ...(opts.env ?? {}), ...opts.internalEnv };
   // ── Missing engine CLI → run its installer visibly (pre-spawn) ───────────────
   // If the agent's engine binary (claude/codex/…) isn't installed, spawning it
   // just dies with "— process exited (code 1) —" and the user has no idea why.
@@ -3170,7 +3192,7 @@ async function processSpawnRequest(filePath: string): Promise<void> {
   const spawnOpts: AgentSpawnOptions = {
     id: workerId, cwd, command, cols: 120, rows: 32,
     args: raw.model ? ['--model', raw.model] : [],
-    hive: meta, isolate, provider: raw.provider, env: brokerEnv
+    hive: meta, isolate, provider: raw.provider, internalEnv: brokerEnv
   };
 
   let res: { ok: boolean; error?: string };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,7 +49,7 @@ import {
   type AgentProvider,
   type ProviderInstallInfo
 } from '../shared/agentProvider';
-import { validateAgentEnv, mergeAgentEnv, claudeConfigDirFrom } from '../shared/agentEnv';
+import { validateAgentEnv, mergeAgentEnv, claudeConfigDirFrom, maskSensitiveEnv } from '../shared/agentEnv';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
 
@@ -825,6 +825,9 @@ function writeFleetSnapshot(): void {
           name: a.name,
           role: a.role ?? (a.isGod ? 'orchestrator' : 'agent'),
           cwd: a.cwd,
+          // Per-agent env (#105) — masked (never raw key material) so Michael can
+          // see WHICH profile a worker runs without fleet.json leaking secrets.
+          env: a.env ? maskSensitiveEnv(a.env) : undefined,
           isGod: !!a.isGod,
           breaker: breaker.levelFor(id),
           tokens,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,7 +23,7 @@ import { MemoryManager } from './memory';
 import { KnowledgeManager } from './knowledge';
 import { MemoryReflector, type ReflectSettings } from './reflect';
 import { PersistStore } from './db';
-import { readAgentUsage, readContextTokens, seedSessionTranscript, resolveSessionCwd } from './transcript';
+import { readAgentUsage, readContextTokens, seedSessionTranscript, resolveSessionCwd, setExtraClaudeConfigDirs } from './transcript';
 import { listIssues, listCIRuns } from './github';
 import { SlackWebhookServer, SlackReplyServer, postSlackReply, type SlackEventFile } from './slack';
 import { WebhookServer, type WebhookInbound, type WebhookTaskStatus } from './webhook';
@@ -84,6 +84,21 @@ const hive = new HiveManager(
     try { wc.send(channel, payload); return true; } catch { return false; }
   }
 );
+// #105 — teach the transcript reader about every CLAUDE_CONFIG_DIR override in
+// play (global default + per-agent), so telemetry/resume see profile sessions.
+setExtraClaudeConfigDirs(() => {
+  const home = homedir();
+  const dirs: string[] = [];
+  const d = claudeConfigDirFrom(readConfig().defaultAgentEnv, home);
+  if (d) dirs.push(d);
+  try {
+    for (const a of Object.values(hive.registry().agents)) {
+      const ad = claudeConfigDirFrom(a.env, home);
+      if (ad) dirs.push(ad);
+    }
+  } catch { /* hive not ready yet — default root still works */ }
+  return dirs;
+});
 // #7C — operator control state (pause/gate/steer/halt), read by the HookServer
 // when deciding hook returns.
 const control = new ControlRegistry();
@@ -1868,6 +1883,9 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
   // workers) — folded AFTER the user-env pass so they win, and never validated
   // or recorded as per-agent env. Idempotent on install-relaunch re-entry.
   if (opts.internalEnv) opts.env = { ...(opts.env ?? {}), ...opts.internalEnv };
+  // The Claude config dir this agent will actually use (#105) — drives resume
+  // seeding + permissions-acceptance below. Null = default ~/.claude.
+  const agentClaudeConfigDir = claudeConfigDirFrom(opts.env, envHome);
   // ── Missing engine CLI → run its installer visibly (pre-spawn) ───────────────
   // If the agent's engine binary (claude/codex/…) isn't installed, spawning it
   // just dies with "— process exited (code 1) —" and the user has no idea why.
@@ -2024,7 +2042,7 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
     const explicitSid = typeof opts.resumeSessionId === 'string' ? opts.resumeSessionId.trim() : '';
     const sid = explicitSid || (opts.resume === true ? hive.lastSession(opts.hive.id) : undefined);
     if (sid && !args.includes('--resume')) {
-      if (seedSessionTranscript(opts.cwd, sid)) {
+      if (seedSessionTranscript(opts.cwd, sid, agentClaudeConfigDir ?? undefined)) {
         args.push('--resume', sid);
         didResume = true;
       } else if (explicitSid) {
@@ -2062,7 +2080,7 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
   // interactive prompt it can't answer and exit code 1. Best-effort, never blocks.
   // Claude-only — other CLIs handle their own permission UX.
   if (claudeProvider) {
-    try { ensureClaudePermissionsAccepted(opts.cwd); } catch { /* never block spawn */ }
+    try { ensureClaudePermissionsAccepted(opts.cwd, agentClaudeConfigDir ?? undefined); } catch { /* never block spawn */ }
   }
   // Suppress first-run interactive prompts for providers that need it (e.g. Codex
   // directory-trust gate via CODEX_NON_INTERACTIVE). Merges into any env already

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,7 +49,7 @@ import {
   type AgentProvider,
   type ProviderInstallInfo
 } from '../shared/agentProvider';
-import { validateAgentEnv, mergeAgentEnv, claudeConfigDirFrom, maskSensitiveEnv } from '../shared/agentEnv';
+import { validateAgentEnv, mergeAgentEnv, claudeConfigDirFrom, maskSensitiveEnv, ENV_MASK } from '../shared/agentEnv';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
 
@@ -86,7 +86,18 @@ const hive = new HiveManager(
 );
 // #105 — teach the transcript reader about every CLAUDE_CONFIG_DIR override in
 // play (global default + per-agent), so telemetry/resume see profile sessions.
+// MEMOIZED: this provider sits under readAgentUsage on the ~30s cost/breaker
+// beat × N agents, and computing it cold re-reads BOTH config.json and
+// registry.json from disk — the exact hot path the transcript cache keeps
+// stat-only. Profiles only change via a spawn or a Settings save, which
+// invalidate explicitly; the short TTL backstops any path that forgets.
+let extraConfigDirsCache: { dirs: string[]; at: number } | null = null;
+const EXTRA_CONFIG_DIRS_TTL_MS = 30_000;
+function invalidateExtraConfigDirs(): void { extraConfigDirsCache = null; }
 setExtraClaudeConfigDirs(() => {
+  if (extraConfigDirsCache && Date.now() - extraConfigDirsCache.at < EXTRA_CONFIG_DIRS_TTL_MS) {
+    return extraConfigDirsCache.dirs;
+  }
   const home = homedir();
   const dirs: string[] = [];
   const d = claudeConfigDirFrom(readConfig().defaultAgentEnv, home);
@@ -97,6 +108,7 @@ setExtraClaudeConfigDirs(() => {
       if (ad) dirs.push(ad);
     }
   } catch { /* hive not ready yet — default root still works */ }
+  extraConfigDirsCache = { dirs, at: Date.now() };
   return dirs;
 });
 // #7C — operator control state (pause/gate/steer/halt), read by the HookServer
@@ -1877,6 +1889,23 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
   // and persists Settings-level defaults into the registry.
   const envHome = homedir();
   if (!opts.agentEnvApplied) {
+    // The roster IPC masks sensitive env values to ENV_MASK ('•••'), so any
+    // renderer state hydrated from it would respawn an agent with literal
+    // bullets in its environment. Resolve masked values MAIN-SIDE from
+    // registry.json (which keeps values verbatim) before validation; a masked
+    // key with no recorded value is a hard, named error — the mask itself must
+    // never reach a child process.
+    if (opts.env && opts.hive?.id) {
+      const maskedKeys = Object.keys(opts.env).filter((k) => opts.env![k] === ENV_MASK);
+      if (maskedKeys.length > 0) {
+        const recorded = hive.registry().agents[opts.hive.id]?.env ?? {};
+        for (const k of maskedKeys) {
+          const real = recorded[k];
+          if (typeof real === 'string' && real !== ENV_MASK) opts.env[k] = real;
+          else return { ok: false, error: `env ${k}: value is masked and not recorded in the registry — re-enter it` };
+        }
+      }
+    }
     const defEnv = validateAgentEnv(readConfig().defaultAgentEnv, envHome);
     if (!defEnv.ok) return { ok: false, error: `default agent env: ${defEnv.error}` };
     const perEnv = validateAgentEnv(opts.env, envHome);
@@ -1886,6 +1915,9 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
     if (opts.hive && Object.keys(perEnv.env).length > 0) opts.hive = { ...opts.hive, env: perEnv.env };
     opts.env = mergeAgentEnv(defEnv.env, perEnv.env);
     opts.agentEnvApplied = true;
+    // A spawn can introduce a new CLAUDE_CONFIG_DIR profile — recompute the
+    // transcript reader's extra-roots on the next usage read.
+    invalidateExtraConfigDirs();
   }
   // Internal injections from internal callers (broker handle for ephemeral
   // workers) — folded AFTER the user-env pass so they win, and never validated
@@ -2289,7 +2321,12 @@ ipcMain.handle('integrations:test', async (_evt, payload: unknown) => {
 
 // ─── IPC: config ────────────────────────────────────────────────────────────
 ipcMain.handle('config:get', (): HarnessConfig => readConfig());
-ipcMain.handle('config:update', (_evt, patch: Partial<HarnessConfig>) => writeConfig(patch));
+ipcMain.handle('config:update', (_evt, patch: Partial<HarnessConfig>) => {
+  // A Settings save can change defaultAgentEnv's CLAUDE_CONFIG_DIR — recompute
+  // the transcript reader's extra-roots on the next usage read.
+  if ('defaultAgentEnv' in patch) invalidateExtraConfigDirs();
+  return writeConfig(patch);
+});
 ipcMain.handle('config:ensureHome', (_evt, path: unknown) => {
   if (typeof path !== 'string' || path.length === 0) return { ok: false, error: 'invalid path' };
   return ensureHarnessHome(path);

--- a/src/main/transcript.ts
+++ b/src/main/transcript.ts
@@ -3,17 +3,39 @@ import os from 'node:os';
 import path from 'node:path';
 import { estimateCostUsd, normalizeModel } from './pricing';
 
-/** Resolve the Claude Code transcript directory for a given working directory.
- *  Claude Code stores per-project transcripts under ~/.claude/projects, keying
- *  each project by its absolute cwd with the leading slash dropped and every
- *  remaining slash turned into a dash (e.g. /Users/me/app → Users-me-app). On
- *  Windows EVERY non-alphanumeric character is dashed (drive colon and
- *  backslashes included): C:\Users\me\app → C--Users-me-app. */
-export function projectDir(cwd: string): string {
-  const key = process.platform === 'win32'
+/** Extra Claude config dirs (from per-agent / default CLAUDE_CONFIG_DIR env,
+ *  #105) beyond the default ~/.claude. Registered lazily by index.ts so this
+ *  module stays free of config/hive imports. */
+let extraConfigDirs: () => string[] = () => [];
+export function setExtraClaudeConfigDirs(provider: () => string[]): void {
+  extraConfigDirs = provider;
+}
+
+function defaultConfigDir(): string {
+  return path.join(os.homedir(), '.claude');
+}
+
+/** Every `projects/` root transcripts may live under: the default ~/.claude
+ *  plus any CLAUDE_CONFIG_DIR overrides. Deduped; order = default first. */
+function projectsRoots(): string[] {
+  const dirs = [defaultConfigDir()];
+  try { dirs.push(...extraConfigDirs()); } catch { /* provider never blocks a read */ }
+  return [...new Set(dirs)].map((d) => path.join(d, 'projects'));
+}
+
+/** The project-dir KEY Claude Code derives from a cwd (absolute path with the
+ *  leading slash dropped and every remaining slash dashed; on Windows every
+ *  non-alphanumeric char is dashed — drive colon and backslashes included). */
+function projectKey(cwd: string): string {
+  return process.platform === 'win32'
     ? cwd.replace(/[^a-zA-Z0-9]/g, '-')
     : cwd.replace(/^\//, '').replaceAll('/', '-');
-  return path.join(os.homedir(), '.claude/projects', key);
+}
+
+/** Resolve the Claude Code transcript directory for a working directory, under
+ *  the given config dir (an agent's CLAUDE_CONFIG_DIR override) or ~/.claude. */
+export function projectDir(cwd: string, configDir?: string): string {
+  return path.join(configDir ?? defaultConfigDir(), 'projects', projectKey(cwd));
 }
 
 /** Ensure session `<sessionId>.jsonl` exists in `cwd`'s Claude project dir so a
@@ -33,19 +55,26 @@ export function projectDir(cwd: string): string {
  *  crafted id like `../../x` would otherwise traverse out of the project dirs). */
 const VALID_SESSION_ID = /^[A-Za-z0-9_-]+$/;
 
-export function seedSessionTranscript(cwd: string, sessionId: string): boolean {
+export function seedSessionTranscript(cwd: string, sessionId: string, configDir?: string): boolean {
   try {
     if (!sessionId || !VALID_SESSION_ID.test(sessionId)) return false;
-    const target = path.join(projectDir(cwd), `${sessionId}.jsonl`);
+    const target = path.join(projectDir(cwd, configDir), `${sessionId}.jsonl`);
     if (existsSync(target)) return true;
-    const projectsRoot = path.join(os.homedir(), '.claude/projects');
-    if (!existsSync(projectsRoot)) return false;
-    for (const dir of readdirSync(projectsRoot)) {
-      const candidate = path.join(projectsRoot, dir, `${sessionId}.jsonl`);
-      if (existsSync(candidate)) {
-        mkdirSync(path.dirname(target), { recursive: true });
-        cpSync(candidate, target);
-        return true;
+    // Search EVERY known projects root (default + CLAUDE_CONFIG_DIR overrides,
+    // #105) — the session may have run under a different profile than the one
+    // this spawn uses.
+    const roots = projectsRoots();
+    const targetRoot = path.dirname(path.dirname(target));
+    if (!roots.includes(targetRoot)) roots.push(targetRoot);
+    for (const projectsRoot of roots) {
+      if (!existsSync(projectsRoot)) continue;
+      for (const dir of readdirSync(projectsRoot)) {
+        const candidate = path.join(projectsRoot, dir, `${sessionId}.jsonl`);
+        if (existsSync(candidate)) {
+          mkdirSync(path.dirname(target), { recursive: true });
+          cpSync(candidate, target);
+          return true;
+        }
       }
     }
     return false;
@@ -64,15 +93,16 @@ export function seedSessionTranscript(cwd: string, sessionId: string): boolean {
 export function resolveSessionCwd(sessionId: string): string | null {
   try {
     if (!sessionId || !VALID_SESSION_ID.test(sessionId)) return null;
-    const projectsRoot = path.join(os.homedir(), '.claude/projects');
-    if (!existsSync(projectsRoot)) return null;
     let best: { file: string; mtime: number } | null = null;
-    for (const dir of readdirSync(projectsRoot)) {
-      const candidate = path.join(projectsRoot, dir, `${sessionId}.jsonl`);
-      try {
-        const st = statSync(candidate);
-        if (!best || st.mtimeMs > best.mtime) best = { file: candidate, mtime: st.mtimeMs };
-      } catch { /* not present in this project dir */ }
+    for (const projectsRoot of projectsRoots()) {
+      if (!existsSync(projectsRoot)) continue;
+      for (const dir of readdirSync(projectsRoot)) {
+        const candidate = path.join(projectsRoot, dir, `${sessionId}.jsonl`);
+        try {
+          const st = statSync(candidate);
+          if (!best || st.mtimeMs > best.mtime) best = { file: candidate, mtime: st.mtimeMs };
+        } catch { /* not present in this project dir */ }
+      }
     }
     if (!best) return null;
     const text = readFileSync(best.file, 'utf8');
@@ -231,19 +261,26 @@ function readFileUsage(dir: string, file: string, sessionId: string | undefined)
 export function readAgentUsage(cwd: string, opts: ReadUsageOptions = {}): AgentUsage {
   const usage = zero();
   try {
-    const dir = projectDir(cwd);
-    if (!existsSync(dir)) return usage;
-    const files = readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
+    const key = projectKey(cwd);
     let lastModel: string | undefined;
-    for (const file of files) {
-      const entry = readFileUsage(dir, file, opts.sessionId);
-      if (!entry) continue;
-      usage.inputTokens += entry.totals.inputTokens;
-      usage.outputTokens += entry.totals.outputTokens;
-      usage.cacheWriteTokens += entry.totals.cacheWriteTokens;
-      usage.cacheReadTokens += entry.totals.cacheReadTokens;
-      usage.estimatedCostUsd += entry.totals.estimatedCostUsd;
-      if (entry.totals.model) lastModel = entry.totals.model;
+    // Multi-root (#105): a CLAUDE_CONFIG_DIR-profiled agent writes its
+    // transcripts under that profile's projects/ root, not ~/.claude. Each
+    // (dir, file) feeds the incremental per-file cache — its key includes the
+    // dir, so profiles never collide and the hot path stays stat-only.
+    for (const root of projectsRoots()) {
+      const dir = path.join(root, key);
+      if (!existsSync(dir)) continue;
+      const files = readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
+      for (const file of files) {
+        const entry = readFileUsage(dir, file, opts.sessionId);
+        if (!entry) continue;
+        usage.inputTokens += entry.totals.inputTokens;
+        usage.outputTokens += entry.totals.outputTokens;
+        usage.cacheWriteTokens += entry.totals.cacheWriteTokens;
+        usage.cacheReadTokens += entry.totals.cacheReadTokens;
+        usage.estimatedCostUsd += entry.totals.estimatedCostUsd;
+        if (entry.totals.model) lastModel = entry.totals.model;
+      }
     }
     if (lastModel) usage.model = lastModel;
     return usage;

--- a/src/main/transcript.ts
+++ b/src/main/transcript.ts
@@ -264,23 +264,37 @@ export function readAgentUsage(cwd: string, opts: ReadUsageOptions = {}): AgentU
     const key = projectKey(cwd);
     let lastModel: string | undefined;
     // Multi-root (#105): a CLAUDE_CONFIG_DIR-profiled agent writes its
-    // transcripts under that profile's projects/ root, not ~/.claude. Each
-    // (dir, file) feeds the incremental per-file cache — its key includes the
-    // dir, so profiles never collide and the hot path stays stat-only.
+    // transcripts under that profile's projects/ root, not ~/.claude. Collect
+    // candidates across EVERY root first, then dedupe by basename — after a
+    // profile switch, seedSessionTranscript (#105) copies the same
+    // <sessionId>.jsonl into a second root for this cwd key, and summing both
+    // would double-count that session's usage. Keep the newest-mtime copy per
+    // basename; a stat failure is best-effort (include the file rather than
+    // drop it — never throw out of a usage read).
+    const candidates = new Map<string, { dir: string; file: string; mtimeMs: number }>();
     for (const root of projectsRoots()) {
       const dir = path.join(root, key);
       if (!existsSync(dir)) continue;
       const files = readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
       for (const file of files) {
-        const entry = readFileUsage(dir, file, opts.sessionId);
-        if (!entry) continue;
-        usage.inputTokens += entry.totals.inputTokens;
-        usage.outputTokens += entry.totals.outputTokens;
-        usage.cacheWriteTokens += entry.totals.cacheWriteTokens;
-        usage.cacheReadTokens += entry.totals.cacheReadTokens;
-        usage.estimatedCostUsd += entry.totals.estimatedCostUsd;
-        if (entry.totals.model) lastModel = entry.totals.model;
+        let mtimeMs = 0;
+        try { mtimeMs = statSync(path.join(dir, file)).mtimeMs; } catch { mtimeMs = Infinity; }
+        const existing = candidates.get(file);
+        if (!existing || mtimeMs >= existing.mtimeMs) candidates.set(file, { dir, file, mtimeMs });
       }
+    }
+    // Each surviving (dir, file) feeds the incremental per-file cache — its key
+    // includes the dir, so profiles never collide and a steady-state call stays
+    // readdir + stat per file (no re-parse).
+    for (const { dir, file } of candidates.values()) {
+      const entry = readFileUsage(dir, file, opts.sessionId);
+      if (!entry) continue;
+      usage.inputTokens += entry.totals.inputTokens;
+      usage.outputTokens += entry.totals.outputTokens;
+      usage.cacheWriteTokens += entry.totals.cacheWriteTokens;
+      usage.cacheReadTokens += entry.totals.cacheReadTokens;
+      usage.estimatedCostUsd += entry.totals.estimatedCostUsd;
+      if (entry.totals.model) lastModel = entry.totals.model;
     }
     if (lastModel) usage.model = lastModel;
     return usage;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -168,6 +168,9 @@ export interface SpawnPtyOptions {
   /** Which CLI to spawn; usually inferred from `command` in the main process. */
   provider?: AgentProvider;
   args?: string[];
+  /** Per-agent env vars (#105), validated + merged in the main process over the
+   *  global defaultAgentEnv. Human-entered only — hire manifests can't carry env. */
+  env?: Record<string, string>;
   cols?: number;
   rows?: number;
   /** When present, the agent is provisioned in the hive at spawn. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -232,6 +232,10 @@ export interface HarnessConfig {
   autoMode: boolean;
   defaultCommand: string;
   defaultModel?: string;
+  /** Env vars merged into EVERY agent spawn (incl. Michael/GOD), set in
+   *  Settings → General. Per-agent env (Add Agent) overrides these. Mirrors
+   *  src/main/config.ts + renderer HarnessConfig (#105). */
+  defaultAgentEnv?: Record<string, string>;
   /** Which provider+model powers the GOD orchestrator ("Michael"). Default
    *  'claude' / 'claude-opus-4-8'. Mirrors src/main/config.ts. */
   godProvider?: AgentProvider;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -760,7 +760,7 @@ const api = {
   drainPendingHires: (): Promise<HireManifest[]> =>
     ipcRenderer.invoke('hire:drainPending'),
   /** Open a file picker and validate the chosen hire-manifest JSON. */
-  importHireFile: (): Promise<{ ok: boolean; manifest?: HireManifest; error?: string }> =>
+  importHireFile: (): Promise<{ ok: boolean; manifest?: HireManifest; warnings?: string[]; error?: string }> =>
     ipcRenderer.invoke('hire:openFile'),
 
   // ─── Quit confirmation ───────────────────────────────────────────────────

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -9,6 +9,7 @@ import { OFFICE_CAST, DEFAULT_CHARACTER, type OfficeCharacterName } from '@/scen
 import { type AccentColorName } from '@/design/tokens';
 import type { HireManifest } from '@shared/hire';
 import { MCP_CATALOG } from '@shared/mcpCatalog';
+import { EnvVarsEditor, envRowsIssue, rowsToEnv, type EnvRow } from './EnvVarsEditor';
 import {
   OSS_LOCAL_PICKS,
   OSS_PROVIDER_PICKS,
@@ -116,7 +117,7 @@ Repos, tools, style, or constraints to respect:
 type SectionKey = 'identity' | 'workspace' | 'engine' | 'briefing';
 const SECTIONS: { key: SectionKey; label: string; hint: string }[] = [
   { key: 'identity',  label: 'Identity',  hint: 'name · character · color' },
-  { key: 'workspace', label: 'Workspace', hint: 'folder · isolation · resume' },
+  { key: 'workspace', label: 'Workspace', hint: 'folder · isolation · resume · env' },
   { key: 'engine',    label: 'Engine',    hint: 'provider · model · command' },
   { key: 'briefing',  label: 'Briefing',  hint: 'description · goal' }
 ];
@@ -208,6 +209,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   // session's transcript into the cwd's project dir and launches `--resume`.
   const [resumeSessionId, setResumeSessionId] = useState('');
   const resuming = resumeSessionId.trim().length > 0;
+  // Per-agent env vars (#105) — e.g. CLAUDE_CONFIG_DIR for a personal profile.
+  const [envRows, setEnvRows] = useState<EnvRow[]>([]);
   // Note shown when the folder was auto-filled from the pasted session id.
   const [folderNote, setFolderNote] = useState<string | undefined>();
   const [error, setError] = useState<string | undefined>();
@@ -296,6 +299,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     if (!name.trim()) { setError('Name is required'); setSection('identity'); return; }
     if (!cwd) { setError('Pick a folder first'); setSection('workspace'); return; }
     if (!command.trim()) { setError('Command is required'); setSection('engine'); return; }
+    const envIssue = envRowsIssue(envRows);
+    if (envIssue) { setError(envIssue); setSection('workspace'); return; }
 
     setBusy(true);
     const id = uniqueId(name);
@@ -318,6 +323,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       isolate: resuming ? false : isolate,
       // #2 — continue an existing Claude session in this agent's cwd.
       resumeSessionId: resuming ? resumeSessionId.trim() : undefined,
+      // Per-agent env vars (#105); validated + merged over defaultAgentEnv in main.
+      env: rowsToEnv(envRows),
       // Provision this agent in the hive (memory + mailbox + identity/protocol).
       hive: {
         id,
@@ -361,6 +368,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       // Persist the resolved worktree path (set only when isolation provisioned
       // one) so a restart can re-enter this exact worktree — see restoreTeam.
       worktreePath: spawnRes.worktreePath,
+      // Per-agent env vars (#105) — recorded so restart/respawn reuse the same environment.
+      env: rowsToEnv(envRows),
       // Crush (seedDelivery:'type-into-tui') hands its hive protocol back here
       // instead of on argv; useHive types it into the TUI after boot. (ondev-b)
       seedPrompt: spawnRes.seedPrompt,
@@ -717,6 +726,16 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                           Will resume this session in the chosen folder (git isolation disabled).
                         </span>
                       )}
+                    </Row>
+
+                    <Row label="Env vars">
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        <EnvVarsEditor rows={envRows} onChange={setEnvRows} />
+                        <span style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>
+                          set on this agent's process — e.g. CLAUDE_CONFIG_DIR=~/.claude-personal
+                          for a separate Claude account. ~ expands to your home folder.
+                        </span>
+                      </div>
                     </Row>
                   </>
                 )}

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -178,6 +178,10 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   );
   const [description, setDescription] = useState(pendingHire?.description ?? 'a fresh harness');
   const [hireMeta, setHireMeta] = useState<HireManifest | null>(pendingHire);
+  // Non-fatal notices from the last file import (e.g. an ignored `env` field,
+  // #105). File-import only for v1 — the deep-link path (pendingHire) delivers
+  // just the manifest with no channel for warnings; see hire.ts for the model.
+  const [hireWarnings, setHireWarnings] = useState<string[]>([]);
 
   // Picking a model rebuilds the command; the command field stays editable for
   // power users (it's the source of truth for the actual spawn).
@@ -288,7 +292,7 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   const importHire = async () => {
     setError(undefined);
     const res = await window.cth.importHireFile();
-    if (res.ok && res.manifest) applyManifest(res.manifest);
+    if (res.ok && res.manifest) { applyManifest(res.manifest); setHireWarnings(res.warnings ?? []); }
     else if (res.error && res.error !== 'cancelled') setError(res.error);
   };
 
@@ -458,6 +462,9 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                     ))}
                   </span>
                 )}
+                {hireWarnings.map((w) => (
+                  <span key={w} style={{ fontSize: 12, marginTop: 2 }}>⚠️ {w}</span>
+                ))}
                 {hireMeta.skills && hireMeta.skills.length > 0 && (
                   <span style={{ display: 'flex', gap: 4, alignItems: 'baseline', flexWrap: 'wrap', marginTop: 2 }}>
                     <span style={{ fontSize: 12 }}>skills this hire activates:</span>

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -93,6 +93,8 @@ export function AgentStrip({ config }: AgentStripProps) {
           // agent id is preserved across restart, so its registry entry,
           // memory.md and inbox reattach by id. No-op without a recorded session.
           resume: true,
+          // Per-agent env vars (#105) — reuse the recorded spawn recipe.
+          env: a.env,
           hive: { id: a.id, name: a.name, provider, cwd, role: a.description }
         });
         if (res.ok) {

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -277,7 +277,8 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
       const entry = acquireTerminal(a.ptyId);
       let cols = 100, rows = 30;
       try { entry.fit.fit(); cols = entry.term.cols; rows = entry.term.rows; } catch { /* host not sized yet */ }
-      const res = await window.cth.spawnPty({ id: a.ptyId, cwd: a.cwd, command: exe, args, provider, cols, rows, hive, resume: opts.resume });
+      // Per-agent env vars (#105) — reuse the recorded spawn recipe.
+      const res = await window.cth.spawnPty({ id: a.ptyId, cwd: a.cwd, command: exe, args, provider, cols, rows, hive, resume: opts.resume, env: a.env });
       if (res.ok) {
         // On a pure resume the model is unchanged — don't overwrite it.
         const patch = opts.resume

--- a/src/renderer/src/components/EnvVarsEditor.tsx
+++ b/src/renderer/src/components/EnvVarsEditor.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { envKeyIssue } from '@shared/agentEnv';
+import { PixelButton } from './PixelButton';
+
+export type EnvRow = { key: string; value: string };
+
+/** Rows → the env record a spawn wants; empty/blank-key rows are dropped.
+ *  Returns undefined when nothing usable is set. */
+export function rowsToEnv(rows: EnvRow[]): Record<string, string> | undefined {
+  const env: Record<string, string> = {};
+  for (const r of rows) if (r.key.trim()) env[r.key.trim()] = r.value;
+  return Object.keys(env).length ? env : undefined;
+}
+
+/** First problem across the rows (mirrors the main-process rules for instant
+ *  feedback — main remains the enforcing boundary), or null when clean. */
+export function envRowsIssue(rows: EnvRow[]): string | null {
+  const seen = new Set<string>();
+  for (const r of rows) {
+    const key = r.key.trim();
+    if (!key) continue;
+    const issue = envKeyIssue(key);
+    if (issue) return issue;
+    if (seen.has(key)) return `duplicate env key "${key}"`;
+    seen.add(key);
+  }
+  return null;
+}
+
+const cellStyle: React.CSSProperties = {
+  padding: '5px 7px 3px',
+  background: 'var(--cth-paper-100)',
+  border: 'none',
+  boxShadow: 'inset 0 0 0 1px var(--cth-ink-700)',
+  fontFamily: 'var(--cth-font-mono)',
+  fontSize: 13,
+  color: 'var(--cth-ink-900)',
+  outline: 'none',
+  minWidth: 0
+};
+
+/** KEY=VALUE row editor for per-agent env vars (#105). Dumb component: owns no
+ *  state — parent holds the rows (Add Agent form state / Settings config). */
+export function EnvVarsEditor({ rows, onChange }: {
+  rows: EnvRow[];
+  onChange: (rows: EnvRow[]) => void;
+}) {
+  const issue = envRowsIssue(rows);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {rows.map((r, i) => (
+        <div key={i} style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <input
+            value={r.key}
+            onChange={(e) => onChange(rows.map((x, j) => (j === i ? { ...x, key: e.target.value } : x)))}
+            placeholder="CLAUDE_CONFIG_DIR"
+            spellCheck={false}
+            style={{ ...cellStyle, width: 200, flexShrink: 0 }}
+          />
+          <span style={{ color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-mono)', fontSize: 13 }}>=</span>
+          <input
+            value={r.value}
+            onChange={(e) => onChange(rows.map((x, j) => (j === i ? { ...x, value: e.target.value } : x)))}
+            placeholder="~/.claude-personal"
+            spellCheck={false}
+            style={{ ...cellStyle, flex: 1 }}
+          />
+          <PixelButton size="sm" variant="ghost" title="remove"
+            onClick={() => onChange(rows.filter((_, j) => j !== i))}>✕</PixelButton>
+        </div>
+      ))}
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <PixelButton size="sm" onClick={() => onChange([...rows, { key: '', value: '' }])}>
+          + env var
+        </PixelButton>
+        {issue && (
+          <span style={{ fontSize: 12, color: 'var(--cth-paprika-700, #b3502e)' }}>{issue}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import { IntegrationsRegistry } from './IntegrationsRegistry';
 import { AiEnginesSettings } from './AiEnginesSettings';
 import { RealtimeDevicePicker } from '@/realtime/DevicePicker';
 import { CostHud } from '@/realtime/CostHud';
+import { EnvVarsEditor, envRowsIssue, rowsToEnv, type EnvRow } from './EnvVarsEditor';
 
 export interface SettingsModalProps {
   config: HarnessConfig;
@@ -140,6 +141,19 @@ export function SettingsModal({ config, onClose }: SettingsModalProps) {
     catch { setNotifications(!next); /* revert on failure */ }
   };
 
+  // --- default agent env vars (#105) — global env merged into every spawn ---
+  const [defaultEnvRows, setDefaultEnvRows] = useState<EnvRow[]>(
+    Object.entries(config.defaultAgentEnv ?? {}).map(([key, value]) => ({ key, value }))
+  );
+  /** Saves as-you-type, like the notifications toggle - but never persists a row
+   *  set with a bad/duplicate key; the editor keeps showing the issue so the user
+   *  can fix it, and the last-valid config on disk is left alone until they do. */
+  const saveDefaultEnv = (nextRows: EnvRow[]) => {
+    setDefaultEnvRows(nextRows);
+    if (envRowsIssue(nextRows)) return;
+    void window.cth.updateConfig({ defaultAgentEnv: rowsToEnv(nextRows) ?? {} });
+  };
+
   // --- circuit-breaker config (Lane A #6 canonical fields, widened view) ---
   // Drives Jim's real breaker: floor-wide TOKEN budget (costCapTokens) + output-
   // token velocity ceiling (circuitBreaker.tokenVelocityPerMin). The token cap
@@ -265,6 +279,7 @@ export function SettingsModal({ config, onClose }: SettingsModalProps) {
       if (!alive) return;
       const cc = c as BreakerCfgView & SlackConfig & { notifications?: boolean };
       setNotifications(cc.notifications === true);
+      setDefaultEnvRows(Object.entries(cc.defaultAgentEnv ?? {}).map(([key, value]) => ({ key, value })));
       setAgentBudget(cc.costCapTokens != null ? String(cc.costCapTokens) : '');
       setVelocityCeiling(cc.circuitBreaker?.tokenVelocityPerMin != null ? String(cc.circuitBreaker.tokenVelocityPerMin) : '');
       setSlackEnabled(cc.slackEnabled ?? false);
@@ -690,6 +705,26 @@ export function SettingsModal({ config, onClose }: SettingsModalProps) {
                               }}>{value}</span>
                             </div>
                           ))}
+                        </div>
+                      </div>
+
+                      <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
+
+                      {/* Global default agent env (#105) */}
+                      <div>
+                        <div style={{
+                          fontFamily: 'var(--cth-font-display)', fontSize: 8, lineHeight: '12px',
+                          color: 'var(--cth-ink-500)', textTransform: 'uppercase', marginBottom: 10
+                        }}>
+                          Agent environment
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                          <span style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-500)' }}>
+                            Env vars for every agent — including Michael. Applies to newly
+                            spawned agents; live terminals keep the env they started with.
+                            Per-agent env vars (Add Agent) override these.
+                          </span>
+                          <EnvVarsEditor rows={defaultEnvRows} onChange={saveDefaultEnv} />
                         </div>
                       </div>
 

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -145,13 +145,24 @@ export function SettingsModal({ config, onClose }: SettingsModalProps) {
   const [defaultEnvRows, setDefaultEnvRows] = useState<EnvRow[]>(
     Object.entries(config.defaultAgentEnv ?? {}).map(([key, value]) => ({ key, value }))
   );
-  /** Saves as-you-type, like the notifications toggle - but never persists a row
-   *  set with a bad/duplicate key; the editor keeps showing the issue so the user
-   *  can fix it, and the last-valid config on disk is left alone until they do. */
+  /** In-place text edits (same row count) only update local state - PERSISTING
+   *  is deferred to blur (see commitDefaultEnv below), so a mid-typing prefix
+   *  (e.g. "P", "PA", "PAT" on the way to reserved "PATH") never reaches
+   *  config.json just because it happened to be a valid-looking key at that
+   *  instant. Add/remove (row count changes) commit immediately instead - those
+   *  are complete, unambiguous actions rather than partial typing, and waiting
+   *  for a later blur would risk losing a deletion if the user closes the modal
+   *  before any field is next focused. */
   const saveDefaultEnv = (nextRows: EnvRow[]) => {
     setDefaultEnvRows(nextRows);
-    if (envRowsIssue(nextRows)) return;
-    void window.cth.updateConfig({ defaultAgentEnv: rowsToEnv(nextRows) ?? {} });
+    if (nextRows.length !== defaultEnvRows.length) commitDefaultEnv(nextRows);
+  };
+  /** Commit rows to disk (defaults to the current state) - never a bad/duplicate
+   *  key; the editor keeps showing the issue so the user can fix it, and the
+   *  last-valid config on disk is left alone until they do. */
+  const commitDefaultEnv = (rows: EnvRow[] = defaultEnvRows) => {
+    if (envRowsIssue(rows)) return;
+    void window.cth.updateConfig({ defaultAgentEnv: rowsToEnv(rows) ?? {} });
   };
 
   // --- circuit-breaker config (Lane A #6 canonical fields, widened view) ---
@@ -724,7 +735,15 @@ export function SettingsModal({ config, onClose }: SettingsModalProps) {
                             spawned agents; live terminals keep the env they started with.
                             Per-agent env vars (Add Agent) override these.
                           </span>
-                          <EnvVarsEditor rows={defaultEnvRows} onChange={saveDefaultEnv} />
+                          {/* onBlur (not onChange) is what persists in-place edits
+                              - see commitDefaultEnv above. React's onBlur bubbles
+                              from any descendant input/button, so this fires
+                              whenever focus leaves a row (including moving between
+                              the key/value fields of the SAME row, which is a
+                              harmless no-op re-save guarded by envRowsIssue). */}
+                          <div onBlur={() => commitDefaultEnv()}>
+                            <EnvVarsEditor rows={defaultEnvRows} onChange={saveDefaultEnv} />
+                          </div>
                         </div>
                       </div>
 

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -893,6 +893,8 @@ export function useHive(config: HarnessConfig | null): void {
           isolate: false,
           // Reattach the agent's prior session so no context is lost on revive.
           resume: true,
+          // Per-agent env vars (#105) — reuse the recorded spawn recipe.
+          env: a.env,
           hive
         });
         if (res.ok) {

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -60,6 +60,10 @@ export interface HarnessConfig {
   defaultCommand: string;
   /** Default model for newly spawned agents (e.g. 'claude-sonnet-4-6[1m]'); unset = CLI default. */
   defaultModel?: string;
+  /** Env vars merged into EVERY agent spawn (incl. Michael/GOD), set in
+   *  Settings → General. Per-agent env (Add Agent) overrides these. Mirrors
+   *  src/main/config.ts (#105). */
+  defaultAgentEnv?: Record<string, string>;
   /** Which provider+model powers the GOD orchestrator ("Michael"). Default
    *  'claude' / 'claude-opus-4-8'. Mirrors src/main/config.ts. */
   godProvider?: AgentProvider;

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -71,6 +71,10 @@ export interface Agent {
   /** When git isolation is enabled, the dedicated worktree path the agent runs
    *  in (its own `agent/<id>` branch); undefined for shared-cwd agents. */
   worktreePath?: string;
+  /** Per-agent env vars the agent is spawned with (#105) — e.g. CLAUDE_CONFIG_DIR
+   *  for a separate Claude profile. Persisted (spawn recipe, like `command`) so
+   *  restore-team / revive / restart respawn with the same environment. */
+  env?: Record<string, string>;
   /** Live context size of the agent's Claude session (tokens), polled from its
    *  transcript. Drives the context gauge on the agent card. */
   contextTokens?: number;

--- a/src/shared/agentEnv.ts
+++ b/src/shared/agentEnv.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-agent environment variables (#105) — validation, merge, and display rules.
+ *
+ * Users can attach env vars to an agent (Add Agent modal) and set a global
+ * default (Settings). The headline use case is Claude Code profiles:
+ * CLAUDE_CONFIG_DIR=~/.claude-personal. Env is plain data end-to-end — there is
+ * NO shell in the spawn path, which is also why we expand a leading `~` here.
+ *
+ * Shared between main and renderer; keep it dependency-free (no electron, no
+ * node imports — `home` is always passed in) so tests can transpile it standalone.
+ */
+
+/** Valid env key: what a POSIX shell would accept as an identifier. */
+export const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Keys that can hijack the child process or break the harness's own plumbing.
+ *  Checked case-insensitively. PATH is owned by pty.ts (the resolved interactive
+ *  shell PATH); NODE_OPTIONS / ELECTRON_RUN_AS_NODE / DYLD_* / LD_* are
+ *  code-injection vectors; AGENT_* / HIVE_* / CTH_* are the hive's identity
+ *  namespace and must never be user-settable. */
+const DENY_EXACT = new Set(['PATH', 'NODE_OPTIONS', 'ELECTRON_RUN_AS_NODE']);
+const DENY_PREFIXES = ['DYLD_', 'LD_', 'AGENT_', 'HIVE_', 'CTH_'];
+
+/** Why this key is not allowed, or null if it's fine. */
+export function envKeyIssue(key: string): string | null {
+  if (!ENV_KEY_RE.test(key)) {
+    return `invalid env key "${key}" (letters, digits, underscore; can't start with a digit)`;
+  }
+  const upper = key.toUpperCase();
+  if (DENY_EXACT.has(upper)) return `env key "${key}" is reserved and can't be overridden`;
+  for (const p of DENY_PREFIXES) {
+    if (upper.startsWith(p)) return `env key "${key}" is reserved (${p}*) and can't be overridden`;
+  }
+  return null;
+}
+
+/** Expand a LEADING `~` (bare or `~/…`) to the home dir. No shell in the spawn
+ *  path means a literal `~` would reach the child unexpanded. `~user` forms are
+ *  left alone — resolving other users' homes is a shell feature we don't want. */
+export function expandTilde(value: string, home: string): string {
+  if (value === '~') return home;
+  if (value.startsWith('~/')) return home + value.slice(1);
+  return value;
+}
+
+export type EnvValidation =
+  | { ok: true; env: Record<string, string> }
+  | { ok: false; error: string };
+
+/** Validate user-supplied env and normalize values (tilde expansion). The main
+ *  process is the enforcing boundary — a bad key FAILS the spawn (never a silent
+ *  drop); the renderer reuses this for immediate inline feedback. */
+export function validateAgentEnv(
+  env: Record<string, string> | undefined,
+  home: string
+): EnvValidation {
+  if (!env) return { ok: true, env: {} };
+  const clean: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    const issue = envKeyIssue(key);
+    if (issue) return { ok: false, error: issue };
+    if (typeof value !== 'string') return { ok: false, error: `env value for "${key}" must be a string` };
+    clean[key] = expandTilde(value, home);
+  }
+  return { ok: true, env: clean };
+}
+
+/** Global default (Settings) → per-agent (Add Agent). Per-agent wins. Internal
+ *  injections (hive identity, BYOK, broker) are merged AFTER this by the spawn
+ *  path, so they always win over user env. */
+export function mergeAgentEnv(
+  defaults: Record<string, string>,
+  perAgent: Record<string, string>
+): Record<string, string> {
+  return { ...defaults, ...perAgent };
+}
+
+/** The effective Claude config dir an env implies: the tilde-expanded
+ *  CLAUDE_CONFIG_DIR, or null when unset (caller falls back to ~/.claude). */
+export function claudeConfigDirFrom(
+  env: Record<string, string> | undefined,
+  home: string
+): string | null {
+  const raw = env?.CLAUDE_CONFIG_DIR;
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  return expandTilde(raw.trim(), home);
+}
+
+/** Keys whose values must never appear on derived surfaces (fleet.json, roster
+ *  IPC, tools/agent-env.cjs). registry.json keeps values verbatim (same trust
+ *  level as config.json); everything derived from it masks. */
+const SENSITIVE_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/i;
+
+export function maskSensitiveEnv(env: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) out[k] = SENSITIVE_KEY_RE.test(k) ? '•••' : v;
+  return out;
+}

--- a/src/shared/agentEnv.ts
+++ b/src/shared/agentEnv.ts
@@ -100,8 +100,13 @@ export function claudeConfigDirFrom(
  *  level as config.json); everything derived from it masks. */
 const SENSITIVE_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/i;
 
+/** The placeholder derived surfaces show instead of a sensitive value. Exported
+ *  so the spawn path can recognize a round-tripped mask and resolve the real
+ *  value from registry.json instead of exporting literal bullets. */
+export const ENV_MASK = '•••';
+
 export function maskSensitiveEnv(env: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(env)) out[k] = SENSITIVE_KEY_RE.test(k) ? '•••' : v;
+  for (const [k, v] of Object.entries(env)) out[k] = SENSITIVE_KEY_RE.test(k) ? ENV_MASK : v;
   return out;
 }

--- a/src/shared/agentEnv.ts
+++ b/src/shared/agentEnv.ts
@@ -21,11 +21,20 @@ export const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DENY_EXACT = new Set(['PATH', 'NODE_OPTIONS', 'ELECTRON_RUN_AS_NODE']);
 const DENY_PREFIXES = ['DYLD_', 'LD_', 'AGENT_', 'HIVE_', 'CTH_'];
 
+/** Object-prototype property names. `clean[key] = value` on a plain object
+ *  silently no-ops (or reaches the prototype chain) for these instead of
+ *  setting an own property, which would otherwise let a key like `__proto__`
+ *  vanish from `validateAgentEnv`'s output without ever failing the spawn —
+ *  a silent drop the module's contract explicitly forbids. Checked
+ *  case-insensitively for the same reason the denylist below is. */
+const RESERVED_PROP_NAMES = new Set(['__proto__', 'prototype', 'constructor']);
+
 /** Why this key is not allowed, or null if it's fine. */
 export function envKeyIssue(key: string): string | null {
   if (!ENV_KEY_RE.test(key)) {
     return `invalid env key "${key}" (letters, digits, underscore; can't start with a digit)`;
   }
+  if (RESERVED_PROP_NAMES.has(key.toLowerCase())) return `env key "${key}" is reserved`;
   const upper = key.toUpperCase();
   if (DENY_EXACT.has(upper)) return `env key "${key}" is reserved and can't be overridden`;
   for (const p of DENY_PREFIXES) {

--- a/src/shared/hire.ts
+++ b/src/shared/hire.ts
@@ -88,6 +88,9 @@ export interface HireValidation {
    *  safe-readonly (write or secret tier). These must be surfaced to the human
    *  for explicit consent before they are enabled — they are NEVER auto-enabled. */
   consentRequired?: string[];
+  /** Non-fatal notices to surface in the import banner (e.g. a manifest carried
+   *  an `env` field — env vars are human-entered only, never imported, #105). */
+  warnings?: string[];
 }
 
 const PROVIDERS: readonly string[] = ['claude', 'antigravity', 'codex'];
@@ -188,6 +191,14 @@ export function validateHireManifest(raw: unknown): HireValidation {
   }
   const author = capped(o.author, 80, 'author', errors);
   const homepage = capped(o.homepage, 300, 'homepage', errors);
+
+  const warnings: string[] = [];
+  // #105 — env vars are code-execution-adjacent (NODE_OPTIONS, DYLD_*), so a
+  // manifest (untrusted input) can never carry them. Not an error — the rest of
+  // the hire imports fine — but the human is told the field was ignored.
+  if (o.env !== undefined) {
+    warnings.push('this hire declared env vars — env is not importable; set it by hand in Workspace → Env vars');
+  }
 
   let provider: HireProvider | undefined;
   if (o.provider !== undefined) {
@@ -307,11 +318,12 @@ export function validateHireManifest(raw: unknown): HireValidation {
 
   if (homepage && !homepage.startsWith('https://')) errors.push('"homepage" must be https');
 
-  if (errors.length > 0 || !name) return { ok: false, errors };
+  if (errors.length > 0 || !name) return { ok: false, errors, ...(warnings.length ? { warnings } : {}) };
   return {
     ok: true,
     errors: [],
     consentRequired: consentRequired.length > 0 ? consentRequired : undefined,
+    ...(warnings.length ? { warnings } : {}),
     manifest: { spec: HIRE_SPEC_V1, name, description, goal, character, accent, provider, model, commandFlags, capabilities, isolate, tokenCap, author, homepage, skills, mcpServers }
   };
 }

--- a/test/agent-env.test.cjs
+++ b/test/agent-env.test.cjs
@@ -55,6 +55,16 @@ check('denylist is case-insensitive on exact names', () => {
   assert.ok(ae.envKeyIssue('Path'));
   assert.ok(ae.envKeyIssue('node_options'));
 });
+check('denylist prefixes are case-insensitive too (lowercase input)', () => {
+  assert.ok(ae.envKeyIssue('dyld_insert_libraries'));
+});
+check('rejects object-prototype property names as keys', () => {
+  assert.ok(ae.envKeyIssue('__proto__'));
+  assert.ok(ae.envKeyIssue('prototype'));
+  assert.ok(ae.envKeyIssue('constructor'));
+  // case-insensitive, same as the rest of envKeyIssue's checks
+  assert.ok(ae.envKeyIssue('__PROTO__'));
+});
 
 // ── validateAgentEnv ─────────────────────────────────────────────────────────
 check('undefined/empty env validates to {}', () => {
@@ -75,6 +85,18 @@ check('a non-string value fails validation', () => {
   const r = ae.validateAgentEnv({ FOO: 42 }, HOME);
   assert.strictEqual(r.ok, false);
   assert.ok(r.error.includes('FOO'));
+});
+check('a __proto__ key fails validation instead of silently vanishing', () => {
+  // NOTE: `{ __proto__: 'x' }` as an object LITERAL sets the prototype slot
+  // (ignored here since 'x' isn't an object/null) rather than creating an own
+  // property — Object.entries on it is empty, so it can't exercise this bug.
+  // A renderer/IPC payload carries `__proto__` as a real own property (this is
+  // exactly what JSON.parse produces, per spec), so that's what we construct.
+  const input = JSON.parse('{"__proto__": "x", "FOO": "bar"}');
+  assert.ok(Object.prototype.hasOwnProperty.call(input, '__proto__'), 'sanity: own prop, not the prototype slot');
+  const r = ae.validateAgentEnv(input, HOME);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.error.includes('__proto__'));
 });
 
 // ── expandTilde ──────────────────────────────────────────────────────────────

--- a/test/agent-env.test.cjs
+++ b/test/agent-env.test.cjs
@@ -1,0 +1,121 @@
+'use strict';
+/**
+ * Per-agent env (#105) tests. Self-contained, no test framework — run with
+ * `node test/agent-env.test.cjs` (mirrors test/agent-provider.test.cjs). The
+ * module under test is dependency-free TypeScript (src/shared/agentEnv.ts), so
+ * we transpile it with the bundled `typescript` compiler into a temp dir and
+ * require the result. Covers key validation, the denylist, merge precedence,
+ * tilde expansion, Claude config-dir resolution, and sensitive-value masking.
+ */
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const ts = require('typescript');
+
+const SHARED = path.join(__dirname, '..', 'src', 'shared');
+const out = fs.mkdtempSync(path.join(os.tmpdir(), 'agentenv-'));
+const src = fs.readFileSync(path.join(SHARED, 'agentEnv.ts'), 'utf8');
+const js = ts.transpileModule(src, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 }
+}).outputText;
+fs.writeFileSync(path.join(out, 'agentEnv.js'), js, 'utf8');
+const ae = require(path.join(out, 'agentEnv.js'));
+
+let failures = 0;
+function check(name, fn) {
+  try { fn(); console.log(`  ok  ${name}`); }
+  catch (e) { failures++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+const HOME = '/Users/tester';
+
+// ── key validation ───────────────────────────────────────────────────────────
+check('accepts a plain key', () => {
+  assert.strictEqual(ae.envKeyIssue('CLAUDE_CONFIG_DIR'), null);
+});
+check('rejects malformed keys', () => {
+  assert.ok(ae.envKeyIssue('9BAD'));
+  assert.ok(ae.envKeyIssue('has space'));
+  assert.ok(ae.envKeyIssue('has-dash'));
+  assert.ok(ae.envKeyIssue(''));
+});
+check('rejects exact denylisted keys', () => {
+  for (const k of ['PATH', 'NODE_OPTIONS', 'ELECTRON_RUN_AS_NODE']) {
+    assert.ok(ae.envKeyIssue(k), `${k} should be denied`);
+  }
+});
+check('rejects denylisted prefixes', () => {
+  for (const k of ['DYLD_INSERT_LIBRARIES', 'LD_PRELOAD', 'AGENT_ID', 'HIVE_ROOT', 'CTH_X']) {
+    assert.ok(ae.envKeyIssue(k), `${k} should be denied`);
+  }
+});
+check('denylist is case-insensitive on exact names', () => {
+  assert.ok(ae.envKeyIssue('Path'));
+  assert.ok(ae.envKeyIssue('node_options'));
+});
+
+// ── validateAgentEnv ─────────────────────────────────────────────────────────
+check('undefined/empty env validates to {}', () => {
+  assert.deepStrictEqual(ae.validateAgentEnv(undefined, HOME), { ok: true, env: {} });
+  assert.deepStrictEqual(ae.validateAgentEnv({}, HOME), { ok: true, env: {} });
+});
+check('valid env passes through with tilde expansion', () => {
+  const r = ae.validateAgentEnv({ CLAUDE_CONFIG_DIR: '~/.claude-personal', FOO: 'bar' }, HOME);
+  assert.strictEqual(r.ok, true);
+  assert.deepStrictEqual(r.env, { CLAUDE_CONFIG_DIR: `${HOME}/.claude-personal`, FOO: 'bar' });
+});
+check('a denylisted key fails validation with the key named', () => {
+  const r = ae.validateAgentEnv({ NODE_OPTIONS: '--require evil' }, HOME);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.error.includes('NODE_OPTIONS'));
+});
+check('a non-string value fails validation', () => {
+  const r = ae.validateAgentEnv({ FOO: 42 }, HOME);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.error.includes('FOO'));
+});
+
+// ── expandTilde ──────────────────────────────────────────────────────────────
+check('expands leading ~/ and bare ~', () => {
+  assert.strictEqual(ae.expandTilde('~/x/y', HOME), `${HOME}/x/y`);
+  assert.strictEqual(ae.expandTilde('~', HOME), HOME);
+});
+check('does not expand mid-string or ~user', () => {
+  assert.strictEqual(ae.expandTilde('a~b', HOME), 'a~b');
+  assert.strictEqual(ae.expandTilde('~other/x', HOME), '~other/x');
+});
+
+// ── mergeAgentEnv ────────────────────────────────────────────────────────────
+check('per-agent env overrides defaults', () => {
+  const merged = ae.mergeAgentEnv({ A: '1', B: '2' }, { B: '3', C: '4' });
+  assert.deepStrictEqual(merged, { A: '1', B: '3', C: '4' });
+});
+
+// ── claudeConfigDirFrom ──────────────────────────────────────────────────────
+check('returns expanded CLAUDE_CONFIG_DIR when set', () => {
+  assert.strictEqual(
+    ae.claudeConfigDirFrom({ CLAUDE_CONFIG_DIR: '~/.claude-personal' }, HOME),
+    `${HOME}/.claude-personal`
+  );
+});
+check('returns null when unset/empty/undefined env', () => {
+  assert.strictEqual(ae.claudeConfigDirFrom({}, HOME), null);
+  assert.strictEqual(ae.claudeConfigDirFrom({ CLAUDE_CONFIG_DIR: '' }, HOME), null);
+  assert.strictEqual(ae.claudeConfigDirFrom(undefined, HOME), null);
+});
+
+// ── maskSensitiveEnv ─────────────────────────────────────────────────────────
+check('masks values whose key looks secret, keeps the rest', () => {
+  const masked = ae.maskSensitiveEnv({
+    OPENAI_API_KEY: 'sk-abc', MY_TOKEN: 't', DB_SECRET: 's', PASSWORD: 'p',
+    CLAUDE_CONFIG_DIR: '/x'
+  });
+  assert.deepStrictEqual(masked, {
+    OPENAI_API_KEY: '•••', MY_TOKEN: '•••', DB_SECRET: '•••', PASSWORD: '•••',
+    CLAUDE_CONFIG_DIR: '/x'
+  });
+});
+
+process.exit(failures ? 1 : 0);

--- a/tools/agent-env.cjs
+++ b/tools/agent-env.cjs
@@ -23,6 +23,7 @@
  * env, no key material). Emits directory PATHS + non-secret session metadata; it
  * never reads or prints file contents, credentials, or API keys. `sessionId` is a
  * non-secret `claude --resume` UUID, already stored plaintext in registry.json.
+ * Per-agent env (#105) is included on output but masked (no raw key material).
  *
  * USAGE (run from anywhere; $HIVE_ROOT or --hive locates the hive):
  *   node tools/agent-env.cjs                 # table of live (non-archived) agents
@@ -61,6 +62,16 @@ function cwdState(cwd) {
   }
 }
 
+/** Mask env values whose key looks like key material — this tool's output is
+ *  documented as non-sensitive (#105). Mirrors src/shared/agentEnv.ts. */
+const SENSITIVE_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/i;
+function maskEnv(env) {
+  if (!env || typeof env !== 'object') return undefined;
+  const out = {};
+  for (const [k, v] of Object.entries(env)) out[k] = SENSITIVE_KEY_RE.test(k) ? '•••' : v;
+  return Object.keys(out).length ? out : undefined;
+}
+
 function buildRecords(hiveRoot) {
   const reg = readJson(path.join(hiveRoot, 'registry.json'), { agents: {} });
   const fleet = readJson(path.join(hiveRoot, 'fleet.json'), { agents: [] });
@@ -83,6 +94,7 @@ function buildRecords(hiveRoot) {
       archived: !!a.archived,
       // --- environment ---
       cwd,
+      env: maskEnv(a.env),
       cwdValid: valid,
       cwdIssue: valid ? null : cs.issue,
       // --- session ---


### PR DESCRIPTION
Closes #105.

## Problem

Users running separate Claude Code accounts (work vs personal via `CLAUDE_CONFIG_DIR=~/.claude-personal claude`) had no way to make Munder Difflin spawn an agent with that profile. Shell aliases aren't visible to the spawner (it resolves the binary via `which`, no shell), and an env-prefixed command string is tokenized and exec'd directly by node-pty, so `CLAUDE_CONFIG_DIR=… claude` fails.

## What this adds

Per-agent environment variables, as plain data on the existing spawn path:

- **Add Agent → Workspace → Env vars**: a `KEY=VALUE` row editor. `~` expands to home.
- **Settings → General → Agent environment**: a global default env inherited by every spawn, including the GOD orchestrator (Michael). Per-agent env overrides the global default; internal injections (hive identity, BYOK keys, broker tokens) always win over user env.
- **`CLAUDE_CONFIG_DIR` follow-through**: when an agent overrides its config dir, token/cost telemetry, session-resume transcript seeding, and Claude permissions-acceptance all target/scan that dir — so a profile agent runs the right account *and* still reports tokens.

## Safety

- Validation runs at the main-process boundary: a bad key (regex-invalid, or a denylisted `PATH`/`NODE_OPTIONS`/`ELECTRON_RUN_AS_NODE`/`DYLD_*`/`LD_*`/`AGENT_*`/`HIVE_*`/`CTH_*`/`__proto__`) **fails the spawn** with a named error, never a silent drop.
- The `pty:spawn` IPC strips the main-internal `agentEnvApplied`/`internalEnv` fields off renderer payloads so they can't bypass validation.
- Hire manifests (untrusted input) **cannot** import env; an `env` field is ignored with a notice on file import.
- Env persists verbatim in `registry.json` (same trust level as `config.json`) but is **masked** (`•••` for `*KEY*`/`*TOKEN*`/`*SECRET*`/…) on every derived surface: `fleet.json`, the `hive:registry` IPC, and `tools/agent-env.cjs`.
- Env round-trips through restore-team / revive / restart respawns.

## Testing

- New `test/agent-env.test.cjs` (18 assertions): validation, denylist (incl. lowercase-prefix + `__proto__`), tilde expansion, merge precedence, config-dir resolution, masking.
- `npm run typecheck` (node + web), all 6 test scripts, and `npm run build` green.
- Design docs: `docs/superpowers/specs/2026-07-08-per-agent-env-vars-design.md`, `docs/superpowers/plans/2026-07-08-per-agent-env-vars.md`.

Note: env is data-only end-to-end — no shell is introduced into the spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
