### PR TITLE
release: v0.3.5 — send-now fix wave + full website/blog/SEO refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] — 2026-08-06
+
+**The queue always has an escape hatch, and the app updates itself for the first time.**
+A fast-follow to 0.3.4: one real workflow fix, a sidebar polish pass, and the first
+release your installed app can pick up on its own — 0.3.4 installs get the
+"v0.3.5 downloaded — Restart to update" toast instead of a trip to the website.
+
+### Fixed
+- **Queued messages are never stuck again.** Pausing floor-wide auto-delivery (the
+  Command Center switch) used to hold every queued message with no explanation and no
+  manual override. Each queued row now grows a **send now** link while the floor is
+  paused: it moves that message to the front and bypasses *only* the pause gate —
+  idle/draft/picker safety and delivery acknowledgement all still apply, so it types in
+  the moment the terminal is genuinely free ("sending when free…" until then). The
+  composer also says why nothing is moving: "held — delivery paused floor-wide", with
+  the full story (and where to resume) on hover.
+
+### Changed
+- **Compact Command Center header.** At sidebar width the old header wrapped its
+  display-font title onto three lines, stacked "runs the floor" word-per-line, and let
+  the two wide toolbar buttons crush everything else. Now: single-line **COMMAND
+  CENTER** title + "Michael runs the floor" subtitle (both ellipsize), and the floor
+  delivery toggle compressed to ▶ `auto` / ⏸ `paused` with the full explanation in its
+  tooltip. The queue header's "clear all" no longer wraps either.
+
+### Notes
+- **First auto-updated release.** 0.3.4 introduced the updater; 0.3.5 is the first
+  version it delivers. Running 0.3.4 apps download this in the background and prompt
+  "Restart to update" (never restarting on their own). 0.3.3 and older have no updater —
+  grab this one from [munderdiffl.in](https://munderdiffl.in) and you're on the train.
+
 ## [0.3.4] — 2026-08-06
 
 **The queue you can trust, a Michael who actually knows the floor, and an IDE that shows

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Munder Difflin v0.3.4
+# Munder Difflin v0.3.5
 
 **A local hive of Claude Code, Antigravity, Codex, Grok & Copilot agents that run themselves** — messaging,
 routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-first and open source.
@@ -7,7 +7,23 @@ routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-f
 
 ---
 
-## What's new in 0.3.4 — *Talk to a Michael who knows the floor, see everything in the IDE*
+## What's new in 0.3.5 — *The queue always has an escape hatch*
+
+A fast-follow to yesterday's big 0.3.4 wave — and the **first release the app delivers to
+itself**: if you're on 0.3.4, it downloads in the background and offers "Restart to
+update". Nothing to download, nothing restarts on its own.
+
+- **"Send now" for a paused floor.** Pausing floor-wide auto-delivery used to strand every
+  queued message with no explanation and no override. Each queued row now gets a **send
+  now** link while the floor is paused — it bypasses only the pause gate (draft/picker/idle
+  safety still hold) and the composer says exactly why the queue is being held.
+- **Compact Command Center header.** No more three-line wrapped title and crushed buttons
+  at sidebar width — single-line title, ellipsizing subtitle, and an icon-sized
+  ▶ auto / ⏸ paused delivery toggle.
+
+---
+
+## What was new in 0.3.4 — *Talk to a Michael who knows the floor, see everything in the IDE*
 
 **A community release plus a four-feature first-party wave.** The terminal/queue
 reliability work is by [**@gts-47**](https://github.com/gts-47) (Vyapak Goyal), with major

--- a/blog/src/posts/launching-munder-difflin-v0-3-5.md
+++ b/blog/src/posts/launching-munder-difflin-v0-3-5.md
@@ -1,0 +1,122 @@
+---
+title: "Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself"
+description: "The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch."
+date: 2026-08-06
+category: story
+categoryLabel: Story
+type: Non-technical
+primaryKeyword: "munder difflin v0.3.5"
+secondaryKeywords: ["voice ai agent orchestration", "git commit history ide electron", "markdown preview ai agent output", "electron app auto update github releases", "grok cli agent", "claude code multi-agent release"]
+tags: ["Story", "Release", "Multi-Agent", "Voice", "IDE", "Open Source"]
+author:
+  name: Chaitanya Giri
+  initials: CG
+faq:
+  - q: "What's new in Munder Difflin v0.3.5?"
+    a: "v0.3.5 is the polish pass on top of the big v0.3.4 wave, so the headline is really both: Michael's talk mode now opens with a live snapshot of every agent and can run nearly the whole app by voice; markdown files preview live in the IDE and open rendered from a ⌘-click in any terminal; the IDE gains a clickable commit history, branch compare, and guarded checkout; Settings was redesigned into six clear tabs; xAI Grok and Kimi Code joined the engine roster; the app now auto-updates from GitHub releases; and v0.3.5 itself fixes the paused-queue dead end with a per-message 'send now' override."
+  - q: "Do I need to reinstall to get v0.3.5?"
+    a: "If you're on v0.3.4 — no. This is the first release the app delivers to itself: it downloads in the background and shows a 'Restart to update' toast; installation only ever happens on your click. If you're on v0.3.3 or older there's no updater in your build, so grab v0.3.5 once from munderdiffl.in and you're on the train from then on."
+  - q: "What can Michael actually do by voice now?"
+    a: "Nearly everything: spawn and archive agents, assign and steer work, resume paused agents, pause or resume floor-wide message delivery, gate specific tools, manage tasks, create schedules, clear an agent's context, and change settings from a strict allowlist. Destructive actions still require you to say a distinct confirm word out loud, secrets can never be touched by voice, and he now answers 'what's everyone doing?' from a live floor snapshot instead of guessing."
+  - q: "What does the git time-machine in the IDE do?"
+    a: "The IDE rail gains HISTORY and COMPARE next to CHANGES. History is a clickable commit graph: pick any commit, see the files it touched, and open side-by-side diffs of exactly what changed. Compare takes any two branches and shows ahead/behind counts and per-file diffs. Checkout is guarded — it refuses to move a dirty tree or pull code out from under an agent that's actively working."
+  - q: "Is the markdown preview safe for agent-generated files?"
+    a: "Yes, by construction. There is no raw-HTML pipeline at all, links never navigate the app (external ones open in your browser, relative .md links open in a new preview), and remote images are blocked by the app's content security policy. Agents write a lot of markdown; you can now read it rendered without trusting it."
+  - q: "How does Munder Difflin compare to YC's qm?"
+    a: "They're complementary answers to the same problem. qm is a multiplayer agent harness for teams — headless, living in Slack and a web UI. Munder Difflin covers the same jobs (security postures, background scheduled work, Slack triggers, shareable skills) as a simpler local-first desktop app, and adds real watchable terminals, voice orchestration, a built-in IDE with git visualization, and auto-update. See our full qm vs Munder Difflin comparison post."
+---
+
+<div class="callout tldr"><span class="ic">TL;DR</span><p><strong>Munder Difflin v0.3.5</strong> caps the biggest release wave we've shipped. <strong>Talk mode grew up</strong>: Michael opens the call already knowing every agent's status and can run nearly the whole app by voice. The IDE became a <strong>git time-machine</strong> — clickable commit history, branch compare, guarded checkout — and <strong>markdown previews</strong> render everywhere agents write them. <strong>Settings got six clear tabs</strong>, <strong>xAI Grok and Kimi Code</strong> joined the engine roster, the whole app got a <strong>professional type-and-color pass with full dark mode</strong> — and from v0.3.4 onward, <strong>the app updates itself</strong>. Free, MIT-licensed, local-first.</p></div>
+
+This is a double-feature post: v0.3.4 shipped the features, v0.3.5 shipped the polish a day
+later, and if you're installing fresh you get both at once. A huge part of this wave is
+community work — the terminal/queue/roster reliability overhaul is by
+[**Vyapak Goyal (@gts-47)**](https://github.com/gts-47), with major fixes by
+[**@qschmick**](https://github.com/qschmick).
+
+## Michael finally knows the floor
+
+Talk mode has been able to *do* things since v0.3.2. What it couldn't do was *know* things
+without looking them up — every "what's everyone working on?" turned into tool calls and
+dead air.
+
+Now the voice session opens with a compact live snapshot of the whole floor — every agent's
+status, engine, context fill, circuit-breaker state, inbox depth, and in-flight tasks — and
+keeps receiving silent floor updates as things change mid-call. Ask what's happening and he
+just answers.
+
+He also graduated from narrator to operator. New voice verbs: **resume** a paused agent,
+pause/resume floor-wide message delivery, **gate specific tools**, delete tasks,
+archive/unarchive agents, **clear an agent's context**, **create schedules**, and **change
+settings** — from a strict allowlist where secrets and dangerous keys are refused outright,
+behavior-changing keys echo old→new values, and anything destructive still waits for you to
+say a distinct confirm word. He even knows what version he's running: ask "what's new in
+this update?" and he reads you the release notes.
+
+## The IDE becomes a git time-machine
+
+v0.3.3's IDE could show you a diff against HEAD. This wave makes it a place you can *move
+through history*:
+
+- **HISTORY** — a clickable commit graph of the whole repo. Pick a commit, see every file
+  it touched, open a side-by-side diff of exactly what changed. "Jump here" checks out any
+  commit — with guards.
+- **COMPARE** — pick any two branches, see ahead/behind counts and per-file diffs, and
+  switch between them safely.
+- **Guarded checkout** — the harness refuses to move a dirty tree, and refuses to yank code
+  out from under an agent whose terminal was active in the last ten seconds. Your agents'
+  work can't be stranded by a curious click.
+
+And because agents write markdown constantly — plans, reports, READMEs — **markdown now
+renders everywhere**: a live **code | split | preview** switch in the IDE, and **⌘-click on
+any `.md` path an agent prints in its terminal** to open a rendered preview instantly.
+Safe by construction: no raw-HTML pipeline exists, links never navigate the app, and remote
+images are blocked by CSP.
+
+## A queue you can trust — and escape
+
+The reliability heart of this wave is Vyapak's work: **one delivery gate for every
+automatic writer**. A single drain loop now owns the "is this terminal free?" decision, and
+automation never wipes your draft or closes your menus — a half-typed prompt or an open
+picker visibly holds delivery instead of being typed over.
+
+v0.3.5 closes the last dead end: pausing floor-wide auto-delivery used to strand queued
+messages with no explanation and no override. Now the composer tells you the queue is held,
+and every queued row gets a **send now** link that bypasses *only* the pause — all the
+draft/picker/idle safety still applies.
+
+Also fixed in the wave: the blank-terminal pane (WebGL context leases), killed processes
+that didn't actually die, breaker false-positives on idle agents, and ~350× faster warm
+usage reads.
+
+## More engines, a calmer face, and an app that updates itself
+
+- **xAI Grok** joins as a full hive citizen and **Kimi Code** as a worker engine — the
+  roster is now nine. The Claude picker adds **Fable 5** (the new default) and **Sonnet 5**.
+- **Settings, redesigned** into six tabs — General, Agents & Models, Autonomy & Budgets,
+  Connections, Voice, Memory & Knowledge — and the default model, autonomy mode, and the
+  full circuit breaker finally have real controls.
+- **A professional design pass**: recalibrated type and muted colors, hairline borders,
+  compact agent cards, and a **full-app dark mode** (not just the terminals).
+- **Auto-update**: the app checks GitHub releases, downloads in the background, and offers
+  "Restart to update" — installation is always your click. v0.3.5 is the first release
+  delivered this way; if you're on 0.3.4, it's probably already waiting for you.
+
+## Where this fits
+
+If you've seen [YC's qm](https://github.com/yc-software/qm) — a multiplayer agent harness
+for teams in Slack and the browser — Munder Difflin is the same idea grown from the other
+end: **local-first, on your desktop, with everything watchable**. Same jobs (postures,
+scheduled background work, Slack, skills), simpler shape, plus the things a desktop app can
+do that a headless harness can't: real terminals, voice, an IDE, auto-update. We wrote up
+[an honest comparison](/blog/qm-vs-munder-difflin/).
+
+## Get it
+
+**[Download v0.3.5](https://github.com/chaitanyagiri/munder-difflin/releases/latest)** for
+macOS, Windows, or Linux — or clone and `npm run dev`. On v0.3.4? Do nothing — the update
+toast will find you. Free, MIT-licensed, local-first.
+
+If Munder Difflin is useful to you, a
+[star on GitHub](https://github.com/chaitanyagiri/munder-difflin) is the single biggest way
+to help it reach more people.

--- a/blog/src/posts/qm-vs-munder-difflin.md
+++ b/blog/src/posts/qm-vs-munder-difflin.md
@@ -1,0 +1,112 @@
+---
+title: "qm vs Munder Difflin: YC's Multiplayer Harness or a Local-First Agent Office?"
+description: "An honest comparison of YC's qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE."
+date: 2026-08-06
+category: comparisons
+categoryLabel: Comparisons
+type: Non-technical
+primaryKeyword: "qm vs munder difflin"
+secondaryKeywords: ["yc qm alternative", "qm claude code", "qm agent harness", "multiplayer agent harness", "local first agent orchestration", "qm y combinator agents"]
+tags: ["Comparisons", "Multi-Agent", "Tools", "Claude Code", "Open Source"]
+author:
+  name: Chaitanya Giri
+  initials: CG
+faq:
+  - q: "What is qm?"
+    a: "qm (github.com/yc-software/qm) is Y Combinator's open-source 'multiplayer agent harness for work' — a headless Node.js core with a web UI and a Slack plugin. Team members get agent 'employees' with isolated workspaces, shared skills with scope-based permissions, background crons and watches, and three security postures (Strict, Auto, Dangerous). It's MIT-licensed and installs via npm."
+  - q: "What's the main difference between qm and Munder Difflin?"
+    a: "Where the harness lives and what you can see. qm is multiplayer-first: a shared server your whole team reaches through Slack and the browser. Munder Difflin is local-first: a desktop app on your machine where every agent is a real CLI process in a real terminal you can watch, with a visual office floor, voice orchestration, and a built-in IDE. They cover the same core jobs — postures, scheduled work, Slack, skills — from opposite ends."
+  - q: "Does Munder Difflin do what qm's security postures do?"
+    a: "Yes, the same job with different controls: a floor-wide auto-mode toggle (the equivalent of switching between approval-gated and autonomous), per-agent pause/halt, voice-level confirm words for destructive actions, tool gating, a circuit breaker for runaway agents, and spend/scope escalation to a human. qm's Strict/Auto/Dangerous is org-level configuration; Munder Difflin's controls are per-floor and per-agent."
+  - q: "Does qm have voice control, an IDE, or git visualization?"
+    a: "Not as of this writing. qm's interfaces are Slack and a web UI. Munder Difflin ships realtime voice orchestration (a talking Michael with live floor context), a built-in Monaco IDE with commit history, branch compare and side-by-side diffs, markdown previews, real watchable terminals, and auto-update."
+  - q: "Which one should I use?"
+    a: "Use qm if your whole team wants one shared harness in Slack with org-level admin control. Use Munder Difflin if you want your agent office on your own machine — watchable, local-first, with voice and an IDE — riding the CLI subscriptions you already pay for. Both are MIT-licensed; some teams will genuinely want both: qm as the shared org layer, Munder Difflin as the personal floor."
+  - q: "Is Munder Difflin older than qm?"
+    a: "Munder Difflin has been shipping public releases since v0.2.0 in mid-2026 and is on v0.3.5 with a stable auto-updating release train, while qm is a newer project that grew popular quickly. Popularity and maturity are different axes — evaluate both against your workflow."
+---
+
+<div class="callout tldr"><span class="ic">TL;DR</span><p><strong>qm</strong> is YC's
+multiplayer agent harness — headless, org-shaped, living in <strong>Slack and a web
+UI</strong>, great when a whole team shares one fleet. <strong>Munder Difflin</strong> is
+the same idea grown from the other end: a <strong>local-first desktop office</strong> where
+every agent is a real CLI process in a terminal you can watch, with <strong>voice
+orchestration, a built-in IDE with git history, and auto-update</strong> — things a
+headless harness doesn't have. Same jobs, opposite ends of the wire. Both MIT-licensed.</p></div>
+
+[qm](https://github.com/yc-software/qm) earned its stars fast — "a multiplayer agent
+harness for work, in Slack and on the web" is a great pitch, and Y Combinator shipping
+open-source agent tooling is good for everyone. We get asked about it a lot, so here's the
+honest comparison.
+
+## The same problem, from opposite ends
+
+Both tools exist because one CLI agent in one terminal doesn't scale: you want several
+agents working in parallel, safely, with scheduled background work and a way to reach them
+from where you already are.
+
+**qm answers it org-first.** A headless Node core (installed via `npm exec qm init`) that
+your team reaches through Slack and a web UI. Each "employee" gets an isolated workspace;
+skills are shared with scope-based permissions and can be promoted org-wide; admins set the
+security posture — **Strict** (approval-gated), **Auto** (default screening), or
+**Dangerous** — for everyone at once. Background work runs as **crons and watches**.
+
+**Munder Difflin answers it desk-first.** A desktop app on your machine where every agent
+is a **real CLI process in a real terminal** — Claude Code, Codex, Antigravity, Copilot,
+Grok, Kimi, and more, riding the subscriptions you already pay for. The floor is visual
+(yes, it looks like The Office), a GOD orchestrator routes work, agents share long-term
+memory, and background work runs as **scheduled missions** with Slack and webhook triggers.
+
+If you map the concepts across, most of qm's vocabulary has a Munder Difflin counterpart:
+
+| Job to be done | qm | Munder Difflin |
+| --- | --- | --- |
+| Safety levels | Strict / Auto / Dangerous postures | Auto-mode toggle, per-agent pause/halt, tool gating, circuit breaker, confirm-word voice safety |
+| Background work | Crons and watches | Scheduled missions + Slack/webhook triggers |
+| Reusable behaviors | Shared skills with scoped permissions | Agent Gallery roles + shareable agent recipes |
+| Reach it from anywhere | Slack + web UI | Slack + Remote Control from your phone |
+| Isolation | Isolated workspaces per employee | Isolated git worktrees per agent |
+| License | MIT | MIT |
+
+## What each has that the other doesn't
+
+**qm's edge is multiplayer.** One shared harness, unified identity, org-level admin,
+skills promotion across scopes. If your team wants a *single* fleet everyone shares from
+Slack, that's qm's home turf, and Munder Difflin doesn't try to be that.
+
+**Munder Difflin's edge is everything you can see and touch:**
+
+- **Real terminals.** Every agent is a watchable CLI process — when something goes
+  sideways, you read the actual session, not a log abstraction.
+- **Voice orchestration.** Flip on talk mode and Michael greets you already knowing every
+  agent's status, steers work, changes settings from an allowlist, and waits for a spoken
+  confirm word before anything destructive.
+- **A built-in IDE.** Monaco (the VS Code engine) one click over the floor: side-by-side
+  diffs of agent changes, clickable commit history, branch compare, guarded checkout, live
+  markdown previews.
+- **Local-first by construction.** No shared server, no code upload — agents, state, and
+  memory live on your machine.
+- **Auto-update.** The app ships its own updates from GitHub releases; you just click
+  "restart to update."
+- **A longer release train.** Public releases since v0.2.0, now at v0.3.5, with the
+  reliability work battle-tested by a growing contributor community.
+
+## Which should you use?
+
+- **Your whole team wants one shared fleet with org-level control → qm.** That's what
+  multiplayer-first buys you.
+- **You want your own agent office, on your own machine, with everything visible → Munder
+  Difflin.** Simpler to adopt (download, open, hire), nothing leaves your computer, and
+  the interfaces — floor, voice, IDE — are things a headless harness structurally can't
+  offer.
+- **Honestly? Some teams will run both.** qm as the shared org layer, Munder Difflin as
+  the personal floor where you watch and steer your own agents. They don't compete for
+  the same seat.
+
+Facts about qm above come from its public README as of August 2026 — check
+[the repo](https://github.com/yc-software/qm) for the current state, because both projects
+move fast.
+
+**[Try Munder Difflin free](https://munderdiffl.in/)** — macOS, Windows, Linux, MIT-licensed.
+And if this comparison helped, a [GitHub star](https://github.com/chaitanyagiri/munder-difflin)
+helps more people find it.

--- a/docs/blog/best-ai-coding-agents/index.html
+++ b/docs/blog/best-ai-coding-agents/index.html
@@ -319,6 +319,24 @@ source.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -351,24 +369,6 @@ source.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/best-claude-code-multi-agent-tools/index.html
+++ b/docs/blog/best-claude-code-multi-agent-tools/index.html
@@ -354,6 +354,24 @@ real team of agents.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -386,24 +404,6 @@ real team of agents.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/claude-code-orchestration-tools-compared/index.html
+++ b/docs/blog/claude-code-orchestration-tools-compared/index.html
@@ -276,6 +276,24 @@ Linux.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -308,24 +326,6 @@ Linux.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/claude-squad-alternative/index.html
+++ b/docs/blog/claude-squad-alternative/index.html
@@ -214,6 +214,24 @@ on macOS, Windows, and Linux.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -246,24 +264,6 @@ on macOS, Windows, and Linux.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/claude-squad-vs-munder-difflin/index.html
+++ b/docs/blog/claude-squad-vs-munder-difflin/index.html
@@ -301,6 +301,24 @@ local-first.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -333,24 +351,6 @@ local-first.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/cline-vs-munder-difflin/index.html
+++ b/docs/blog/cline-vs-munder-difflin/index.html
@@ -292,6 +292,24 @@ licensed.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -324,24 +342,6 @@ licensed.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/command-center-guide/index.html
+++ b/docs/blog/command-center-guide/index.html
@@ -235,7 +235,7 @@
 
   <footer class="post-foot wrap"><div class="prevnext">
       <a class="pn prev" href="/blog/crewai-autogen-vs-a-local-agent-harness/"><span class="k">← Older</span><span class="t">CrewAI and AutoGen vs a Local Agent Harness: Framework or App?</span></a>
-      <span></span>
+      <a class="pn next" href="/blog/qm-vs-munder-difflin/"><span class="k">Newer →</span><span class="t">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</span></a>
     </div>
     <section class="related">
       <h2>Related in Guides</h2>

--- a/docs/blog/conductor-claude-code-alternative/index.html
+++ b/docs/blog/conductor-claude-code-alternative/index.html
@@ -215,6 +215,24 @@ coordinated team locally — it’s free and open source.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -247,24 +265,6 @@ coordinated team locally — it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/crewai-autogen-vs-a-local-agent-harness/index.html
+++ b/docs/blog/crewai-autogen-vs-a-local-agent-harness/index.html
@@ -240,6 +240,24 @@
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -272,24 +290,6 @@
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/tmux-and-scripts-vs-an-agent-harness/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>4 min</span>
-    </div>
-    <h3><a href="/blog/tmux-and-scripts-vs-an-agent-harness/">Running Agents in tmux vs an Agent Harness</a></h3>
-    <p class="dek">tmux panes, git worktrees, shell scripts, and cron will absolutely run several Claude Code sessions at once. Here&#39;s what that DIY setup does well, where it breaks at scale, and what a purpose-built agent harness automates.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/tmux-and-scripts-vs-an-agent-harness/" aria-label="Read: Running Agents in tmux vs an Agent Harness">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/crystal-claude-code-alternative/index.html
+++ b/docs/blog/crystal-claude-code-alternative/index.html
@@ -212,6 +212,24 @@ actually remember — free and open source.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -244,24 +262,6 @@ actually remember — free and open source.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/feed.xml
+++ b/docs/blog/feed.xml
@@ -4,9 +4,25 @@
   <subtitle>Guides, deep dives, and comparisons on running multi-agent Claude Code: orchestration, agent memory, automation, and the tooling landscape.</subtitle>
   <link href="https://munderdiffl.in/blog/feed.xml" rel="self" />
   <link href="https://munderdiffl.in/blog/" />
-  <updated>2026-07-03T00:00:00.000Z</updated>
+  <updated>2026-08-06T00:00:00.000Z</updated>
   <id>https://munderdiffl.in/blog/</id>
   <author><name>Chaitanya Giri</name><uri>https://munderdiffl.in</uri></author>
+  <entry>
+    <title>Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</title>
+    <link href="https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/" />
+    <id>https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/</id>
+    <published>2026-08-06T00:00:00.000Z</published>
+    <updated>2026-08-06T00:00:00.000Z</updated><category term="Story" />
+    <summary>The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</summary>
+  </entry>
+  <entry>
+    <title>qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</title>
+    <link href="https://munderdiffl.in/blog/qm-vs-munder-difflin/" />
+    <id>https://munderdiffl.in/blog/qm-vs-munder-difflin/</id>
+    <published>2026-08-06T00:00:00.000Z</published>
+    <updated>2026-08-06T00:00:00.000Z</updated><category term="Comparisons" />
+    <summary>An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</summary>
+  </entry>
   <entry>
     <title>The Command Center: Kanban, Fleet, and Budgets in One Place</title>
     <link href="https://munderdiffl.in/blog/command-center-guide/" />
@@ -470,21 +486,5 @@
     <published>2026-06-04T00:00:00.000Z</published>
     <updated>2026-06-04T00:00:00.000Z</updated><category term="Internals" />
     <summary>Why a local agent hive coordinates through plain files, not Redis or RabbitMQ: the zero-ops wins, the real tradeoffs, and where files hit a ceiling.</summary>
-  </entry>
-  <entry>
-    <title>How AI Agents Remember: Semantic Memory in a Hive</title>
-    <link href="https://munderdiffl.in/blog/how-agents-remember-semantic-memory/" />
-    <id>https://munderdiffl.in/blog/how-agents-remember-semantic-memory/</id>
-    <published>2026-06-04T00:00:00.000Z</published>
-    <updated>2026-06-04T00:00:00.000Z</updated><category term="Memory" />
-    <summary>A code-grounded guide to how AI agents remember — the MemPalace mine loop, per-agent wings, and wake-up digest that give a Claude Code hive shared recall.</summary>
-  </entry>
-  <entry>
-    <title>How AI Agents Verify Their Own Work (Before Saying &#39;Done&#39;)</title>
-    <link href="https://munderdiffl.in/blog/how-ai-agents-verify-their-own-work/" />
-    <id>https://munderdiffl.in/blog/how-ai-agents-verify-their-own-work/</id>
-    <published>2026-06-04T00:00:00.000Z</published>
-    <updated>2026-06-04T00:00:00.000Z</updated><category term="Concepts" />
-    <summary>The discipline that makes an autonomous coding agent trustworthy: prove every claim, reproduce the green, and check the fix — not just the intent.</summary>
   </entry>
 </feed>

--- a/docs/blog/github-copilot-cli-vs-claude-code-for-hive-work/index.html
+++ b/docs/blog/github-copilot-cli-vs-claude-code-for-hive-work/index.html
@@ -284,6 +284,24 @@
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -316,24 +334,6 @@
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/tmux-and-scripts-vs-an-agent-harness/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>4 min</span>
-    </div>
-    <h3><a href="/blog/tmux-and-scripts-vs-an-agent-harness/">Running Agents in tmux vs an Agent Harness</a></h3>
-    <p class="dek">tmux panes, git worktrees, shell scripts, and cron will absolutely run several Claude Code sessions at once. Here&#39;s what that DIY setup does well, where it breaks at scale, and what a purpose-built agent harness automates.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/tmux-and-scripts-vs-an-agent-harness/" aria-label="Read: Running Agents in tmux vs an Agent Harness">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/how-ai-answer-engines-choose-sources/index.html
+++ b/docs/blog/how-ai-answer-engines-choose-sources/index.html
@@ -266,6 +266,24 @@ broader map of the tooling AI engines cite, see our
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -298,24 +316,6 @@ broader map of the tooling AI engines cite, see our
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/how-to-choose-a-multi-agent-tool/index.html
+++ b/docs/blog/how-to-choose-a-multi-agent-tool/index.html
@@ -279,6 +279,24 @@ local-first.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -311,24 +329,6 @@ local-first.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -84,19 +84,19 @@
   building a self-coordinating hive of agents with a GOD orchestrator you talk to.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
-    <a class="chip" aria-current="page">All<span class="ct">115</span></a>
+    <a class="chip" aria-current="page">All<span class="ct">117</span></a>
     
     <a class="chip" href="/blog/topics/guides/">guides<span class="ct">34</span></a>
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     
@@ -107,6 +107,48 @@
 
 
 <div class="wrap featured"><article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+
+</div>
+
+
+<section class="wrap">
+  <div class="post-grid">
+    <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-guides" href="/blog/command-center-guide/" aria-hidden="true" tabindex="-1">
     <span>GUIDES</span>
   </a>
@@ -124,13 +166,7 @@
     </div>
   </div>
 </article>
-
-</div>
-
-
-<section class="wrap">
-  <div class="post-grid">
-    <article class="card">
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>

--- a/docs/blog/launching-munder-difflin-v0-2-0/index.html
+++ b/docs/blog/launching-munder-difflin-v0-2-0/index.html
@@ -314,6 +314,24 @@ the next release is built the same way this one was.</p>
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -346,24 +364,6 @@ the next release is built the same way this one was.</p>
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-2-4/index.html
+++ b/docs/blog/launching-munder-difflin-v0-2-4/index.html
@@ -266,6 +266,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -298,24 +316,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-2-8/index.html
+++ b/docs/blog/launching-munder-difflin-v0-2-8/index.html
@@ -276,6 +276,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -308,24 +326,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-0/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-0/index.html
@@ -268,6 +268,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -300,24 +318,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-2-8/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-2-8/">Launching Munder Difflin v0.2.8: Shareable Hires</a></h3>
-    <p class="dek">Munder Difflin v0.2.8 ships Shareable Hires: a one-click, portable agent role manifest + The Hiring Fair gallery. Click a hire link, review every field, then spawn it yourself.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-2-8/" aria-label="Read: Launching Munder Difflin v0.2.8: Shareable Hires">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-2/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-2/index.html
@@ -269,6 +269,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -301,24 +319,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-2-8/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-2-8/">Launching Munder Difflin v0.2.8: Shareable Hires</a></h3>
-    <p class="dek">Munder Difflin v0.2.8 ships Shareable Hires: a one-click, portable agent role manifest + The Hiring Fair gallery. Click a hire link, review every field, then spawn it yourself.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-2-8/" aria-label="Read: Launching Munder Difflin v0.2.8: Shareable Hires">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-3/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-3/index.html
@@ -260,6 +260,24 @@ help it reach more people.</p>
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -292,24 +310,6 @@ help it reach more people.</p>
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-2-8/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-2-8/">Launching Munder Difflin v0.2.8: Shareable Hires</a></h3>
-    <p class="dek">Munder Difflin v0.2.8 ships Shareable Hires: a one-click, portable agent role manifest + The Hiring Fair gallery. Click a hire link, review every field, then spawn it yourself.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-2-8/" aria-label="Read: Launching Munder Difflin v0.2.8: Shareable Hires">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-5/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-5/index.html
@@ -1,0 +1,378 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself — Munder Difflin Blog</title>
+<meta name="description" content="The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch." />
+<link rel="canonical" href="https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/" />
+
+<link rel="icon" type="image/png" href="https://munderdiffl.in/logo.png" />
+<link rel="apple-touch-icon" href="https://munderdiffl.in/logo.png" />
+<meta name="theme-color" content="#F5F2E8" />
+
+<!-- Open Graph -->
+<meta property="og:site_name" content="Munder Difflin Blog" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself — Munder Difflin Blog" />
+<meta property="og:description" content="The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch." />
+<meta property="og:url" content="https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/" />
+<meta property="og:image" content="https://munderdiffl.in/media/og.png" />
+<meta property="og:locale" content="en_US" />
+<meta property="article:published_time" content="2026-08-06T00:00:00.000Z" />
+<meta property="article:author" content="Chaitanya Giri" />
+<meta property="article:tag" content="Story" />
+<meta property="article:tag" content="Release" />
+<meta property="article:tag" content="Multi-Agent" />
+<meta property="article:tag" content="Voice" />
+<meta property="article:tag" content="IDE" />
+<meta property="article:tag" content="Open Source" />
+
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself — Munder Difflin Blog" />
+<meta name="twitter:description" content="The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch." />
+<meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
+
+<link rel="alternate" type="application/atom+xml" title="Munder Difflin Blog" href="https://munderdiffl.in/blog/feed.xml" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/blog/assets/blog.css" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself",
+  "description": "The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.",
+  "image": ["https://munderdiffl.in/media/og.png"],
+  "datePublished": "2026-08-06T00:00:00.000Z",
+  "dateModified": "2026-08-06T00:00:00.000Z",
+  "author": { "@type": "Person", "name": "Chaitanya Giri" },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Munder Difflin",
+    "logo": { "@type": "ImageObject", "url": "https://munderdiffl.in/logo.png" }
+  },
+  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/" },
+  "keywords": "munder difflin v0.3.5, voice ai agent orchestration, git commit history ide electron, markdown preview ai agent output, electron app auto update github releases, grok cli agent, claude code multi-agent release",
+  "articleSection": "Story",
+  "inLanguage": "en-US",
+  "url": "https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://munderdiffl.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://munderdiffl.in/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself", "item": "https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What's new in Munder Difflin v0.3.5?", "acceptedAnswer": { "@type": "Answer", "text": "v0.3.5 is the polish pass on top of the big v0.3.4 wave, so the headline is really both: Michael's talk mode now opens with a live snapshot of every agent and can run nearly the whole app by voice; markdown files preview live in the IDE and open rendered from a ⌘-click in any terminal; the IDE gains a clickable commit history, branch compare, and guarded checkout; Settings was redesigned into six clear tabs; xAI Grok and Kimi Code joined the engine roster; the app now auto-updates from GitHub releases; and v0.3.5 itself fixes the paused-queue dead end with a per-message 'send now' override." } },
+    { "@type": "Question", "name": "Do I need to reinstall to get v0.3.5?", "acceptedAnswer": { "@type": "Answer", "text": "If you're on v0.3.4 — no. This is the first release the app delivers to itself: it downloads in the background and shows a 'Restart to update' toast; installation only ever happens on your click. If you're on v0.3.3 or older there's no updater in your build, so grab v0.3.5 once from munderdiffl.in and you're on the train from then on." } },
+    { "@type": "Question", "name": "What can Michael actually do by voice now?", "acceptedAnswer": { "@type": "Answer", "text": "Nearly everything: spawn and archive agents, assign and steer work, resume paused agents, pause or resume floor-wide message delivery, gate specific tools, manage tasks, create schedules, clear an agent's context, and change settings from a strict allowlist. Destructive actions still require you to say a distinct confirm word out loud, secrets can never be touched by voice, and he now answers 'what's everyone doing?' from a live floor snapshot instead of guessing." } },
+    { "@type": "Question", "name": "What does the git time-machine in the IDE do?", "acceptedAnswer": { "@type": "Answer", "text": "The IDE rail gains HISTORY and COMPARE next to CHANGES. History is a clickable commit graph: pick any commit, see the files it touched, and open side-by-side diffs of exactly what changed. Compare takes any two branches and shows ahead/behind counts and per-file diffs. Checkout is guarded — it refuses to move a dirty tree or pull code out from under an agent that's actively working." } },
+    { "@type": "Question", "name": "Is the markdown preview safe for agent-generated files?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, by construction. There is no raw-HTML pipeline at all, links never navigate the app (external ones open in your browser, relative .md links open in a new preview), and remote images are blocked by the app's content security policy. Agents write a lot of markdown; you can now read it rendered without trusting it." } },
+    { "@type": "Question", "name": "How does Munder Difflin compare to YC's qm?", "acceptedAnswer": { "@type": "Answer", "text": "They're complementary answers to the same problem. qm is a multiplayer agent harness for teams — headless, living in Slack and a web UI. Munder Difflin covers the same jobs (security postures, background scheduled work, Slack triggers, shareable skills) as a simpler local-first desktop app, and adds real watchable terminals, voice orchestration, a built-in IDE with git visualization, and auto-update. See our full qm vs Munder Difflin comparison post." } }
+    
+  ]
+}
+</script>
+
+
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<nav id="nav">
+  <a class="brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+    <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+  </a>
+  <span class="spacer"></span>
+  <div class="links">
+    <a href="/blog/">Latest</a>
+    <a href="/blog/topics/">Topics</a>
+    <a href="/blog/about/">About</a>
+    <a href="https://munderdiffl.in">↗ Product</a>
+  </div>
+  <div class="nav-actions">
+    <a class="btn sm" href="https://munderdiffl.in/blog/feed.xml" aria-label="RSS feed">⤵ RSS</a>
+    <a class="btn sm primary" href="https://munderdiffl.in/#install">⤓ Download</a>
+  </div>
+</nav>
+
+<main id="main">
+
+<article>
+  <header class="post-head wrap">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/blog/">Blog</a>
+      <span>/</span>
+      <a href="/blog/topics/story/">Story</a>
+    </nav>
+    <h1>Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</h1>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="byline">
+      <span class="av" aria-hidden="true">CG</span>
+      <strong>Chaitanya Giri</strong>
+      <span class="dot" aria-hidden="true">·</span>
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true">·</span>
+      <span>4 min read</span>
+      <span class="tag kind">Story</span>
+    </div>
+  </header>
+
+  <div class="post-wrap wrap">
+    <div class="prose">
+      <div class="callout tldr"><span class="ic">TL;DR</span><p><strong>Munder Difflin v0.3.5</strong> caps the biggest release wave we've shipped. <strong>Talk mode grew up</strong>: Michael opens the call already knowing every agent's status and can run nearly the whole app by voice. The IDE became a <strong>git time-machine</strong> — clickable commit history, branch compare, guarded checkout — and <strong>markdown previews</strong> render everywhere agents write them. <strong>Settings got six clear tabs</strong>, <strong>xAI Grok and Kimi Code</strong> joined the engine roster, the whole app got a <strong>professional type-and-color pass with full dark mode</strong> — and from v0.3.4 onward, <strong>the app updates itself</strong>. Free, MIT-licensed, local-first.</p></div>
+<p>This is a double-feature post: v0.3.4 shipped the features, v0.3.5 shipped the polish a day
+later, and if you’re installing fresh you get both at once. A huge part of this wave is
+community work — the terminal/queue/roster reliability overhaul is by
+<a href="https://github.com/gts-47"><strong>Vyapak Goyal (@gts-47)</strong></a>, with major fixes by
+<a href="https://github.com/qschmick"><strong>@qschmick</strong></a>.</p>
+<h2 id="michael-finally-knows-the-floor" tabindex="-1">Michael finally knows the floor <a class="anchor" href="#michael-finally-knows-the-floor" aria-hidden="true">#</a></h2>
+<p>Talk mode has been able to <em>do</em> things since v0.3.2. What it couldn’t do was <em>know</em> things
+without looking them up — every “what’s everyone working on?” turned into tool calls and
+dead air.</p>
+<p>Now the voice session opens with a compact live snapshot of the whole floor — every agent’s
+status, engine, context fill, circuit-breaker state, inbox depth, and in-flight tasks — and
+keeps receiving silent floor updates as things change mid-call. Ask what’s happening and he
+just answers.</p>
+<p>He also graduated from narrator to operator. New voice verbs: <strong>resume</strong> a paused agent,
+pause/resume floor-wide message delivery, <strong>gate specific tools</strong>, delete tasks,
+archive/unarchive agents, <strong>clear an agent’s context</strong>, <strong>create schedules</strong>, and <strong>change
+settings</strong> — from a strict allowlist where secrets and dangerous keys are refused outright,
+behavior-changing keys echo old→new values, and anything destructive still waits for you to
+say a distinct confirm word. He even knows what version he’s running: ask “what’s new in
+this update?” and he reads you the release notes.</p>
+<h2 id="the-ide-becomes-a-git-time-machine" tabindex="-1">The IDE becomes a git time-machine <a class="anchor" href="#the-ide-becomes-a-git-time-machine" aria-hidden="true">#</a></h2>
+<p>v0.3.3’s IDE could show you a diff against HEAD. This wave makes it a place you can <em>move
+through history</em>:</p>
+<ul>
+<li><strong>HISTORY</strong> — a clickable commit graph of the whole repo. Pick a commit, see every file
+it touched, open a side-by-side diff of exactly what changed. “Jump here” checks out any
+commit — with guards.</li>
+<li><strong>COMPARE</strong> — pick any two branches, see ahead/behind counts and per-file diffs, and
+switch between them safely.</li>
+<li><strong>Guarded checkout</strong> — the harness refuses to move a dirty tree, and refuses to yank code
+out from under an agent whose terminal was active in the last ten seconds. Your agents’
+work can’t be stranded by a curious click.</li>
+</ul>
+<p>And because agents write markdown constantly — plans, reports, READMEs — <strong>markdown now
+renders everywhere</strong>: a live <strong>code | split | preview</strong> switch in the IDE, and <strong>⌘-click on
+any <code>.md</code> path an agent prints in its terminal</strong> to open a rendered preview instantly.
+Safe by construction: no raw-HTML pipeline exists, links never navigate the app, and remote
+images are blocked by CSP.</p>
+<h2 id="a-queue-you-can-trust-and-escape" tabindex="-1">A queue you can trust — and escape <a class="anchor" href="#a-queue-you-can-trust-and-escape" aria-hidden="true">#</a></h2>
+<p>The reliability heart of this wave is Vyapak’s work: <strong>one delivery gate for every
+automatic writer</strong>. A single drain loop now owns the “is this terminal free?” decision, and
+automation never wipes your draft or closes your menus — a half-typed prompt or an open
+picker visibly holds delivery instead of being typed over.</p>
+<p>v0.3.5 closes the last dead end: pausing floor-wide auto-delivery used to strand queued
+messages with no explanation and no override. Now the composer tells you the queue is held,
+and every queued row gets a <strong>send now</strong> link that bypasses <em>only</em> the pause — all the
+draft/picker/idle safety still applies.</p>
+<p>Also fixed in the wave: the blank-terminal pane (WebGL context leases), killed processes
+that didn’t actually die, breaker false-positives on idle agents, and ~350× faster warm
+usage reads.</p>
+<h2 id="more-engines-a-calmer-face-and-an-app-that-updates-itself" tabindex="-1">More engines, a calmer face, and an app that updates itself <a class="anchor" href="#more-engines-a-calmer-face-and-an-app-that-updates-itself" aria-hidden="true">#</a></h2>
+<ul>
+<li><strong>xAI Grok</strong> joins as a full hive citizen and <strong>Kimi Code</strong> as a worker engine — the
+roster is now nine. The Claude picker adds <strong>Fable 5</strong> (the new default) and <strong>Sonnet 5</strong>.</li>
+<li><strong>Settings, redesigned</strong> into six tabs — General, Agents &amp; Models, Autonomy &amp; Budgets,
+Connections, Voice, Memory &amp; Knowledge — and the default model, autonomy mode, and the
+full circuit breaker finally have real controls.</li>
+<li><strong>A professional design pass</strong>: recalibrated type and muted colors, hairline borders,
+compact agent cards, and a <strong>full-app dark mode</strong> (not just the terminals).</li>
+<li><strong>Auto-update</strong>: the app checks GitHub releases, downloads in the background, and offers
+“Restart to update” — installation is always your click. v0.3.5 is the first release
+delivered this way; if you’re on 0.3.4, it’s probably already waiting for you.</li>
+</ul>
+<h2 id="where-this-fits" tabindex="-1">Where this fits <a class="anchor" href="#where-this-fits" aria-hidden="true">#</a></h2>
+<p>If you’ve seen <a href="https://github.com/yc-software/qm">YC’s qm</a> — a multiplayer agent harness
+for teams in Slack and the browser — Munder Difflin is the same idea grown from the other
+end: <strong>local-first, on your desktop, with everything watchable</strong>. Same jobs (postures,
+scheduled background work, Slack, skills), simpler shape, plus the things a desktop app can
+do that a headless harness can’t: real terminals, voice, an IDE, auto-update. We wrote up
+<a href="/blog/qm-vs-munder-difflin/">an honest comparison</a>.</p>
+<h2 id="get-it" tabindex="-1">Get it <a class="anchor" href="#get-it" aria-hidden="true">#</a></h2>
+<p><strong><a href="https://github.com/chaitanyagiri/munder-difflin/releases/latest">Download v0.3.5</a></strong> for
+macOS, Windows, or Linux — or clone and <code>npm run dev</code>. On v0.3.4? Do nothing — the update
+toast will find you. Free, MIT-licensed, local-first.</p>
+<p>If Munder Difflin is useful to you, a
+<a href="https://github.com/chaitanyagiri/munder-difflin">star on GitHub</a> is the single biggest way
+to help it reach more people.</p>
+
+
+      
+      <section class="faq" aria-label="Frequently asked questions">
+        <h2 id="faq">FAQ</h2>
+        
+        <div class="qa">
+          <p class="q">What&#39;s new in Munder Difflin v0.3.5?</p>
+          <p class="a">v0.3.5 is the polish pass on top of the big v0.3.4 wave, so the headline is really both: Michael&#39;s talk mode now opens with a live snapshot of every agent and can run nearly the whole app by voice; markdown files preview live in the IDE and open rendered from a ⌘-click in any terminal; the IDE gains a clickable commit history, branch compare, and guarded checkout; Settings was redesigned into six clear tabs; xAI Grok and Kimi Code joined the engine roster; the app now auto-updates from GitHub releases; and v0.3.5 itself fixes the paused-queue dead end with a per-message &#39;send now&#39; override.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Do I need to reinstall to get v0.3.5?</p>
+          <p class="a">If you&#39;re on v0.3.4 — no. This is the first release the app delivers to itself: it downloads in the background and shows a &#39;Restart to update&#39; toast; installation only ever happens on your click. If you&#39;re on v0.3.3 or older there&#39;s no updater in your build, so grab v0.3.5 once from munderdiffl.in and you&#39;re on the train from then on.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">What can Michael actually do by voice now?</p>
+          <p class="a">Nearly everything: spawn and archive agents, assign and steer work, resume paused agents, pause or resume floor-wide message delivery, gate specific tools, manage tasks, create schedules, clear an agent&#39;s context, and change settings from a strict allowlist. Destructive actions still require you to say a distinct confirm word out loud, secrets can never be touched by voice, and he now answers &#39;what&#39;s everyone doing?&#39; from a live floor snapshot instead of guessing.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">What does the git time-machine in the IDE do?</p>
+          <p class="a">The IDE rail gains HISTORY and COMPARE next to CHANGES. History is a clickable commit graph: pick any commit, see the files it touched, and open side-by-side diffs of exactly what changed. Compare takes any two branches and shows ahead/behind counts and per-file diffs. Checkout is guarded — it refuses to move a dirty tree or pull code out from under an agent that&#39;s actively working.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Is the markdown preview safe for agent-generated files?</p>
+          <p class="a">Yes, by construction. There is no raw-HTML pipeline at all, links never navigate the app (external ones open in your browser, relative .md links open in a new preview), and remote images are blocked by the app&#39;s content security policy. Agents write a lot of markdown; you can now read it rendered without trusting it.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">How does Munder Difflin compare to YC&#39;s qm?</p>
+          <p class="a">They&#39;re complementary answers to the same problem. qm is a multiplayer agent harness for teams — headless, living in Slack and a web UI. Munder Difflin covers the same jobs (security postures, background scheduled work, Slack triggers, shareable skills) as a simpler local-first desktop app, and adds real watchable terminals, voice orchestration, a built-in IDE with git visualization, and auto-update. See our full qm vs Munder Difflin comparison post.</p>
+        </div>
+        
+      </section>
+      
+
+      
+      <hr />
+      <div class="share">
+        <span class="lbl">Tags</span>
+        <a class="tag" href="/blog/tags/story/">Story</a><a class="tag" href="/blog/tags/release/">Release</a><a class="tag" href="/blog/tags/multi-agent/">Multi-Agent</a><a class="tag" href="/blog/tags/voice/">Voice</a><a class="tag" href="/blog/tags/ide/">IDE</a><a class="tag" href="/blog/tags/open-source/">Open Source</a>
+      </div>
+      
+    </div>
+
+    
+    <aside class="toc-rail" aria-label="Table of contents">
+      <div class="tt">On this page</div>
+      <ol>
+        <li class="lvl-2"><a href="#michael-finally-knows-the-floor">Michael finally knows the floor</a></li><li class="lvl-2"><a href="#the-ide-becomes-a-git-time-machine">The IDE becomes a git time-machine</a></li><li class="lvl-2"><a href="#a-queue-you-can-trust-and-escape">A queue you can trust — and escape</a></li><li class="lvl-2"><a href="#more-engines-a-calmer-face-and-an-app-that-updates-itself">More engines, a calmer face, and an app that updates itself</a></li><li class="lvl-2"><a href="#where-this-fits">Where this fits</a></li><li class="lvl-2"><a href="#get-it">Get it</a></li>
+      </ol>
+    </aside>
+    
+  </div>
+
+  <footer class="post-foot wrap"><div class="prevnext">
+      <a class="pn prev" href="/blog/qm-vs-munder-difflin/"><span class="k">← Older</span><span class="t">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</span></a>
+      <span></span>
+    </div>
+    <section class="related">
+      <h2>Related in Story</h2>
+      <div class="post-grid">
+        <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-07-03">Jul 3, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-3/">Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support</a></h3>
+    <p class="dek">Munder Difflin v0.3.3 adds a full Monaco IDE — file tree, editor tabs, save, and side-by-side git diffs of your agents&#39; changes — plus GitHub Copilot CLI as a first-class agent engine, our first community-contributed provider.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-06-27">Jun 27, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
+    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-06-21">Jun 21, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>6 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
+    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
+    </div>
+  </div>
+</article>
+
+      </div>
+    </section>
+    
+  </footer>
+</article>
+
+</main>
+<footer>
+  <div class="wrap">
+    <div class="foot-top">
+      <a class="foot-brand brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+        <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+      </a>
+      <div class="foot-links">
+        <a href="/blog/">Latest</a>
+        <a href="/blog/topics/">Topics</a>
+        <a href="/blog/about/">About</a>
+        <a href="https://munderdiffl.in/blog/feed.xml">RSS</a>
+        <a href="https://github.com/chaitanyagiri/munder-difflin">GitHub</a>
+        <a href="https://munderdiffl.in">munderdiffl.in ↗</a>
+      </div>
+    </div>
+    <div class="foot-meta">
+      © 2026 Munder Difflin · Local-first · MIT-licensed ·
+      Built on <a href="https://munderdiffl.in">Electron, React, Pixi.js, xterm.js &amp; node-pty</a>.
+      Run an office of agents while you sleep.
+    </div>
+  </div>
+</footer>
+
+<script>
+  // sticky-nav border on scroll
+  (function () {
+    var nav = document.getElementById('nav');
+    if (!nav) return;
+    var onScroll = function () { nav.classList.toggle('scrolled', window.scrollY > 8); };
+    onScroll(); window.addEventListener('scroll', onScroll, { passive: true });
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/blog/local-first-vs-cloud-agent-sdks/index.html
+++ b/docs/blog/local-first-vs-cloud-agent-sdks/index.html
@@ -310,6 +310,24 @@ to run agents on your own terms — free and open source.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -342,24 +360,6 @@ to run agents on your own terms — free and open source.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/one-prompt-automated-pr-review/index.html
+++ b/docs/blog/one-prompt-automated-pr-review/index.html
@@ -195,6 +195,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -227,24 +245,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/orca-vs-munder-difflin/index.html
+++ b/docs/blog/orca-vs-munder-difflin/index.html
@@ -288,6 +288,24 @@
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -320,24 +338,6 @@
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/tmux-and-scripts-vs-an-agent-harness/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>4 min</span>
-    </div>
-    <h3><a href="/blog/tmux-and-scripts-vs-an-agent-harness/">Running Agents in tmux vs an Agent Harness</a></h3>
-    <p class="dek">tmux panes, git worktrees, shell scripts, and cron will absolutely run several Claude Code sessions at once. Here&#39;s what that DIY setup does well, where it breaks at scale, and what a purpose-built agent harness automates.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/tmux-and-scripts-vs-an-agent-harness/" aria-label="Read: Running Agents in tmux vs an Agent Harness">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/qm-vs-munder-difflin/index.html
+++ b/docs/blog/qm-vs-munder-difflin/index.html
@@ -1,0 +1,405 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office? — Munder Difflin Blog</title>
+<meta name="description" content="An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE." />
+<link rel="canonical" href="https://munderdiffl.in/blog/qm-vs-munder-difflin/" />
+
+<link rel="icon" type="image/png" href="https://munderdiffl.in/logo.png" />
+<link rel="apple-touch-icon" href="https://munderdiffl.in/logo.png" />
+<meta name="theme-color" content="#F5F2E8" />
+
+<!-- Open Graph -->
+<meta property="og:site_name" content="Munder Difflin Blog" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office? — Munder Difflin Blog" />
+<meta property="og:description" content="An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE." />
+<meta property="og:url" content="https://munderdiffl.in/blog/qm-vs-munder-difflin/" />
+<meta property="og:image" content="https://munderdiffl.in/media/og.png" />
+<meta property="og:locale" content="en_US" />
+<meta property="article:published_time" content="2026-08-06T00:00:00.000Z" />
+<meta property="article:author" content="Chaitanya Giri" />
+<meta property="article:tag" content="Comparisons" />
+<meta property="article:tag" content="Multi-Agent" />
+<meta property="article:tag" content="Tools" />
+<meta property="article:tag" content="Claude Code" />
+<meta property="article:tag" content="Open Source" />
+
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office? — Munder Difflin Blog" />
+<meta name="twitter:description" content="An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE." />
+<meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
+
+<link rel="alternate" type="application/atom+xml" title="Munder Difflin Blog" href="https://munderdiffl.in/blog/feed.xml" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/blog/assets/blog.css" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "qm vs Munder Difflin: YC's Multiplayer Harness or a Local-First Agent Office?",
+  "description": "An honest comparison of YC's qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.",
+  "image": ["https://munderdiffl.in/media/og.png"],
+  "datePublished": "2026-08-06T00:00:00.000Z",
+  "dateModified": "2026-08-06T00:00:00.000Z",
+  "author": { "@type": "Person", "name": "Chaitanya Giri" },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Munder Difflin",
+    "logo": { "@type": "ImageObject", "url": "https://munderdiffl.in/logo.png" }
+  },
+  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://munderdiffl.in/blog/qm-vs-munder-difflin/" },
+  "keywords": "qm vs munder difflin, yc qm alternative, qm claude code, qm agent harness, multiplayer agent harness, local first agent orchestration, qm y combinator agents",
+  "articleSection": "Comparisons",
+  "inLanguage": "en-US",
+  "url": "https://munderdiffl.in/blog/qm-vs-munder-difflin/"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://munderdiffl.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://munderdiffl.in/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "qm vs Munder Difflin: YC's Multiplayer Harness or a Local-First Agent Office?", "item": "https://munderdiffl.in/blog/qm-vs-munder-difflin/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What is qm?", "acceptedAnswer": { "@type": "Answer", "text": "qm (github.com/yc-software/qm) is Y Combinator's open-source 'multiplayer agent harness for work' — a headless Node.js core with a web UI and a Slack plugin. Team members get agent 'employees' with isolated workspaces, shared skills with scope-based permissions, background crons and watches, and three security postures (Strict, Auto, Dangerous). It's MIT-licensed and installs via npm." } },
+    { "@type": "Question", "name": "What's the main difference between qm and Munder Difflin?", "acceptedAnswer": { "@type": "Answer", "text": "Where the harness lives and what you can see. qm is multiplayer-first: a shared server your whole team reaches through Slack and the browser. Munder Difflin is local-first: a desktop app on your machine where every agent is a real CLI process in a real terminal you can watch, with a visual office floor, voice orchestration, and a built-in IDE. They cover the same core jobs — postures, scheduled work, Slack, skills — from opposite ends." } },
+    { "@type": "Question", "name": "Does Munder Difflin do what qm's security postures do?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, the same job with different controls: a floor-wide auto-mode toggle (the equivalent of switching between approval-gated and autonomous), per-agent pause/halt, voice-level confirm words for destructive actions, tool gating, a circuit breaker for runaway agents, and spend/scope escalation to a human. qm's Strict/Auto/Dangerous is org-level configuration; Munder Difflin's controls are per-floor and per-agent." } },
+    { "@type": "Question", "name": "Does qm have voice control, an IDE, or git visualization?", "acceptedAnswer": { "@type": "Answer", "text": "Not as of this writing. qm's interfaces are Slack and a web UI. Munder Difflin ships realtime voice orchestration (a talking Michael with live floor context), a built-in Monaco IDE with commit history, branch compare and side-by-side diffs, markdown previews, real watchable terminals, and auto-update." } },
+    { "@type": "Question", "name": "Which one should I use?", "acceptedAnswer": { "@type": "Answer", "text": "Use qm if your whole team wants one shared harness in Slack with org-level admin control. Use Munder Difflin if you want your agent office on your own machine — watchable, local-first, with voice and an IDE — riding the CLI subscriptions you already pay for. Both are MIT-licensed; some teams will genuinely want both: qm as the shared org layer, Munder Difflin as the personal floor." } },
+    { "@type": "Question", "name": "Is Munder Difflin older than qm?", "acceptedAnswer": { "@type": "Answer", "text": "Munder Difflin has been shipping public releases since v0.2.0 in mid-2026 and is on v0.3.5 with a stable auto-updating release train, while qm is a newer project that grew popular quickly. Popularity and maturity are different axes — evaluate both against your workflow." } }
+    
+  ]
+}
+</script>
+
+
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<nav id="nav">
+  <a class="brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+    <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+  </a>
+  <span class="spacer"></span>
+  <div class="links">
+    <a href="/blog/">Latest</a>
+    <a href="/blog/topics/">Topics</a>
+    <a href="/blog/about/">About</a>
+    <a href="https://munderdiffl.in">↗ Product</a>
+  </div>
+  <div class="nav-actions">
+    <a class="btn sm" href="https://munderdiffl.in/blog/feed.xml" aria-label="RSS feed">⤵ RSS</a>
+    <a class="btn sm primary" href="https://munderdiffl.in/#install">⤓ Download</a>
+  </div>
+</nav>
+
+<main id="main">
+
+<article>
+  <header class="post-head wrap">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/blog/">Blog</a>
+      <span>/</span>
+      <a href="/blog/topics/comparisons/">Comparisons</a>
+    </nav>
+    <h1>qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</h1>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="byline">
+      <span class="av" aria-hidden="true">CG</span>
+      <strong>Chaitanya Giri</strong>
+      <span class="dot" aria-hidden="true">·</span>
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true">·</span>
+      <span>3 min read</span>
+      <span class="tag kind">Comparisons</span>
+    </div>
+  </header>
+
+  <div class="post-wrap wrap">
+    <div class="prose">
+      <div class="callout tldr"><span class="ic">TL;DR</span><p><strong>qm</strong> is YC's
+multiplayer agent harness — headless, org-shaped, living in <strong>Slack and a web
+UI</strong>, great when a whole team shares one fleet. <strong>Munder Difflin</strong> is
+the same idea grown from the other end: a <strong>local-first desktop office</strong> where
+every agent is a real CLI process in a terminal you can watch, with <strong>voice
+orchestration, a built-in IDE with git history, and auto-update</strong> — things a
+headless harness doesn't have. Same jobs, opposite ends of the wire. Both MIT-licensed.</p></div>
+<p><a href="https://github.com/yc-software/qm">qm</a> earned its stars fast — “a multiplayer agent
+harness for work, in Slack and on the web” is a great pitch, and Y Combinator shipping
+open-source agent tooling is good for everyone. We get asked about it a lot, so here’s the
+honest comparison.</p>
+<h2 id="the-same-problem-from-opposite-ends" tabindex="-1">The same problem, from opposite ends <a class="anchor" href="#the-same-problem-from-opposite-ends" aria-hidden="true">#</a></h2>
+<p>Both tools exist because one CLI agent in one terminal doesn’t scale: you want several
+agents working in parallel, safely, with scheduled background work and a way to reach them
+from where you already are.</p>
+<p><strong>qm answers it org-first.</strong> A headless Node core (installed via <code>npm exec qm init</code>) that
+your team reaches through Slack and a web UI. Each “employee” gets an isolated workspace;
+skills are shared with scope-based permissions and can be promoted org-wide; admins set the
+security posture — <strong>Strict</strong> (approval-gated), <strong>Auto</strong> (default screening), or
+<strong>Dangerous</strong> — for everyone at once. Background work runs as <strong>crons and watches</strong>.</p>
+<p><strong>Munder Difflin answers it desk-first.</strong> A desktop app on your machine where every agent
+is a <strong>real CLI process in a real terminal</strong> — Claude Code, Codex, Antigravity, Copilot,
+Grok, Kimi, and more, riding the subscriptions you already pay for. The floor is visual
+(yes, it looks like The Office), a GOD orchestrator routes work, agents share long-term
+memory, and background work runs as <strong>scheduled missions</strong> with Slack and webhook triggers.</p>
+<p>If you map the concepts across, most of qm’s vocabulary has a Munder Difflin counterpart:</p>
+<table>
+<thead>
+<tr>
+<th>Job to be done</th>
+<th>qm</th>
+<th>Munder Difflin</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Safety levels</td>
+<td>Strict / Auto / Dangerous postures</td>
+<td>Auto-mode toggle, per-agent pause/halt, tool gating, circuit breaker, confirm-word voice safety</td>
+</tr>
+<tr>
+<td>Background work</td>
+<td>Crons and watches</td>
+<td>Scheduled missions + Slack/webhook triggers</td>
+</tr>
+<tr>
+<td>Reusable behaviors</td>
+<td>Shared skills with scoped permissions</td>
+<td>Agent Gallery roles + shareable agent recipes</td>
+</tr>
+<tr>
+<td>Reach it from anywhere</td>
+<td>Slack + web UI</td>
+<td>Slack + Remote Control from your phone</td>
+</tr>
+<tr>
+<td>Isolation</td>
+<td>Isolated workspaces per employee</td>
+<td>Isolated git worktrees per agent</td>
+</tr>
+<tr>
+<td>License</td>
+<td>MIT</td>
+<td>MIT</td>
+</tr>
+</tbody>
+</table>
+<h2 id="what-each-has-that-the-other-doesnt" tabindex="-1">What each has that the other doesn’t <a class="anchor" href="#what-each-has-that-the-other-doesnt" aria-hidden="true">#</a></h2>
+<p><strong>qm’s edge is multiplayer.</strong> One shared harness, unified identity, org-level admin,
+skills promotion across scopes. If your team wants a <em>single</em> fleet everyone shares from
+Slack, that’s qm’s home turf, and Munder Difflin doesn’t try to be that.</p>
+<p><strong>Munder Difflin’s edge is everything you can see and touch:</strong></p>
+<ul>
+<li><strong>Real terminals.</strong> Every agent is a watchable CLI process — when something goes
+sideways, you read the actual session, not a log abstraction.</li>
+<li><strong>Voice orchestration.</strong> Flip on talk mode and Michael greets you already knowing every
+agent’s status, steers work, changes settings from an allowlist, and waits for a spoken
+confirm word before anything destructive.</li>
+<li><strong>A built-in IDE.</strong> Monaco (the VS Code engine) one click over the floor: side-by-side
+diffs of agent changes, clickable commit history, branch compare, guarded checkout, live
+markdown previews.</li>
+<li><strong>Local-first by construction.</strong> No shared server, no code upload — agents, state, and
+memory live on your machine.</li>
+<li><strong>Auto-update.</strong> The app ships its own updates from GitHub releases; you just click
+“restart to update.”</li>
+<li><strong>A longer release train.</strong> Public releases since v0.2.0, now at v0.3.5, with the
+reliability work battle-tested by a growing contributor community.</li>
+</ul>
+<h2 id="which-should-you-use" tabindex="-1">Which should you use? <a class="anchor" href="#which-should-you-use" aria-hidden="true">#</a></h2>
+<ul>
+<li><strong>Your whole team wants one shared fleet with org-level control → qm.</strong> That’s what
+multiplayer-first buys you.</li>
+<li><strong>You want your own agent office, on your own machine, with everything visible → Munder
+Difflin.</strong> Simpler to adopt (download, open, hire), nothing leaves your computer, and
+the interfaces — floor, voice, IDE — are things a headless harness structurally can’t
+offer.</li>
+<li><strong>Honestly? Some teams will run both.</strong> qm as the shared org layer, Munder Difflin as
+the personal floor where you watch and steer your own agents. They don’t compete for
+the same seat.</li>
+</ul>
+<p>Facts about qm above come from its public README as of August 2026 — check
+<a href="https://github.com/yc-software/qm">the repo</a> for the current state, because both projects
+move fast.</p>
+<p><strong><a href="https://munderdiffl.in/">Try Munder Difflin free</a></strong> — macOS, Windows, Linux, MIT-licensed.
+And if this comparison helped, a <a href="https://github.com/chaitanyagiri/munder-difflin">GitHub star</a>
+helps more people find it.</p>
+
+
+      
+      <section class="faq" aria-label="Frequently asked questions">
+        <h2 id="faq">FAQ</h2>
+        
+        <div class="qa">
+          <p class="q">What is qm?</p>
+          <p class="a">qm (github.com/yc-software/qm) is Y Combinator&#39;s open-source &#39;multiplayer agent harness for work&#39; — a headless Node.js core with a web UI and a Slack plugin. Team members get agent &#39;employees&#39; with isolated workspaces, shared skills with scope-based permissions, background crons and watches, and three security postures (Strict, Auto, Dangerous). It&#39;s MIT-licensed and installs via npm.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">What&#39;s the main difference between qm and Munder Difflin?</p>
+          <p class="a">Where the harness lives and what you can see. qm is multiplayer-first: a shared server your whole team reaches through Slack and the browser. Munder Difflin is local-first: a desktop app on your machine where every agent is a real CLI process in a real terminal you can watch, with a visual office floor, voice orchestration, and a built-in IDE. They cover the same core jobs — postures, scheduled work, Slack, skills — from opposite ends.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Does Munder Difflin do what qm&#39;s security postures do?</p>
+          <p class="a">Yes, the same job with different controls: a floor-wide auto-mode toggle (the equivalent of switching between approval-gated and autonomous), per-agent pause/halt, voice-level confirm words for destructive actions, tool gating, a circuit breaker for runaway agents, and spend/scope escalation to a human. qm&#39;s Strict/Auto/Dangerous is org-level configuration; Munder Difflin&#39;s controls are per-floor and per-agent.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Does qm have voice control, an IDE, or git visualization?</p>
+          <p class="a">Not as of this writing. qm&#39;s interfaces are Slack and a web UI. Munder Difflin ships realtime voice orchestration (a talking Michael with live floor context), a built-in Monaco IDE with commit history, branch compare and side-by-side diffs, markdown previews, real watchable terminals, and auto-update.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Which one should I use?</p>
+          <p class="a">Use qm if your whole team wants one shared harness in Slack with org-level admin control. Use Munder Difflin if you want your agent office on your own machine — watchable, local-first, with voice and an IDE — riding the CLI subscriptions you already pay for. Both are MIT-licensed; some teams will genuinely want both: qm as the shared org layer, Munder Difflin as the personal floor.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Is Munder Difflin older than qm?</p>
+          <p class="a">Munder Difflin has been shipping public releases since v0.2.0 in mid-2026 and is on v0.3.5 with a stable auto-updating release train, while qm is a newer project that grew popular quickly. Popularity and maturity are different axes — evaluate both against your workflow.</p>
+        </div>
+        
+      </section>
+      
+
+      
+      <hr />
+      <div class="share">
+        <span class="lbl">Tags</span>
+        <a class="tag" href="/blog/tags/comparisons/">Comparisons</a><a class="tag" href="/blog/tags/multi-agent/">Multi-Agent</a><a class="tag" href="/blog/tags/tools/">Tools</a><a class="tag" href="/blog/tags/claude-code/">Claude Code</a><a class="tag" href="/blog/tags/open-source/">Open Source</a>
+      </div>
+      
+    </div>
+
+    
+    <aside class="toc-rail" aria-label="Table of contents">
+      <div class="tt">On this page</div>
+      <ol>
+        <li class="lvl-2"><a href="#the-same-problem-from-opposite-ends">The same problem, from opposite ends</a></li><li class="lvl-2"><a href="#what-each-has-that-the-other-doesnt">What each has that the other doesn’t</a></li><li class="lvl-2"><a href="#which-should-you-use">Which should you use?</a></li>
+      </ol>
+    </aside>
+    
+  </div>
+
+  <footer class="post-foot wrap"><div class="prevnext">
+      <a class="pn prev" href="/blog/command-center-guide/"><span class="k">← Older</span><span class="t">The Command Center: Kanban, Fleet, and Budgets in One Place</span></a>
+      <a class="pn next" href="/blog/launching-munder-difflin-v0-3-5/"><span class="k">Newer →</span><span class="t">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</span></a>
+    </div>
+    <section class="related">
+      <h2>Related in Comparisons</h2>
+      <div class="post-grid">
+        <article class="card">
+  <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-07-03">Jul 3, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/crewai-autogen-vs-a-local-agent-harness/">CrewAI and AutoGen vs a Local Agent Harness: Framework or App?</a></h3>
+    <p class="dek">CrewAI, AutoGen (now Microsoft Agent Framework), and LangGraph are frameworks — Python you write to build your own agent system. A multi-agent harness is an app you download that runs a team on your repos today. Here&#39;s how to tell which one you actually need.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-label="Read: CrewAI and AutoGen vs a Local Agent Harness: Framework or App?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-comparisons" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-07-03">Jul 3, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/">GitHub Copilot CLI vs Claude Code as Hive Workers</a></h3>
+    <p class="dek">How GitHub Copilot CLI and Claude Code behave as agent engines inside a multi-agent harness: hooks, inbox mail, orchestration, session lifecycle — and why the right answer is to run both.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-07-03">Jul 3, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
+    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+
+      </div>
+    </section>
+    
+  </footer>
+</article>
+
+</main>
+<footer>
+  <div class="wrap">
+    <div class="foot-top">
+      <a class="foot-brand brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+        <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+      </a>
+      <div class="foot-links">
+        <a href="/blog/">Latest</a>
+        <a href="/blog/topics/">Topics</a>
+        <a href="/blog/about/">About</a>
+        <a href="https://munderdiffl.in/blog/feed.xml">RSS</a>
+        <a href="https://github.com/chaitanyagiri/munder-difflin">GitHub</a>
+        <a href="https://munderdiffl.in">munderdiffl.in ↗</a>
+      </div>
+    </div>
+    <div class="foot-meta">
+      © 2026 Munder Difflin · Local-first · MIT-licensed ·
+      Built on <a href="https://munderdiffl.in">Electron, React, Pixi.js, xterm.js &amp; node-pty</a>.
+      Run an office of agents while you sleep.
+    </div>
+  </div>
+</footer>
+
+<script>
+  // sticky-nav border on scroll
+  (function () {
+    var nav = document.getElementById('nav');
+    if (!nav) return;
+    var onScroll = function () { nav.classList.toggle('scrolled', window.scrollY > 8); };
+    onScroll(); window.addEventListener('scroll', onScroll, { passive: true });
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/blog/tags/claude-code/index.html
+++ b/docs/blog/tags/claude-code/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Claude Code</h1>
-  <p class="lead">44 posts tagged <strong>Claude Code</strong>.</p>
+  <p class="lead">45 posts tagged <strong>Claude Code</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>

--- a/docs/blog/tags/comparisons/index.html
+++ b/docs/blog/tags/comparisons/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Comparisons</h1>
-  <p class="lead">16 posts tagged <strong>Comparisons</strong>.</p>
+  <p class="lead">17 posts tagged <strong>Comparisons</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>

--- a/docs/blog/tags/ide/index.html
+++ b/docs/blog/tags/ide/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#IDE</h1>
-  <p class="lead">2 posts tagged <strong>IDE</strong>.</p>
+  <p class="lead">3 posts tagged <strong>IDE</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-guides" href="/blog/how-to-use-the-built-in-monaco-ide/" aria-hidden="true" tabindex="-1">
     <span>GUIDES</span>
   </a>

--- a/docs/blog/tags/multi-agent/index.html
+++ b/docs/blog/tags/multi-agent/index.html
@@ -57,11 +57,47 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Multi-Agent</h1>
-  <p class="lead">79 posts tagged <strong>Multi-Agent</strong>.</p>
+  <p class="lead">81 posts tagged <strong>Multi-Agent</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>

--- a/docs/blog/tags/open-source/index.html
+++ b/docs/blog/tags/open-source/index.html
@@ -57,11 +57,47 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Open Source</h1>
-  <p class="lead">13 posts tagged <strong>Open Source</strong>.</p>
+  <p class="lead">15 posts tagged <strong>Open Source</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/release/index.html
+++ b/docs/blog/tags/release/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Release</h1>
-  <p class="lead">7 posts tagged <strong>Release</strong>.</p>
+  <p class="lead">8 posts tagged <strong>Release</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/story/index.html
+++ b/docs/blog/tags/story/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Story</h1>
-  <p class="lead">10 posts tagged <strong>Story</strong>.</p>
+  <p class="lead">11 posts tagged <strong>Story</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/tools/index.html
+++ b/docs/blog/tags/tools/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Tools</h1>
-  <p class="lead">9 posts tagged <strong>Tools</strong>.</p>
+  <p class="lead">10 posts tagged <strong>Tools</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/best-ai-coding-agents/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>

--- a/docs/blog/tags/voice/index.html
+++ b/docs/blog/tags/voice/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Voice</h1>
-  <p class="lead">2 posts tagged <strong>Voice</strong>.</p>
+  <p class="lead">3 posts tagged <strong>Voice</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-concepts" href="/blog/voice-as-a-control-plane-for-agent-fleets/" aria-hidden="true" tabindex="-1">
     <span>CONCEPTS</span>
   </a>

--- a/docs/blog/the-office-parody-behind-munder-difflin/index.html
+++ b/docs/blog/the-office-parody-behind-munder-difflin/index.html
@@ -268,6 +268,24 @@ Michael’s already at his desk. Free and open source.</p>
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -300,24 +318,6 @@ Michael’s already at his desk. Free and open source.</p>
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/tmux-and-scripts-vs-an-agent-harness/index.html
+++ b/docs/blog/tmux-and-scripts-vs-an-agent-harness/index.html
@@ -227,6 +227,24 @@
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -259,24 +277,6 @@
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/topics/comparisons/index.html
+++ b/docs/blog/topics/comparisons/index.html
@@ -62,7 +62,7 @@
   </nav>
   <p class="eyebrow">Topic</p>
   <h1>comparisons</h1>
-  <p class="lead">16 posts in this cluster.</p>
+  <p class="lead">17 posts in this cluster.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
     <a class="chip" href="/blog/">All</a>
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/" aria-current="page">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/" aria-current="page">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     
@@ -89,6 +89,24 @@
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>

--- a/docs/blog/topics/concepts/index.html
+++ b/docs/blog/topics/concepts/index.html
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/" aria-current="page">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     

--- a/docs/blog/topics/guides/index.html
+++ b/docs/blog/topics/guides/index.html
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     

--- a/docs/blog/topics/index.html
+++ b/docs/blog/topics/index.html
@@ -83,6 +83,15 @@
       </div>
     </a>
     
+    <a class="card" href="/blog/topics/comparisons/" style="text-decoration:none">
+      <span class="thumb t-comparisons" aria-hidden="true">COMPARISONS</span>
+      <div class="body">
+        <h3 style="color:var(--ink)">comparisons</h3>
+        <p class="dek">17 posts.</p>
+        <div class="foot"><span class="more">View topic →</span></div>
+      </div>
+    </a>
+    
     <a class="card" href="/blog/topics/internals/" style="text-decoration:none">
       <span class="thumb t-internals" aria-hidden="true">INTERNALS</span>
       <div class="body">
@@ -92,11 +101,11 @@
       </div>
     </a>
     
-    <a class="card" href="/blog/topics/comparisons/" style="text-decoration:none">
-      <span class="thumb t-comparisons" aria-hidden="true">COMPARISONS</span>
+    <a class="card" href="/blog/topics/story/" style="text-decoration:none">
+      <span class="thumb t-story" aria-hidden="true">STORY</span>
       <div class="body">
-        <h3 style="color:var(--ink)">comparisons</h3>
-        <p class="dek">16 posts.</p>
+        <h3 style="color:var(--ink)">story</h3>
+        <p class="dek">10 posts.</p>
         <div class="foot"><span class="more">View topic →</span></div>
       </div>
     </a>
@@ -105,15 +114,6 @@
       <span class="thumb t-orchestration" aria-hidden="true">ORCHESTRATION</span>
       <div class="body">
         <h3 style="color:var(--ink)">orchestration</h3>
-        <p class="dek">9 posts.</p>
-        <div class="foot"><span class="more">View topic →</span></div>
-      </div>
-    </a>
-    
-    <a class="card" href="/blog/topics/story/" style="text-decoration:none">
-      <span class="thumb t-story" aria-hidden="true">STORY</span>
-      <div class="body">
-        <h3 style="color:var(--ink)">story</h3>
         <p class="dek">9 posts.</p>
         <div class="foot"><span class="more">View topic →</span></div>
       </div>
@@ -143,9 +143,9 @@
   <div class="filters" style="padding-top:36px">
     <span class="eyebrow" style="align-self:center">Tags</span>
     
-    <a class="chip" href="/blog/tags/multi-agent/">Multi-Agent<span class="ct">79</span></a>
+    <a class="chip" href="/blog/tags/multi-agent/">Multi-Agent<span class="ct">81</span></a>
     
-    <a class="chip" href="/blog/tags/claude-code/">Claude Code<span class="ct">44</span></a>
+    <a class="chip" href="/blog/tags/claude-code/">Claude Code<span class="ct">45</span></a>
     
     <a class="chip" href="/blog/tags/guides/">Guides<span class="ct">23</span></a>
     
@@ -155,29 +155,29 @@
     
     <a class="chip" href="/blog/tags/concepts/">Concepts<span class="ct">18</span></a>
     
-    <a class="chip" href="/blog/tags/comparisons/">Comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/tags/comparisons/">Comparisons<span class="ct">17</span></a>
+    
+    <a class="chip" href="/blog/tags/open-source/">Open Source<span class="ct">15</span></a>
     
     <a class="chip" href="/blog/tags/local-first/">Local-First<span class="ct">13</span></a>
     
-    <a class="chip" href="/blog/tags/open-source/">Open Source<span class="ct">13</span></a>
-    
     <a class="chip" href="/blog/tags/automation/">Automation<span class="ct">11</span></a>
     
-    <a class="chip" href="/blog/tags/story/">Story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/tags/story/">Story<span class="ct">11</span></a>
+    
+    <a class="chip" href="/blog/tags/tools/">Tools<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/tags/getting-started/">Getting Started<span class="ct">9</span></a>
     
-    <a class="chip" href="/blog/tags/tools/">Tools<span class="ct">9</span></a>
-    
     <a class="chip" href="/blog/tags/memory/">Memory<span class="ct">8</span></a>
+    
+    <a class="chip" href="/blog/tags/release/">Release<span class="ct">8</span></a>
     
     <a class="chip" href="/blog/tags/human-in-the-loop/">Human-in-the-Loop<span class="ct">7</span></a>
     
     <a class="chip" href="/blog/tags/security/">Security<span class="ct">7</span></a>
     
     <a class="chip" href="/blog/tags/cost/">Cost<span class="ct">7</span></a>
-    
-    <a class="chip" href="/blog/tags/release/">Release<span class="ct">7</span></a>
     
     <a class="chip" href="/blog/tags/mempalace/">MemPalace<span class="ct">6</span></a>
     
@@ -215,7 +215,11 @@
     
     <a class="chip" href="/blog/tags/seo/">SEO<span class="ct">3</span></a>
     
+    <a class="chip" href="/blog/tags/voice/">Voice<span class="ct">3</span></a>
+    
     <a class="chip" href="/blog/tags/engines/">Engines<span class="ct">3</span></a>
+    
+    <a class="chip" href="/blog/tags/ide/">IDE<span class="ct">3</span></a>
     
     <a class="chip" href="/blog/tags/god/">GOD<span class="ct">2</span></a>
     
@@ -248,10 +252,6 @@
     <a class="chip" href="/blog/tags/code-review/">Code Review<span class="ct">2</span></a>
     
     <a class="chip" href="/blog/tags/agent-design/">Agent Design<span class="ct">2</span></a>
-    
-    <a class="chip" href="/blog/tags/voice/">Voice<span class="ct">2</span></a>
-    
-    <a class="chip" href="/blog/tags/ide/">IDE<span class="ct">2</span></a>
     
     <a class="chip" href="/blog/tags/subagents/">Subagents<span class="ct">1</span></a>
     

--- a/docs/blog/topics/internals/index.html
+++ b/docs/blog/topics/internals/index.html
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/" aria-current="page">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     

--- a/docs/blog/topics/memory/index.html
+++ b/docs/blog/topics/memory/index.html
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/" aria-current="page">memory<span class="ct">5</span></a>
     

--- a/docs/blog/topics/orchestration/index.html
+++ b/docs/blog/topics/orchestration/index.html
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/" aria-current="page">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     

--- a/docs/blog/topics/story/index.html
+++ b/docs/blog/topics/story/index.html
@@ -62,7 +62,7 @@
   </nav>
   <p class="eyebrow">Topic</p>
   <h1>story</h1>
-  <p class="lead">9 posts in this cluster.</p>
+  <p class="lead">10 posts in this cluster.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
     <a class="chip" href="/blog/">All</a>
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/" aria-current="page">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/" aria-current="page">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     
@@ -89,6 +89,24 @@
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/topics/use-cases/index.html
+++ b/docs/blog/topics/use-cases/index.html
@@ -71,13 +71,13 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    
     <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
-    
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/topics/memory/">memory<span class="ct">5</span></a>
     

--- a/docs/blog/vibe-kanban-alternative/index.html
+++ b/docs/blog/vibe-kanban-alternative/index.html
@@ -217,6 +217,24 @@ routing happen for you — free and open source.</p>
       <h2>Related in Comparisons</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>COMPARISONS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/qm-vs-munder-difflin/">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</a></h3>
+    <p class="dek">An honest comparison of YC&#39;s qm and Munder Difflin: both orchestrate fleets of CLI coding agents with security postures, scheduled background work, and Slack — one as a headless multiplayer harness for teams, one as a local-first desktop office with real terminals, voice, and a built-in IDE.</p>
+    <div class="foot">
+      <span class="tag kind">Comparisons</span>
+      <a class="more" href="/blog/qm-vs-munder-difflin/" aria-label="Read: qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/crewai-autogen-vs-a-local-agent-harness/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>
@@ -249,24 +267,6 @@ routing happen for you — free and open source.</p>
     <div class="foot">
       <span class="tag kind">Comparisons</span>
       <a class="more" href="/blog/github-copilot-cli-vs-claude-code-for-hive-work/" aria-label="Read: GitHub Copilot CLI vs Claude Code as Hive Workers">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-comparisons" href="/blog/orca-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
-    <span>COMPARISONS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-07-03">Jul 3, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/orca-vs-munder-difflin/">Orca vs Munder Difflin: Agent IDE or Agent Office?</a></h3>
-    <p class="dek">Orca is a YC-backed Agent IDE for driving coding agents side by side in isolated worktrees. Munder Difflin is an agent office that runs itself. An honest comparison of the two — and when each one is the right pick.</p>
-    <div class="foot">
-      <span class="tag kind">Comparisons</span>
-      <a class="more" href="/blog/orca-vs-munder-difflin/" aria-label="Read: Orca vs Munder Difflin: Agent IDE or Agent Office?">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/why-we-built-munder-difflin/index.html
+++ b/docs/blog/why-we-built-munder-difflin/index.html
@@ -210,6 +210,24 @@ Munder Difflin</a> — it’s open source and local-first, on macOS, Windows, an
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -242,24 +260,6 @@ Munder Difflin</a> — it’s open source and local-first, on macOS, Windows, an
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,11 +29,11 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "Munder Difflin",
-  "description": "Run a virtual office of AI agents on any computer. Munder Difflin is a highly capable local multi-agent harness that makes a multi-CLI agent cluster work 24/7 for you — Claude Code, Codex, Antigravity, and GitHub Copilot CLI with Slack and webhook integration. New in v0.3.3: a built-in Monaco IDE and GitHub Copilot CLI support.",
+  "description": "Run a virtual office of AI agents on any computer. Munder Difflin is a highly capable local multi-agent harness that makes a multi-CLI agent cluster work 24/7 for you — Claude Code, Codex, Antigravity, Grok, and GitHub Copilot CLI with Slack and webhook integration. New in v0.3.5: voice orchestration with live floor context, markdown previews, git history & branch compare in the built-in IDE, and auto-update.",
   "url": "https://munderdiffl.in/",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "macOS, Windows, Linux",
-  "softwareVersion": "0.3.3",
+  "softwareVersion": "0.3.5",
   "downloadUrl": "https://github.com/chaitanyagiri/munder-difflin/releases/latest",
   "softwareHelp": "https://github.com/chaitanyagiri/munder-difflin#readme",
   "license": "https://github.com/chaitanyagiri/munder-difflin/blob/main/LICENSE",
@@ -64,6 +64,28 @@
   "name": "Munder Difflin",
   "url": "https://munderdiffl.in/",
   "inLanguage": "en-US"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "Is Munder Difflin really free?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes. Munder Difflin is MIT-licensed and free forever — download it or build from source. It drives the agent subscriptions you already pay for (Claude Code, Codex, Antigravity), so there's no new bill." } },
+    { "@type": "Question", "name": "Do I need new API keys to use Munder Difflin?",
+      "acceptedAnswer": { "@type": "Answer", "text": "No. If claude, codex, or agy already work in your terminal, they work here — the harness runs the same CLI processes under your existing login or subscription. You can optionally add your own keys or local LLMs in Settings." } },
+    { "@type": "Question", "name": "Does my code leave my machine?",
+      "acceptedAnswer": { "@type": "Answer", "text": "No. The harness is local-first: agents are real CLI processes in local terminals, each in an isolated git worktree, with state in a local SQLite file. The only network traffic is what your own CLIs already make to their providers." } },
+    { "@type": "Question", "name": "Which agent CLIs does Munder Difflin support?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, OpenCode, Crush, pi.dev — and, new in v0.3.4, xAI Grok and Kimi Code. Each gets a desk, a mailbox, and shared memory; most can even play the orchestrator." } },
+    { "@type": "Question", "name": "How is Munder Difflin different from YC's qm?",
+      "acceptedAnswer": { "@type": "Answer", "text": "qm is a multiplayer agent harness for teams, headless, living in Slack and a web UI. Munder Difflin covers the same jobs — security postures, background crons and watches, Slack triggers, shareable skills — as a simpler, local-first desktop app that's been shipping stably since v0.2, and adds what qm doesn't have: real terminals you can watch, voice orchestration, a built-in IDE with commit history and branch compare, and auto-update." } },
+    { "@type": "Question", "name": "Can Munder Difflin really run for days without me?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes. The hive keeps iterating on its own and escalates to you (desktop, Slack, or voice) only when something needs a human: spend limits, scope changes, or destructive operations. You can steer mid-run or stop gracefully at any time." } },
+    { "@type": "Question", "name": "Why does Munder Difflin look like The Office?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Because watching a wall of log lines is miserable. The pixel office floor is a real visualization — every avatar maps to a live agent. An affectionate parody; not affiliated with NBC." } }
+  ]
 }
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -763,16 +785,16 @@
   <div class="wrap">
     <div class="chip-wrap reveal" id="verWrap">
       <button class="chip" id="verChip" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="verPop">
-        <span class="new">NEW</span> <b>v0.3.3</b> · Local agent harness
+        <span class="new">NEW</span> <b>v0.3.5</b> · Local agent harness
       </button>
-      <div class="ver-pop" id="verPop" role="dialog" aria-label="What's new in v0.3.3">
-        <h4>What's new in v0.3.3</h4>
+      <div class="ver-pop" id="verPop" role="dialog" aria-label="What's new in v0.3.5">
+        <h4>What's new in v0.3.5</h4>
         <ul>
-          <li><b>Built-in Monaco IDE</b> — file tree, editor tabs, and side-by-side git diffs of your agents' changes, one click over the floor.</li>
-          <li><b>GitHub Copilot CLI</b> joins the engine roster — our first community-contributed provider.</li>
-          <li><b>New landing experience</b> — dark mode, narrated video tour, and a theme toggle.</li>
+          <li><b>Michael knows the floor</b> — talk mode opens with a live snapshot of every agent and stays current mid-call; he can now run nearly the whole app by voice.</li>
+          <li><b>Git time-machine in the IDE</b> — clickable commit history, branch compare, and guarded checkout. Plus live markdown previews everywhere (⌘-click a .md path in any terminal).</li>
+          <li><b>The app updates itself</b> — new releases download in the background and wait for your "restart to update" click. Also: xAI Grok joins the engine roster.</li>
         </ul>
-        <a class="more" href="/blog/launching-munder-difflin-v0-3-3/">Read the launch post →</a>
+        <a class="more" href="/blog/launching-munder-difflin-v0-3-5/">Read the launch post →</a>
       </div>
     </div>
     <h1 class="hero-title reveal">Forever running cli agent cluster to do all your work</h1>
@@ -965,14 +987,15 @@
       <!-- Talk mode (wide) -->
       <div class="fcard span-2 reveal">
         <div class="fcard-body" style="padding: 26px 28px;">
-          <div class="fcard-title"><span class="ic">🎙️</span> Talk mode — run the floor by voice <span class="badge badge-new">NEW in v0.3.2</span></div>
-          <p class="fcard-desc">Flip it on and Michael greets you out loud. Describe the goal; he spawns hires, assigns and
-            steers the work, reads back memory or any agent's status on request, and speaks up when it's done.
-            Hands-free orchestration — with the same human-in-the-loop confirms before anything risky.</p>
+          <div class="fcard-title"><span class="ic">🎙️</span> Talk mode — a Michael who knows the floor <span class="badge badge-new">NEW in v0.3.4</span></div>
+          <p class="fcard-desc">Flip it on and Michael greets you out loud — already knowing <b>every agent's status, context
+            fill, and in-flight work</b>, and staying current mid-call as the floor changes. Describe the goal; he spawns hires,
+            assigns and steers, manages tasks and schedules, changes settings from a strict allowlist, and speaks up when it's
+            done. Hands-free orchestration — destructive actions still wait for you to say "confirm" out loud.</p>
           <div class="badges">
-            <span class="badge"><span class="dot" style="background:#FBD7CD;"></span>Realtime voice orchestrator</span>
-            <span class="badge"><span class="dot" style="background:var(--sky);"></span>Hands-free hive control</span>
-            <span class="badge"><span class="dot" style="background:var(--mint);"></span>Speaks up when work's done</span>
+            <span class="badge"><span class="dot" style="background:#FBD7CD;"></span>Live floor context, mid-call</span>
+            <span class="badge"><span class="dot" style="background:var(--sky);"></span>Full app control by voice</span>
+            <span class="badge"><span class="dot" style="background:var(--mint);"></span>Confirm-word safety for anything risky</span>
           </div>
         </div>
       </div>
@@ -980,15 +1003,16 @@
       <!-- Monaco IDE (wide) -->
       <div class="fcard span-2 reveal">
         <div class="fcard-body" style="padding: 26px 28px;">
-          <div class="fcard-title"><span class="ic">📝</span> A real IDE, built into the floor <span class="badge badge-new">NEW in v0.3.3</span></div>
+          <div class="fcard-title"><span class="ic">📝</span> A real IDE, built into the floor <span class="badge badge-new">UPGRADED in v0.3.4</span></div>
           <p class="fcard-desc">One click opens a full <b>Monaco IDE</b> — the same editor engine as VS&nbsp;Code — right over the office.
-            Browse the file tree, review every change your agents made as a <b>side-by-side git diff</b>, edit in tabs with
-            dirty-state tracking, and save with <b>Cmd/Ctrl+S</b>. No context switch, no external editor — read, tweak, and
-            approve agent work where it happens.</p>
+            Review every agent change as a <b>side-by-side git diff</b>, walk the <b>clickable commit history</b> and open any
+            commit's diffs, <b>compare branches</b> file-by-file, and check out safely (it refuses to move a dirty tree or yank
+            code from under a working agent). Markdown gets a live <b>code | split | preview</b> switch, and ⌘-clicking any
+            <code>.md</code> path an agent prints opens a rendered preview instantly.</p>
           <div class="badges">
             <span class="badge"><span class="dot" style="background:var(--sky);"></span>Monaco editor (VS Code engine)</span>
-            <span class="badge"><span class="dot" style="background:var(--mint);"></span>Git diff vs HEAD</span>
-            <span class="badge"><span class="dot" style="background:#E4DEFB;"></span>File tree + editor tabs</span>
+            <span class="badge"><span class="dot" style="background:var(--mint);"></span>Commit history &amp; branch compare</span>
+            <span class="badge"><span class="dot" style="background:#E4DEFB;"></span>Live markdown preview</span>
           </div>
         </div>
       </div>
@@ -1035,6 +1059,9 @@
       <div class="mini"><span class="ic">🧩</span><div class="t"><span class="lbl">Agent Gallery</span><span class="sub">Off-the-shelf hires you review &amp; spawn</span></div></div>
       <div class="mini"><span class="ic">🔐</span><div class="t"><span class="lbl">Integrations registry</span><span class="sub">Services behind a write-only secret broker</span></div></div>
       <div class="mini"><span class="ic">📡</span><div class="t"><span class="lbl">Remote control</span><span class="sub">Check in and steer from your phone</span></div></div>
+      <div class="mini"><span class="ic">⬆️</span><div class="t"><span class="lbl">Auto-update</span><span class="sub">Downloads new releases, you click restart</span></div></div>
+      <div class="mini"><span class="ic">📄</span><div class="t"><span class="lbl">Markdown previews</span><span class="sub">⌘-click any .md an agent prints</span></div></div>
+      <div class="mini"><span class="ic">🎛️</span><div class="t"><span class="lbl">Six-tab Settings</span><span class="sub">Models, autonomy, budgets, voice, memory</span></div></div>
     </div>
   </div>
 </section>
@@ -1216,7 +1243,11 @@
       </details>
       <details class="faq-item reveal">
         <summary>Which agent CLIs are supported?</summary>
-        <div class="a">Claude Code, OpenAI Codex, Antigravity (Gemini), OpenCode, Crush, pi.dev — and, new in v0.3.3, <b>GitHub Copilot CLI</b>. Each gets a desk, a mailbox, and shared memory; most can even play the orchestrator. Mix and match on the same floor.</div>
+        <div class="a">Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, OpenCode, Crush, pi.dev — and, new in v0.3.4, <b>xAI Grok</b> and <b>Kimi Code</b>. Each gets a desk, a mailbox, and shared memory; most can even play the orchestrator. Mix and match on the same floor.</div>
+      </details>
+      <details class="faq-item reveal">
+        <summary>How is this different from YC's qm?</summary>
+        <div class="a">They're solving the same problem from different ends. <a href="https://github.com/yc-software/qm" rel="nofollow">qm</a> is a multiplayer agent harness for teams — headless, living in Slack and a web UI. Munder Difflin covers the same jobs — security postures, background crons and watches, Slack triggers, shareable skills — as a <b>simpler, local-first desktop app</b> that's been shipping stably since v0.2: real terminals you can watch, voice orchestration, a built-in IDE with commit history and branch compare, and auto-update. If you want your agent office on your own machine with everything visible, that's us. <a href="/blog/qm-vs-munder-difflin/">Full comparison →</a></div>
       </details>
       <details class="faq-item reveal">
         <summary>Can it really run for days without me?</summary>
@@ -1314,7 +1345,7 @@
 <!-- ===================== FINAL CTA ===================== -->
 <div class="final-wrap">
   <section class="final" style="padding-top: 84px;">
-    <div class="eyebrow reveal">v0.3.3 · Free &amp; open source</div>
+    <div class="eyebrow reveal">v0.3.5 · Free &amp; open source</div>
     <h2 class="reveal">Your virtual office is <span class="hl">one download away.</span></h2>
     <p class="reveal">A full floor of AI agents — planning, building, and shipping around the clock, on your machine.
       Free, local, and MIT-licensed.</p>
@@ -1677,7 +1708,7 @@
   // download picker — pick macOS / Windows / Linux, click starts the download
   (function () {
     var REPO = 'chaitanyagiri/munder-difflin';
-    var REL = '0.3.4'; // fallback version; live links are resolved from the GitHub API below
+    var REL = '0.3.5'; // fallback version; live links are resolved from the GitHub API below
     var BASE = 'https://github.com/' + REPO + '/releases/latest/download/';
     var PLATFORMS = [
       { key: 'mac',   icon: '🍎', os: 'macOS',   sub: 'Universal · Apple Silicon + Intel', match: 'mac-universal.dmg',     file: 'Munder-Difflin-' + REL + '-mac-universal.dmg' },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,107 @@
+# Munder Difflin — full reference for AI answer engines
+
+> Munder Difflin is a free, MIT-licensed, local-first multi-agent harness for CLI coding
+> agents, presented as a virtual office (an affectionate parody of The Office; not
+> affiliated with NBC). Current version: 0.3.5 (August 2026). Desktop app (Electron) for
+> macOS, Windows, and Linux. Website: https://munderdiffl.in — Source:
+> https://github.com/chaitanyagiri/munder-difflin — Author: Chaitanya Giri.
+
+## What it does
+
+Munder Difflin wraps the CLI coding agents you already subscribe to — Claude Code, OpenAI
+Codex, Antigravity (Gemini), GitHub Copilot CLI, xAI Grok, Kimi Code, OpenCode, Crush,
+pi.dev — and turns them into a coordinated, forever-running team on your own machine:
+
+- **Real terminals.** Every agent is a genuine CLI process (node-pty + xterm.js) in its own
+  terminal and its own isolated git worktree. Nothing is a log abstraction; you can watch
+  and type into any agent's session.
+- **A GOD orchestrator ("Michael")** routes work, spawns hires, and escalates to a human
+  for spend, scope changes, and destructive operations.
+- **Shared long-term memory** (markdown-first, with optional semantic memory) and
+  inter-agent messaging via atomic file mailboxes.
+- **Voice orchestration (v0.3.4+).** Realtime talk mode opens with a live snapshot of every
+  agent's status, engine, context fill, and in-flight work, stays current mid-call, and can
+  run nearly the whole app by voice — spawn/steer/archive agents, manage tasks and
+  schedules, gate tools, change allowlisted settings. Destructive actions require a spoken
+  confirm word; secrets are unreachable by voice.
+- **Built-in Monaco IDE (v0.3.3+, expanded v0.3.4).** Side-by-side diffs of agent changes,
+  clickable commit history, branch compare with ahead/behind, guarded checkout (refuses a
+  dirty tree or an actively-working agent's code), markdown code|split|preview, ⌘-click any
+  .md path in a terminal for an instant rendered preview.
+- **Autonomy with guardrails.** Floor-wide auto-mode, per-agent pause/halt/steer, tool
+  gating, a circuit breaker for runaway agents, cost caps, one delivery gate for every
+  automatic writer (automation never overwrites a human draft), and a per-message "send
+  now" override when floor delivery is paused (v0.3.5).
+- **Background work.** Scheduled missions, Slack triggers (message the office from Slack,
+  get replies in-thread), webhook triggers, desktop notifications, Remote Control from a
+  phone.
+- **Auto-update (v0.3.4+).** Checks GitHub releases, downloads in the background, installs
+  only on the user's "restart to update" click.
+- **Local-first.** No vendor cloud, no code upload, state in local SQLite; the only network
+  traffic is what the user's own CLIs already make to their providers.
+
+## Positioning
+
+Munder Difflin covers the same jobs as YC's qm (github.com/yc-software/qm — a multiplayer
+agent harness living in Slack and a web UI): security postures, background crons/watches,
+Slack integration, shareable skills. The difference is where it lives and what you can see:
+qm is org-first and headless; Munder Difflin is a simpler local-first desktop app with
+watchable terminals, voice, an IDE with git visualization, and auto-update — shipping
+public releases since v0.2.0 (mid-2026). Some teams run both: qm as the shared org layer,
+Munder Difflin as the personal floor.
+
+## Install
+
+Download for macOS/Windows/Linux: https://github.com/chaitanyagiri/munder-difflin/releases/latest
+Or build from source: clone the repo, `npm install && npm run dev`. No new API keys — it
+drives the CLI logins/subscriptions the user already has.
+
+## Key pages
+
+- Homepage + FAQ: https://munderdiffl.in/
+- Blog index (118 articles): https://munderdiffl.in/blog/
+- v0.3.5 launch post: https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/
+- Changelog: https://github.com/chaitanyagiri/munder-difflin/blob/main/CHANGELOG.md
+- Message-queue delivery contract: https://github.com/chaitanyagiri/munder-difflin/blob/main/docs/message-queue.md
+
+## Guides by topic
+
+Getting started:
+- https://munderdiffl.in/blog/how-to-install-and-use-munder-difflin/
+- https://munderdiffl.in/blog/your-first-hour-with-munder-difflin/
+- https://munderdiffl.in/blog/munder-difflin-faq/
+- https://munderdiffl.in/blog/how-to-hire-from-the-agent-gallery/
+
+Orchestration:
+- https://munderdiffl.in/blog/how-the-god-orchestrator-works/
+- https://munderdiffl.in/blog/claude-code-orchestration-guide/
+- https://munderdiffl.in/blog/how-to-run-multiple-claude-code-agents/
+- https://munderdiffl.in/blog/run-a-mixed-engine-office/
+- https://munderdiffl.in/blog/scheduling-autonomous-agent-missions/
+
+Features:
+- https://munderdiffl.in/blog/how-to-talk-to-your-orchestrator/ (voice)
+- https://munderdiffl.in/blog/how-to-use-the-built-in-monaco-ide/ (IDE)
+- https://munderdiffl.in/blog/command-center-guide/ (kanban, fleet, budgets)
+- https://munderdiffl.in/blog/give-claude-code-long-term-memory/ (memory)
+- https://munderdiffl.in/blog/trigger-ai-agents-from-slack/ (Slack)
+
+Comparisons:
+- https://munderdiffl.in/blog/qm-vs-munder-difflin/
+- https://munderdiffl.in/blog/claude-squad-vs-munder-difflin/
+- https://munderdiffl.in/blog/orca-vs-munder-difflin/
+- https://munderdiffl.in/blog/cline-vs-munder-difflin/
+- https://munderdiffl.in/blog/best-claude-code-multi-agent-tools/
+- https://munderdiffl.in/blog/claude-code-git-worktrees-vs-hive/
+
+Concepts / engineering:
+- https://munderdiffl.in/blog/what-is-a-multi-agent-harness/
+- https://munderdiffl.in/blog/what-is-harness-engineering/
+- https://munderdiffl.in/blog/building-reliable-ai-agents/
+- https://munderdiffl.in/blog/security-for-ai-coding-agents/
+- https://munderdiffl.in/blog/the-lethal-trifecta-for-coding-agents/
+
+## License
+
+MIT. Free forever; no paid tier. The project asks only for a GitHub star:
+https://github.com/chaitanyagiri/munder-difflin

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,42 @@
+# Munder Difflin
+
+> Munder Difflin is a free, MIT-licensed, local-first multi-agent harness for CLI coding
+> agents. It turns Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI,
+> xAI Grok, Kimi Code, OpenCode, Crush, and pi.dev into a coordinated "office" of agents on
+> your own computer — each agent a real CLI process in a real terminal, with shared
+> long-term memory, inter-agent messaging, a GOD orchestrator, scheduled missions, Slack
+> and webhook triggers, realtime voice orchestration, a built-in Monaco IDE with git
+> history and branch compare, markdown previews, and auto-update. Current version: 0.3.5
+> (August 2026). Desktop app for macOS, Windows, and Linux. No vendor cloud; code never
+> leaves your machine. It covers the same jobs as YC's qm (security postures, background
+> crons/watches, Slack, shared skills) as a simpler local-first desktop app, and adds what
+> a headless harness doesn't have: watchable terminals, voice, an IDE, auto-update.
+
+## Product
+
+- [Homepage](https://munderdiffl.in/): features, download links, FAQ
+- [GitHub repository](https://github.com/chaitanyagiri/munder-difflin): source, issues, releases
+- [Latest release](https://github.com/chaitanyagiri/munder-difflin/releases/latest): macOS dmg, Windows setup, Linux AppImage
+- [Changelog](https://github.com/chaitanyagiri/munder-difflin/blob/main/CHANGELOG.md)
+
+## Key guides
+
+- [What's new in v0.3.5](https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/): the v0.3.4+v0.3.5 release wave
+- [How to install and use Munder Difflin](https://munderdiffl.in/blog/how-to-install-and-use-munder-difflin/)
+- [Your first hour with Munder Difflin](https://munderdiffl.in/blog/your-first-hour-with-munder-difflin/)
+- [Frequently asked questions](https://munderdiffl.in/blog/munder-difflin-faq/)
+- [How the GOD orchestrator works](https://munderdiffl.in/blog/how-the-god-orchestrator-works/)
+- [How to talk to your orchestrator (voice)](https://munderdiffl.in/blog/how-to-talk-to-your-orchestrator/)
+- [How to use the built-in Monaco IDE](https://munderdiffl.in/blog/how-to-use-the-built-in-monaco-ide/)
+
+## Comparisons
+
+- [qm vs Munder Difflin](https://munderdiffl.in/blog/qm-vs-munder-difflin/): YC's multiplayer harness vs a local-first agent office
+- [Claude Squad vs Munder Difflin](https://munderdiffl.in/blog/claude-squad-vs-munder-difflin/)
+- [Best Claude Code multi-agent tools](https://munderdiffl.in/blog/best-claude-code-multi-agent-tools/)
+
+## Full content
+
+- [Blog index](https://munderdiffl.in/blog/): 118 articles on multi-agent orchestration, Claude Code, and harness engineering
+- [Sitemap](https://munderdiffl.in/sitemap.xml)
+- [llms-full.txt](https://munderdiffl.in/llms-full.txt): extended version of this file

--- a/docs/message-queue.md
+++ b/docs/message-queue.md
@@ -51,10 +51,17 @@ The front of an agent's MD queue is delivered only when **all** of these hold:
 | Condition | Why |
 |---|---|
 | agent status is `idle` | don't interrupt a running turn |
-| auto-delivery not paused | per-agent control switch |
+| auto-delivery not paused — **or the message was manually released** | floor-wide switch (Command Center); see below |
 | past the boot grace window | the CLI is still painting its banner |
 | `isTerminalAutomationSafe(ptyId)` | the user owns the prompt — see below |
 | 4.5 s since the last delivery to this agent | back-to-back sends jam the TUI |
+
+**Manual release (v0.3.5).** While floor-wide auto-delivery is paused, every queued row
+shows a **send now** link. Clicking it sets `manual: true` on that message and moves it
+to the front of its queue. The drain then bypasses **only the pause check** for that
+message — every other condition in this table still applies, so a manually released
+message waits for idle, respects your draft/picker, and is acknowledged the same way.
+The pause gate holds everything else untouched.
 
 Delivery is acknowledged only after both PTY writes (the text, then the submit) have
 succeeded. A failure leaves the message visible in the queue and it retries.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -10,13 +10,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://munderdiffl.in/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url><loc>https://munderdiffl.in/blog/</loc><changefreq>daily</changefreq><priority>0.9</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
   <url><loc>https://munderdiffl.in/blog/about/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url>
+    <loc>https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/</loc>
+    <lastmod>2026-08-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://munderdiffl.in/blog/qm-vs-munder-difflin/</loc>
+    <lastmod>2026-08-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <url>
     <loc>https://munderdiffl.in/blog/command-center-guide/</loc>
     <lastmod>2026-07-03</lastmod>
@@ -709,10 +721,10 @@
   </url>
   <url><loc>https://munderdiffl.in/blog/topics/guides/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/concepts/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
-  <url><loc>https://munderdiffl.in/blog/topics/internals/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/comparisons/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
-  <url><loc>https://munderdiffl.in/blog/topics/orchestration/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://munderdiffl.in/blog/topics/internals/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/story/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://munderdiffl.in/blog/topics/orchestration/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/memory/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/use-cases/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/multi-agent/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -722,17 +734,17 @@
   <url><loc>https://munderdiffl.in/blog/tags/orchestration/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/concepts/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/comparisons/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/local-first/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/open-source/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/local-first/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/automation/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/story/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/getting-started/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/tools/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/getting-started/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/memory/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/release/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/human-in-the-loop/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/security/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/cost/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/release/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/mempalace/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/use-cases/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/hive/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -751,7 +763,9 @@
   <url><loc>https://munderdiffl.in/blog/tags/agentic-ai/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/aeo/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/seo/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/voice/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/engines/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/ide/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/god/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/messaging/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/faq/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -768,8 +782,6 @@
   <url><loc>https://munderdiffl.in/blog/tags/codex/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/code-review/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/agent-design/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/voice/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/ide/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/subagents/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/markdown/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/coordination/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munder-difflin",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "Local multi-agent harness for Claude Code: autonomous agents that message, route, and remember — coordinated by a GOD orchestrator and visualized as avatars at work.",
   "main": "out/main/index.js",


### PR DESCRIPTION
Ships v0.3.5: the paused-queue "send now" fix + Command Center header compaction (already on main via #117), plus everything around the release — changelog, RELEASE.md, delivery-contract doc, full landing-page version sweep (which had never absorbed 0.3.4), updated feature cards, a new FAQPage JSON-LD block, the combined 0.3.4+0.3.5 launch post, a qm-vs-munder-difflin comparison post, regenerated blog/sitemap/feed, and new llms.txt/llms-full.txt for answer engines.

First release delivered via the 0.3.4 auto-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)