### PR TITLE
Release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] — 2026-08-08
+
+**A machine with nothing installed on it can now run agents.**
+Every fix in this release is about the same failure: the app assumed the user's machine
+already had things on it — a shell to expand `~`, a `node` on PATH, an npm to install
+with — and when it didn't, agents died with a bare exit code and no explanation. Plus a
+long-standing office bug where the floor went blank and never came back.
+
+### Fixed
+- **`~/dev/foo` no longer fails with "cwd does not exist".** Only a shell expands `~`;
+  Node treats it as a literal directory, so a typed `~/…` path failed every existence
+  check and the agent never spawned. `~` is now expanded once at ingestion, so the
+  registry only ever stores an absolute cwd — which also repairs existing `~` entries
+  that had been reading as "not absolute" forever.
+- **Hooks stopped silently dying with exit 127.** Agent CLIs run hooks through `sh -c`
+  with a bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — nvm's node isn't there, so every
+  hook payload was lost: no live status, no Stop→inbox drain, no session ids. Every hook
+  shim now runs under the Node the app already bundles.
+- **`node` is on every agent's PATH.** An MCP server declared as `node ./server.js`, a
+  provider CLI that shells out, a `.cjs` an agent wrote itself — all died with 127 on a
+  machine with no system node. The bundled runtime is now *appended* to the agent's PATH,
+  never prepended, so anyone with their own node keeps their own version.
+- **The office floor comes back after losing its GPU context.** Chromium caps live WebGL
+  contexts and silently evicts the oldest — always the office, since it starts first,
+  once enough agent terminals are open. Pixi reported nothing, so the floor simply went
+  blank until you restarted the app. It now detects the loss and rebuilds the scene.
+- **God no longer messages agents that no longer exist.** A live roster of the floor is
+  pushed into the orchestrator's context on session start and on every prompt, instead of
+  relying on it to re-read `fleet.json` — which is why it went stale across restarts.
+
+### Added
+- **Node and npm install themselves when they're missing.** Selecting an engine on a
+  machine with no Node used to print `npm install -g …` and run it anyway, so the user
+  watched `npm: command not found` scroll past. The app now fetches the latest Node LTS
+  straight from nodejs.org, verifies it against the official `SHASUMS256.txt` before
+  anything executes, installs it visibly in that agent's terminal, and then installs the
+  CLI. If you already have Node 20 or newer, it is left completely alone.
+- **An honest dead end instead of a doomed command.** When no installer can succeed, the
+  banner names the missing piece and runs nothing at all.
+
 ## [0.3.5] — 2026-08-06
 
 **The queue always has an escape hatch, and the app updates itself for the first time.**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Munder Difflin v0.3.5
+# Munder Difflin v0.3.6
 
 **A local hive of Claude Code, Antigravity, Codex, Grok & Copilot agents that run themselves** — messaging,
 routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-first and open source.
@@ -7,7 +7,45 @@ routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-f
 
 ---
 
-## What's new in 0.3.5 — *The queue always has an escape hatch*
+## What's new in 0.3.6 — *A machine with nothing on it can run agents*
+
+Every fix here is the same failure wearing different clothes: the app assumed your machine
+already had things on it — a shell to expand `~`, a `node` on PATH, an npm to install with
+— and when it didn't, agents died with a bare exit code and no explanation. Plus one
+long-standing office bug where the floor went blank and never came back.
+
+- **Node and npm install themselves.** Pick an engine on a machine with no Node and the app
+  now fetches the latest Node LTS straight from nodejs.org, **verifies it against the
+  official `SHASUMS256.txt` before anything runs**, installs it visibly in that agent's own
+  terminal, and then installs the CLI. Already have Node 20 or newer? It's left completely
+  alone. And when no installer can possibly succeed, the banner names the missing piece and
+  runs *nothing* — instead of the old behaviour of running `npm install -g …` on a machine
+  with no npm and letting you watch `command not found` scroll past.
+- **Hooks stopped silently dying with exit 127.** Agent CLIs run hooks through `sh -c` with
+  a bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — nvm's node isn't on it — so every hook
+  payload was being lost: no live status, no Stop→inbox drain, no session ids. Every shim
+  now runs under the Node the app already ships. This is also why the orchestrator kept
+  going stale across restarts.
+- **`node` is on every agent's PATH.** An MCP server declared as `node ./server.js`, a
+  provider CLI that shells out, a `.cjs` an agent wrote for itself — all died with 127 with
+  no system node. The bundled runtime is now *appended*, never prepended, so if you have
+  your own node you keep your own version.
+- **`~/dev/foo` no longer fails with "cwd does not exist."** Only a shell expands `~`; Node
+  treats it as a literal folder name. Paths are expanded once on the way in, so the registry
+  only ever holds absolute paths — which also repairs existing `~` entries that had been
+  reading as invalid forever.
+- **Michael stops messaging agents that don't exist.** A live roster of the floor is pushed
+  into the orchestrator's context on session start and on every prompt, rather than trusting
+  it to go re-read `fleet.json` on its own.
+- **The office floor survives losing its GPU context.** 0.3.4 leased WebGL contexts for
+  *terminals* when Chromium started evicting the oldest past ~16 — the office floor was the
+  remaining victim, and always the first to go since it's created at startup. Pixi reported
+  nothing at all, so the floor just went blank until you restarted. It now notices and
+  rebuilds itself.
+
+---
+
+## What was new in 0.3.5 — *The queue always has an escape hatch*
 
 A fast-follow to yesterday's big 0.3.4 wave — and the **first release the app delivers to
 itself**: if you're on 0.3.4, it downloads in the background and offers "Restart to

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/office-gl-recovery.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munder-difflin",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "description": "Local multi-agent harness for Claude Code: autonomous agents that message, route, and remember — coordinated by a GOD orchestrator and visualized as avatars at work.",
   "main": "out/main/index.js",

--- a/src/main/cliInstall.ts
+++ b/src/main/cliInstall.ts
@@ -7,6 +7,10 @@
  */
 import type { AgentProvider, ProviderInstallInfo } from '../shared/agentProvider';
 import { installInfoForProvider } from '../shared/agentProvider';
+import type { NodeInstaller } from './nodeInstall';
+import { buildNodeInstallScript } from './nodeInstall';
+
+export type InstallRungKind = 'npm' | 'node-then-npm' | 'native' | 'manual';
 
 /** Pick which rung of the install ladder to run, given what this machine has.
  *
@@ -15,17 +19,27 @@ import { installInfoForProvider } from '../shared/agentProvider';
  *  command anyway and run it — so the user watched `npm: command not found`
  *  scroll past and concluded the app was broken. Classify first:
  *
- *    npm present                   → npm install (unchanged; the common case)
- *    npm absent, native installer  → the vendor's self-contained installer
- *    npm absent, no native         → manual only. Do NOT run a doomed command.
+ *    npm usable                        → npm install (unchanged; the common case)
+ *    npm absent, Node installer found  → install real Node + npm, THEN npm install
+ *    npm absent, native installer      → the vendor's self-contained installer
+ *    neither                           → manual only. Do NOT run a doomed command.
  *
- *  We never auto-install a system Node, touch nvm, or edit the user's shell rc —
- *  a missing runtime is the user's to resolve, and the manual rung says so. */
+ *  Founder decision (2026-08-07) put `node-then-npm` ABOVE `native`, reversing the
+ *  earlier "never auto-install a system Node" rule: a user who only ever gets the
+ *  node-free Claude installer still has no runtime for MCP servers, hooks, or any
+ *  other provider — so the default is to fix the machine, not to route around it.
+ *  `native` survives as the fallback for when no installer could be resolved
+ *  (offline, or a platform nodejs.org ships no package for).
+ *
+ *  `npmAvailable` means npm is present AND its Node is new enough (see
+ *  nodeInstall.NODE_FLOOR_MAJOR) — an ancient Node routes into the upgrade rung. */
 export function chooseInstallRung(
   info: ProviderInstallInfo,
-  npmAvailable: boolean
-): { command?: string; kind: 'npm' | 'native' | 'manual'; nodeMissing: boolean } {
+  npmAvailable: boolean,
+  nodeInstaller?: NodeInstaller | null
+): { command?: string; kind: InstallRungKind; nodeMissing: boolean } {
   if (info.command && npmAvailable) return { command: info.command, kind: 'npm', nodeMissing: false };
+  if (info.command && nodeInstaller) return { command: info.command, kind: 'node-then-npm', nodeMissing: true };
   if (info.nativeCommand) return { command: info.nativeCommand, kind: 'native', nodeMissing: !npmAvailable };
   return { kind: 'manual', nodeMissing: !npmAvailable };
 }
@@ -42,11 +56,16 @@ export function buildMissingCliScript(
   bin: string,
   provider: AgentProvider,
   npmAvailable: boolean,
-  platform: string = process.platform
+  platform: string = process.platform,
+  nodeInstaller?: NodeInstaller | null
 ): string {
   const info: ProviderInstallInfo = installInfoForProvider(provider, platform);
   const safeBin = (bin || provider).replace(/[^A-Za-z0-9._-]/g, '') || provider;
-  const rung = chooseInstallRung(info, npmAvailable);
+  const rung = chooseInstallRung(info, npmAvailable, nodeInstaller);
+  // Only the rung that actually needs it gets the Node install spliced in.
+  const nodeSteps = rung.kind === 'node-then-npm' && nodeInstaller
+    ? buildNodeInstallScript(nodeInstaller, platform)
+    : null;
   const cmd = rung.command; // trusted constant, or undefined → manual hint only
   const label = info.label;
   const docs = info.docsUrl;
@@ -58,7 +77,16 @@ export function buildMissingCliScript(
     // We avoid `if errorlevel` branching (untestable here) — a combined success/
     // failure hint after the install is robust and satisfies the manual-fallback DoD.
     const parts: string[] = ['echo.', `echo ${rule}`, `echo   Engine CLI not found:  ${safeBin}`, 'echo.'];
-    if (rung.nodeMissing) {
+    if (nodeSteps && nodeInstaller) {
+      parts.push(
+        'echo   Node.js is not installed on this machine, so the usual npm',
+        `echo   installer cannot run yet. Installing Node ${nodeInstaller.version} ^(+ npm^) first,`,
+        'echo   straight from nodejs.org, checksum-verified.',
+        'echo.',
+        ...nodeSteps,
+        'echo.'
+      );
+    } else if (rung.nodeMissing) {
       parts.push('echo   Node.js is not installed on this machine, so the usual', 'echo   npm installer cannot run here.', 'echo.');
     }
     if (cmd) {
@@ -102,7 +130,19 @@ export function buildMissingCliScript(
     `echo '  Engine CLI not found:  ${safeBin}'`,
     `echo ''`
   ];
-  if (rung.nodeMissing) {
+  if (nodeSteps && nodeInstaller) {
+    // The default path on a bare machine: fix the runtime, then use it. Every
+    // step aborts the whole script on failure, so the npm install below only
+    // ever runs against a Node that actually landed.
+    lines.push(
+      `echo '  Node.js is not installed on this machine, so the usual npm'`,
+      `echo '  installer cannot run yet. Installing Node ${nodeInstaller.version} (+ npm) first,'`,
+      `echo '  straight from nodejs.org, checksum-verified.'`,
+      `echo ''`,
+      ...nodeSteps,
+      `echo ''`
+    );
+  } else if (rung.nodeMissing) {
     lines.push(
       `echo '  Node.js is not installed on this machine, so the usual npm'`,
       `echo '  installer cannot run here.'`,

--- a/src/main/cliInstall.ts
+++ b/src/main/cliInstall.ts
@@ -1,0 +1,154 @@
+/**
+ * The missing-engine-CLI install ladder.
+ *
+ * Split out of index.ts deliberately: it imports NOTHING from electron, so the
+ * decision ("which installer can actually succeed on this machine?") and the
+ * script it emits are both testable without booting an app.
+ */
+import type { AgentProvider, ProviderInstallInfo } from '../shared/agentProvider';
+import { installInfoForProvider } from '../shared/agentProvider';
+
+/** Pick which rung of the install ladder to run, given what this machine has.
+ *
+ *  Every provider's `installCommand` is `npm install -g …`, which needs npm,
+ *  which needs node. On a machine with no node the banner used to print that
+ *  command anyway and run it — so the user watched `npm: command not found`
+ *  scroll past and concluded the app was broken. Classify first:
+ *
+ *    npm present                   → npm install (unchanged; the common case)
+ *    npm absent, native installer  → the vendor's self-contained installer
+ *    npm absent, no native         → manual only. Do NOT run a doomed command.
+ *
+ *  We never auto-install a system Node, touch nvm, or edit the user's shell rc —
+ *  a missing runtime is the user's to resolve, and the manual rung says so. */
+export function chooseInstallRung(
+  info: ProviderInstallInfo,
+  npmAvailable: boolean
+): { command?: string; kind: 'npm' | 'native' | 'manual'; nodeMissing: boolean } {
+  if (info.command && npmAvailable) return { command: info.command, kind: 'npm', nodeMissing: false };
+  if (info.nativeCommand) return { command: info.nativeCommand, kind: 'native', nodeMissing: !npmAvailable };
+  return { kind: 'manual', nodeMissing: !npmAvailable };
+}
+
+/** Build the shell script the missing-CLI auto-install path runs IN PLACE of a
+ *  missing engine CLI. When a rung of the ladder above is runnable it prints a
+ *  banner then RUNS it visibly (so the user can watch + finish any sign-in);
+ *  otherwise it prints a manual instruction only and runs nothing. The script is
+ *  emitted in the target platform's shell syntax ($SHELL on unix, cmd.exe on
+ *  Windows) — `platform` is a parameter only so the Windows branch is reachable
+ *  from a test on macOS. The only user-derived value (the missing binary name) is
+ *  sanitized to a safe identifier; the install commands are trusted constants. */
+export function buildMissingCliScript(
+  bin: string,
+  provider: AgentProvider,
+  npmAvailable: boolean,
+  platform: string = process.platform
+): string {
+  const info: ProviderInstallInfo = installInfoForProvider(provider, platform);
+  const safeBin = (bin || provider).replace(/[^A-Za-z0-9._-]/g, '') || provider;
+  const rung = chooseInstallRung(info, npmAvailable);
+  const cmd = rung.command; // trusted constant, or undefined → manual hint only
+  const label = info.label;
+  const docs = info.docsUrl;
+  const rule = '------------------------------------------------------------';
+
+  if (platform === 'win32') {
+    // ONE cmd.exe line: `&` chains steps, `^&` prints a literal ampersand, and the
+    // script carries NO double-quotes (it is wrapped verbatim in `/d /s /c "..."`).
+    // We avoid `if errorlevel` branching (untestable here) — a combined success/
+    // failure hint after the install is robust and satisfies the manual-fallback DoD.
+    const parts: string[] = ['echo.', `echo ${rule}`, `echo   Engine CLI not found:  ${safeBin}`, 'echo.'];
+    if (rung.nodeMissing) {
+      parts.push('echo   Node.js is not installed on this machine, so the usual', 'echo   npm installer cannot run here.', 'echo.');
+    }
+    if (cmd) {
+      if (rung.kind === 'native') parts.push(`echo   Using the self-contained ${label} installer instead ^(no Node needed^):`);
+      else parts.push(`echo   Installing the ${label} CLI now so you can watch:`);
+      parts.push(
+        'echo.',
+        `echo     ${cmd}`,
+        `echo ${rule}`,
+        'echo.',
+        cmd,
+        'echo.',
+        'echo   [done] If it succeeded, the agent launches automatically.',
+        'echo   If it failed, run the command above manually, then restart the agent.'
+      );
+    } else {
+      if (rung.nodeMissing) {
+        parts.push(
+          `echo   Install Node.js ^(nodejs.org^), then the ${label} CLI:`,
+          `echo     ${info.command ?? ''}`,
+          'echo   …or install the CLI by whatever method its docs recommend.'
+        );
+      } else {
+        parts.push(
+          `echo   No bundled installer for the ${label} provider.`,
+          'echo   Install it manually, then restart the agent to launch it.'
+        );
+      }
+      if (docs) parts.push(`echo   Docs: ${docs}`);
+      parts.push(`echo ${rule}`);
+    }
+    return parts.join(' & ');
+  }
+
+  // unix ($SHELL -lc <script>): one statement per line, single-quoted echo text so
+  // no shell metacharacter expands. We avoid `!` so any shell with history
+  // expansion never fires. npm is found via the interactive PATH spawn() injects.
+  const lines: string[] = [
+    `echo ''`,
+    `echo '${rule}'`,
+    `echo '  Engine CLI not found:  ${safeBin}'`,
+    `echo ''`
+  ];
+  if (rung.nodeMissing) {
+    lines.push(
+      `echo '  Node.js is not installed on this machine, so the usual npm'`,
+      `echo '  installer cannot run here.'`,
+      `echo ''`
+    );
+  }
+  if (cmd) {
+    lines.push(
+      ...(rung.kind === 'native'
+        ? [`echo '  Using the self-contained ${label} installer instead (no Node needed) —'`,
+           `echo '  finish any sign-in it prompts for, then come back to this terminal.'`]
+        : [`echo '  Installing the ${label} CLI now so you can watch — finish any'`,
+           `echo '  sign-in it prompts for, then come back to this terminal.'`]),
+      `echo ''`,
+      `echo '    ${cmd}'`,
+      `echo '${rule}'`,
+      `echo ''`,
+      cmd,
+      `__clirc=$?`,
+      `echo ''`,
+      `if [ $__clirc -eq 0 ]; then`,
+      `  echo '  [done] Installed — launching the agent…'`,
+      `else`,
+      `  echo "  [x] Install exited with code $__clirc — finish it manually:"`,
+      `  echo '    ${cmd}'`,
+      ...(docs ? [`  echo '    Docs: ${docs}'`] : []),
+      `  echo '  Then restart the agent to launch it.'`,
+      `fi`
+    );
+  } else if (rung.nodeMissing) {
+    // The honest dead end: no node, and this vendor ships no node-free installer.
+    // Say what is actually missing instead of running a command that cannot work.
+    lines.push(
+      `echo '  Install Node.js (nodejs.org), then the ${label} CLI:'`,
+      ...(info.command ? [`echo '    ${info.command}'`] : []),
+      `echo '  …or install the CLI by whatever method its docs recommend.'`,
+      ...(docs ? [`echo '  Docs: ${docs}'`] : []),
+      `echo '${rule}'`
+    );
+  } else {
+    lines.push(
+      `echo '  No bundled installer for the ${label} provider.'`,
+      `echo '  Install it manually, then restart the agent to launch it.'`,
+      ...(docs ? [`echo '  Docs: ${docs}'`] : []),
+      `echo '${rule}'`
+    );
+  }
+  return lines.join(String.fromCharCode(10));
+}

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -10,6 +10,7 @@ import {
   type AgentProvider
 } from '../shared/agentProvider';
 import { defaultMcpDefaults } from '../shared/mcpCatalog';
+import { expandTilde } from './fs';
 import type { IntegrationRecord } from '../shared/integrations';
 
 /** A recurring auto-dispatched mission fired on an interval by the scheduler. */
@@ -419,6 +420,16 @@ export function readConfig(): HarnessConfig {
 export function writeConfig(patch: Partial<HarnessConfig>): HarnessConfig {
   const current = readConfig();
   const next: HarnessConfig = { ...current, ...patch };
+  // Project INGESTION — a registered repo is typed by hand ("~/dev/foo") as often
+  // as it is picked from the folder dialog. Expand `~` here so the persisted list
+  // (and therefore every agent's default cwd) is ABSOLUTE; Node's fs/spawn treat
+  // `~` as a literal directory name and the spawn dies with `cwd does not exist`.
+  if (Array.isArray(patch.registeredRepos)) {
+    const seen = new Set<string>();
+    next.registeredRepos = patch.registeredRepos
+      .map((r) => expandTilde(r))
+      .filter((r) => r && !seen.has(r) && (seen.add(r), true));
+  }
   // Track recently-opened hive homes so the launch picker can list them. Any write
   // that SETS harnessHome (onboarding finish, changeHome) promotes it to the front,
   // deduped and capped. Skips empty/null so a clear doesn't pollute the list.

--- a/src/main/fs.ts
+++ b/src/main/fs.ts
@@ -84,6 +84,34 @@ export async function writeFileText(root: string, rel: string, content: string):
   }
 }
 
+/**
+ * Expand a leading `~` to the user's home dir and return an absolute, normalized
+ * path. SYNC on purpose — every consumer (spawn guards, cwd validation, config
+ * writes) is synchronous.
+ *
+ * Only a SHELL expands `~`; Node's `fs`/`child_process` treat it as a literal
+ * directory name, so a user-typed `~/dev/foo` fails every existsSync/statSync and
+ * dies with `cwd does not exist`. This is applied at INGESTION (project add,
+ * `pty:spawn`) so the registry only ever stores an ABSOLUTE cwd, with
+ * defense-in-depth at the consumers.
+ *
+ * Non-tilde absolute paths are returned resolved/normalized. Anything that is
+ * still RELATIVE after expansion is returned untouched (trimmed) so callers keep
+ * their own "not-absolute" errors instead of it being silently resolved against
+ * the Electron process cwd. Empty input passes straight through. Windows paths
+ * (`C:\…`, UNC) are unaffected — they never start with `~`.
+ */
+export function expandTilde(p: string): string {
+  if (typeof p !== 'string') return p;
+  const t = p.trim();
+  if (!t) return p;
+  let out = t;
+  if (t === '~') out = homedir();
+  else if (t.startsWith('~/') || t.startsWith('~\\')) out = join(homedir(), t.slice(2));
+  if (!isAbsolute(out)) return t;
+  return resolve(out);
+}
+
 /** Existence/metadata check for an ABSOLUTE path (v0.3.4 — backs the terminal
  *  ⌘-click markdown flow). `~/` is expanded here (the renderer doesn't know
  *  the home dir). Read-only metadata: returns whether a regular file exists and

--- a/src/main/hiddenClaude.ts
+++ b/src/main/hiddenClaude.ts
@@ -2,6 +2,7 @@ import * as pty from 'node-pty';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { resolveCommand, userShellPath } from './shellEnv';
+import { expandTilde } from './fs';
 import { projectDir } from './transcript';
 import { ensureKilled } from './procKill';
 
@@ -98,10 +99,13 @@ function extractLastAssistantText(cwd: string, spawnedAt: number): string | null
 export function runHiddenClaude(prompt: string, opts: HiddenClaudeOptions): Promise<HiddenClaudeResult> {
   return new Promise((resolve) => {
     if (!prompt.trim()) { resolve({ ok: false, error: 'empty prompt' }); return; }
-    if (!opts.cwd || !existsSync(opts.cwd)) {
+    // Defense-in-depth: `~` is shell syntax, not a path Node understands.
+    const cwd = opts.cwd ? expandTilde(opts.cwd) : opts.cwd;
+    if (!cwd || !existsSync(cwd)) {
       resolve({ ok: false, error: `cwd does not exist: ${opts.cwd}` });
       return;
     }
+    opts = { ...opts, cwd };
 
     const binary = (opts.command || 'claude').trim().split(/\s+/)[0] || 'claude';
     const exe = resolveCommand(binary);

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -19,7 +19,7 @@
  */
 import {
   existsSync, mkdirSync, readFileSync, writeFileSync, renameSync,
-  readdirSync, statSync, rmSync, appendFileSync, symlinkSync, copyFileSync
+  readdirSync, statSync, rmSync, appendFileSync, symlinkSync, copyFileSync, chmodSync
 } from 'node:fs';
 import { join, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
@@ -36,6 +36,7 @@ import {
   type AgentProvider
 } from '../shared/agentProvider';
 import { MCP_CATALOG } from '../shared/mcpCatalog';
+import { expandTilde } from './fs';
 
 /** The subset of HarnessConfig the hive consumes for the default-MCP merge.
  *  Kept as a local shape so hive.ts never imports the foundation-owned config
@@ -324,6 +325,72 @@ export class HiveManager {
     return root ? join(root, 'bin', 'hive-proxy.cjs') : null;
   }
 
+  /**
+   * The BUNDLED-NODE launcher: `<root>/bin/hive-node` (POSIX) / `hive-node.cmd`
+   * (Windows). Every `.cjs` shim in the hive is executed through it.
+   *
+   * Why it exists: hooks are run by the agent CLI through a plain
+   * `/bin/sh -c` with a bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. A user whose
+   * node comes from nvm (PATH set only by an interactive login shell) has NO node
+   * there, so a hook written as `node "<shim>"` exits **127 — command not found**
+   * and every payload is silently lost: no live status, no Stop→inbox drain, no
+   * session ids. Electron's own binary IS a full Node runtime under
+   * `ELECTRON_RUN_AS_NODE=1`, and it is guaranteed present (it is us).
+   *
+   * A wrapper SCRIPT rather than an inline `ELECTRON_RUN_AS_NODE=1 "<exe>" …`
+   * prefix because that prefix is POSIX-sh syntax — it is a hard error under
+   * cmd.exe, which is what runs hook commands on Windows. The wrapper also gives
+   * agents a `$HIVE_NODE` they can invoke directly (running the Electron binary
+   * WITHOUT the env var would launch a second app window, not a script).
+   *
+   * Rewritten on every bootstrap, so an app update/move re-bakes execPath.
+   */
+  private nodeLauncherPath(): string | null {
+    const root = this.root();
+    if (!root) return null;
+    return join(root, 'bin', process.platform === 'win32' ? 'hive-node.cmd' : 'hive-node');
+  }
+
+  /** Write the launcher described above. Best-effort: on failure callers fall
+   *  back to bare `node`, i.e. exactly the pre-fix behavior. */
+  private writeNodeLauncher(): void {
+    const p = this.nodeLauncherPath();
+    if (!p) return;
+    try {
+      if (process.platform === 'win32') {
+        writeFileSync(p, `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`, 'utf8');
+      } else {
+        writeFileSync(p, `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${process.execPath}" "$@"\n`, 'utf8');
+        chmodSync(p, 0o755);
+      }
+    } catch (e) {
+      console.error('[hive] writeNodeLauncher failed:', e);
+    }
+  }
+
+  /** The launcher path if it is actually on disk, else null (→ callers fall back
+   *  to bare `node`, i.e. exactly the pre-fix behavior — never worse than before). */
+  private nodeLauncher(): string | null {
+    const p = this.nodeLauncherPath();
+    return p && existsSync(p) ? p : null;
+  }
+
+  /** Build a hook command string that runs `script` under the guaranteed node,
+   *  DOUBLE-QUOTED (safe for paths with spaces). */
+  private nodeRun(script: string, ...args: string[]): string {
+    const launcher = this.nodeLauncher();
+    return [launcher ? `"${launcher}"` : 'node', `"${script}"`, ...args].join(' ');
+  }
+
+  /** Same, but UNQUOTED — for the CLIs whose hook config mangles embedded quotes
+   *  (agy on cmd.exe) or stores the command in a quote-sensitive literal (codex's
+   *  single-quoted TOML). Safe because both the hive root and the launcher inside
+   *  it are space-free by construction; this only preserves each installer's
+   *  existing quoting convention while swapping `node` for the bundled runtime. */
+  private nodeRunUnquoted(script: string, ...args: string[]): string {
+    return [this.nodeLauncher() ?? 'node', script, ...args].join(' ');
+  }
+
   /** One proxy sidecar per live proxy-tier agent, keyed by agentId. Spawned in
    *  ensureAgent, killed on PTY exit / removeAgent / app quit (index.ts) — so a
    *  dead agent never leaks an orphan loopback listener. */
@@ -371,6 +438,9 @@ export class HiveManager {
     writeFileSync(this.shimPath()!, HOOK_SHIM, 'utf8');
     // The proxy-bridge sidecar for hookless CLIs (qwen). Same refresh policy.
     writeFileSync(this.proxyShimPath()!, PROXY_BRIDGE_SHIM, 'utf8');
+    // The bundled-node launcher every shim above is invoked through — MUST be
+    // written before any hook installer runs (they probe for it).
+    this.writeNodeLauncher();
 
     if (!existsSync(join(root, '.git'))) {
       this.git(['init', '-q'], root);
@@ -384,6 +454,10 @@ export class HiveManager {
    *  Best-effort; never throws (a stat error degrades to invalid). */
   private cwdValidity(cwd: string | undefined): { valid: boolean; issue: string | null } {
     if (!cwd || typeof cwd !== 'string') return { valid: false, issue: 'missing' };
+    // Defense-in-depth: a `~/…` cwd from an older registry entry (written before
+    // ingestion-time expansion) would read as 'not-absolute' forever. Expand first
+    // so the roster reports the truth about the directory the spawn would use.
+    cwd = expandTilde(cwd);
     if (!isAbsolute(cwd)) return { valid: false, issue: 'not-absolute' };
     try {
       return statSync(cwd).isDirectory()
@@ -447,6 +521,9 @@ export class HiveManager {
     const prev = reg.agents[meta.id];
     // Validate the working directory at the source so a bad value is visible on
     // the roster (cwdValid) rather than silently spawning into a nonexistent dir.
+    // Store the EXPANDED cwd, never the raw `~/…` the user typed — the registry is
+    // read by hooks, the roster and the worker watcher, none of which run a shell.
+    if (meta.cwd) meta = { ...meta, cwd: expandTilde(meta.cwd) };
     const cwd = this.cwdValidity(meta.cwd);
     reg.agents[meta.id] = {
       ...prev,
@@ -475,6 +552,14 @@ export class HiveManager {
       HIVE_ROOT: root,
       AGENT_DIR: dir
     };
+    // The bundled-node launcher, so an agent can run the hive's .cjs helpers (KG
+    // CLI, Slack reply helper) even when `node` is not on its PATH. The agent's
+    // system prompt tells it to use `"$HIVE_NODE" <script>`; invoking the Electron
+    // binary directly would open a second app window, so this must stay the
+    // wrapper path and never process.execPath.
+    // Always set (falls back to plain `node`) so agent-facing commands can be
+    // written as `"$HIVE_NODE" <script>` unconditionally and never expand to "".
+    env.HIVE_NODE = this.nodeLauncher() ?? 'node';
 
     const claudeProvider = isClaudeProvider(meta.provider ?? 'claude');
 
@@ -686,7 +771,9 @@ export class HiveManager {
    *  scopes the filesystem/git servers; cfg (the consent map) gates which servers
    *  are written. Claude-only — this is invoked solely on the Claude spawn path. */
   private hookSettings(shim: string, cwd: string, cfg: McpDefaultsMap, theme?: 'light' | 'dark'): unknown {
-    const cmd = `node "${shim}"`;
+    // Bundled node, NOT bare `node` — see nodeLauncherPath(). Claude runs each of
+    // these through `sh -c` with a stripped PATH, where `node` is often absent.
+    const cmd = this.nodeRun(shim);
     const entry = (matcher?: string) => ({
       ...(matcher ? { matcher } : {}),
       hooks: [{ type: 'command', command: cmd }]
@@ -921,7 +1008,7 @@ export class HiveManager {
     // stable $KG_CLI / $KG_ROOT env vars injected at spawn — no paths/counts that
     // would change per spawn and bust the prompt cache.
     const knowledgeLine = knowledgeGraph
-      ? 'Enterprise knowledge: this organisation has a private Knowledge Graph of its own documents, policies, and business context. When a task needs that context — company-specific facts, house style, internal processes — query it instead of guessing: run `node "$KG_CLI" search "<query>"` for ranked passages, `node "$KG_CLI" list` to see what is available, and `node "$KG_CLI" get <id>` for a full document.'
+      ? 'Enterprise knowledge: this organisation has a private Knowledge Graph of its own documents, policies, and business context. When a task needs that context — company-specific facts, house style, internal processes — query it instead of guessing: run `"$HIVE_NODE" "$KG_CLI" search "<query>"` for ranked passages, `"$HIVE_NODE" "$KG_CLI" list` to see what is available, and `"$HIVE_NODE" "$KG_CLI" get <id>` for a full document. ($HIVE_NODE is the harness\'s bundled Node — use it instead of bare `node`, which may not be on your PATH.)'
       : '';
     const godLine = meta.isGod
       ? 'You are the GOD / ORCHESTRATOR of this hive — your job is to ORCHESTRATE, not to implement: maintain live situational awareness and delegate the work. (1) AWARENESS — always know what is going on: keep an accurate picture of every agent (active vs archived/idle), the task board, and all in-flight work; drain your inbox continually and triage every other agent\'s requests, answering clarifications so the team runs autonomously. (2) DELEGATE — decompose work and fan it out to the hive agents via their inboxes (route messages and assign owners; do not do their jobs); do NOT take on grunt implementation yourself. Stay aware of who is already on the floor and delegate OPPORTUNISTICALLY: BEFORE you spawn anything, CHECK THE LIVE ROSTER (active agents in registry.json + their state in fleet.json) and prefer routing to an EXISTING agent that fits — above all when the request names one ("ask Pam to…", "have Jim…"), route to that agent instead of reflexively creating a new one. Reuse an idle or already-running agent whose role matches; only spawn a fresh agent when no existing one is a sensible fit, and say that you checked. One capable owner beats a duplicate. (3) OWN ONLY THE IMPORTANT, high-leverage things — task decomposition, dispatch decisions, sign-offs, conflict resolution, branch integration, and final QA — and remain the sole scribe of board.md. You are otherwise fully autonomous — there is NO separate approval queue. For the genuinely critical (destructive actions, spending real money, scope changes, unresolvable conflicts), ask the human directly in your own session and let the tool-permission prompt gate the action; the human approves natively, including remotely from their phone via /remote-control. Keep the team unblocked. When you DISPATCH a task, write it as a 4-part contract so the agent can run autonomously: (1) OBJECTIVE — the concrete goal; (2) OUTPUT — the expected deliverable/format; (3) TOOLS — what to use or avoid, and any references to read instead of re-deriving; (4) BOUNDARIES — scope limits + the definition of done. Pass references (file paths, message ids, board sections), not pasted content — keep dispatches short.'
@@ -932,7 +1019,7 @@ export class HiveManager {
     const guardrailsLine = 'Guardrails: a circuit breaker watches the floor — a "Circuit breaker: steer/constrain" message means you are looping or overspending, so STOP repeating, summarize what you tried, and follow it. Be token-frugal (a floor-wide or per-agent token budget can pause you). The shared plan has two parts: board.md (freeform; god is the sole scribe) and tasks.json (structured kanban — todo/doing/blocked/done).';
     const slackLine = meta.isGod
       ? 'SLACK REPLIES: When composing a Slack reply (or writing the `result` field of a Slack-origin kanban card), you MUST: (1) directly address what the user asked — never a bare "done"; (2) include the relevant specifics, outcome, and details; (3) format for Slack mrkdwn — open with a short *bold* headline, use bullet points for multiple items, wrap code/paths in `backtick` blocks, keep it concise (no walls of text). When finishing a Slack-origin task, always write a complete, user-facing, well-formatted `result` on the kanban card — the system posts it verbatim to Slack as the done reply.'
-      : 'SLACK REPLIES: If god dispatches you a task that came from Slack, it will include an exact `node "<helper>" --channel … --thread … --text "…"` reply command — when you finish, run it to post your result back to that thread yourself. The reply must be SUBSTANTIVE Slack mrkdwn (a short *bold* headline + the actual outcome/specifics/links), NEVER a bare "done".';
+      : 'SLACK REPLIES: If god dispatches you a task that came from Slack, it will include an exact `"$HIVE_NODE" "<helper>" --channel … --thread … --text "…"` reply command — when you finish, run it VERBATIM to post your result back to that thread yourself. The reply must be SUBSTANTIVE Slack mrkdwn (a short *bold* headline + the actual outcome/specifics/links), NEVER a bare "done".';
     return [
       `You are "${meta.name}" (${meta.id}), an autonomous agent in a collaborating hive of Claude agents.`,
       `Your private workspace is ${dir}. The shared hive is ${root}. Full protocol: ${root}/PROTOCOL.md.`,
@@ -1316,12 +1403,13 @@ export class HiveManager {
     const shim = join(root, 'bin', 'agy-hook.cjs');
     mkdirSync(join(root, 'bin'), { recursive: true });
     writeFileSync(shim, AGY_HOOK_SHIM, 'utf8');
+    // Bundled node, not bare `node` — agy's hooks run with a stripped PATH too.
     const tool = (event: string) => ({
       matcher: '*',
-      hooks: [{ type: 'command', command: `node ${shim} ${event}`, timeout: 0 }]
+      hooks: [{ type: 'command', command: this.nodeRunUnquoted(shim, event), timeout: 0 }]
     });
     const plain = (event: string) => ({
-      hooks: [{ type: 'command', command: `node ${shim} ${event}`, timeout: 0 }]
+      hooks: [{ type: 'command', command: this.nodeRunUnquoted(shim, event), timeout: 0 }]
     });
     const group = {
       PreToolUse: [tool('PreToolUse')],
@@ -1405,7 +1493,7 @@ export class HiveManager {
           'SessionStart', 'UserPromptSubmit', 'PreCompact', 'PostCompact'];
         config += '\n# --- munder-hive lifecycle hooks (auto-generated; do not edit) ---\n';
         for (const ev of events) {
-          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = 'node ${shim}'\ntimeout = 0\n`;
+          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = '${this.nodeRunUnquoted(shim)}'\ntimeout = 0\n`;
         }
       }
       writeFileSync(join(home, 'config.toml'), config, 'utf8');
@@ -1521,7 +1609,9 @@ export class HiveManager {
       const tool = (matcher?: string) => ({
         ...(matcher ? { matcher } : {}),
         // Let Grok apply its event-aware defaults (5s normally, 600s for Stop).
-        hooks: [{ type: 'command', command: `node ${shim}` }]
+        // Grok is a HOOK bridge (not a proxy sidecar), so it is hit by the same
+        // `node: command not found` 127 — bundled node here too.
+        hooks: [{ type: 'command', command: this.nodeRun(shim) }]
       });
       const hooks = {
         PreToolUse: [tool('.*')],

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1640,6 +1640,76 @@ export class HiveManager {
     if (!root) return;
     try { writeFileSync(join(root, 'fleet.json'), JSON.stringify(snapshot, null, 2), 'utf8'); } catch { /* noop */ }
   }
+
+  /** Is this agent the hive's god/orchestrator? */
+  isGod(agentId: string): boolean {
+    try {
+      const reg = this.registry();
+      return reg.godId === agentId || !!reg.agents[agentId]?.isGod;
+    } catch { return false; }
+  }
+
+  /**
+   * A compact, one-shot LIVE ROSTER line built from `fleet.json` — injected into
+   * god's context as `additionalContext` on SessionStart and every
+   * UserPromptSubmit (see HookServer).
+   *
+   * Why: fleet.json/registry.json are always fresh on disk (8s snapshot +
+   * archiveOrphanedAgents on boot + PTY-exit archiving), but god's CONTEXT is not.
+   * After an app restart god resumes a session whose transcript still describes
+   * the OLD floor, and it will happily message agents that no longer exist. It is
+   * told to read fleet.json, but "told to" is not "always knows" — so we push the
+   * truth in on every turn instead. One line, so the cost is negligible.
+   *
+   * Returns null when there is nothing to say (no hive, no snapshot, no agents),
+   * so the hook stays a no-op rather than injecting noise.
+   */
+  rosterContext(): string | null {
+    const root = this.root();
+    if (!root) return null;
+    try {
+      const raw = readFileSync(join(root, 'fleet.json'), 'utf8');
+      const snap = JSON.parse(raw) as {
+        ts?: number;
+        agents?: Array<{
+          id: string; name?: string; role?: string; isGod?: boolean;
+          breaker?: string; tokens?: number; usd?: number;
+          lastTool?: string | null; lastActiveSecAgo?: number | null; inboxBacklog?: number;
+        }>;
+      };
+      const agents = Array.isArray(snap.agents) ? snap.agents : [];
+      if (!agents.length) return null;
+
+      const ago = (s: number | null | undefined): string =>
+        typeof s !== 'number' ? 'unknown'
+          : s < 90 ? `${s}s ago`
+            : s < 5400 ? `${Math.round(s / 60)}m ago`
+              : `${Math.round(s / 3600)}h ago`;
+
+      // Cap the list so a big floor can't crowd out the actual prompt. The
+      // remainder is still counted, and fleet.json is one Read away.
+      const MAX = 24;
+      const shown = agents.slice(0, MAX);
+      const rows = shown.map((a) => {
+        const bits = [a.role ?? 'agent',
+          typeof a.lastActiveSecAgo === 'number' ? `active ${ago(a.lastActiveSecAgo)}` : 'no activity yet'];
+        if (a.tokens) bits.push(`${Math.round(a.tokens / 1000)}k tok`);
+        if (a.usd) bits.push(`$${a.usd.toFixed(2)}`);
+        if (a.inboxBacklog) bits.push(`inbox ${a.inboxBacklog}`);
+        if (a.breaker && a.breaker !== 'ok' && a.breaker !== 'none') bits.push(`breaker ${a.breaker}`);
+        if (a.isGod) bits.push('you');
+        return `${a.id}${a.name ? ` "${a.name}"` : ''} (${bits.join(', ')})`;
+      });
+      const more = agents.length > shown.length ? ` +${agents.length - shown.length} more` : '';
+      const age = typeof snap.ts === 'number' ? ago(Math.round((Date.now() - snap.ts) / 1000)) : 'unknown';
+
+      return `[LIVE ROSTER — auto-injected from ${join(root, 'fleet.json')}, snapshot ${age}] `
+        + `${agents.length} ACTIVE agent(s): ${rows.join('; ')}.${more} `
+        + 'This is the CURRENT floor and it SUPERSEDES any roster earlier in this conversation — '
+        + 'agents you remember that are absent here have been archived or killed, so do not message them. '
+        + 'Route work to someone on this list before spawning anyone new.';
+    } catch { return null; }
+  }
   logTail(n = 200): unknown[] {
     const root = this.root();
     if (!root || !existsSync(join(root, 'log.jsonl'))) return [];

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -388,12 +388,15 @@ export class HiveManager {
    * This dir is APPENDED to the agent's PATH (see pty.spawn), never prepended: a
    * user who has their own node keeps their own version — we are strictly the
    * fallback. Prepending would silently swap every agent's node for Electron's
-   * (the v22 line at time of writing) underneath the user's own projects.
+   * (20.18.1 as of Electron 32.3.3) underneath the user's own projects.
    *
    * NOTE: `node` only — deliberately no `npm`/`npx`. Electron bundles the Node
    * RUNTIME, not the npm CLI (which is ~12MB of JS we do not ship), so an `npm`
    * wrapper here could only be a stub that fails confusingly. A missing `npm` is
-   * the honest signal; see the missing-CLI ladder in index.ts, which detects it.
+   * the honest signal; the install ladder (main/cliInstall.ts) detects it and
+   * installs a REAL system Node — which brings npm with it. This shim is only the
+   * last resort for when that install could not run (offline, or a platform with
+   * no official installer).
    */
   runtimeBinDir(): string | null {
     const root = this.root();

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -375,6 +375,54 @@ export class HiveManager {
     return p && existsSync(p) ? p : null;
   }
 
+  /**
+   * `<root>/bin/runtime` — the same bundled-node trick as `hive-node`, but the
+   * wrapper is NAMED `node`, so anything that resolves `node` off PATH finds one.
+   *
+   * `hive-node` only covers commands WE generate. It does nothing for node that
+   * the agent's own work needs at runtime: an MCP server declared as
+   * `node ./server.js`, a provider CLI that shells out to node, a `.cjs` helper an
+   * agent wrote itself. On a machine with no system node those all die with 127
+   * exactly like the hooks did.
+   *
+   * This dir is APPENDED to the agent's PATH (see pty.spawn), never prepended: a
+   * user who has their own node keeps their own version — we are strictly the
+   * fallback. Prepending would silently swap every agent's node for Electron's
+   * (the v22 line at time of writing) underneath the user's own projects.
+   *
+   * NOTE: `node` only — deliberately no `npm`/`npx`. Electron bundles the Node
+   * RUNTIME, not the npm CLI (which is ~12MB of JS we do not ship), so an `npm`
+   * wrapper here could only be a stub that fails confusingly. A missing `npm` is
+   * the honest signal; see the missing-CLI ladder in index.ts, which detects it.
+   */
+  runtimeBinDir(): string | null {
+    const root = this.root();
+    return root ? join(root, 'bin', 'runtime') : null;
+  }
+
+  /** Write the `node` shim described above. Best-effort: on failure the dir is
+   *  simply absent from PATH and behavior is exactly as before. */
+  private writeRuntimeShims(): void {
+    const dir = this.runtimeBinDir();
+    if (!dir) return;
+    try {
+      mkdirSync(dir, { recursive: true });
+      if (process.platform === 'win32') {
+        writeFileSync(
+          join(dir, 'node.cmd'),
+          `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`,
+          'utf8'
+        );
+      } else {
+        const p = join(dir, 'node');
+        writeFileSync(p, `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${process.execPath}" "$@"\n`, 'utf8');
+        chmodSync(p, 0o755);
+      }
+    } catch (e) {
+      console.error('[hive] writeRuntimeShims failed:', e);
+    }
+  }
+
   /** Build a hook command string that runs `script` under the guaranteed node,
    *  DOUBLE-QUOTED (safe for paths with spaces). */
   private nodeRun(script: string, ...args: string[]): string {
@@ -441,6 +489,8 @@ export class HiveManager {
     // The bundled-node launcher every shim above is invoked through — MUST be
     // written before any hook installer runs (they probe for it).
     this.writeNodeLauncher();
+    // …and the PATH-visible `node` fallback for the agent's OWN subprocesses.
+    this.writeRuntimeShims();
 
     if (!existsSync(join(root, '.git'))) {
       this.git(['init', '-q'], root);

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -241,12 +241,31 @@ export class HookServer {
 
     // 7C.2 — mid-run steering: inject queued operator guidance as context on the
     // next eligible hook (no fragile typing into the TUI). Delivered once.
+    // Merged with the roster line below so the two injections never displace each
+    // other (only ONE additionalContext can be returned per hook).
+    let steer: string | null = null;
     if ((event === 'UserPromptSubmit' || event === 'PostToolUse') && agentId && this.control) {
-      const steer = this.control.takeSteer(agentId);
-      if (steer) {
-        this.emit(agentId, event, p);
-        return { hookSpecificOutput: { hookEventName: event, additionalContext: steer } };
-      }
+      steer = this.control.takeSteer(agentId) ?? null;
+    }
+
+    // Keep god's roster CURRENT. fleet.json is always fresh on disk, but god's
+    // context is not: after a restart it resumes a transcript describing the old
+    // floor and messages agents that are long gone. Push the live roster in as
+    // additionalContext at the start of each session and on every prompt, so god
+    // knows the floor all the time instead of only when it remembers to Read.
+    // God-only and one line — every other agent is unaffected.
+    const wantsRoster = (event === 'SessionStart' || event === 'UserPromptSubmit')
+      && !!agentId && this.hive.isGod(agentId);
+    const roster = wantsRoster ? this.hive.rosterContext() : null;
+
+    if (steer || roster) {
+      this.emit(agentId, event, p);
+      return {
+        hookSpecificOutput: {
+          hookEventName: event,
+          additionalContext: [roster, steer].filter(Boolean).join('\n\n')
+        }
+      };
     }
 
     // A Notification hook that means "the agent is blocked waiting for the user"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -54,9 +54,9 @@ import {
   nonInteractiveEnvForProvider,
   providerPreset,
   installInfoForProvider,
-  type AgentProvider,
-  type ProviderInstallInfo
+  type AgentProvider
 } from '../shared/agentProvider';
+import { buildMissingCliScript, chooseInstallRung } from './cliInstall';
 import {
   CODEX_REMOTE_SOCKET_RELATIVE,
   codexRemoteAliasPath,
@@ -1848,89 +1848,6 @@ function installAppMenu(): void {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
-/** Build the shell script the missing-CLI auto-install path runs IN PLACE of a
- *  missing engine CLI. When the provider has a known installer it prints a banner
- *  then RUNS the install visibly (so the user can watch + finish any sign-in);
- *  otherwise it prints a manual instruction only and runs nothing. The script is
- *  emitted in the current platform shell's syntax ($SHELL on unix, cmd.exe on
- *  Windows). The only user-derived value (the missing binary name) is sanitized to
- *  a safe identifier; the install command itself is a trusted hardcoded constant. */
-function buildMissingCliScript(bin: string, provider: AgentProvider): string {
-  const info: ProviderInstallInfo = installInfoForProvider(provider);
-  const safeBin = (bin || provider).replace(/[^A-Za-z0-9._-]/g, '') || provider;
-  const cmd = info.command; // trusted constant, or undefined → manual hint only
-  const label = info.label;
-  const docs = info.docsUrl;
-  const rule = '------------------------------------------------------------';
-
-  if (process.platform === 'win32') {
-    // ONE cmd.exe line: `&` chains steps, `^&` prints a literal ampersand, and the
-    // script carries NO double-quotes (it is wrapped verbatim in `/d /s /c "..."`).
-    // We avoid `if errorlevel` branching (untestable here) — a combined success/
-    // failure hint after the install is robust and satisfies the manual-fallback DoD.
-    const parts: string[] = ['echo.', `echo ${rule}`, `echo   Engine CLI not found:  ${safeBin}`, 'echo.'];
-    if (cmd) {
-      parts.push(
-        `echo   Installing the ${label} CLI now so you can watch:`,
-        'echo.',
-        `echo     ${cmd}`,
-        `echo ${rule}`,
-        'echo.',
-        cmd,
-        'echo.',
-        'echo   [done] If it succeeded, the agent launches automatically.',
-        'echo   If it failed, run the command above manually, then restart the agent.'
-      );
-    } else {
-      parts.push(
-        `echo   No bundled installer for the ${label} provider.`,
-        'echo   Install it manually, then restart the agent to launch it.'
-      );
-      if (docs) parts.push(`echo   Docs: ${docs}`);
-      parts.push(`echo ${rule}`);
-    }
-    return parts.join(' & ');
-  }
-
-  // unix ($SHELL -lc <script>): one statement per line, single-quoted echo text so
-  // no shell metacharacter expands. We avoid `!` so any shell with history
-  // expansion never fires. npm is found via the interactive PATH spawn() injects.
-  const lines: string[] = [
-    `echo ''`,
-    `echo '${rule}'`,
-    `echo '  Engine CLI not found:  ${safeBin}'`,
-    `echo ''`
-  ];
-  if (cmd) {
-    lines.push(
-      `echo '  Installing the ${label} CLI now so you can watch — finish any'`,
-      `echo '  sign-in it prompts for, then come back to this terminal.'`,
-      `echo ''`,
-      `echo '    ${cmd}'`,
-      `echo '${rule}'`,
-      `echo ''`,
-      cmd,
-      `__clirc=$?`,
-      `echo ''`,
-      `if [ $__clirc -eq 0 ]; then`,
-      `  echo '  [done] Installed — launching the agent…'`,
-      `else`,
-      `  echo "  [x] Install exited with code $__clirc — finish it manually:"`,
-      `  echo '    ${cmd}'`,
-      ...(docs ? [`  echo '    Docs: ${docs}'`] : []),
-      `  echo '  Then restart the agent to launch it.'`,
-      `fi`
-    );
-  } else {
-    lines.push(
-      `echo '  No bundled installer for the ${label} provider.'`,
-      `echo '  Install it manually, then restart the agent to launch it.'`,
-      ...(docs ? [`echo '  Docs: ${docs}'`] : []),
-      `echo '${rule}'`
-    );
-  }
-  return lines.join(String.fromCharCode(10));
-}
 
 // ─── IPC: pty lifecycle ─────────────────────────────────────────────────────
 /** Codex stores its rollout transcripts under a PER-AGENT CODEX_HOME
@@ -2049,6 +1966,11 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
   {
     const bin = opts.command.trim().split(/\s+/)[0] || opts.command;
     if (bin && !opts.noAutoInstall && !ptyManager.isCommandAvailable(bin)) {
+      // The installer commands are `npm install -g …`. Probe for npm the same way
+      // we probe for the engine CLI, so a no-Node machine gets the node-free rung
+      // (or an honest manual hint) instead of watching `npm: not found` scroll by.
+      const npmAvailable = ptyManager.isCommandAvailable('npm');
+      const rung = chooseInstallRung(installInfoForProvider(provider), npmAvailable);
       const res = ptyManager.spawn(
         {
           id: opts.id,
@@ -2056,7 +1978,7 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
           command: bin,
           cols: opts.cols,
           rows: opts.rows,
-          shellScript: buildMissingCliScript(bin, provider)
+          shellScript: buildMissingCliScript(bin, provider, npmAvailable)
         },
         owner
       );
@@ -2065,7 +1987,11 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       // (no user click). Only when an installer actually RAN (a provider with no
       // bundled installer just prints a manual hint and exits 0 — relaunching there
       // would spawn the still-missing binary and die) and the PTY actually started.
-      if (res.ok && installInfoForProvider(provider).command) {
+      // …keyed on the RUNG, not on `installCommand`: the manual rung prints a hint
+      // and exits 0, and relaunching there would just respawn the still-missing
+      // binary and die with the bare "process exited (code 1)" this whole path exists
+      // to replace.
+      if (res.ok && rung.command) {
         pendingInstallRelaunch.set(opts.id, { opts, owner, bin });
       }
       syncKeepAwake();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,7 +16,7 @@ import {
   readConfig, writeConfig, resetConfig, ensureHarnessHome, ensureClaudePermissionsAccepted,
   modelForRole, OPS_STANDUP_MISSION, HEARTBEAT_MISSION, COMPACT_MAINTENANCE_MISSION, type HarnessConfig, type ScheduledMission
 } from './config';
-import { listDir, readFileText, writeFileText, statAbs } from './fs';
+import { listDir, readFileText, writeFileText, statAbs, expandTilde } from './fs';
 import {
   getBranch, getStatus, getLog, getBranches, getAheadBehind, isRepo, getDiff, mainRepoRoot,
   addWorktree, removeWorktree, worktreeHasUnintegratedWork, worktreeIsGcSafe,
@@ -422,7 +422,9 @@ function teardownPty(id: string): void {
 function informGod(subject: string, body: string, slack?: { channel: string; thread_ts: string }): void {
   try {
     const slackLine = slack
-      ? `\n\n[SLACK] Close the loop — post a reply to channel ${slack.channel} thread ${slack.thread_ts} via:\n  node "${slackReplyScriptPath()}" --channel ${slack.channel} --thread ${slack.thread_ts} --text "<your message>"`
+      // `$HIVE_NODE` (injected into every agent's env) — NOT bare `node`, which is
+      // absent from the PATH of any machine whose node comes from nvm.
+      ? `\n\n[SLACK] Close the loop — post a reply to channel ${slack.channel} thread ${slack.thread_ts} via:\n  "$HIVE_NODE" "${slackReplyScriptPath()}" --channel ${slack.channel} --thread ${slack.thread_ts} --text "<your message>"`
       : '';
     hive.send({ to: 'god', act: 'inform', subject, body: body + slackLine }, 'ephemeral-worker');
   } catch (e) {
@@ -1029,7 +1031,7 @@ let lastSlackUrl: string | undefined;
 function buildAutonomousRequestProtocol(channel: string, threadTs: string, helperPath: string): string {
   return `[AUTONOMOUS REQUEST PROTOCOL — this request arrived via Slack; no interactive human is watching] Handle it under this protocol:
 1. ROUTE FAST — triage and hand this to the single most-relevant agent right away. CHECK THE LIVE ROSTER FIRST (active agents in registry.json + their state in fleet.json) and prefer an EXISTING agent that fits — especially when the request names one ("ask Pam…", "have Jim…"): route to that agent and only spawn a new one if none is a sensible fit. Decompose only if it genuinely needs several. Don't sit on it.
-2. DELEGATE WITH THE REPLY HANDLE — tell that agent to do the work autonomously AND to post its result back to THIS Slack thread itself when done, using exactly: node "${helperPath}" --channel ${channel} --thread ${threadTs} --text "<substantive result>"
+2. DELEGATE WITH THE REPLY HANDLE — tell that agent to do the work autonomously AND to post its result back to THIS Slack thread itself when done, using exactly: "$HIVE_NODE" "${helperPath}" --channel ${channel} --thread ${threadTs} --text "<substantive result>" ($HIVE_NODE is the harness's bundled Node, injected into every agent's env — bare "node" is not on the hook/agent PATH on many machines.)
 3. AUTONOMOUS EXECUTION — no interactive questions. PAUSE/ask ONLY for high-severity actions: pushing to main or any remote; buying or spawning infrastructure or paid services; deleting an existing repo, file, or folder it did not create. Stay READ-ONLY at critical infrastructure and git-push-type changes unless explicitly approved.
 4. DIRECT, SUBSTANTIVE REPLY — the agent posts a real Slack-mrkdwn answer (short *bold* headline + the actual outcome/specifics/links), NEVER a bare "done"/":white_check_mark:".
 5. REPORT TO GOD — the agent then tells you (Michael) what it did.
@@ -2010,7 +2012,17 @@ ipcMain.handle('pty:spawn', async (evt, opts: AgentSpawnOptions) => {
  *  it can ALSO be invoked by the god-triggered ephemeral-worker watcher (which has
  *  no renderer `evt`). `owner` is the window that should receive this PTY's output
  *  (null → the primary window). Behavior-identical to the prior inline handler. */
-async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebContents | null): Promise<{ ok: boolean; error?: string; worktreePath?: string; resumeNotFound?: boolean; resumed?: boolean; seedPrompt?: string }> {
+async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebContents | null): Promise<{ ok: boolean; error?: string; cwd?: string; worktreePath?: string; resumeNotFound?: boolean; resumed?: boolean; seedPrompt?: string }> {
+  // ── cwd INGESTION — expand `~` exactly once, here ───────────────────────────
+  // This is the single door every agent spawn comes through (`pty:spawn` IPC and
+  // the god-triggered ephemeral-worker watcher), so it is where a user-typed
+  // `~/dev/foo` becomes an absolute path. Only a shell expands `~`; Node treats it
+  // as a literal dir, so without this every downstream existsSync/statSync fails
+  // with `cwd does not exist`. Expanding BEFORE hive provisioning is what makes the
+  // registry store an ABSOLUTE cwd (and `cwdValid: true`). The resolved value is
+  // returned to the caller so the renderer records the same absolute path.
+  opts.cwd = expandTilde(opts.cwd);
+  if (opts.hive) opts.hive = { ...opts.hive, cwd: expandTilde(opts.hive.cwd) };
   // Which CLI is this? Explicit wins; else inferred from the binary
   // (claude/codex/grok/agy). Non-Claude providers skip every Claude-only spawn step
   // below. Persist the resolved provider onto opts (+ hive meta) so the registry
@@ -2336,7 +2348,9 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
   // The restore flow re-enters this exact worktree (cwd = worktreePath) so a
   // restored isolated agent resumes in the CORRECT checkout, not the base repo.
   const worktreePath = worktreePaths.get(opts.id);
-  return { ...res, ...(worktreePath ? { worktreePath } : {}), ...(resumeNotFound ? { resumeNotFound: true } : {}), ...(didResume ? { resumed: true } : {}), ...(seedPrompt ? { seedPrompt } : {}) };
+  // `cwd` echoes back the TILDE-EXPANDED absolute path so the renderer's agent
+  // record matches what the registry and the PTY actually used.
+  return { ...res, cwd: opts.cwd, ...(worktreePath ? { worktreePath } : {}), ...(resumeNotFound ? { resumeNotFound: true } : {}), ...(didResume ? { resumed: true } : {}), ...(seedPrompt ? { seedPrompt } : {}) };
 }
 ipcMain.handle('pty:write', (_evt, id: string, data: string) => {
   if (typeof id !== 'string' || typeof data !== 'string') return { ok: false, error: 'invalid args' };
@@ -3498,7 +3512,9 @@ async function processSpawnRequest(filePath: string): Promise<void> {
   const workerId = `worker-${reqId}`;
   if (liveWorkers.has(workerId)) { fail(`worker "${workerId}" already running`); return; }
 
-  const cwd = typeof raw.cwd === 'string' && raw.cwd.trim() ? raw.cwd.trim() : '';
+  // Worker request files are hand/LLM-authored, so `~/…` shows up here too — expand
+  // before the existence check (Node reads `~` literally).
+  const cwd = typeof raw.cwd === 'string' && raw.cwd.trim() ? expandTilde(raw.cwd) : '';
   if (!cwd || !existsSync(cwd)) { fail(`"cwd" missing or not found (${cwd || 'unset'})`); return; }
 
   const command = typeof raw.command === 'string' && raw.command.trim() ? raw.command.trim() : (readConfig().defaultCommand ?? 'claude');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,6 +57,7 @@ import {
   type AgentProvider
 } from '../shared/agentProvider';
 import { buildMissingCliScript, chooseInstallRung } from './cliInstall';
+import { detectNodeVersion, nodeIsUsable, resolveNodeInstaller } from './nodeInstall';
 import {
   CODEX_REMOTE_SOCKET_RELATIVE,
   codexRemoteAliasPath,
@@ -1969,8 +1970,17 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       // The installer commands are `npm install -g …`. Probe for npm the same way
       // we probe for the engine CLI, so a no-Node machine gets the node-free rung
       // (or an honest manual hint) instead of watching `npm: not found` scroll by.
-      const npmAvailable = ptyManager.isCommandAvailable('npm');
-      const rung = chooseInstallRung(installInfoForProvider(provider), npmAvailable);
+      // An npm whose Node is BELOW the floor counts as unavailable: founder rule
+      // (2026-08-07) is "their Node newer than ours → leave it alone; absent or
+      // older → install the latest stable for them".
+      const npmAvailable =
+        ptyManager.isCommandAvailable('npm') &&
+        nodeIsUsable(detectNodeVersion(ptyManager.commandPath('node')));
+      // Only reach the network when we actually need to (npm missing/too old);
+      // resolveNodeInstaller is timeout-bounded and returns null offline, which
+      // simply drops the ladder to the native/manual rung.
+      const nodeInstaller = npmAvailable ? null : await resolveNodeInstaller();
+      const rung = chooseInstallRung(installInfoForProvider(provider), npmAvailable, nodeInstaller);
       const res = ptyManager.spawn(
         {
           id: opts.id,
@@ -1978,7 +1988,7 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
           command: bin,
           cols: opts.cols,
           rows: opts.rows,
-          shellScript: buildMissingCliScript(bin, provider, npmAvailable)
+          shellScript: buildMissingCliScript(bin, provider, npmAvailable, process.platform, nodeInstaller)
         },
         owner
       );

--- a/src/main/nodeInstall.ts
+++ b/src/main/nodeInstall.ts
@@ -1,0 +1,224 @@
+/**
+ * Installing Node.js itself, so a machine with nothing on it can still run agents.
+ *
+ * Founder decision (2026-08-07), superseding the earlier "never auto-install a
+ * system Node" constraint: by DEFAULT we install the real thing — latest stable
+ * (LTS) Node + the npm that ships with it — into the user's system. Electron's
+ * bundled Node stays as a last-resort fallback only (see hive.runtimeBinDir).
+ *
+ * The user has to type their password: every official installer writes outside the
+ * home directory. That happens VISIBLY in the same terminal as every other
+ * installer in this app — we never elevate silently.
+ *
+ * Because we run an installer as root, the download is CHECKSUM-VERIFIED against
+ * nodejs.org's own SHASUMS256.txt before anything executes. A mismatch aborts.
+ *
+ * Nothing here imports electron: the URL/artifact/script logic is all pure, so it
+ * is testable without booting an app.
+ */
+
+/** Lowest Node major we consider usable. Below this we offer the upgrade; at or
+ *  above it we leave the user's own install completely alone — an existing,
+ *  working toolchain is never "upgraded" out from under them. Chosen as Electron's
+ *  own bundled line, i.e. the floor we already know every code path tolerates. */
+export const NODE_FLOOR_MAJOR = 20;
+
+const DIST = 'https://nodejs.org/dist';
+
+export interface NodeDistEntry {
+  version: string;              // 'v24.19.0'
+  lts: false | string;          // false | 'Krypton'
+  npm?: string;
+}
+
+export interface NodeInstaller {
+  version: string;              // 'v24.19.0'
+  npmVersion?: string;
+  file: string;                 // 'node-v24.19.0.pkg'
+  url: string;
+  sha256: string;
+  kind: 'pkg' | 'msi' | 'tar';
+}
+
+/** Major version of `v24.19.0` / `24.19.0`, or null if unparseable. */
+export function nodeMajor(version: string | null | undefined): number | null {
+  const m = /^v?(\d+)\./.exec((version ?? '').trim());
+  return m ? Number(m[1]) : null;
+}
+
+/** Whether the user's own Node is good enough to be left alone. */
+export function nodeIsUsable(version: string | null | undefined): boolean {
+  const major = nodeMajor(version);
+  return major !== null && major >= NODE_FLOOR_MAJOR;
+}
+
+type VersionProbe = (nodePath: string) => string;
+
+const execNodeVersion: VersionProbe = (nodePath) =>
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('node:child_process')
+    .execFileSync(nodePath, ['--version'], { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] });
+
+/** `node --version` from the binary the user's PATH actually resolves (see
+ *  pty.commandPath). Null when node is absent or the probe fails at all — both
+ *  mean "we cannot vouch for this runtime", which routes into the install rung
+ *  rather than silently assuming it is fine. */
+export function detectNodeVersion(
+  nodePath: string | null | undefined,
+  probe: VersionProbe = execNodeVersion
+): string | null {
+  if (!nodePath) return null;
+  try {
+    const out = (probe(nodePath) || '').trim();
+    return /^v?\d+\./.test(out) ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Newest LTS in nodejs.org's index.json. The index is newest-first, and `lts` is
+ *  the codename (or false), so the first truthy one is the latest stable line.
+ *  We deliberately do NOT take index[0] — that is the current/odd release, which
+ *  is not what "latest stable" means to a user who just wants things to work. */
+export function pickLatestLts(index: NodeDistEntry[]): NodeDistEntry | null {
+  return index.find((e) => e && e.lts) ?? null;
+}
+
+/** The installer artifact for a platform/arch.
+ *
+ *  Names are derived here but VALIDATED against SHASUMS256.txt by the caller —
+ *  index.json's `files` array is not trustworthy for this: it lists no
+ *  `win-arm64-msi` even though `node-<v>-arm64.msi` is published, and its
+ *  `osx-x64-pkg` entry actually denotes the single UNIVERSAL `node-<v>.pkg`.
+ *
+ *  Linux has no official installer package — only tarballs — so it gets the
+ *  tar kind, unpacked into /usr/local. */
+export function nodeArtifactFor(
+  version: string,
+  platform: string,
+  arch: string
+): { file: string; kind: NodeInstaller['kind'] } | null {
+  if (platform === 'darwin') return { file: `node-${version}.pkg`, kind: 'pkg' };
+  if (platform === 'win32') {
+    const a = arch === 'arm64' ? 'arm64' : 'x64';
+    return { file: `node-${version}-${a}.msi`, kind: 'msi' };
+  }
+  if (platform === 'linux') {
+    const a = arch === 'arm64' ? 'arm64' : arch === 'x64' ? 'x64' : null;
+    if (!a) return null;
+    return { file: `node-${version}-linux-${a}.tar.xz`, kind: 'tar' };
+  }
+  return null;
+}
+
+/** Pull one file's digest out of a SHASUMS256.txt body ("<sha>  <file>" lines). */
+export function shaFor(shasums: string, file: string): string | null {
+  for (const line of shasums.split('\n')) {
+    const m = /^([0-9a-f]{64})\s+(\S+)\s*$/.exec(line.trim());
+    if (m && m[2] === file) return m[1];
+  }
+  return null;
+}
+
+export const distUrl = (version: string, file: string): string => `${DIST}/${version}/${file}`;
+
+type Fetcher = (url: string) => Promise<{ ok: boolean; text: () => Promise<string> }>;
+
+/** This runs INSIDE a spawn, so it must never hang the launch: an unreachable
+ *  nodejs.org has to fail fast and drop the ladder to its next rung. */
+const timedFetch: Fetcher = (url) =>
+  fetch(url, { signal: AbortSignal.timeout(6000) }) as unknown as ReturnType<Fetcher>;
+
+/** Resolve the exact installer to run on THIS machine, checksum included.
+ *  Returns null on any failure (offline, unsupported platform, artifact not in
+ *  SHASUMS256) — callers then fall back down the ladder rather than guessing. */
+export async function resolveNodeInstaller(
+  platform: string = process.platform,
+  arch: string = process.arch,
+  fetchImpl: Fetcher = timedFetch
+): Promise<NodeInstaller | null> {
+  try {
+    const indexRes = await fetchImpl(`${DIST}/index.json`);
+    if (!indexRes.ok) return null;
+    const index = JSON.parse(await indexRes.text()) as NodeDistEntry[];
+    const lts = pickLatestLts(index);
+    if (!lts) return null;
+
+    const artifact = nodeArtifactFor(lts.version, platform, arch);
+    if (!artifact) return null;
+
+    const shaRes = await fetchImpl(`${DIST}/${lts.version}/SHASUMS256.txt`);
+    if (!shaRes.ok) return null;
+    const sha256 = shaFor(await shaRes.text(), artifact.file);
+    // No digest → we would be running an unverified installer as root. Refuse.
+    if (!sha256) return null;
+
+    return {
+      version: lts.version,
+      npmVersion: lts.npm,
+      file: artifact.file,
+      url: distUrl(lts.version, artifact.file),
+      sha256,
+      kind: artifact.kind
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The visible install script: download → VERIFY → install, aborting on any step.
+ *
+ *  POSIX form is newline-separated statements for `$SHELL -lc`. Windows form is
+ *  ONE `&`-chained cmd.exe line with NO double quotes — it is wrapped verbatim in
+ *  `cmd /d /s /c "<script>"`, where a single embedded quote would end the command
+ *  line early and execute the remainder as garbage. */
+export function buildNodeInstallScript(installer: NodeInstaller, platform: string): string[] {
+  const { version, url, sha256, file } = installer;
+
+  if (platform === 'win32') {
+    // certutil is the only hashing tool guaranteed present; `findstr` does the
+    // compare because cmd has no string equality on command output. msiexec's
+    // own UAC prompt is the elevation — we never call it silently.
+    const f = `%TEMP%\\${file}`;
+    return [
+      `echo   Downloading Node.js ${version} ^(official installer^)...`,
+      `curl -fSL ${url} -o ${f}`,
+      `if errorlevel 1 exit /b 1`,
+      `echo   Verifying checksum...`,
+      `certutil -hashfile ${f} SHA256 | findstr /i /c:${sha256} >nul`,
+      `if errorlevel 1 (echo   [x] CHECKSUM MISMATCH - refusing to install ^& exit /b 1)`,
+      `echo   Installing - approve the Windows prompt if it appears...`,
+      `msiexec /i ${f} /passive /norestart`,
+      `if errorlevel 1 exit /b 1`,
+      `set PATH=%ProgramFiles%\\nodejs;%PATH%`
+    ];
+  }
+
+  // macOS ships `shasum`; Linux ships `sha256sum`. Neither ships both.
+  const verify = platform === 'darwin'
+    ? `echo "${sha256}  $__f" | shasum -a 256 -c - >/dev/null`
+    : `echo "${sha256}  $__f" | sha256sum -c - >/dev/null`;
+  const install = platform === 'darwin'
+    ? `sudo installer -pkg "$__f" -target /`
+    // No official Linux package — the tarball IS the distribution. --strip-components
+    // drops the versioned top dir so bin/ lands directly in /usr/local/bin.
+    : `sudo tar -xJf "$__f" -C /usr/local --strip-components=1`;
+
+  return [
+    `echo '  Downloading Node.js ${version} (official installer)...'`,
+    `__tmp=$(mktemp -d)`,
+    `__f=$__tmp/${file}`,
+    `curl -fSL --progress-bar ${url} -o "$__f" || { echo '  [x] Download failed.'; exit 1; }`,
+    `echo '  Verifying checksum...'`,
+    `${verify} || { echo '  [x] CHECKSUM MISMATCH - refusing to install.'; rm -rf "$__tmp"; exit 1; }`,
+    `echo ''`,
+    `echo '  Installing Node.js. Enter your password if prompted -'`,
+    `echo '  the official installer writes outside your home directory.'`,
+    `echo ''`,
+    `${install} || { echo '  [x] Node install failed.'; rm -rf "$__tmp"; exit 1; }`,
+    `rm -rf "$__tmp"`,
+    // The shell that is running this script captured PATH before node existed.
+    `PATH=/usr/local/bin:$PATH`,
+    `export PATH`
+  ];
+}

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -167,6 +167,15 @@ export class PtyManager {
     return this.resolveCommand(command).found;
   }
 
+  /** The absolute path a bare command resolves to for THIS user, or null when it
+   *  isn't installed. Same resolution + cache as spawn(), so a caller that probes
+   *  a binary (e.g. `node --version`, to decide whether it is too old to keep)
+   *  inspects exactly the executable an agent would have run. */
+  commandPath(command: string): string | null {
+    const r = this.resolveCommand(command);
+    return r.found ? r.path : null;
+  }
+
   /** Session cache of SUCCESSFUL command resolutions. Each miss costs a full
    *  interactive-shell launch (`$SHELL -ilc which …` sources the user's whole
    *  zshrc — nvm/asdf init is routinely ~1s) run synchronously on the main

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -3,6 +3,7 @@ import type { WebContents } from 'electron';
 import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { ensureKilled } from './procKill';
+import { expandTilde } from './fs';
 import { captureFromLoginShell, userShellPath } from './shellEnv';
 
 interface PtySession {
@@ -234,6 +235,10 @@ export class PtyManager {
     if (this.sessions.has(opts.id)) {
       return { ok: false, error: `pty already exists for id ${opts.id}` };
     }
+    // Defense-in-depth: cwd is already tilde-expanded at ingestion (spawnAgentCore),
+    // but any other caller reaching the PTY directly gets the same treatment —
+    // `existsSync('~/dev/foo')` is always false, only a shell expands `~`.
+    opts = { ...opts, cwd: expandTilde(opts.cwd) };
     if (!existsSync(opts.cwd)) {
       return { ok: false, error: `cwd does not exist: ${opts.cwd}` };
     }

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -1,10 +1,32 @@
 import * as pty from 'node-pty';
 import type { WebContents } from 'electron';
 import { existsSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { ensureKilled } from './procKill';
 import { expandTilde } from './fs';
 import { captureFromLoginShell, userShellPath } from './shellEnv';
+
+/** APPEND the hive's bundled-node dir (`<HIVE_ROOT>/bin/runtime`, which holds a
+ *  shim literally named `node`) to a child's PATH.
+ *
+ *  Layer 1 routed the commands WE generate through `hive-node`. This covers the
+ *  ones we don't: an MCP server declared as `node ./server.js`, a provider CLI
+ *  that shells out to node, a helper script the agent wrote itself. With no
+ *  system node those all die with 127 — the same bug, one level down.
+ *
+ *  APPENDED, never prepended: a user who has their own node keeps it, and we are
+ *  only the fallback. Prepending would silently swap the node version under the
+ *  user's own projects for Electron's, which is a different (and wrong) product
+ *  decision. No-ops when there is no hive root or the dir was never written. */
+export function withHiveRuntimeFallback(path: string, hiveRoot?: string): string {
+  if (!hiveRoot) return path;
+  const dir = join(hiveRoot, 'bin', 'runtime');
+  if (!existsSync(dir)) return path;
+  const entries = path.split(delimiter).filter(Boolean);
+  if (entries.includes(dir)) return path; // re-spawn of a live agent
+  return [...entries, dir].join(delimiter);
+}
 
 interface PtySession {
   id: string;
@@ -248,9 +270,10 @@ export class PtyManager {
       // for the session (shellEnv.userShellPath, fenced against rc-file noise) —
       // the interactive-shell launch it replaces cost ~1s of main-thread freeze
       // on EVERY spawn.
-      const userPath = process.platform === 'win32'
-        ? (process.env.PATH || '')
-        : userShellPath();
+      const userPath = withHiveRuntimeFallback(
+        process.platform === 'win32' ? (process.env.PATH || '') : userShellPath(),
+        opts.env?.HIVE_ROOT
+      );
 
       // On Windows, .cmd/.bat files (and extensionless shims) cannot be executed
       // directly by CreateProcess — only .exe/.com can. Route them through cmd.exe.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -546,7 +546,9 @@ const api = {
   version: __APP_VERSION__,
 
   // ─── PTY ─────────────────────────────────────────────────────────────────
-  spawnPty: (opts: SpawnPtyOptions): Promise<{ ok: boolean; error?: string; worktreePath?: string; resumeNotFound?: boolean; resumed?: boolean; seedPrompt?: string }> =>
+  /** `cwd` in the result is the TILDE-EXPANDED absolute path main actually spawned
+   *  into — the renderer stores that, not the raw `~/…` the user typed. */
+  spawnPty: (opts: SpawnPtyOptions): Promise<{ ok: boolean; error?: string; cwd?: string; worktreePath?: string; resumeNotFound?: boolean; resumed?: boolean; seedPrompt?: string }> =>
     ipcRenderer.invoke('pty:spawn', opts),
   writePty: (id: string, data: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('pty:write', id, data),

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -272,6 +272,12 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     setCwd(p);
     try {
       const updated = await window.cth.updateConfig({ registeredRepos: next });
+      // Main expands `~` when it persists registeredRepos, so adopt the stored
+      // (absolute) list — otherwise a typed "~/dev/foo" stays literal in this
+      // modal's state and rides along into the spawn.
+      const stored = updated.registeredRepos ?? next;
+      setRepos(stored);
+      if (stored[0]) setCwd(stored[0]);
       onConfigChange?.(updated);
     } catch { /* best-effort persist */ }
   };
@@ -358,15 +364,19 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       console.warn(`[add-agent] resume session "${resumeSessionId.trim()}" not found — started a fresh session`);
     }
 
+    // Main expands `~` at ingestion and echoes back the absolute path it actually
+    // spawned into — record THAT, so this agent's cwd matches the hive registry
+    // (and survives a restart, where nothing re-expands it).
+    const spawnedCwd = spawnRes.cwd || cwd;
     const agent: Agent = {
       id,
       name: name.trim(),
       character,
       accent,
       description: description.trim() || 'a fresh harness',
-      project: basename(cwd),
+      project: basename(spawnedCwd),
       tmuxTarget: '',
-      cwd,
+      cwd: spawnedCwd,
       goal: goal.trim() || undefined,
       status: 'idle',
       action: resuming && spawnRes.resumeNotFound ? 'session not found — fresh start' : 'starting up',
@@ -388,8 +398,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     // Remember the folder for the next hire: promote it to the front of the
     // registeredRepos quick-picks (the modal's default cwd) so back-to-back
     // hires land in the same project without re-picking.
-    if (cwd && repos[0] !== cwd) {
-      const nextRepos = [cwd, ...repos.filter((r) => r !== cwd)];
+    if (spawnedCwd && repos[0] !== spawnedCwd) {
+      const nextRepos = [spawnedCwd, ...repos.filter((r) => r !== spawnedCwd && r !== cwd)];
       void window.cth.updateConfig({ registeredRepos: nextRepos })
         .then((updated) => onConfigChange?.(updated))
         .catch(() => { /* best-effort */ });

--- a/src/renderer/src/scene/office/OfficeFloor.tsx
+++ b/src/renderer/src/scene/office/OfficeFloor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Application, Container, Graphics, Ticker, Texture } from 'pixi.js';
 // PixiJS uses new Function() internally, blocked by Electron CSP — this patches it.
 import 'pixi.js/unsafe-eval';
@@ -12,6 +12,7 @@ import { hexToNumber, DEFAULT_CHARACTER } from './cast';
 import { pickSoloLine, pickExchange, type BreakSpot } from './cafeteriaLines';
 import { colors } from '@/design/tokens';
 import { loadTheme, resolveThemeMap, themeTilesetUrls } from './themeLoader';
+import { installContextLossRecovery } from './glRecovery';
 import type { Tile, Facing, ErrandKind, ErrandSpot } from './themeRegistry';
 
 // The map, tileset atlases, desk-claim order, errand spots, coffee-economy
@@ -159,6 +160,10 @@ export function OfficeFloor() {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const appRef = useRef<Application | null>(null);
   const mountIdRef = useRef(0);
+  // Bumped when the WebGL context is evicted; a dep of the effect below, so the
+  // whole scene is torn down and rebuilt through the existing mount path rather
+  // than through a second, parallel recovery routine.
+  const [glGeneration, setGlGeneration] = useState(0);
   // The active office theme (store mirror of config.officeTheme). Changing it
   // tears down and rebuilds the whole scene on the new map/cast (see deps below).
   const officeTheme = useStore((s) => s.officeTheme);
@@ -200,6 +205,27 @@ export function OfficeFloor() {
       if (mountIdRef.current !== mountId) { safeDestroy(app); return; }
       while (host.firstChild) host.removeChild(host.firstChild);
       host.appendChild(app.canvas);
+
+      // This canvas holds the OLDEST WebGL context in the process (it is built at
+      // startup), so it is the one Chromium evicts once enough xterm terminals —
+      // each of which takes a context via @xterm/addon-webgl — are open. Pixi
+      // reports nothing when that happens: the floor just goes blank forever.
+      // Rebuild instead. See glRecovery.ts.
+      (app as any).__glRecovery = installContextLossRecovery(app.canvas, {
+        onRebuild: () => { if (mountIdRef.current === mountId) setGlGeneration((n) => n + 1); },
+        onGiveUp: () => {
+          if (mountIdRef.current !== mountId) return;
+          const note = document.createElement('div');
+          note.style.cssText =
+            'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;' +
+            'padding:24px;color:#ffd0b5;font-family:monospace;font-size:13px;text-align:center;white-space:pre-wrap;';
+          note.textContent =
+            'The office floor lost its GPU context.\n\n' +
+            'Too many terminals are using the GPU at once.\n' +
+            'Close a few agent terminals, or restart the app, to bring it back.';
+          host.appendChild(note);
+        }
+      });
 
       // Load tilesets in theme order (texture[i] lines up with map tilesets[i]).
       const tilesetTextures = await Promise.all(
@@ -1655,6 +1681,7 @@ export function OfficeFloor() {
       mountIdRef.current++;
       const a = appRef.current;
       if (a) {
+        (a as any).__glRecovery?.();
         (a as any).__resize?.disconnect?.();
         try { (a as any).__unsub?.(); } catch { /* noop */ }
         try { (a as any).__offMessage?.(); } catch { /* noop */ }
@@ -1664,7 +1691,7 @@ export function OfficeFloor() {
       appRef.current = null;
       while (host.firstChild) host.removeChild(host.firstChild);
     };
-  }, [officeTheme]);
+  }, [officeTheme, glGeneration]);
 
   return (
     <div

--- a/src/renderer/src/scene/office/glRecovery.ts
+++ b/src/renderer/src/scene/office/glRecovery.ts
@@ -1,0 +1,78 @@
+/**
+ * Surviving a lost WebGL context.
+ *
+ * Chromium caps how many WebGL contexts one renderer process may hold (~16) and,
+ * when a new one pushes past the cap, it EVICTS THE OLDEST — logging only
+ * "WARNING: Too many active WebGL contexts. Oldest context will be lost."
+ *
+ * The office floor's context is created at app startup, so it is always the
+ * oldest one alive. Every terminal xterm opens takes another context
+ * (@xterm/addon-webgl), so on a busy floor — enough agents, or a second window —
+ * the office is the first thing evicted. Pixi does not notice: no exception, no
+ * rejected promise, no failure banner. The canvas simply stops drawing and the
+ * office goes blank until the app is restarted. That is the blank-office bug.
+ *
+ * xterm already handles this by falling back to its DOM renderer. Pixi has no
+ * such fallback, so the scene has to be rebuilt instead. This module is only the
+ * event wiring, kept separate from OfficeFloor so the recovery policy — cancel
+ * the event, debounce, cap the retries, give up loudly — is testable against a
+ * plain EventTarget with no browser, no GPU and no Pixi.
+ */
+
+export interface GlRecoveryOptions {
+  /** Rebuild attempts before we stop fighting for a context. */
+  maxRebuilds?: number;
+  /** Wait before rebuilding: the eviction arrives mid-storm (several contexts
+   *  are usually created at once), and claiming one back immediately just races
+   *  the terminals that displaced us. */
+  delayMs?: number;
+  /** Rebuild the scene (in OfficeFloor: bump the effect's generation dep). */
+  onRebuild: () => void;
+  /** Called once, when the retry budget is spent — the caller should say
+   *  something visible rather than leaving a silently blank canvas. */
+  onGiveUp?: () => void;
+  /** Injectable for tests. */
+  schedule?: (fn: () => void, ms: number) => unknown;
+  log?: (msg: string) => void;
+}
+
+export const DEFAULT_MAX_REBUILDS = 3;
+export const DEFAULT_REBUILD_DELAY_MS = 1500;
+
+/** Listen for context loss on `canvas` and rebuild. Returns an uninstall fn;
+ *  call it from the effect cleanup so a torn-down scene stops responding. */
+export function installContextLossRecovery(
+  canvas: EventTarget,
+  opts: GlRecoveryOptions
+): () => void {
+  const max = opts.maxRebuilds ?? DEFAULT_MAX_REBUILDS;
+  const delay = opts.delayMs ?? DEFAULT_REBUILD_DELAY_MS;
+  const schedule = opts.schedule ?? ((fn, ms) => setTimeout(fn, ms));
+  const log = opts.log ?? ((m: string) => console.warn(m));
+
+  let rebuilds = 0;
+  let live = true;
+
+  const onLost = (e: Event) => {
+    // WITHOUT preventDefault the browser will never hand the context back — the
+    // canvas is dead for good. This one line is the difference between a
+    // recoverable scene and a permanently blank one.
+    e.preventDefault();
+    if (!live) return;
+    if (rebuilds >= max) {
+      log(`[OfficeFloor] WebGL context lost again after ${max} rebuilds — too many live contexts on this floor; giving up until restart`);
+      opts.onGiveUp?.();
+      live = false;
+      return;
+    }
+    rebuilds += 1;
+    log(`[OfficeFloor] WebGL context lost (Chromium evicted the oldest context) — rebuilding the scene, attempt ${rebuilds}/${max}`);
+    schedule(() => { if (live) opts.onRebuild(); }, delay);
+  };
+
+  canvas.addEventListener('webglcontextlost', onLost as EventListener, false);
+  return () => {
+    live = false;
+    canvas.removeEventListener('webglcontextlost', onLost as EventListener, false);
+  };
+}

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -146,6 +146,17 @@ export interface AgentProviderPreset {
    *  when undefined, the user is shown a manual instruction only and nothing is
    *  auto-run. MUST be a trusted, hardcoded constant — never user/manifest input. */
   installCommand?: string;
+  /** A SELF-CONTAINED installer that needs no Node/npm at all, per platform.
+   *
+   *  `installCommand` is `npm install -g …` for every provider, which silently
+   *  assumes npm — i.e. node — is already on the machine. When it isn't, the
+   *  missing-CLI banner prints a command that CANNOT succeed, so the user watches
+   *  an installer fail instead of an app work. Where the vendor ships a native
+   *  installer we run that instead (see buildMissingCliScript's ladder).
+   *
+   *  Trusted, hardcoded constants — never user/manifest input. MUST contain no
+   *  double-quotes: the Windows form is wrapped verbatim in `cmd /d /s /c "…"`. */
+  nativeInstallCommand?: { posix: string; win32: string };
   /** Optional docs URL surfaced as a manual-setup hint in the missing-CLI banner. */
   docsUrl?: string;
   resumeSubcommand?: string; // CLIs that resume via a subcommand instead of a flag (Codex: `codex resume [OPTIONS] [SESSION_ID]`)
@@ -169,6 +180,12 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     resumeFlag: '--resume',
     // Official Claude Code install (npm global). Used by the missing-CLI auto-install.
     installCommand: 'npm install -g @anthropic-ai/claude-code',
+    // Anthropic's official native installer — a standalone binary, no node/npm.
+    // The only rung of the ladder that works on a machine with no Node at all.
+    nativeInstallCommand: {
+      posix: 'curl -fsSL https://claude.ai/install.sh | bash',
+      win32: 'powershell -c irm https://claude.ai/install.ps1 ^| iex'
+    },
     docsUrl: 'https://docs.claude.com/en/docs/claude-code'
   },
   {
@@ -566,11 +583,22 @@ export function commandGroupsForProvider(provider: AgentProvider): CmdGroup[] {
  *  is the friendly CLI name; `docsUrl` is an optional manual-setup link. */
 export interface ProviderInstallInfo {
   command?: string;
+  /** A node-free installer for this platform, when the vendor ships one. */
+  nativeCommand?: string;
   label: string;
   docsUrl?: string;
 }
 
-export function installInfoForProvider(provider: AgentProvider): ProviderInstallInfo {
+export function installInfoForProvider(
+  provider: AgentProvider,
+  platform: string = process.platform
+): ProviderInstallInfo {
   const p = providerPreset(provider);
-  return { command: p.installCommand, label: p.label, docsUrl: p.docsUrl };
+  const native = p.nativeInstallCommand;
+  return {
+    command: p.installCommand,
+    nativeCommand: native ? (platform === 'win32' ? native.win32 : native.posix) : undefined,
+    label: p.label,
+    docsUrl: p.docsUrl
+  };
 }

--- a/test/cli-install-ladder.test.cjs
+++ b/test/cli-install-ladder.test.cjs
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Every provider's `installCommand` is `npm install -g …`. On a machine with no
+ * Node, the missing-CLI banner used to print that command and RUN it — so a fresh
+ * user watched `npm: command not found` scroll past and concluded the app was
+ * broken. The ladder classifies first and only ever runs something that can work.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { chooseInstallRung, buildMissingCliScript } = loadTs('src/main/cliInstall.ts');
+const { installInfoForProvider } = loadTs('src/shared/agentProvider.ts');
+
+const script = (provider, npmAvailable, platform) =>
+  buildMissingCliScript(provider, provider, npmAvailable, platform);
+
+test('with npm present the ladder is unchanged — npm install, for every provider', () => {
+  for (const provider of ['claude', 'codex', 'opencode', 'crush', 'copilot']) {
+    const info = installInfoForProvider(provider);
+    const rung = chooseInstallRung(info, true);
+    assert.equal(rung.kind, 'npm', provider);
+    assert.equal(rung.command, info.command, provider);
+    assert.equal(rung.nodeMissing, false, provider);
+  }
+});
+
+test('with npm absent, a provider shipping a native installer uses it', () => {
+  const rung = chooseInstallRung(installInfoForProvider('claude'), false);
+  assert.equal(rung.kind, 'native');
+  assert.equal(rung.nodeMissing, true);
+  assert.doesNotMatch(rung.command, /\bnpm\b/, 'the whole point is that npm is not there');
+});
+
+test('with npm absent and no native installer, NOTHING is run', () => {
+  const info = installInfoForProvider('codex');
+  assert.equal(info.nativeCommand, undefined, 'fixture assumes codex has no native installer');
+  const rung = chooseInstallRung(info, false);
+  assert.equal(rung.kind, 'manual');
+  assert.equal(rung.command, undefined, 'a command here would be the doomed `npm install -g`');
+});
+
+test('the no-node script explains the real problem instead of failing at it', () => {
+  const out = script('codex', false);
+  assert.match(out, /Node\.js is not installed/);
+  assert.match(out, /nodejs\.org/, 'tell the user where to get it');
+  assert.match(out, /Docs: https/, 'and keep the provider docs link');
+
+  // The npm command may still be SHOWN (as the follow-up step) but must never be
+  // an executed line: every executable line here is an `echo`.
+  const executable = out.split('\n').filter((l) => l.trim() && !/^\s*echo\b/.test(l.trim()));
+  assert.deepEqual(executable, [], `these would run on a machine with no node: ${executable}`);
+});
+
+test('the native rung actually runs, and says why it differs', () => {
+  const out = script('claude', false);
+  assert.match(out, /no Node needed/);
+  const native = installInfoForProvider('claude').nativeCommand;
+  assert.ok(out.split('\n').includes(native), 'the installer must be an executed line, not only echoed');
+});
+
+test('with npm present nothing mentions a missing Node', () => {
+  const out = script('claude', true);
+  assert.doesNotMatch(out, /Node\.js is not installed/);
+  assert.ok(out.split('\n').includes('npm install -g @anthropic-ai/claude-code'));
+});
+
+test('the Windows script stays a single quote-free cmd.exe line', () => {
+  // It is wrapped verbatim in `cmd /d /s /c "<script>"` — one embedded double
+  // quote ends the command line early and the rest executes as garbage.
+  for (const provider of ['claude', 'codex']) {
+    for (const npm of [true, false]) {
+      const out = buildMissingCliScript(provider, provider, npm, 'win32');
+      assert.ok(!out.includes('"'), `${provider}/${npm}: embedded quote`);
+      assert.ok(!out.includes('\n'), `${provider}/${npm}: must be one line`);
+    }
+  }
+  assert.match(buildMissingCliScript('claude', 'claude', false, 'win32'), /powershell/,
+    'the native rung must be the PowerShell form on Windows, not the curl one');
+});
+
+test('a hostile binary name cannot inject a command into the banner', () => {
+  const out = script('claude', true).split('\n');
+  const evil = buildMissingCliScript("x'; rm -rf /; echo '", 'claude', true).split('\n');
+  assert.equal(evil.length, out.length, 'no extra statements');
+  assert.ok(evil.some((l) => l.includes('xrm-rf')), 'sanitized to a bare identifier');
+  assert.ok(!evil.some((l) => /rm -rf \//.test(l)));
+});

--- a/test/expand-tilde.test.cjs
+++ b/test/expand-tilde.test.cjs
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * `~` is a SHELL convention — Node's fs/child_process treat it as a literal
+ * directory name. Adding a project with `~/dev/foo` therefore died on
+ * "cwd does not exist". expandTilde is the single shared expander that fixes it.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { expandTilde } = loadTs('src/main/fs.ts');
+
+const HOME = os.homedir();
+
+test('expands the tilde-home forms', () => {
+  assert.equal(expandTilde('~/dev/proj'), path.join(HOME, 'dev/proj'));
+  assert.equal(expandTilde('~'), HOME, 'a bare ~ is a valid cwd too');
+  assert.equal(expandTilde('~/'), HOME);
+  assert.equal(expandTilde('  ~/dev/proj  '), path.join(HOME, 'dev/proj'), 'pasted paths carry whitespace');
+});
+
+test('leaves absolute paths alone (beyond normalizing)', () => {
+  assert.equal(expandTilde('/a/b/c'), '/a/b/c');
+  assert.equal(expandTilde('/a/b/c/'), '/a/b/c');
+  assert.equal(expandTilde('/a/b/../c'), '/a/c');
+});
+
+test('does not touch anything that is not a tilde-home path', () => {
+  assert.equal(expandTilde(''), '');
+  assert.equal(expandTilde('~notauser/x'), '~notauser/x', '~user is not a form we expand');
+  assert.equal(expandTilde('C:\\Users\\me\\proj'), 'C:\\Users\\me\\proj', 'windows paths must survive');
+});
+
+test('a still-relative path is returned untouched, NOT resolved', () => {
+  // Deliberate: resolving here would silently anchor the path to the Electron
+  // process cwd. Callers keep their own "not absolute" error instead.
+  assert.equal(expandTilde('relative/path'), 'relative/path');
+  assert.equal(expandTilde('./rel'), './rel');
+});
+
+test('the expanded path is what fs can actually stat — the original bug', () => {
+  assert.equal(fs.existsSync('~'), false, 'the literal "~" never exists on disk');
+  const expanded = expandTilde('~');
+  assert.equal(path.isAbsolute(expanded), true);
+  assert.equal(fs.existsSync(expanded), true);
+});

--- a/test/hive-cwd.test.cjs
+++ b/test/hive-cwd.test.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Ingestion guarantee: whatever the user types, the hive registry stores an
+ * ABSOLUTE cwd. A `~/…` entry used to land verbatim and then read
+ * "not absolute" / cwdValid:false forever, so the agent could never spawn.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-hive-cwd-'));
+}
+
+function registryOf(home) {
+  return JSON.parse(fs.readFileSync(path.join(home, 'hive', 'registry.json'), 'utf8'));
+}
+
+test('a "~/…" cwd is expanded before it reaches the registry', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: '~' });
+
+  const agent = registryOf(home).agents.a1;
+  assert.equal(agent.cwd, os.homedir(), 'the registry must hold the resolved path');
+  assert.equal(path.isAbsolute(agent.cwd), true);
+  assert.equal(agent.cwdValid, true, 'the raw "~" is what made this false');
+});
+
+test('an absolute cwd is unchanged', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
+
+  const agent = registryOf(home).agents.a1;
+  assert.equal(agent.cwd, home);
+  assert.equal(agent.cwdValid, true);
+});
+
+test('cwdValidity repairs a "~" left in an older registry', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  // Entries written before the fix are still on disk; reading one must not
+  // report it as permanently invalid.
+  assert.equal(hive.cwdValidity('~').valid, true);
+  assert.equal(hive.cwdValidity(path.join('~', 'definitely-not-here-xyz')).valid, false,
+    'expansion must not paper over a genuinely missing directory');
+  assert.equal(hive.cwdValidity('relative/path').valid, false,
+    'a relative path is still an error, not silently resolved');
+});

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -1,0 +1,186 @@
+'use strict';
+
+/**
+ * Hooks run under `/bin/sh` with a bare PATH (`/usr/bin:/bin:…`). A hook command
+ * of `node "<shim>"` therefore exits 127 — "node: command not found" — on every
+ * machine where node lives in a shell-managed prefix (nvm, volta, Homebrew).
+ *
+ * The fix is `<hive>/bin/hive-node`: a one-line wrapper around Electron's OWN
+ * bundled node (`ELECTRON_RUN_AS_NODE=1 exec "<execPath>"`). Every hook installer
+ * must route through it.
+ *
+ * A wrapper SCRIPT rather than an inline `ELECTRON_RUN_AS_NODE=1 "<exe>" …`
+ * prefix, because that prefix is POSIX-sh syntax and a hard error under cmd.exe —
+ * which is what runs hook commands on Windows.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+
+const POSIX = process.platform !== 'win32';
+const STRIPPED_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-hive-node-'));
+}
+
+const launcherIn = (home) =>
+  path.join(home, 'hive', 'bin', POSIX ? 'hive-node' : 'hive-node.cmd');
+
+/** Every file under `dir`. */
+function walk(dir, out = []) {
+  for (const e of fs.existsSync(dir) ? fs.readdirSync(dir, { withFileTypes: true }) : []) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else out.push(p);
+  }
+  return out;
+}
+
+/** Sweep every config an installer wrote for commands that invoke one of our
+ *  shims. Path-agnostic on purpose, so a new installer cannot be missed. */
+function hookCommandsUnder(home) {
+  const shim = /(cth-hook\.cjs|agy-hook\.cjs|grok-hook\.cjs)/;
+  const found = [];
+  for (const file of walk(home)) {
+    let text;
+    try { text = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    if (!shim.test(text)) continue;
+    // JSON hook configs: "command": "<…>"      TOML (codex): command = '<…>'
+    for (const m of text.matchAll(/"command"\s*:\s*"((?:[^"\\]|\\.)*)"/g)) found.push(JSON.parse(`"${m[1]}"`));
+    for (const m of text.matchAll(/command = '([^']+)'/g)) found.push(m[1]);
+  }
+  return found.filter((c) => shim.test(c));
+}
+
+const usesLauncher = (cmd, launcher) => cmd.startsWith(launcher) || cmd.startsWith(`"${launcher}"`);
+
+async function run(cmd, env) {
+  return new Promise((resolve) => {
+    const child = spawn('/bin/sh', ['-c', cmd], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.stdin.end(JSON.stringify({ hook_event_name: 'Stop', session_id: 's1' }));
+    child.on('close', (code) => resolve({ code, stderr }));
+  });
+}
+
+test('ensureHive writes an executable bundled-node launcher', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
+
+  const launcher = launcherIn(home);
+  assert.equal(fs.existsSync(launcher), true);
+  const body = fs.readFileSync(launcher, 'utf8');
+  assert.match(body, /ELECTRON_RUN_AS_NODE=1/, 'without this the binary opens a second app window');
+  assert.ok(body.includes(process.execPath), 'execPath is re-baked each bootstrap so an app move/update heals');
+  if (POSIX) assert.ok(fs.statSync(launcher).mode & 0o111, 'must be executable');
+});
+
+test('the claude hook + statusLine commands run through the launcher', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
+
+  const launcher = launcherIn(home);
+  const settings = JSON.parse(fs.readFileSync(path.join(home, 'hive/agents/a1/settings.json'), 'utf8'));
+  const commands = [
+    ...Object.values(settings.hooks).flatMap((matchers) => matchers.flatMap((m) => m.hooks.map((h) => h.command))),
+    settings.statusLine.command
+  ];
+
+  assert.ok(commands.length > 0);
+  for (const cmd of commands) assert.equal(usesLauncher(cmd, launcher), true, cmd);
+});
+
+test('every hook installer routes through the launcher — none left on bare node', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
+
+  // agy and grok install into the USER's home. Redirect it, and refuse to run
+  // rather than write into the developer's real ~/.gemini / ~/.grok.
+  const realHome = process.env.HOME;
+  const realProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  t.after(() => {
+    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
+    if (realProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = realProfile;
+  });
+  assert.equal(os.homedir(), home, 'home redirect failed — aborting before touching the real home');
+
+  hive.installAgyHooks();
+  hive.installGrokHooks();
+  hive.installCodexHooks(path.join(home, 'hive/agents/a1'));
+
+  const launcher = launcherIn(home);
+  const commands = hookCommandsUnder(home);
+  // claude (Stop/statusLine/…) + agy + grok + codex.
+  assert.ok(commands.length >= 4, `expected commands from all installers, got ${commands.length}`);
+  const bare = commands.filter((c) => !usesLauncher(c, launcher));
+  assert.deepEqual(bare, [], 'these hook commands would exit 127 wherever node is not on the bare PATH');
+
+  for (const shim of ['agy-hook.cjs', 'grok-hook.cjs']) {
+    assert.ok(commands.some((c) => c.includes(shim)), `${shim} installer produced no command`);
+  }
+});
+
+test('a hook fires with NO node on PATH, and its payload reaches HIVE_SOCK', { skip: !POSIX }, async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
+
+  const sock = path.join(home, 'hive', 'hooks.sock');
+  try { fs.unlinkSync(sock); } catch { /* not there */ }
+
+  const received = [];
+  const server = net.createServer((conn) => {
+    let buf = '';
+    conn.on('error', () => { /* the shim may hang up first */ });
+    conn.on('data', (d) => { buf += d; });
+    // The shim writes its payload and waits for OUR end() — it never half-closes,
+    // so the payload is only complete on 'close', not 'end'.
+    conn.on('close', () => { if (buf) received.push(buf); });
+    conn.write(JSON.stringify({ ok: true }) + '\n', () => conn.end());
+  });
+  server.on('error', () => { /* keep a socket error out of the test process */ });
+  await new Promise((resolve) => server.listen(sock, resolve));
+  t.after(() => server.close());
+
+  const env = { PATH: STRIPPED_PATH, HIVE_SOCK: sock, AGENT_ID: 'a1', HOME: home };
+  const shim = path.join(home, 'hive/bin/cth-hook.cjs');
+
+  // Control: the command shape used before the fix. Only meaningful if node is
+  // genuinely absent from the stripped PATH (it is on a dev machine using nvm,
+  // volta or Homebrew; it is not on an image with /usr/bin/node).
+  const probe = await run('command -v node', env);
+  if (probe.code !== 0) {
+    const before = await run(`node "${shim}"`, env);
+    assert.equal(before.code, 127, 'the bug: bare `node` is not resolvable from a hook');
+  }
+
+  // NOTE: async spawn, not spawnSync — the shim connects back to a socket THIS
+  // process is serving, so a sync call would block our own event loop and
+  // deadlock the handshake.
+  const settings = JSON.parse(fs.readFileSync(path.join(home, 'hive/agents/a1/settings.json'), 'utf8'));
+  const after = await run(settings.hooks.Stop[0].hooks[0].command, env);
+  assert.equal(after.code, 0, `hook failed under a stripped PATH: ${after.stderr}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.ok(received.length > 0, 'nothing arrived at HIVE_SOCK');
+  assert.match(received[0], /"hook_event_name"\s*:\s*"Stop"/);
+});

--- a/test/hive-roster-injection.test.cjs
+++ b/test/hive-roster-injection.test.cjs
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * God has to know the LIVE floor across its own restarts — a roster it read once
+ * goes stale, and it then messages agents that were archived or killed. So the
+ * roster is PUSHED into god's context (SessionStart + every prompt) rather than
+ * pulled.
+ *
+ * Only one `additionalContext` may be returned per hook, so the roster and the
+ * operator-steer path must MERGE — otherwise they silently displace each other.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+// hooks.ts pulls Notification from electron; outside Electron that resolve gives
+// a path string, so seed the cache with the surface the server actually touches.
+const electron = require.resolve('electron');
+require.cache[electron] = {
+  id: electron,
+  filename: electron,
+  loaded: true,
+  exports: { Notification: class { show() {} static isSupported() { return false; } } }
+};
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+const { HookServer } = loadTs('src/main/hooks.ts');
+
+const CONFIG = { notifications: false };
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-roster-inj-'));
+}
+
+async function floor(t, { steer } = {}) {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent({ id: 'god-1', name: 'Michael', provider: 'claude', cwd: home, isGod: true });
+  await hive.ensureAgent({ id: 'jim-1', name: 'Jim', provider: 'claude', cwd: home });
+
+  const control = steer
+    ? { takeSteer: (id) => (id === 'god-1' ? steer : null), shouldHalt: () => false, toolDecision: () => ({ deny: false }) }
+    : undefined;
+  const server = new HookServer(hive, () => null, () => CONFIG, control, undefined);
+  const fire = (agent_id, hook_event_name) => server.handle({ agent_id, hook_event_name, session_id: 's1' });
+  return { home, hive, server, fire };
+}
+
+function snapshot(hive) {
+  hive.writeFleetSnapshot({
+    ts: Date.now() - 4000,
+    agents: [
+      { id: 'god-1', name: 'Michael', role: 'orchestrator', isGod: true, breaker: 'ok', tokens: 812_400, usd: 4.2199, lastActiveSecAgo: 6, inboxBacklog: 2 },
+      { id: 'jim-1', name: 'Jim', role: 'agent', breaker: 'warn', tokens: 120_401, usd: 1.0231, lastActiveSecAgo: 240, inboxBacklog: 0 },
+      { id: 'pam-1', name: 'Pam', role: 'agent', breaker: 'ok', tokens: 0, usd: 0, lastActiveSecAgo: null, inboxBacklog: 0 }
+    ]
+  });
+}
+
+const context = (res) => res?.hookSpecificOutput?.additionalContext ?? '';
+
+test('the roster line carries the whole floor and its state', async (t) => {
+  const { hive } = await floor(t);
+  assert.equal(hive.rosterContext(), null, 'no snapshot yet — inject nothing rather than noise');
+
+  snapshot(hive);
+  const line = hive.rosterContext();
+
+  assert.ok(!line.includes('\n'), 'must stay a single compact line');
+  for (const id of ['god-1', 'jim-1', 'pam-1']) assert.ok(line.includes(id), `missing ${id}`);
+  assert.match(line, /812k tok/);
+  assert.match(line, /\$4\.22/);
+  assert.match(line, /inbox 2/);
+  assert.match(line, /breaker warn/);
+  assert.match(line, /god-1[^;]*you/, 'god has to be able to spot itself');
+  assert.match(line, /no activity yet/, 'an agent that never ran must not read as "active never"');
+  assert.match(line, /SUPERSEDES/, 'the point is to override what god remembers');
+  assert.ok(line.length < 1200, `too long for a 3-agent floor: ${line.length} chars`);
+});
+
+test('god gets the roster on SessionStart and on every prompt — nobody else does', async (t) => {
+  const { hive, fire } = await floor(t);
+  snapshot(hive);
+
+  const start = await fire('god-1', 'SessionStart');
+  assert.match(context(start), /LIVE ROSTER/);
+  assert.equal(start.hookSpecificOutput.hookEventName, 'SessionStart');
+  assert.match(context(await fire('god-1', 'UserPromptSubmit')), /LIVE ROSTER/);
+
+  assert.doesNotMatch(context(await fire('jim-1', 'SessionStart')), /LIVE ROSTER/);
+  assert.doesNotMatch(context(await fire('jim-1', 'UserPromptSubmit')), /LIVE ROSTER/);
+  assert.doesNotMatch(context(await fire('god-1', 'PostToolUse')), /LIVE ROSTER/,
+    'prompt boundaries only — not once per tool call');
+});
+
+test('a queued operator steer is not swallowed by the roster', async (t) => {
+  const steer = 'OPERATOR: stop and summarize.';
+  const { hive, fire } = await floor(t, { steer });
+  snapshot(hive);
+
+  const ctx = context(await fire('god-1', 'UserPromptSubmit'));
+  assert.match(ctx, /LIVE ROSTER/);
+  assert.ok(ctx.includes(steer), 'only one additionalContext exists — the two must merge, not race');
+});
+
+test('a corrupt fleet.json degrades to no injection instead of throwing into a hook', async (t) => {
+  const { home, hive, fire } = await floor(t);
+  snapshot(hive);
+  fs.writeFileSync(path.join(home, 'hive', 'fleet.json'), '{ not json');
+
+  assert.equal(hive.rosterContext(), null);
+  const res = await fire('god-1', 'SessionStart');
+  assert.doesNotMatch(context(res), /LIVE ROSTER/);
+});

--- a/test/hive-runtime-path.test.cjs
+++ b/test/hive-runtime-path.test.cjs
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Layer 1 fixed the commands WE generate (every hook shim runs through
+ * `hive-node`). It did nothing for node the agent's own work needs: an MCP server
+ * declared as `node ./server.js`, a provider CLI that shells out to node, a helper
+ * an agent wrote itself. With no system node those die with 127 — same bug, one
+ * level down.
+ *
+ * `<hive>/bin/runtime/` holds a shim literally NAMED `node`, APPENDED to the
+ * agent's PATH. Appended, not prepended: a user with their own node keeps their
+ * own version, and we are strictly the fallback.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+const { withHiveRuntimeFallback } = loadTs('src/main/pty.ts');
+
+const POSIX = process.platform !== 'win32';
+const STRIPPED_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+const SEP = path.delimiter;
+
+async function hiveIn(t) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-runtime-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
+  return { home, hive, root: path.join(home, 'hive') };
+}
+
+test('bootstrap materializes a PATH-visible `node`', async (t) => {
+  const { hive, root } = await hiveIn(t);
+
+  const dir = hive.runtimeBinDir();
+  assert.equal(dir, path.join(root, 'bin', 'runtime'));
+  const shim = path.join(dir, POSIX ? 'node' : 'node.cmd');
+  assert.equal(fs.existsSync(shim), true, 'nothing resolves `node` here without it');
+
+  const body = fs.readFileSync(shim, 'utf8');
+  assert.match(body, /ELECTRON_RUN_AS_NODE=1/, 'without this the binary opens a second app window');
+  assert.ok(body.includes(process.execPath), 'execPath is re-baked each bootstrap so an app move/update heals');
+  if (POSIX) assert.ok(fs.statSync(shim).mode & 0o111, 'must be executable');
+});
+
+test('npm and npx are deliberately NOT shimmed', async (t) => {
+  const { hive } = await hiveIn(t);
+  // Electron bundles the Node runtime, not the npm CLI. A stub named `npm` would
+  // make `npm install` fail confusingly instead of being honestly absent — which
+  // is what the missing-CLI ladder (cli-install-ladder.test.cjs) detects.
+  const present = fs.readdirSync(hive.runtimeBinDir());
+  assert.deepEqual(present.filter((f) => /^(npm|npx)(\.cmd)?$/.test(f)), []);
+});
+
+test('the runtime dir is APPENDED — the user\'s own node still wins', async (t) => {
+  const { root } = await hiveIn(t);
+  const dir = path.join(root, 'bin', 'runtime');
+
+  const out = withHiveRuntimeFallback(`/usr/local/bin${SEP}/usr/bin`, root);
+  assert.equal(out, `/usr/local/bin${SEP}/usr/bin${SEP}${dir}`);
+  assert.ok(out.indexOf('/usr/local/bin') < out.indexOf(dir),
+    'prepending would silently swap the node version under the user\'s own projects');
+
+  assert.equal(withHiveRuntimeFallback(out, root), out, 'a respawn must not keep appending');
+});
+
+test('no hive root, or no runtime dir, leaves PATH exactly as it was', async (t) => {
+  const original = `/usr/local/bin${SEP}/usr/bin`;
+  assert.equal(withHiveRuntimeFallback(original, undefined), original, 'plain terminals are untouched');
+
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'md-runtime-none-'));
+  t.after(() => fs.rmSync(empty, { recursive: true, force: true }));
+  assert.equal(withHiveRuntimeFallback(original, empty), original,
+    'a pre-fix hive that never wrote the dir must degrade, not point PATH at nothing');
+});
+
+test('`node` resolves and RUNS with no node on PATH — the whole point', { skip: !POSIX }, async (t) => {
+  const { root } = await hiveIn(t);
+
+  const bare = { PATH: STRIPPED_PATH };
+  const probe = spawnSync('/bin/sh', ['-c', 'command -v node'], { env: bare, encoding: 'utf8' });
+  if (probe.status === 0) {
+    // An image with /usr/bin/node — the control is meaningless, but the fallback
+    // assertion below still must hold.
+    t.diagnostic(`node already on the stripped PATH at ${probe.stdout.trim()}`);
+  } else {
+    const before = spawnSync('/bin/sh', ['-c', 'node -e "process.exit(0)"'], { env: bare, encoding: 'utf8' });
+    assert.equal(before.status, 127, 'the bug: an agent-spawned `node` is not resolvable');
+  }
+
+  const env = { PATH: withHiveRuntimeFallback(STRIPPED_PATH, root) };
+  const after = spawnSync('/bin/sh', ['-c', 'node -p "1+1"'], { env, encoding: 'utf8' });
+  assert.equal(after.status, 0, `node still unresolvable: ${after.stderr}`);
+  assert.equal(after.stdout.trim(), '2', 'it must be a real Node, not just an executable file');
+});

--- a/test/node-install.test.cjs
+++ b/test/node-install.test.cjs
@@ -1,0 +1,235 @@
+/**
+ * The system-Node auto-installer.
+ *
+ * Founder decision (2026-08-07) reversed the earlier "never auto-install a system
+ * Node" rule: on a machine with no usable Node we install the REAL thing (latest
+ * LTS + the npm it ships with), and only then run `npm install -g <cli>`. These
+ * tests pin the parts that are dangerous to get wrong — we hand a script to a
+ * shell that will run an installer as root — without touching the network:
+ * `resolveNodeInstaller` takes an injectable fetch, and every other function is pure.
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+const load = require('./load-ts.cjs');
+
+const {
+  NODE_FLOOR_MAJOR, nodeMajor, nodeIsUsable, detectNodeVersion,
+  pickLatestLts, nodeArtifactFor, shaFor, distUrl,
+  resolveNodeInstaller, buildNodeInstallScript
+} = load('src/main/nodeInstall.ts');
+const { chooseInstallRung, buildMissingCliScript } = load('src/main/cliInstall.ts');
+
+const SHA = 'a'.repeat(64);
+const SHA2 = 'b'.repeat(64);
+
+/** The shape nodejs.org/dist/index.json actually returns: NEWEST FIRST, with the
+ *  odd/current release on top and `lts` being a codename or literal false. */
+const INDEX = [
+  { version: 'v26.7.0', lts: false, npm: '11.20.0' },
+  { version: 'v25.4.1', lts: false, npm: '11.18.0' },
+  { version: 'v24.19.0', lts: 'Krypton', npm: '11.17.0' },
+  { version: 'v22.20.0', lts: 'Jod', npm: '10.9.3' }
+];
+
+function fakeFetch(map) {
+  return async (url) => {
+    if (!(url in map)) return { ok: false, text: async () => '' };
+    return { ok: true, text: async () => map[url] };
+  };
+}
+
+const OK_FETCH = fakeFetch({
+  'https://nodejs.org/dist/index.json': JSON.stringify(INDEX),
+  'https://nodejs.org/dist/v24.19.0/SHASUMS256.txt':
+    `${SHA}  node-v24.19.0.pkg\n${SHA2}  node-v24.19.0-x64.msi\n${SHA}  node-v24.19.0-linux-x64.tar.xz\n`
+});
+
+// ── version gate ────────────────────────────────────────────────────────────
+
+test('a Node at or above the floor is left alone; below it is not', () => {
+  assert.equal(nodeMajor('v24.19.0'), 24);
+  assert.equal(nodeMajor('20.18.1'), 20);
+  assert.equal(nodeMajor('rubbish'), null);
+  assert.equal(nodeIsUsable(`v${NODE_FLOOR_MAJOR}.0.0`), true);
+  assert.equal(nodeIsUsable(`v${NODE_FLOOR_MAJOR - 1}.99.99`), false);
+  // Absent / unparseable must NOT read as usable — that is the whole gate.
+  assert.equal(nodeIsUsable(null), false);
+  assert.equal(nodeIsUsable(''), false);
+});
+
+test('detectNodeVersion returns null rather than guessing when the probe fails', () => {
+  assert.equal(detectNodeVersion('/usr/bin/node', () => 'v24.19.0\n'), 'v24.19.0');
+  assert.equal(detectNodeVersion(null, () => 'v24.19.0'), null);
+  assert.equal(detectNodeVersion('/usr/bin/node', () => { throw new Error('ENOENT'); }), null);
+  // Garbage on stdout is not a version. Treating it as one would skip the install.
+  assert.equal(detectNodeVersion('/usr/bin/node', () => 'command not found'), null);
+});
+
+// ── picking what to download ────────────────────────────────────────────────
+
+test('latest STABLE means newest LTS, never index[0] (the current/odd release)', () => {
+  assert.equal(pickLatestLts(INDEX).version, 'v24.19.0');
+  assert.notEqual(pickLatestLts(INDEX).version, INDEX[0].version);
+  assert.equal(pickLatestLts([{ version: 'v26.7.0', lts: false }]), null);
+});
+
+test('artifact names match what nodejs.org actually publishes', () => {
+  // macOS ships ONE universal .pkg — there is no -x64/-arm64 variant.
+  assert.deepEqual(nodeArtifactFor('v24.19.0', 'darwin', 'arm64'), { file: 'node-v24.19.0.pkg', kind: 'pkg' });
+  assert.deepEqual(nodeArtifactFor('v24.19.0', 'darwin', 'x64'), { file: 'node-v24.19.0.pkg', kind: 'pkg' });
+  assert.deepEqual(nodeArtifactFor('v24.19.0', 'win32', 'arm64'), { file: 'node-v24.19.0-arm64.msi', kind: 'msi' });
+  assert.deepEqual(nodeArtifactFor('v24.19.0', 'win32', 'x64'), { file: 'node-v24.19.0-x64.msi', kind: 'msi' });
+  assert.deepEqual(nodeArtifactFor('v24.19.0', 'linux', 'x64'), { file: 'node-v24.19.0-linux-x64.tar.xz', kind: 'tar' });
+  // Unsupported: no artifact rather than a URL that 404s mid-install.
+  assert.equal(nodeArtifactFor('v24.19.0', 'linux', 'mips'), null);
+  assert.equal(nodeArtifactFor('v24.19.0', 'aix', 'ppc64'), null);
+});
+
+test('shaFor matches the exact file, not a prefix of another entry', () => {
+  const body = `${SHA}  node-v24.19.0.pkg\n${SHA2}  node-v24.19.0-x64.msi\n`;
+  assert.equal(shaFor(body, 'node-v24.19.0.pkg'), SHA);
+  assert.equal(shaFor(body, 'node-v24.19.0-x64.msi'), SHA2);
+  assert.equal(shaFor(body, 'node-v24.19.0-arm64.msi'), null);
+  assert.equal(distUrl('v24.19.0', 'node-v24.19.0.pkg'), 'https://nodejs.org/dist/v24.19.0/node-v24.19.0.pkg');
+});
+
+test('resolveNodeInstaller returns the LTS artifact with its real digest', async () => {
+  const got = await resolveNodeInstaller('darwin', 'arm64', OK_FETCH);
+  assert.equal(got.version, 'v24.19.0');
+  assert.equal(got.npmVersion, '11.17.0');
+  assert.equal(got.file, 'node-v24.19.0.pkg');
+  assert.equal(got.url, 'https://nodejs.org/dist/v24.19.0/node-v24.19.0.pkg');
+  assert.equal(got.sha256, SHA);
+  assert.equal(got.kind, 'pkg');
+});
+
+test('resolveNodeInstaller refuses rather than running an unverified installer', async () => {
+  // Artifact published but absent from SHASUMS256 → no digest → no install.
+  assert.equal(await resolveNodeInstaller('win32', 'arm64', OK_FETCH), null);
+  // Offline / 5xx on either fetch.
+  assert.equal(await resolveNodeInstaller('darwin', 'arm64', fakeFetch({})), null);
+  assert.equal(await resolveNodeInstaller('darwin', 'arm64', async () => { throw new Error('ENETDOWN'); }), null);
+  // Unsupported platform never reaches the network at all.
+  assert.equal(await resolveNodeInstaller('sunos', 'x64', OK_FETCH), null);
+});
+
+// ── the script we hand to a root-capable shell ──────────────────────────────
+
+const INSTALLER = {
+  version: 'v24.19.0', npmVersion: '11.17.0', file: 'node-v24.19.0.pkg',
+  url: 'https://nodejs.org/dist/v24.19.0/node-v24.19.0.pkg', sha256: SHA, kind: 'pkg'
+};
+const WIN_INSTALLER = { ...INSTALLER, file: 'node-v24.19.0-x64.msi', kind: 'msi',
+  url: 'https://nodejs.org/dist/v24.19.0/node-v24.19.0-x64.msi' };
+
+test('every posix install script verifies the checksum BEFORE it elevates', () => {
+  for (const platform of ['darwin', 'linux']) {
+    const script = buildNodeInstallScript(
+      platform === 'darwin' ? INSTALLER : { ...INSTALLER, file: 'node-v24.19.0-linux-x64.tar.xz', kind: 'tar' },
+      platform
+    ).join('\n');
+    const verifyAt = script.indexOf(SHA);
+    const elevateAt = script.indexOf('sudo ');
+    assert.ok(verifyAt > -1, `${platform}: digest never checked`);
+    assert.ok(elevateAt > -1, `${platform}: never installs`);
+    assert.ok(verifyAt < elevateAt, `${platform}: elevates before verifying`);
+    // A mismatch must ABORT on its OWN line, not warn and carry on into sudo.
+    // (Asserted per-line: a regex spanning to some later `exit 1` passes even
+    // when the mismatch branch only prints — which is the bug that matters.)
+    const mismatch = script.split('\n').find((l) => l.includes('CHECKSUM MISMATCH'));
+    assert.ok(mismatch, `${platform}: no mismatch branch at all`);
+    assert.ok(/exit 1/.test(mismatch), `${platform}: mismatch warns but continues: ${mismatch}`);
+    assert.ok(script.indexOf('CHECKSUM MISMATCH') < elevateAt, `${platform}: mismatch checked after sudo`);
+    // The download must fail loudly too, on its own line.
+    const dl = script.split('\n').find((l) => l.includes('curl -fSL'));
+    assert.ok(dl && /exit 1/.test(dl), `${platform}: a failed download falls through: ${dl}`);
+  }
+});
+
+test('posix script uses the hashing tool that platform actually ships', () => {
+  const mac = buildNodeInstallScript(INSTALLER, 'darwin').join('\n');
+  const lin = buildNodeInstallScript({ ...INSTALLER, kind: 'tar' }, 'linux').join('\n');
+  assert.match(mac, /shasum -a 256 -c -/);
+  assert.ok(!/sha256sum/.test(mac), 'macOS does not ship sha256sum');
+  assert.match(lin, /sha256sum -c -/);
+  assert.ok(!/shasum -a 256/.test(lin), 'most linux images do not ship shasum');
+  assert.match(mac, /sudo installer -pkg/);
+  assert.match(lin, /sudo tar -xJf/);
+  // The running shell captured PATH before node existed — it must be re-pointed.
+  assert.match(mac, /PATH=\/usr\/local\/bin:\$PATH/);
+});
+
+test('the Windows install script survives cmd /d /s /c quoting', () => {
+  const parts = buildNodeInstallScript(WIN_INSTALLER, 'win32');
+  const line = parts.join(' & ');
+  // Wrapped verbatim in `cmd /d /s /c "<script>"` — one embedded quote truncates it.
+  assert.ok(!line.includes('"'), 'double quote would end the command line early');
+  assert.ok(!line.includes('\n'), 'must stay a single line');
+  // Literal ampersands inside a parenthesized block have to be escaped.
+  assert.ok(!/[^^]&(?!\s)/.test(line.replace(/ & /g, ' ')), 'unescaped & inside a block');
+  assert.match(line, /certutil -hashfile .* SHA256 \| findstr \/i \/c:a{64}/);
+  assert.match(line, /msiexec \/i .* \/passive \/norestart/);
+  assert.ok(line.indexOf(SHA) < line.indexOf('msiexec'), 'elevates before verifying');
+});
+
+// ── the ladder ──────────────────────────────────────────────────────────────
+
+test('a usable npm is untouched — no Node install is ever spliced in', () => {
+  for (const provider of ['claude', 'codex', 'opencode', 'copilot']) {
+    const rung = chooseInstallRung(
+      { command: 'npm install -g x', nativeCommand: 'curl x | bash', label: 'X' }, true, INSTALLER
+    );
+    assert.equal(rung.kind, 'npm');
+    assert.equal(rung.nodeMissing, false);
+    const s = buildMissingCliScript(provider, provider, true, 'darwin', INSTALLER);
+    assert.ok(!s.includes('nodejs.org'), `${provider}: offered a Node install to a machine that has one`);
+    assert.ok(!s.includes('sudo'), `${provider}: asked for a password it does not need`);
+  }
+});
+
+test('no usable npm + a resolvable installer → node-then-npm, ABOVE the native rung', () => {
+  // Claude Code is the only provider with a node-free native installer, so it is
+  // the one case where the two rungs compete. Founder ruled: fix the machine.
+  const info = { command: 'npm install -g @anthropic-ai/claude-code', nativeCommand: 'curl -fsSL https://claude.ai/install.sh | bash', label: 'Claude Code' };
+  const rung = chooseInstallRung(info, false, INSTALLER);
+  assert.equal(rung.kind, 'node-then-npm');
+  assert.equal(rung.command, info.command);
+  assert.equal(rung.nodeMissing, true);
+});
+
+test('node-then-npm installs Node first, then the CLI with it', () => {
+  const s = buildMissingCliScript('claude', 'claude', false, 'darwin', INSTALLER);
+  const nodeAt = s.indexOf('sudo installer -pkg');
+  const cliAt = s.lastIndexOf('npm install -g');
+  assert.ok(nodeAt > -1, 'no Node install');
+  assert.ok(cliAt > nodeAt, 'CLI install must come after Node lands');
+  assert.match(s, /Installing Node v24\.19\.0 \(\+ npm\) first/);
+  // The Node script exits non-zero on failure, so the npm line is unreachable
+  // unless Node actually installed — that is what makes the ordering safe.
+  const mismatch = s.split('\n').find((l) => l.includes('CHECKSUM MISMATCH'));
+  assert.ok(mismatch && /exit 1/.test(mismatch), `mismatch must abort before npm: ${mismatch}`);
+});
+
+test('no installer resolvable (offline/unsupported) falls back, never fabricates one', () => {
+  const info = { command: 'npm install -g @anthropic-ai/claude-code', nativeCommand: 'curl -fsSL https://claude.ai/install.sh | bash', label: 'Claude Code' };
+  assert.equal(chooseInstallRung(info, false, null).kind, 'native');
+  assert.equal(chooseInstallRung(info, false, undefined).kind, 'native');
+  // A provider with no native installer and no Node → manual hint, runs nothing.
+  const bare = { command: 'npm install -g @openai/codex', label: 'Codex' };
+  const manual = chooseInstallRung(bare, false, null);
+  assert.equal(manual.kind, 'manual');
+  assert.equal(manual.command, undefined);
+  const s = buildMissingCliScript('codex', 'codex', false, 'darwin', null);
+  for (const line of s.split('\n')) {
+    const t = line.trim();
+    if (t) assert.match(t, /^(echo |if |fi$|else$)/, `manual rung EXECUTED: ${t}`);
+  }
+});
+
+test('the Windows node-then-npm script is still one quote-free line', () => {
+  const s = buildMissingCliScript('claude', 'claude', false, 'win32', WIN_INSTALLER);
+  assert.ok(!s.includes('\n'), 'must stay a single line');
+  assert.ok(!s.includes('"'), 'double quote would end the command line early');
+  assert.ok(s.indexOf('msiexec') < s.lastIndexOf('npm install -g'), 'Node must land before the CLI install');
+  assert.match(s, /set PATH=%ProgramFiles%\\nodejs;%PATH%/);
+});

--- a/test/office-gl-recovery.test.cjs
+++ b/test/office-gl-recovery.test.cjs
@@ -1,0 +1,129 @@
+/**
+ * The blank-office bug.
+ *
+ * Chromium caps live WebGL contexts per renderer process (~16) and evicts the
+ * OLDEST when a new one pushes past the cap. The office floor's context is
+ * created at app startup, so it is always the oldest; every terminal xterm opens
+ * takes another one (@xterm/addon-webgl). On a busy floor the office is evicted,
+ * Pixi says nothing at all, and the canvas is blank until the app restarts.
+ *
+ * CONFIRMED against the shipped v0.3.5 build over CDP: creating 24 extra WebGL
+ * contexts produced "WARNING: Too many active WebGL contexts. Oldest context will
+ * be lost." and fired `webglcontextlost` on the office canvas, while the terminal
+ * logged its own graceful "[terminal] webgl context lost — falling back to DOM
+ * renderer". The office had no such fallback. These tests pin the one it has now.
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+const load = require('./load-ts.cjs');
+
+const {
+  installContextLossRecovery, DEFAULT_MAX_REBUILDS, DEFAULT_REBUILD_DELAY_MS
+} = load('src/renderer/src/scene/office/glRecovery.ts');
+
+/** A canvas stand-in: EventTarget is all the recovery code touches. */
+function fakeCanvas() { return new EventTarget(); }
+function lose(canvas) {
+  // cancelable so defaultPrevented actually reports whether preventDefault ran —
+  // that call is what allows the browser to hand the context back at all.
+  const e = new Event('webglcontextlost', { cancelable: true });
+  canvas.dispatchEvent(e);
+  return e;
+}
+/** Collect scheduled callbacks instead of waiting on real timers. */
+function fakeClock() {
+  const queue = [];
+  return {
+    schedule: (fn, ms) => { queue.push({ fn, ms }); return queue.length; },
+    runAll: () => { const q = queue.splice(0); q.forEach((j) => j.fn()); return q; },
+    get pending() { return queue.length; },
+    get delays() { return queue.map((j) => j.ms); }
+  };
+}
+
+test('a lost context rebuilds the scene instead of leaving it blank', () => {
+  const canvas = fakeCanvas();
+  const clock = fakeClock();
+  let rebuilds = 0;
+  installContextLossRecovery(canvas, { onRebuild: () => rebuilds++, schedule: clock.schedule, log: () => {} });
+
+  lose(canvas);
+  assert.equal(rebuilds, 0, 'rebuild must be deferred, not immediate');
+  assert.equal(clock.pending, 1);
+  clock.runAll();
+  assert.equal(rebuilds, 1, 'the scene never came back');
+});
+
+test('preventDefault is called — without it the context is gone for good', () => {
+  const canvas = fakeCanvas();
+  installContextLossRecovery(canvas, { onRebuild: () => {}, schedule: () => {}, log: () => {} });
+  assert.equal(lose(canvas).defaultPrevented, true);
+});
+
+test('the rebuild is delayed so it does not race the eviction storm', () => {
+  const canvas = fakeCanvas();
+  const clock = fakeClock();
+  installContextLossRecovery(canvas, { onRebuild: () => {}, schedule: clock.schedule, log: () => {} });
+  lose(canvas);
+  // Several contexts are usually created at once; claiming one straight back
+  // just loses it again to the next terminal in the same burst.
+  assert.ok(clock.delays[0] >= 500, `rebuild delay too short: ${clock.delays[0]}`);
+  assert.equal(clock.delays[0], DEFAULT_REBUILD_DELAY_MS);
+});
+
+test('retries are capped, then it gives up LOUDLY rather than staying blank', () => {
+  const canvas = fakeCanvas();
+  const clock = fakeClock();
+  let rebuilds = 0, gaveUp = 0;
+  const logs = [];
+  installContextLossRecovery(canvas, {
+    onRebuild: () => rebuilds++, onGiveUp: () => gaveUp++,
+    schedule: clock.schedule, log: (m) => logs.push(m)
+  });
+
+  for (let i = 0; i < DEFAULT_MAX_REBUILDS; i++) { lose(canvas); clock.runAll(); }
+  assert.equal(rebuilds, DEFAULT_MAX_REBUILDS);
+  assert.equal(gaveUp, 0, 'gave up while it still had budget');
+
+  lose(canvas);
+  clock.runAll();
+  assert.equal(gaveUp, 1, 'a silently blank canvas is the bug — it must surface');
+  assert.equal(rebuilds, DEFAULT_MAX_REBUILDS, 'kept rebuilding past the cap');
+
+  // And it stays given-up: no infinite fight for a context we cannot keep.
+  lose(canvas); clock.runAll();
+  assert.equal(gaveUp, 1);
+  assert.equal(rebuilds, DEFAULT_MAX_REBUILDS);
+  assert.ok(logs.some((m) => /giving up/i.test(m)), 'nothing explains the blank floor');
+});
+
+test('uninstalling stops recovery — a torn-down scene must not resurrect itself', () => {
+  const canvas = fakeCanvas();
+  const clock = fakeClock();
+  let rebuilds = 0;
+  const off = installContextLossRecovery(canvas, { onRebuild: () => rebuilds++, schedule: clock.schedule, log: () => {} });
+
+  // Loss already in flight when the component unmounts: the queued rebuild must
+  // not fire against a destroyed Pixi app.
+  lose(canvas);
+  off();
+  clock.runAll();
+  assert.equal(rebuilds, 0, 'rebuilt after teardown');
+
+  lose(canvas);
+  assert.equal(clock.pending, 0, 'still listening after uninstall');
+});
+
+test('recovery survives repeated losses across rebuilds, one budget per install', () => {
+  const canvas = fakeCanvas();
+  const clock = fakeClock();
+  let rebuilds = 0;
+  installContextLossRecovery(canvas, { onRebuild: () => rebuilds++, schedule: clock.schedule, log: () => {}, maxRebuilds: 1 });
+  lose(canvas); clock.runAll();
+  assert.equal(rebuilds, 1);
+  // A fresh install (what the next mount does) gets its own budget.
+  const canvas2 = fakeCanvas();
+  installContextLossRecovery(canvas2, { onRebuild: () => rebuilds++, schedule: clock.schedule, log: () => {}, maxRebuilds: 1 });
+  lose(canvas2); clock.runAll();
+  assert.equal(rebuilds, 2);
+});


### PR DESCRIPTION
## Release v0.3.6

Founder-greenlit. Packs the stability/runtime/UX fixes completed since v0.3.5. **Scope-guaranteed:** only `src/**`, `test/**`, `package.json`, `CHANGELOG.md`, `RELEASE.md` — nothing from any other in-flight work.

### What's in it (7 commits, 2 fix branches merged)
- **`913b8ad`** — expand `~` at ingestion so adding a project with a `~/…` path works; run every hook shim under the bundled Node (fixes the exit-127 hook failures across all providers).
- **`7384906`** — push a live roster into god's context on SessionStart + every prompt (fixes restart staleness).
- **`85946c2`** — tests locking in the cwd/tilde, bundled-node hook, and roster-injection fixes.
- **`60ecca0`** — put the bundled Node on the agent PATH; stop offering an installer that cannot run.
- **`0b95976`** — install a real system Node + npm when the machine has none (latest LTS, checksum-verified against nodejs.org SHASUMS256, admin password entered by the user in the same PTY).
- **`71324c6`** — recover the office floor when Chromium evicts its WebGL context (was a permanent blank floor; now rebuilds, capped at 3 attempts).

### Verification
- 92/92 focused tests, typecheck clean (node + web), build green — verified on the branch.
- Behavioural claims mutation-verified.
- Version bumped 0.3.5 → 0.3.6; `CHANGELOG.md` + `RELEASE.md` updated (release.yml uses `RELEASE.md` verbatim as the GitHub release body).

### Known risk (founder-accepted)
`0b95976`'s system-Node install path (download → checksum → `sudo installer` / `msiexec`) is exercised only by offline unit tests — it has never actually installed Node on a real machine, and the Windows path has never touched real Windows. The founder accepted this risk explicitly ("it looks stable enough"). First place to look if we get install-related reports post-release.

### Release mechanics (verified)
- APPLE_* signing/notarization secrets confirmed present in the repo → the tagged build will be signed + notarized + stapled, so v0.3.5 users auto-update.
- Merges cleanly to `main` (fast-forwardable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
