### PR TITLE
fix(queue): "send now" escape hatch while floor auto-delivery is paused

### DIFF
--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -139,33 +139,48 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
         }}>
           <SpritePortrait character={agent.character} scale={1} />
         </div>
+        {/* Title + subtitle truncate; the control cluster never shrinks. At
+            sidebar width the old header wrapped its 24-char display-font title
+            onto three lines and "runs the floor" word-per-line under the two
+            wide buttons — everything here is single-line by construction. */}
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{
-            fontFamily: 'var(--cth-font-display)', fontSize: 10, lineHeight: '14px', color: 'var(--cth-ink-900)'
-          }}>MICHAEL · COMMAND CENTER</div>
-          <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginTop: 1 }}>
+            fontFamily: 'var(--cth-font-display)', fontSize: 10, lineHeight: '14px', color: 'var(--cth-ink-900)',
+            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+          }}>COMMAND CENTER</div>
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginTop: 1, minWidth: 0 }}>
             <PixelBadge status={agent.status} />
-            <span style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>runs the floor</span>
+            <span style={{
+              fontSize: 12, color: 'var(--cth-ink-500)',
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+            }}>Michael runs the floor</span>
           </div>
         </div>
         {/* v0.3.4: floor-wide auto-delivery lives HERE (one switch for every
-            agent's queue), and the IDE opens from agent level, not the toolbar. */}
-        <PixelButton
-          variant={floorDeliveryPaused ? 'primary' : 'secondary'}
-          size="sm"
-          onClick={() => { void toggleFloorDelivery(); }}
-        >
-          <span title={floorDeliveryPaused
-            ? 'Automatic queue delivery is PAUSED for every agent — messages stay queued until resumed'
-            : 'Automatic queue delivery is ON for every agent — click to pause the whole floor'}>
-            {floorDeliveryPaused ? 'delivery paused' : 'auto-delivery on'}
-          </span>
-        </PixelButton>
-        <PixelButton variant="secondary" size="sm" onClick={() => useStore.getState().setIdeOpen(true)}>
-          <span title="Open the IDE — file editor + git diff" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-            <Icon name="code" /> IDE
-          </span>
-        </PixelButton>
+            agent's queue), and the IDE opens from agent level, not the toolbar.
+            Short labels — the tooltips carry the full explanation. */}
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
+          <PixelButton
+            variant={floorDeliveryPaused ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={() => { void toggleFloorDelivery(); }}
+          >
+            <span
+              title={floorDeliveryPaused
+                ? 'Automatic queue delivery is PAUSED for every agent — messages stay queued until resumed'
+                : 'Automatic queue delivery is ON for every agent — click to pause the whole floor'}
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+            >
+              <Icon name={floorDeliveryPaused ? 'pause' : 'play'} />
+              {floorDeliveryPaused ? 'paused' : 'auto'}
+            </span>
+          </PixelButton>
+          <PixelButton variant="secondary" size="sm" onClick={() => useStore.getState().setIdeOpen(true)}>
+            <span title="Open the IDE — file editor + git diff" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              <Icon name="code" /> IDE
+            </span>
+          </PixelButton>
+        </div>
       </div>
 
       {/* Tab bar — an auto-fit grid of equal-width cells. The tabs wrap onto

--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -162,7 +162,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
     : !idle
     ? `${agent.name} is busy — ${queue.length} queued`
     : deliveryPaused && !queue[0]?.manual
-    ? 'held — auto-delivery is paused floor-wide (resume it in the Command Center, or "send now" a message below)'
+    ? 'held — delivery paused floor-wide'
     : block === 'draft'
     ? `held — ${agent.name}'s terminal has unsent text on its prompt`
     : block === 'picker'
@@ -212,11 +212,16 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
           }}>{queue.length}</span>
         )}
         {statusHint && (
-          <span style={{
-            fontSize: 12,
-            color: idle ? 'var(--cth-ink-700)' : 'var(--cth-ink-500)',
-            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
-          }}>{statusHint}</span>
+          <span
+            title={deliveryPaused && !queue[0]?.manual
+              ? 'Auto-delivery is paused for the whole floor. Resume it in the Command Center, or use "send now" on a message below.'
+              : statusHint}
+            style={{
+              fontSize: 12,
+              color: idle ? 'var(--cth-ink-700)' : 'var(--cth-ink-500)',
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+            }}
+          >{statusHint}</span>
         )}
         {(block === 'draft' || block === 'picker') && agent.ptyId && (
           <button
@@ -247,7 +252,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
             onClick={() => clearQueue(agent.id)}
             title="Clear all queued messages"
             style={{
-              marginLeft: 'auto',
+              marginLeft: 'auto', flexShrink: 0, whiteSpace: 'nowrap',
               border: 'none', background: 'transparent', cursor: 'pointer',
               fontFamily: 'var(--cth-font-ui)', fontSize: 12,
               color: 'var(--cth-ink-500)'

--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -30,6 +30,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   const queue = useStore((s) => s.messageQueues[agent.id]) ?? EMPTY_QUEUE;
   const enqueueMessage = useStore((s) => s.enqueueMessage);
   const removeQueuedMessage = useStore((s) => s.removeQueuedMessage);
+  const releaseQueuedMessage = useStore((s) => s.releaseQueuedMessage);
   const clearQueue = useStore((s) => s.clearQueue);
 
   // Draft lives in the store, keyed by agent — switching agents remounts this
@@ -151,10 +152,17 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   // the hint claimed it was sending while nothing moved — so poll it and say so.
   const block = useTerminalBlock(agent.ptyId, queue.length > 0 && idle);
 
+  // Floor-wide auto-delivery pause (Command Center switch) also holds the queue.
+  // Without saying so — and without the per-row "send now" override — messages
+  // look permanently stuck with no explanation and no escape hatch.
+  const deliveryPaused = useDeliveryPaused(agent.id, queue.length > 0);
+
   const statusHint = queue.length === 0
     ? null
     : !idle
     ? `${agent.name} is busy — ${queue.length} queued`
+    : deliveryPaused && !queue[0]?.manual
+    ? 'held — auto-delivery is paused floor-wide (resume it in the Command Center, or "send now" a message below)'
     : block === 'draft'
     ? `held — ${agent.name}'s terminal has unsent text on its prompt`
     : block === 'picker'
@@ -259,6 +267,8 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
               key={m.id}
               index={i}
               message={m}
+              paused={deliveryPaused}
+              onSendNow={() => releaseQueuedMessage(agent.id, m.id)}
               onRemove={() => removeQueuedMessage(agent.id, m.id)}
             />
           ))}
@@ -379,13 +389,40 @@ function useTerminalBlock(ptyId: string | undefined, active: boolean): TerminalA
   return block === 'settling' ? null : block;
 }
 
+/** Poll the floor-wide auto-delivery pause (main-process control state) while
+ * this agent has messages waiting. 2s is plenty — the pause flips on human
+ * timescales, and the drain re-reads the live snapshot before every send. */
+function useDeliveryPaused(agentId: string, active: boolean): boolean {
+  const [paused, setPaused] = useState(false);
+  useEffect(() => {
+    if (!active) { setPaused(false); return; }
+    let alive = true;
+    const read = () => {
+      window.cth.controlSnapshot(agentId)
+        .then((s) => { if (alive) setPaused(!!s?.autoDeliveryPaused); })
+        .catch(() => { /* main not ready — assume not paused */ });
+    };
+    read();
+    const iv = setInterval(read, 2000);
+    return () => { alive = false; clearInterval(iv); };
+  }, [agentId, active]);
+  return paused;
+}
+
 /**
  * One pending queue row. Collapsed it clamps to 2 lines; "see more" expands it
  * in place so a long message can be read without hovering for the tooltip. The
  * toggle only renders when the text actually clips, so short messages stay tidy.
  */
 function QueuedMessageRow(
-  { index, message, onRemove }: { index: number; message: QueuedMessage; onRemove: () => void }
+  { index, message, paused, onSendNow, onRemove }: {
+    index: number;
+    message: QueuedMessage;
+    /** Floor-wide auto-delivery is paused — offer the per-message override. */
+    paused: boolean;
+    onSendNow: () => void;
+    onRemove: () => void;
+  }
 ) {
   const [expanded, setExpanded] = useState(false);
   const [clipped, setClipped] = useState(false);
@@ -436,17 +473,36 @@ function QueuedMessageRow(
                 })
           }}
         >{message.text}</div>
-        {(clipped || expanded) && (
-          <button
-            onClick={() => setExpanded((e) => !e)}
-            title={expanded ? 'Collapse this message' : 'Show the full message'}
-            style={{
-              alignSelf: 'flex-start',
-              border: 'none', background: 'transparent', cursor: 'pointer', padding: 0,
-              fontFamily: 'var(--cth-font-ui)', fontSize: 12, lineHeight: '16px',
-              color: 'var(--cth-ink-500)', textDecoration: 'underline'
-            }}
-          >{expanded ? 'see less' : 'see more'}</button>
+        {(clipped || expanded || paused) && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            {(clipped || expanded) && (
+              <button
+                onClick={() => setExpanded((e) => !e)}
+                title={expanded ? 'Collapse this message' : 'Show the full message'}
+                style={{
+                  border: 'none', background: 'transparent', cursor: 'pointer', padding: 0,
+                  fontFamily: 'var(--cth-font-ui)', fontSize: 12, lineHeight: '16px',
+                  color: 'var(--cth-ink-500)', textDecoration: 'underline'
+                }}
+              >{expanded ? 'see less' : 'see more'}</button>
+            )}
+            {paused && !message.manual && (
+              <button
+                onClick={onSendNow}
+                title="Deliver this message even though auto-delivery is paused. It moves to the front of the queue and types in as soon as the terminal is free."
+                style={{
+                  border: 'none', background: 'transparent', cursor: 'pointer', padding: 0,
+                  fontFamily: 'var(--cth-font-ui)', fontSize: 12, lineHeight: '16px',
+                  color: 'var(--cth-ink-900)', textDecoration: 'underline'
+                }}
+              >send now</button>
+            )}
+            {paused && message.manual && (
+              <span style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-500)' }}>
+                sending when free…
+              </span>
+            )}
+          </div>
         )}
       </div>
       <button

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -648,7 +648,11 @@ export function useHive(config: HarnessConfig | null): void {
       if (!next || !target?.ptyId || target.status !== 'idle') return { sent: false };
       const now = Date.now();
       const control = await window.cth.controlSnapshot(target.id);
-      if (control?.autoDeliveryPaused) return { sent: false };
+      // The pause gate holds everything EXCEPT messages the user explicitly
+      // released with "send now" (m.manual) — otherwise a paused floor leaves
+      // the queue with no escape hatch at all. Idle/draft/picker safety below
+      // still applies to manual messages; only the pause is bypassed.
+      if (control?.autoDeliveryPaused && !next.manual) return { sent: false };
       // Hold queued messages until the target finishes its boot sequence.
       if ((bootGraceUntil.current[target.id] ?? 0) >= now) return { sent: false };
       // The user owns the prompt: a draft they are writing, or a menu they

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -113,6 +113,10 @@ export interface QueuedMessage {
    *  `text`. Used by Slack-origin work to carry the autonomy preamble to god's
    *  prompt without polluting the human-readable kanban card title (= raw `text`). */
   instruction?: string;
+  /** User clicked "send now" while floor-wide auto-delivery was paused. Bypasses
+   *  ONLY the pause gate in the drain loop — idle/draft/picker safety still hold,
+   *  so it delivers the moment the terminal is actually free. */
+  manual?: boolean;
 }
 
 // 'files' retired in v0.3.4 (the per-agent IDE button superseded it) — a
@@ -227,6 +231,9 @@ interface State {
   enqueueMessage: (agentId: string, text: string, meta?: { slack?: { channel: string; thread_ts: string }; instruction?: string }) => void;
   /** Drop a single queued message (user removed it, or it was just delivered). */
   removeQueuedMessage: (agentId: string, messageId: string) => void;
+  /** "Send now" while floor auto-delivery is paused: marks the message manual
+   *  (drain bypasses the pause gate for it) and moves it to the queue front. */
+  releaseQueuedMessage: (agentId: string, messageId: string) => void;
   /** Clear an agent's entire pending queue. */
   clearQueue: (agentId: string) => void;
   setAddAgentOpen: (open: boolean) => void;
@@ -702,6 +709,19 @@ export const useStore = create<State>((set) => ({
       const current = s.messageQueues[agentId];
       if (!current) return s;
       const next = current.filter((m) => m.id !== messageId);
+      const messageQueues = { ...s.messageQueues, [agentId]: next };
+      persistQueues(messageQueues);
+      return { messageQueues };
+    }),
+  releaseQueuedMessage: (agentId, messageId) =>
+    set((s) => {
+      const current = s.messageQueues[agentId];
+      const target = current?.find((m) => m.id === messageId);
+      if (!current || !target) return s;
+      const next = [
+        { ...target, manual: true },
+        ...current.filter((m) => m.id !== messageId)
+      ];
       const messageQueues = { ...s.messageQueues, [agentId]: next };
       persistQueues(messageQueues);
       return { messageQueues };


### PR DESCRIPTION
Pausing floor-wide auto-delivery (the Command Center switch) held every queued message with no explanation in the composer and no manual way to deliver one — queues looked permanently stuck until the floor was unpaused.

**What changed**
- `QueuedMessage.manual` — set when the user clicks **send now** on a queued row; the drain loop bypasses **only** the pause gate for it (`useHive.ts`). Idle, draft, picker, cooldown, and boot-grace safety all still apply.
- `releaseQueuedMessage` store action — marks the message manual and moves it to the front of the queue.
- Composer now polls the pause state while messages are waiting, shows an honest hint ("held — auto-delivery is paused floor-wide (resume it in the Command Center, or 'send now' a message below)"), and each queued row gets a **send now** link while paused, turning into "sending when free…" once released.

**Verification**: typecheck (node+web) clean, `test:focused` 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)