### PR TITLE
release(v0.3.7): auto-update actually works + trimmed site, README, and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] — 2026-08-08
+
+**Auto-update, fixed.**
+It never ran. Not once, in any packaged build, since it shipped in v0.3.4 — and the app had no
+way to tell you so.
+
+### Fixed
+- **The native updater actually runs.** `electron-updater` is CommonJS and exposes `autoUpdater`
+  through a lazy `Object.defineProperty` getter, which Node's `cjs-module-lexer` cannot see. So
+  `await import('electron-updater')` produced a namespace with no `autoUpdater` export — only
+  `.default.autoUpdater` — and destructuring it yielded `undefined`. The first line of setup threw
+  `TypeError: Cannot set properties of undefined (setting 'autoDownload')` into a `catch` that
+  silently latched notify-only mode for the whole session. Every packaged build from v0.3.4 to
+  v0.3.6 could therefore only ever offer "open the releases page". Invisible in development,
+  because the whole path sits behind `app.isPackaged`.
+- **Updater failures are no longer swallowed.** Every error is emitted to the renderer *and*
+  appended to `updater.log` in the app's data folder. The old `catch` discarded the message, which
+  is precisely why the bug above survived three releases.
+- **A single blip no longer disables updates for the session.** The notify-only downgrade is
+  per-check now, not a permanent latch, and a re-check can never clobber an already-staged update.
+
+### Added
+- **The toolbar version is an update control.** Next to the logo it shows `checking…`,
+  `vX.Y.Z ready to install` (click to download), live download progress, and **restart to update**
+  (click to apply). With nothing pending, a click runs a manual check — the app previously only
+  checked 30 seconds after launch and then every six hours, with no way to ask.
+- **`update-available` and `download-progress` are surfaced**, so a multi-minute download is
+  visible instead of looking like nothing happened. New `update:download` and `update:current` IPC:
+  one-click download, and a reloaded window pulls the current state instead of waiting for the next
+  tick.
+- **9 tests** over the update state model (`src/shared/updateState.ts`), covering the rule that bit
+  here — a re-check must never wipe a staged "restart to update" — and that the underlying error
+  reaches the UI.
+
+### Changed
+- **Website, README and release notes trimmed.** The landing page drops the demo-video section and
+  dark mode; the README's 48-row feature table becomes a scannable grouped list; `RELEASE.md` leads
+  with the current release instead of stacking every prior one in full.
+
+> **Upgrading from v0.3.5 or v0.3.6?** Those builds carry the broken updater and cannot fetch this
+> fix themselves — install v0.3.7 manually once. From v0.3.7 onward, updates arrive on their own.
+
 ## [0.3.6] — 2026-08-08
 
 **A machine with nothing installed on it can now run agents.**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ you talk to, and visualized as avatars at work on a shared office floor.
 
 <p>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
-  <a href="./CHANGELOG.md"><img alt="Version: 0.3.3" src="https://img.shields.io/badge/version-0.3.3-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
+  <a href="./CHANGELOG.md"><img alt="Version: 0.3.7" src="https://img.shields.io/badge/version-0.3.7-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
   <img alt="Status: prototype" src="https://img.shields.io/badge/status-working%20prototype-F4F1EA.svg?style=flat-square&labelColor=6E1423">
   <img alt="Platform: macOS | Windows | Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-F4F1EA.svg?style=flat-square&labelColor=6E1423">
   <a href="./CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
@@ -109,59 +109,40 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
 
 ## Features
 
-| Area | What works today |
-|---|---|
-| **Real terminals** | Spawn Claude Code, Antigravity (`agy` / Gemini), OpenAI Codex (GPT), xAI Grok, Kimi Code, or a custom command in a `node-pty` PTY. Full read/write/resize/kill, live streaming over IPC, multi-agent. |
-| **Built-in Monaco IDE** | A per-agent **IDE** button opens a full-window Monaco editor (self-hosted — no CDN): **CHANGES · HISTORY · COMPARE** git rails *(v0.3.4)* — clickable commit graph, per-commit diffs, branch compare with ahead/behind, guarded checkout — plus the workspace file tree, editor tabs, and **Cmd/Ctrl+S** save. All fs/git access is brokered through the main process. |
-| **Markdown previews** *(new in v0.3.4)* | Markdown files render beautifully: a **code / split / preview** switch in the IDE with live re-render, and **⌘-click any `.md` path in an agent's terminal** for an instant preview overlay. Safe by construction for agent-generated files (no raw-HTML pipeline). |
-| **Voice orchestration with live context** *(v0.3.4)* | Talk to Michael and he *knows the floor*: a per-agent snapshot at connect plus silent live updates mid-call. He can act on nearly everything — resume/pause agents, delivery, tool gates, tasks, schedules, context clears, allowlisted settings — with destructive actions gated behind spoken confirmation. |
-| **Multi-provider hive** | Claude Code, Antigravity, Codex, and Grok workers can all participate in the same hive. Claude uses native hooks; Antigravity gets a native `agy-hook` bridge; Grok gets an AGENT_ID-scoped lifecycle-hook adapter; Codex receives the protocol as its initial prompt and participates through inbox/outbox routing. |
-| **The hive** | On-disk multi-agent layer: per-agent identity + long-term memory, atomic-file mailboxes, a shared blackboard, append-only event log, single-committer git. |
-| **GOD orchestrator** | An always-on supervisor agent that adjudicates traffic, routes tasks, scribes the blackboard, and escalates only critical items to you. |
-| **Memory layer** | Markdown-first long-term memory per agent, mined into a shared semantic palace for instant recall; searchable from the UI. Degrades gracefully when the index isn't installed. |
-| **Office floor** | Pixi.js scene with a Tiled office map, camera, recolored cast, pathfinding, seat assignment, and tool-bubble overlays. |
-| **Message handoffs** | When the hive routes a message, an envelope flies from sender to recipient (tinted by speech-act; escalations fly to the door) and pops an arrival sparkle. |
-| **Per-agent panel** | Live terminal, command bar to type back, fullscreen terminal, sandboxed file browser + CodeMirror editor, and a git tab (status, log, commit graph, branches). |
-| **Approvals & memory panels** | Human-in-the-loop approval queue for escalations; a memory search panel over the shared palace. |
-| **Onboarding wizard** | First-run setup: harness home, registered repos, default command, auto-mode. |
-| **Design system** | Fully tokenized SNES / Animal-Crossing aesthetic — pixel panels, buttons, badges, hand-drawn icons. See [`DESIGN.md`](./DESIGN.md). |
-| **Command Center** | Michael's control surface: Terminal, Floor (roster + dispatch + per-agent model selector + live fleet monitoring), Memory (MemPalace + text search + memory graph), Activity (log + board + real token telemetry + observability + CI watcher), Tasks (kanban board with dependencies + status tracking), and a dedicated Schedules tab (recurring missions + adaptive heartbeat). |
-| **Talk to Michael (Realtime Michael)** | A low-latency **voice channel to the GOD orchestrator** (OpenAI Realtime API over WebRTC), alongside the async terminal. Press **Talk** and Michael listens, answers, and *acts* in real time — reads the hive and, behind spoken **echo-back confirmation** for destructive verbs, creates/assigns tasks, dispatches, spawns/kills workers, and steers the floor (attributed to a distinct **michael-voice** actor). He greets you on connect, **speaks task completions the moment they land** ("respond when done"), and runs under a live cost meter with a hard spend cap + idle auto-disconnect. **BYOK OpenAI key** — decrypted main-only, minted into short-lived ephemeral session tokens, never read back to the renderer. |
-| **Per-agent git worktrees** | 'Git isolation' toggle in Add Agent auto-provisions a dedicated worktree per agent on spawn and tears it down on kill — agents never collide on branches. |
-| **Token & cost telemetry** | Activity tab reads `~/.claude/projects/` JSONL transcripts and surfaces real token counts + estimated USD cost per agent per session, backed by a durable cost ledger that survives restarts. |
-| **Per-agent token budgets** | Set a token budget per agent and watch live fleet monitoring track consumption across the whole roster — paired with the cost/runaway circuit breaker to keep spend in check. |
-| **Observability** | Live OpenTelemetry collector with per-model cost attribution, a fleet grid, and a per-agent tool-span waterfall — see exactly what every agent is doing and what it costs, in real time. |
-| **Context-window gauge** | Each agent card's progress bar is a context-window gauge — see how much of the model's context each agent has consumed at a glance. |
-| **Circuit breaker** | A cost/runaway guard with a steer → constrain → stop ladder: the breaker nudges, then constrains, then stops agents that loop, storm errors, or blow their budget. |
-| **HITL gate & mid-run control** | Human-in-the-loop gate, mid-run steer, and graceful stop — all driven through Claude Code hook returns, so you can intervene without killing the session. |
-| **Durable persistence** | SQLite-backed durable store keeps window bounds + history across restarts, alongside the durable cost ledger and persisted session IDs. |
-| **MemoryReflector** | Memory condensation that summarizes and bounds per-agent memory over time, so long-term memory doesn't grow without limit. |
-| **Configurable home folder** | Point the hive/memory home at any folder, with a safe move that relocates existing state without losing it. |
-| **Restore team** | One-click "Restore team" rebuilds last session's workers after a harness restart — no more re-adding agents by hand. |
-| **Selectable agent engines** | Each agent — and Michael himself — runs on a pluggable engine: Claude Code, Antigravity, OpenAI Codex, **OpenCode**, **Crush**, **pi.dev**, **GitHub Copilot CLI** (new in v0.3.3 — community-contributed, print-mode `copilot -p` with model picker and `--resume`), or a local provider (a claw/qwen backend proxy). Choose the engine per hire from a visual provider/hive picker; the orchestrator's own engine is swappable from onboarding or a change-engine flow. BYOK keys + local-LLM endpoints for the CLI engines live in **Settings → AI Engines**. |
-| **BYOK keys + local LLMs** | **Settings → AI Engines** collects per-provider API keys (Anthropic / OpenAI / Google / OpenRouter / Groq) stored **write-only** in the encrypted secret broker — never read back into the renderer, materialized main-only at spawn — plus per-engine **local base-URLs** (Ollama / LM Studio / vLLM) and default-model fields. The OpenCode / Crush / pi.dev engines pick these up at spawn. |
-| **OSS-model quick-picks** | Hiring a worker on a local-capable engine (OpenCode / Crush / pi.dev) surfaces curated open-source model quick-picks — a **Local** bucket (Mac-runnable Ollama tags: gpt-oss 20B/120B, Qwen3, DeepSeek-R1, Mistral Small, Llama 3.3 70B …) and a **third-party OSS provider** bucket (BYOK via Groq / OpenRouter) — that fill the engine-correct slug (`local/<tag>` for OpenCode, `ollama/<tag>` for Crush/pi) and rebuild the spawn command. Two how-to guides — [run on open models](https://munderdiffl.in/blog/run-munder-difflin-on-open-models/) and [run on a Mac Mini](https://munderdiffl.in/blog/run-munder-difflin-on-a-mac-mini/) — are linked inline. |
-| **Provider-agnostic idle backstop** | A PTY-quiescence fallback flips any silent-but-pinned-`working` agent back to *idle*, so the idle inbox-wake nudge always drains a non-Claude orchestrator even if a bridge's turn-end signal (`Stop` / `session.idle` / `agent_end`) never fires — the safety net under shipping every new engine as god-eligible. |
-| **Self-healing engine install** | When a chosen engine's CLI binary is missing, the harness runs its installer in the terminal, then **auto restart-and-continues** into the freshly-installed binary in place — no dead-end, no manual click, idempotent so the installer never fires twice. |
-| **Per-hire skills + MCP catalog** | Every hire carries a manifest of allowed skills + MCP servers (default-deny over a shared catalog). Bundled skills ship with the app, and a consent UI surfaces every skill/MCP a hire wants before it can use it — untrusted hire input is reviewed, never auto-granted. |
-| **Integrations registry + secret broker** | A declarative integrations registry with a registry-driven Settings UI and a loopback secret broker: secrets are write-only (set once, never read back into the renderer) and reached only through the broker. Ships with a first wave of declarative templates. |
-| **Slack-spawned ephemeral workers** | Michael can spawn an isolated worker straight from a Slack request, have it post its reply back into the thread, then tear it down safely — with worktree GC, per-worker token caps, and a teardown gate that never auto-discards unintegrated work. Live workers appear in a dedicated Workers tab. |
-| **Temporal date-range skills** | A family of date-range skills (today / yesterday / thisWeek / lastWeek / thisMonth / thisQuarter / thisYear / lastMonth / last7Days / last30Days … plus an arbitrary-range resolver) turns a named window into concrete ISO dates, with a worker capability catalog so each spawned worker knows exactly what tools/integrations it has. |
-| **Shareable hires + the Agent Gallery** | Import a ready-made agent role — provider, model, flags, goal, capabilities, token budget — from a `munderdifflin://hire` deep link or a local manifest file. Import only *pre-fills* the Add-Agent modal (behind an "imported" banner); spawning stays a human click. The manifest is validated as untrusted input (no executable field, a default-deny flag allowlist, an https-only bounded fetch). Browse ready-made roles, including six off-the-shelf hires, at the [Agent Gallery](https://munderdiffl.in/hires/). |
-| **Task kanban** | Dependency-aware kanban board in the Command Center Tasks tab — assign tasks to agents, track status across todo/doing/blocked/done, wire dependencies so work starts in order. |
-| **Scheduled missions & heartbeat** | Recurring auto-dispatch missions with label, interval, target agent, and body — plus a scheduler heartbeat that re-engages the floor when it goes quiet. Missions now live in their own Schedules tab with last/next-fired times. |
-| **Terminal work-order handoff** | Providers without an inbox-drain hook receive hive mail as a `WORK ORDER FROM HIVE` typed into their terminal; if the renderer is unavailable, the message bounces to the GOD agent instead of disappearing. |
-| **Message queue that respects your prompt** | Park messages for a busy agent; one drain loop delivers them the moment it goes idle. Every automatic writer — queued messages, inbox wake-ups, scheduled `/compact` — goes through that one gate, so nothing ever lands on top of a line you're mid-way through writing. Unsent text of yours badges the agent **"your draft"** so a held queue never looks like an idle agent. See [`docs/message-queue.md`](./docs/message-queue.md). |
-| **Slack/webhook ingress** | Slack and generic webhook ingress expose local endpoints through tunnelmole, so POSTs pass straight through and failed tunnels surface a real error instead of a silent broken URL. |
-| **GitHub ingestion** | Pull open issues from any registered repo via the `gh` CLI and assign them to agents with one click from the Command Center. |
-| **CI status watcher** | Live pass/fail/in-progress status for GitHub Actions runs, visible in the Activity tab for every registered repo. |
-| **Threaded chat** | Every hive message is grouped by conversation and rendered as a reply chain in each agent's Messages tab — readable, replyable, auditable. |
-| **Desktop notifications** | Native OS notifications when an agent finishes a task or is waiting for your input. |
-| **Agent archival** | Closing an agent tab archives it (memory + history preserved) rather than destroying it. |
-| **Avatar states** | Avatars reflect real work — including new v0.2.0 states for *compacting* (context compaction) and *looping* (circuit-breaker intervention), on top of crisper HiDPI floor text and high-contrast speech bubbles. |
+**The floor**
+- **Every terminal is a real agent.** Claude Code, Antigravity (Gemini), OpenAI Codex, xAI Grok, Kimi Code, OpenCode, Crush, pi.dev, GitHub Copilot CLI, or a custom command — each in its own `node-pty` PTY, rendered with xterm.js.
+- **Every agent is an avatar.** A Pixi.js office floor where agents walk to stations, envelopes fly desk to desk, and avatar state reflects real work.
+- **A GOD orchestrator you talk to.** It routes tasks, adjudicates traffic, and escalates only what needs a human. Or press **Talk** and run the floor by voice.
+- **Per-agent git worktrees.** Optional isolation so parallel agents never collide on branches.
+
+**Memory & coordination**
+- **The hive** — per-agent memory, atomic-file mailboxes, a shared blackboard, an append-only event log, single-committer git.
+- **Semantic recall** — markdown memory mined into a shared palace, searchable from the UI, with condensation so it doesn't grow forever.
+- **Enterprise Knowledge Graph** — your own documents and policies, queryable by any agent.
+
+**Control & safety**
+- **Human gates** — spend, scope, and destructive ops escalate to you. Steer mid-run or stop gracefully.
+- **Circuit breaker** — a steer → constrain → stop ladder for agents that loop, storm errors, or blow their budget.
+- **Budgets & telemetry** — per-agent token budgets, real cost from transcripts, a durable ledger, OTel spans, and a tool waterfall.
+
+**Command Center**
+- Kanban tasks with dependencies, scheduled missions + heartbeat, live fleet monitoring, memory search, activity log, and a CI watcher.
+- **Built-in Monaco IDE** — file tree, editor tabs, save, plus CHANGES · HISTORY · COMPARE git rails with commit graph, diffs, branch compare, and guarded checkout. All fs/git access brokered through main.
+
+**Getting work in and out**
+- **Slack & webhooks** — message a channel or POST a webhook; Michael can spawn an ephemeral worker, reply in-thread, and tear it down.
+- **Shareable hires + Agent Gallery** — import a role from a `munderdifflin://hire` link; import only pre-fills the form, a human still spawns it. Browse roles at the [Agent Gallery](https://munderdiffl.in/hires/).
+- **BYOK keys + local LLMs** — per-provider keys in a write-only secret broker, plus Ollama / LM Studio / vLLM base URLs. Guides: [open models](https://munderdiffl.in/blog/run-munder-difflin-on-open-models/) · [Mac Mini](https://munderdiffl.in/blog/run-munder-difflin-on-a-mac-mini/).
+- **Auto-update** — new releases download in the background; you click restart.
 
 > [!NOTE]
-> **Status: v0.3.3 — a built-in Monaco IDE + GitHub Copilot CLI.** Two headliners. **A real IDE on the floor**: a title-bar **IDE** button opens a full-window **Monaco** editor (the VS&nbsp;Code editor engine, fully self-hosted — no CDN) over the office — a **git CHANGES rail with side-by-side diffs vs HEAD** for reviewing exactly what your agents changed, a workspace **file tree**, **editor tabs** with dirty-state tracking and **Cmd/Ctrl+S** save (hardened against losing keystrokes typed during an in-flight save), with **all fs/git access brokered through the main process** — the renderer touches no disk. And **GitHub Copilot CLI joins the engine roster** (the **first community-contributed provider**, [PR #101](https://github.com/chaitanyagiri/munder-difflin/pull/101) by [@anxkhn](https://github.com/anxkhn)): hire a Copilot-powered worker in its documented non-interactive print mode (`copilot -p` with `-s --allow-all-tools --no-ask-user` gated by the floor auto-mode toggle), a **model picker** (Claude Sonnet 4.5 default · GPT-5.4 · auto), `--resume` session continuity, and the official npm installer offered when the CLI is missing — authenticated by your **existing GitHub Copilot login**, no new keys. (Honest caveat: print mode exits per turn and has no hook bridge, so routed inbox mail bounces to the GOD orchestrator rather than draining — Copilot workers shine on dispatched, self-contained tasks.) Built on **v0.3.2 — Talk to Michael (Realtime Michael)**: a **low-latency voice channel to the GOD orchestrator** over the OpenAI Realtime API (WebRTC) — he reads the hive and, behind spoken **echo-back confirmation**, dispatches, spawns, kills, and steers, speaks completions the moment they land, under a live cost meter with spend cap and idle auto-disconnect (BYOK OpenAI key, minted main-only into ephemeral tokens). Built on **v0.3.1** (three more engines — **OpenCode · Crush · pi.dev** — each a worker *and* Michael, with **BYOK keys + local LLMs**) and **v0.3.0**'s platform release — **selectable agent engines**, an **integrations registry + loopback secret broker**, **Slack-spawned ephemeral workers**, **temporal date-range skills**, and the **Agent Gallery**. Everything from **v0.2.0–v0.3.2** — shareable hires, Free Flow voice dictation, the enterprise Knowledge Graph, multi-window "floors", the rich composer, agent session resume, observability, the circuit breaker, durable persistence, Command Center, task kanban, GitHub/CI integration, and the Schedules tab — remains functional and shipping. macOS (signed), Windows, and Linux builds are available on the releases page.
+> **Status: v0.3.7 — auto-update, fixed.** A CommonJS/ESM import bug meant the native updater
+> silently never ran in any packaged build from v0.3.4 on, so the app could only ever offer a link
+> to the releases page. It now works, the toolbar version doubles as the update button, and update
+> errors reach the UI and a log file instead of being swallowed. **Existing v0.3.5 / v0.3.6 installs
+> carry the broken updater and must install v0.3.7 manually, once** — after that, updates are automatic.
+> macOS (signed & notarized), Windows, and Linux builds are on the
+> [releases page](https://github.com/chaitanyagiri/munder-difflin/releases/latest).
 
 <div align="right">(<a href="#munder-difflin">↑ back to top</a>)</div>
 
@@ -175,20 +156,13 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
   ```bash
   xcode-select --install
   ```
-- At least one supported terminal-agent CLI on your `PATH`: **[Claude Code](https://claude.com/claude-code)**
-  (`claude`, the default command), **Antigravity** (`agy`, Gemini), **OpenAI Codex** (`codex`),
-  **xAI Grok** (`grok`), **Kimi Code** (`kimi`), **OpenCode** (`opencode`), **Crush** (`crush`), or
-  **pi.dev** (`pi`). Claude uses native hooks, Antigravity uses the `agy-hook` bridge, Grok uses an
-  AGENT_ID-scoped lifecycle-hook adapter, Codex participates through initial-prompt protocol injection
-  plus inbox/outbox routing, and OpenCode / Crush / pi.dev wire in via a native-plugin / proxy / hooks
-  bridge respectively. A missing engine CLI self-heals — the harness runs the installer in the
-  terminal, then auto restart-and-continues into the freshly-installed binary.
-- *Optional:* **bring-your-own API keys + local LLMs.** For the CLI engines, set per-provider keys and
-  local base-URLs (Ollama / LM Studio / vLLM) in **Settings → AI Engines**; see the guides on
-  [running on open models](https://munderdiffl.in/blog/run-munder-difflin-on-open-models/) and
-  [running on a Mac Mini](https://munderdiffl.in/blog/run-munder-difflin-on-a-mac-mini/).
-- *Optional:* the semantic memory index for instant cross-session recall (the app works without it —
-  markdown memory still functions).
+- At least one supported agent CLI on your `PATH` — **[Claude Code](https://claude.com/claude-code)**
+  (`claude`, the default), **Antigravity** (`agy`), **OpenAI Codex** (`codex`), **xAI Grok** (`grok`),
+  **Kimi Code** (`kimi`), **OpenCode** (`opencode`), **Crush** (`crush`), **pi.dev** (`pi`), or
+  **GitHub Copilot** (`copilot`). Most missing CLIs self-heal: the harness runs the installer in the
+  terminal and continues into the new binary.
+- *Optional:* **your own API keys and local LLMs** in **Settings → AI Engines** (Ollama / LM Studio / vLLM).
+- *Optional:* the semantic memory index for instant cross-session recall — markdown memory works without it.
 
 ### Install & run
 
@@ -299,39 +273,19 @@ chrome. The 15 avatars are the cast of *The Office*, differentiated by hair/skin
 
 ## Roadmap
 
-Shipped in **v0.2.0–v0.3.2**:
-
-- [x] **Talk to Michael — Realtime Michael (v0.3.2)** — a low-latency **voice channel to the GOD orchestrator** (OpenAI Realtime API over WebRTC) next to the async terminal. Michael listens, answers, and *acts* in real time — reading the hive and, behind spoken **echo-back confirmation** for destructive verbs, creating/assigning tasks, dispatching, spawning/killing workers, and steering the floor as a distinct **michael-voice** actor. Greets you on connect, **speaks completions** the moment they land ("respond when done"), and runs under a **live cost meter + spend cap + idle auto-disconnect**. **BYOK OpenAI key** — decrypted main-only, minted into short-lived ephemeral tokens, never read back to the renderer (requires Realtime API access; human-verified end-to-end). Plus **Slack hardening** (proactive posting off by default, no sends without an explicit thread), a dedicated **auto-compact maintenance schedule**, and **per-agent environment metadata**.
-- [x] **Three more engines — OpenCode · Crush · pi.dev (v0.3.1)** — each selectable as a worker *and* as Michael, via a native-plugin / proxy / hooks bridge, with **BYOK keys + local LLMs** in **Settings → AI Engines**, **OSS-model quick-picks** in Add-Agent, a **self-healing engine installer**, and a **provider-agnostic idle backstop**. Two local-setup guides: [run on open models](https://munderdiffl.in/blog/run-munder-difflin-on-open-models/) · [run on a Mac Mini](https://munderdiffl.in/blog/run-munder-difflin-on-a-mac-mini/). *(Live runtime verification with real model calls is an on-device check pending BYOK keys / a local LLM.)*
-- [x] **Selectable agent engines + per-hire capabilities** — a pluggable engine per hire (Claude Code / Antigravity / Codex / local provider) and a swappable Michael engine, each with its own consented skills + MCP catalog.
-- [x] **Integrations registry + loopback secret broker** — write-only secrets, a registry-driven Settings UI, and a first wave of declarative templates.
-- [x] **Slack-spawned ephemeral workers** — Michael spawns an isolated worker from a Slack request, replies in-thread, then tears it down safely (worktree GC + per-worker token caps), surfaced in a Workers tab.
-- [x] **Temporal date-range skills + worker capability catalog** — named windows resolve to concrete ISO dates, and each worker can read exactly what tools/integrations it has.
-- [x] **Agent Gallery + six off-the-shelf hires** — *The Hiring Fair* rebranded, with a visual Provider/Hive picker in onboarding and add-agent and feature-aware onboarding.
-- [x] **Wake-reliability hardening** — auto-revive wedged terminals, catch up missed schedules, and re-arm the hive message router (draining any mail that piled up) when the machine wakes.
-- [x] **Shareable hires** — import a role-configured agent from a `munderdifflin://hire` deep link or a local manifest; import pre-fills the Add-Agent modal (the human spawns), and the manifest is validated as untrusted input. Ready-made roles live in the [Agent Gallery](https://munderdiffl.in/hires/).
-
-- [x] **Heartbeat** — scheduler heartbeat that re-engages the floor when it goes quiet, with last/next-fired times surfaced in the Schedules tab.
-- [x] **Memory reflection** — the MemoryReflector summarizes and bounds per-agent memory over time to prevent unbounded growth.
-- [x] **Persistence** — SQLite-backed durable store for window bounds + history across restarts, plus a durable cost ledger and persisted session IDs.
-- [x] **Hook-driven avatars** — broadened hook→station coverage and caged the synthetic demo loop, with new *compacting* and *looping* avatar states.
-- [x] **Multi-provider floor** — Claude Code, Antigravity (`agy` / Gemini), OpenAI Codex, and xAI Grok can participate in the same hive through native or provider-specific lifecycle-hook bridges.
-- [x] **Dedicated Schedules tab** — recurring missions and the adaptive heartbeat have their own Command Center tab.
-- [x] **Tunnelmole ingress** — Slack and generic webhook public URLs use tunnelmole instead of localtunnel.
-- [x] **Voice dictation (Free Flow)** — hold Option to talk; Groq Whisper transcribes speech straight into the message composer (gated on a Groq key, encrypted at rest).
-- [x] **Enterprise Knowledge Graph** — a multimodal store of your own documents/policies/context, with a CLI agents query for ranked passages and full documents.
-- [x] **Multi-window "floors"** — isolated office windows, each with its own set of agents and per-PTY routing.
-- [x] **Rich message composer** — file & image attachments (files button or paste-to-attach) as removable chips above a taller, resizable input.
-- [x] **Session resume** — agents reattach their prior conversation across an app restart, with a per-agent *Restart & Continue* button; restored workers re-enter their existing worktree.
-- [x] **Terminal file-drop** — drag a file onto an agent's terminal to inject its absolute, shell-escaped path into the session.
+Shipped through **v0.3.7** — nine agent engines with BYOK keys and local LLMs, voice orchestration,
+the hive (memory · mailboxes · blackboard · event log), Command Center with kanban and schedules,
+a built-in Monaco IDE with git rails, integrations registry + secret broker, Slack-spawned workers,
+shareable hires and the Agent Gallery, observability and the circuit breaker, durable persistence,
+session resume, multi-window floors, and working auto-update.
+Full history in [`CHANGELOG.md`](./CHANGELOG.md).
 
 Next up:
 
-- [ ] **More chat integrations** — Telegram and richer chat bridges that pipe a channel straight into Michael's queue (and route his replies back out), so you can run the floor from your phone.
-- [x] **More engines & providers** — the engine abstraction is in (Claude Code, Antigravity, Codex, local providers), **v0.3.1 shipped OpenCode, Crush, and pi.dev** as worker+god engines with BYOK keys + local LLMs, and **v0.3.4 adds xAI Grok and Kimi Code**. Keep adding engines and broadening the per-hire capability catalog on top of it.
-- [ ] **More integration templates** — grow the integrations registry beyond the first-wave templates.
-- [ ] **Fuller avatar coverage** — push the remaining station visits and tool-bubbles to be driven 100% by real Claude Code hook events.
-- [ ] **Durable layout & command history** — extend persistence to agent layout and per-session command history.
+- [ ] **More chat integrations** — Telegram and richer chat bridges that pipe a channel into Michael's queue and route replies back out.
+- [ ] **More engines & integration templates** — keep growing the engine roster and the integrations registry.
+- [ ] **Fuller avatar coverage** — drive the remaining station visits and tool-bubbles entirely from real hook events.
+- [ ] **Durable layout & command history** — extend persistence to agent layout and per-session history.
 
 <div align="right">(<a href="#munder-difflin">↑ back to top</a>)</div>
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Munder Difflin v0.3.6
+# Munder Difflin v0.3.7
 
 **A local hive of Claude Code, Antigravity, Codex, Grok & Copilot agents that run themselves** — messaging,
 routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-first and open source.
@@ -7,208 +7,56 @@ routing, and remembering, coordinated by a GOD orchestrator you talk to. Local-f
 
 ---
 
-## What's new in 0.3.6 — *A machine with nothing on it can run agents*
+## What's new in 0.3.7 — *Auto-update, fixed*
 
-Every fix here is the same failure wearing different clothes: the app assumed your machine
-already had things on it — a shell to expand `~`, a `node` on PATH, an npm to install with
-— and when it didn't, agents died with a bare exit code and no explanation. Plus one
-long-standing office bug where the floor went blank and never came back.
+**Auto-update never actually ran.** Not once, in any packaged build, since it shipped in
+v0.3.4. `electron-updater` is a CommonJS module that exposes `autoUpdater` through a lazy
+getter, which Node's module lexer can't see — so `await import('electron-updater')` handed
+back `undefined`, and the very first line of setup threw
+`TypeError: Cannot set properties of undefined (setting 'autoDownload')`. That landed in a
+`catch` that silently switched the app to notify-only mode, which is why the only thing it
+could ever offer was a link to the releases page. It never showed up in testing because the
+whole path is skipped in development.
 
-- **Node and npm install themselves.** Pick an engine on a machine with no Node and the app
-  now fetches the latest Node LTS straight from nodejs.org, **verifies it against the
-  official `SHASUMS256.txt` before anything runs**, installs it visibly in that agent's own
-  terminal, and then installs the CLI. Already have Node 20 or newer? It's left completely
-  alone. And when no installer can possibly succeed, the banner names the missing piece and
-  runs *nothing* — instead of the old behaviour of running `npm install -g …` on a machine
-  with no npm and letting you watch `command not found` scroll past.
-- **Hooks stopped silently dying with exit 127.** Agent CLIs run hooks through `sh -c` with
-  a bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — nvm's node isn't on it — so every hook
-  payload was being lost: no live status, no Stop→inbox drain, no session ids. Every shim
-  now runs under the Node the app already ships. This is also why the orchestrator kept
-  going stale across restarts.
-- **`node` is on every agent's PATH.** An MCP server declared as `node ./server.js`, a
-  provider CLI that shells out, a `.cjs` an agent wrote for itself — all died with 127 with
-  no system node. The bundled runtime is now *appended*, never prepended, so if you have
-  your own node you keep your own version.
-- **`~/dev/foo` no longer fails with "cwd does not exist."** Only a shell expands `~`; Node
-  treats it as a literal folder name. Paths are expanded once on the way in, so the registry
-  only ever holds absolute paths — which also repairs existing `~` entries that had been
-  reading as invalid forever.
-- **Michael stops messaging agents that don't exist.** A live roster of the floor is pushed
-  into the orchestrator's context on session start and on every prompt, rather than trusting
-  it to go re-read `fleet.json` on its own.
-- **The office floor survives losing its GPU context.** 0.3.4 leased WebGL contexts for
-  *terminals* when Chromium started evicting the oldest past ~16 — the office floor was the
-  remaining victim, and always the first to go since it's created at startup. Pixi reported
-  nothing at all, so the floor just went blank until you restarted. It now notices and
-  rebuilds itself.
+- **The native updater works.** New releases download in the background and wait for your
+  click. macOS builds are Developer ID signed, notarized, and stapled, so the update installs
+  cleanly.
+- **The version in the toolbar is now the update button.** Top-left, next to the logo: it
+  shows `checking…`, then `v0.3.8 ready to install`, then live download progress, then
+  **restart to update**. With nothing pending, clicking it checks on demand — previously the
+  app only ever checked 30 seconds after launch and then every six hours, with no way to ask.
+- **Nothing fails silently any more.** Update errors now reach the UI *and* an `updater.log`
+  in the app's data folder. The old code threw the error away, which is exactly why this
+  survived three releases.
+- **One network blip no longer disables updates for the session.** The fallback to
+  notify-only is now per-check instead of a permanent latch, and a re-check can't wipe out an
+  update you've already got staged.
+
+> [!IMPORTANT]
+> **If you're on v0.3.5 or v0.3.6, this one is a manual install.** Those builds carry the
+> broken updater, so they can't fetch this fix by themselves — grab the download below once.
+> From v0.3.7 onward, updates arrive on their own.
 
 ---
 
-## What was new in 0.3.5 — *The queue always has an escape hatch*
+## Previously
 
-A fast-follow to yesterday's big 0.3.4 wave — and the **first release the app delivers to
-itself**: if you're on 0.3.4, it downloads in the background and offers "Restart to
-update". Nothing to download, nothing restarts on its own.
+- **0.3.6** — *a machine with nothing on it can run agents*: Node and npm install themselves
+  (verified against the official `SHASUMS256.txt`), hooks stopped dying with exit 127, `~/dev/foo`
+  paths resolve, and the office floor rebuilds itself after losing its GPU context.
+- **0.3.5** — a **send now** escape hatch for a paused message queue, and a compact Command
+  Center header.
+- **0.3.4** — talk mode that knows the floor, markdown previews, the IDE git time-machine
+  (history + branch compare), redesigned Settings, xAI Grok and Kimi Code, and a single
+  delivery gate for every automatic writer. Community work by
+  [@gts-47](https://github.com/gts-47) and [@qschmick](https://github.com/qschmick).
+- **0.3.3** — the built-in Monaco IDE, and GitHub Copilot CLI as the first community-contributed
+  engine ([@anxkhn](https://github.com/anxkhn)).
+- **0.3.2** — Realtime Michael: a voice channel to the GOD orchestrator.
+- **0.3.1** — three more engines: OpenCode, Crush, and pi.dev.
 
-- **"Send now" for a paused floor.** Pausing floor-wide auto-delivery used to strand every
-  queued message with no explanation and no override. Each queued row now gets a **send
-  now** link while the floor is paused — it bypasses only the pause gate (draft/picker/idle
-  safety still hold) and the composer says exactly why the queue is being held.
-- **Compact Command Center header.** No more three-line wrapped title and crushed buttons
-  at sidebar width — single-line title, ellipsizing subtitle, and an icon-sized
-  ▶ auto / ⏸ paused delivery toggle.
+Full history in the [CHANGELOG](https://github.com/chaitanyagiri/munder-difflin/blob/main/CHANGELOG.md).
 
----
-
-## What was new in 0.3.4 — *Talk to a Michael who knows the floor, see everything in the IDE*
-
-**A community release plus a four-feature first-party wave.** The terminal/queue
-reliability work is by [**@gts-47**](https://github.com/gts-47) (Vyapak Goyal), with major
-fixes by [**@qschmick**](https://github.com/qschmick).
-
-- **Talk mode grows up.** Michael's voice session opens with a live per-agent floor
-  snapshot and keeps receiving silent floor updates mid-call — ask "what's everyone doing"
-  and he just knows. He can also *do* nearly everything now: resume agents, pause/resume
-  message delivery, gate tools, manage tasks and schedules, clear an agent's context, and
-  change settings from a strict allowlist — destructive actions still require you to say
-  "confirm" out loud. He even knows what version he's running and what's new in it.
-- **Markdown previews.** ⌘-click any `.md` path an agent prints in its terminal → an
-  instant rendered preview. In the IDE, markdown files get a code | split | preview switch
-  that re-renders live as you type. Safe by construction for agent-generated files.
-- **Git time-machine.** The IDE rail gains **History** (a clickable commit graph — pick a
-  commit, see its files, open side-by-side diffs) and **Compare** (two branches,
-  ahead/behind, per-file diffs), plus guarded checkout that refuses to move a dirty tree
-  or yank code from under a working agent.
-- **Settings, redesigned.** Six clear tabs; the default agent model, autonomy mode, and
-  the full circuit breaker finally have controls; dead rows and buried toggles are gone.
-
-- **Auto-update.** The app now checks GitHub releases, downloads the new version in the background,
-  and offers a **"restart to update"** toast — installation is always your click; nothing restarts on
-  its own. Toggle in Settings → General. (Starts working for installs **on 0.3.4+** — grab this one
-  from the site once more.)
-- **One delivery gate for every automatic writer.** The message queue kept breaking because multiple
-  loops each decided when it was safe to type into a terminal. Now a single drain loop owns that
-  decision — and automation **never wipes your draft or closes your menus**: a user draft or open
-  picker holds delivery (visible as a new **"your draft"** badge), and expired blocks type *after*
-  your text instead of over it. The full contract is written down in
-  [`docs/message-queue.md`](https://github.com/chaitanyagiri/munder-difflin/blob/main/docs/message-queue.md). *(gts-47)*
-- **Blank-terminal pane fixed at all three roots** — WebGL contexts are leased per attached terminal
-  (Chromium silently kills the oldest past ~16 live contexts, which is exactly what a big
-  restore-team did), the initial-redraw latch only arms on success, and the repaint marker survives a
-  failed refresh. *(gts-47)*
-- **xAI Grok + Kimi Code join the engine roster** — Grok as a full hive citizen (lifecycle-hook
-  adapter, guarded inbox delivery, `--resume`), Kimi as a worker engine. Plus **Fable 5 and
-  Sonnet 5** in the Claude picker (Fable 5 is the new default), and the two "default" entries are
-  finally tellable-apart. *(gts-47)*
-- **A fullscreen agent roster rail** — repo-grouped (worktree-aware), inline notes, drag-to-reorder,
-  restore-team built in; **Remote Control sessions are named after the agent**; the **roster is
-  shared between dev and packaged builds**; restore-team runs in parallel and on open. *(gts-47)*
-- **Codex resume actually resumes** (subcommand + session-owner `CODEX_HOME` detection) and Codex
-  workers get **Codex Remote** — threads visible in ChatGPT mobile. *(gts-47)*
-- **Killed processes actually die** — every kill path escalates to a process-group kill, so trapped
-  SIGHUPs and reparented MCP servers no longer leak PIDs
-  ([#110](https://github.com/chaitanyagiri/munder-difflin/pull/110), qschmick). Also from qschmick:
-  the **breaker false-positive storm on idle/compacting agents** is gone
-  ([#112](https://github.com/chaitanyagiri/munder-difflin/pull/112)), warm usage reads are **~350×
-  faster** ([#111](https://github.com/chaitanyagiri/munder-difflin/pull/111)), and spawns no longer
-  freeze the app ([#114](https://github.com/chaitanyagiri/munder-difflin/pull/114)).
-- **Scheduled auto-compact is now opt-in (default OFF)** with a switch in Settings → General and the
-  Schedules tab — and it's provider-aware when on.
-
-Full details in the
-[CHANGELOG](https://github.com/chaitanyagiri/munder-difflin/blob/main/CHANGELOG.md).
-
----
-
-## What's new in 0.3.3 — *A built-in Monaco IDE + GitHub Copilot CLI*
-
-**Read your agents' work where it happens.** The title bar gains an **IDE** button that opens a
-full-window **Monaco** editor (the VS Code editor engine) over the office floor — and the engine
-roster grows to **seven** with **GitHub Copilot CLI**, our **first community-contributed provider**.
-
-- **Built-in Monaco IDE.** A toggleable full-window overlay (the floor, terminals, and voice UX are
-  untouched underneath): a **git CHANGES rail** listing every file your agents touched — click one
-  for a **read-only, side-by-side diff against HEAD** — plus the workspace **file tree**, **editor
-  tabs** with dirty-state dots, and **Cmd/Ctrl+S** save. Monaco is **fully self-hosted** (bundled
-  workers, no CDN), themed to the harness palette, and **every fs/git call is brokered through the
-  main process** — the renderer holds no direct disk access. Also hardened: keystrokes typed while
-  a save is in flight can no longer be silently lost.
-- **GitHub Copilot CLI as an agent engine** (`copilot`, npm `@github/copilot`) — contributed in
-  [PR #101](https://github.com/chaitanyagiri/munder-difflin/pull/101) by
-  [**@anxkhn**](https://github.com/anxkhn). Hire a Copilot-powered worker in its documented
-  non-interactive **print mode** (`copilot -p "<prompt>" -s --allow-all-tools --no-ask-user`), with
-  the auto-approval flags **gated by the floor auto-mode toggle** like every other engine, a
-  **model picker** (Claude Sonnet 4.5 default · GPT-5.4 · auto), best-effort `--resume` session
-  continuity, voice-hire support, and the official npm installer offered when the CLI is missing —
-  authenticated by your **existing GitHub Copilot login**, no new keys. Honest caveat: print mode
-  exits per turn with no hook bridge, so routed inbox mail **bounces back to the GOD orchestrator**
-  rather than draining — Copilot workers shine on dispatched, self-contained tasks.
-
----
-
-## What's new in 0.3.2 — *Realtime Michael: talk to the GOD orchestrator*
-
-**Talk to Michael.** The headline is **Realtime Michael** — a low-latency **voice channel to the
-GOD orchestrator**, running alongside the async terminal floor. Press **Talk**, and Michael listens,
-answers, and *acts* in real time.
-
-- **Talk to the GOD orchestrator by voice.** A new low-latency realtime channel (OpenAI Realtime API
-  over WebRTC) sits next to the async terminal. A **Talk** toggle — on Michael's card and in any
-  fullscreen terminal — opens a mic session with echo-cancellation, semantic-VAD turn-taking +
-  barge-in, and a device picker. Michael runs his own persona and answers in a natural voice, with an
-  `Off → Connecting → Listening → Responding → Working` state machine live on his card.
-- **Reads the hive, acts behind echo-back confirm.** He reads the floor (tasks, board, memory,
-  agents, activity, cost) and — behind a spoken **echo-back confirmation** for anything destructive —
-  creates and assigns work, dispatches agents, spawns and kills workers, and steers the floor. Every
-  voice action is attributed to a distinct **michael-voice** actor that pings the GOD terminal, so a
-  voice-driven dispatch is auditable; there are hard refusals for killing the GOD agent or targeting
-  all agents at once.
-- **Voice read-layer over hive messages.** Michael can now read message *content*, not just
-  metadata: a read/brief-only `get_messages` tool surfaces a **full message by id, one mailbox, or
-  the latest across the floor** — with **all secret redaction done main-side** so the voice layer
-  only ever receives already-redacted bodies (no provider / Slack / GitHub / AWS / Google key, JWT,
-  PEM block, or `Bearer` token can leak). Read-only — it adds no new write path.
-- **"Respond when done."** Voice-dispatched work reports back on its own: a completion watcher
-  detects when a dispatched task finishes and **pushes the event into the live session so Michael
-  speaks it unprompted**; if the session is closed, completions queue to a desktop notification and a
-  warm-start on reconnect.
-- **BYOK, main-only.** Bring-your-own OpenAI key: the key is decrypted **main-only**, minted into
-  short-lived ephemeral session tokens, and **never reaches the renderer**. A live session cost meter
-  sits by the Talk toggle, with a hard **spend cap** and an **idle auto-disconnect** so a
-  forgotten-open mic can't run up a bill.
-- **Slack hardening + maintenance.** Proactive Slack posting is **off by default** (no sends without
-  an explicit channel + thread), auto-compaction becomes a **dedicated maintenance schedule**
-  decoupled from standups (so editing standups can't silently drop it), and each agent now carries
-  queryable **per-agent environment metadata** with a working-directory validity guard.
-
-> **Live verification note.** The realtime voice loop is **human-verified end-to-end** on a real
-> OpenAI key — connect → mic → Michael answers via the read tools, and the full destructive path
-> (spoken echo-back confirm → spawn / kill / dispatch → worker appears on the floor → completion
-> spoken back) was exercised live. It requires **your own OpenAI key with Realtime API access**;
-> without one the **Talk** button stays visibly disabled with a "needs OpenAI key" cue. The new
-> voice-message read-layer's redaction battery is unit-tested in lockstep with the main process; its
-> end-to-end voice read is human-gated like all realtime work.
-
----
-
-## What's new in 0.3.1 — *Three more engines: OpenCode · Crush · pi.dev*
-
-The floor gained three new coding CLIs, each usable as a **worker and as Michael**, with
-**bring-your-own keys + local LLMs**: **OpenCode** (`opencode`) via a native-plugin bridge,
-**Crush** (`crush`, Charmbracelet's Go TUI) via a per-agent proxy bridge, and **pi.dev** (`pi`) via a
-hooks bridge. A new **Settings → AI Engines** panel collects per-provider **API keys** (stored
-write-only, encrypted) and **local base-URLs** (Ollama / LM Studio / vLLM). Plus two reliability
-fixes: the **message router now survives system sleep** (re-arms and drains the backlog on wake), and
-**Codex workers get full filesystem + auto-approval from spawn** (parity with Claude).
-
-Everything from **v0.3.0** (selectable engines, integrations registry + loopback secret broker,
-Slack-spawned ephemeral workers, Agent Gallery) and earlier — Free Flow voice dictation, the
-enterprise Knowledge Graph, multi-window "floors", the rich message composer, agent session resume,
-and drag-a-file path injection — is included.
-See the [CHANGELOG](https://github.com/chaitanyagiri/munder-difflin/blob/main/CHANGELOG.md) for full detail.
-
----
 
 ## ⤓ Downloads
 

--- a/blog/src/posts/whats-up-with-munder-difflin.md
+++ b/blog/src/posts/whats-up-with-munder-difflin.md
@@ -1,0 +1,189 @@
+---
+title: "What's Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own"
+description: "Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it."
+date: 2026-08-08
+category: story
+categoryLabel: Story
+type: Non-technical
+primaryKeyword: "munder difflin v0.3.7"
+secondaryKeywords: ["personal agi harness", "local multi agent harness update", "claude code multi-agent release notes", "voice ai agent orchestration", "electron auto update fix", "open source agent harness"]
+tags: ["Story", "Release", "Multi-Agent", "Voice", "IDE", "Open Source"]
+author:
+  name: Chaitanya Giri
+  initials: CG
+faq:
+  - q: "What's new in Munder Difflin v0.3.7?"
+    a: "v0.3.7 fixes auto-update, which had silently never worked in any packaged build since it shipped in v0.3.4. A CommonJS export vanished across the ESM import boundary, the resulting error was swallowed by a catch block, and the app quietly fell back to just linking you to the releases page. The version number in the toolbar is now the update button — it shows download progress and turns into 'restart to update' — and update failures now reach both the UI and a log file instead of disappearing."
+  - q: "What shipped between v0.3.3 and v0.3.7?"
+    a: "Four releases in about six weeks. v0.3.4 was the big wave: voice orchestration that opens with a live snapshot of every agent and can run nearly the whole app, markdown previews everywhere, a git time-machine in the built-in IDE (commit history, branch compare, guarded checkout), a six-tab Settings redesign, xAI Grok and Kimi Code engines, and one single delivery gate for every automatic writer. v0.3.5 added a 'send now' escape hatch for a paused queue. v0.3.6 made a machine with nothing installed on it able to run agents — Node and npm install themselves, verified against Apple's published checksums. v0.3.7 fixed auto-update."
+  - q: "Do I need to reinstall to get v0.3.7?"
+    a: "Yes, once. Every build from v0.3.4 through v0.3.6 carries the broken updater and cannot fetch the fix that repairs it — the one bootstrap problem a self-updating app can't solve for itself. Download v0.3.7 from munderdiffl.in or the GitHub releases page. From v0.3.7 onward, updates download in the background and wait for your restart."
+  - q: "How many agent CLIs does Munder Difflin support?"
+    a: "Nine: Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, xAI Grok, Kimi Code, OpenCode, Crush, and pi.dev. Each gets a desk, a mailbox, and shared memory, and most can play the GOD orchestrator role themselves. You can mix engines on the same floor, and bring your own API keys or point them at local models through Ollama, LM Studio, or vLLM."
+  - q: "Is Munder Difflin free?"
+    a: "Yes. MIT-licensed, free forever, and local-first. It drives the agent CLI subscriptions you already pay for rather than adding a bill of its own, and your code never leaves your machine."
+---
+
+<div class="callout tldr"><span class="ic">TL;DR</span><p>Six weeks, four releases. <strong>Michael learned the floor</strong> and can now run nearly the whole app by voice. The IDE became a <strong>git time-machine</strong>. Two more engines brought the roster to <strong>nine</strong>. The message queue got <strong>one gate</strong> instead of four competing loops. A machine with <strong>nothing installed on it</strong> can now run agents. And <strong>auto-update — which had never once worked</strong> — actually works. If you're on v0.3.5 or v0.3.6, you'll need to grab v0.3.7 by hand, once.</p></div>
+
+AGI is not going to arrive as an event. No announcement, no threshold, no day the sky
+changes colour. It's arriving diffused — your agents, running on your context, doing your
+work, on hardware you own.
+
+Garry Tan puts the next decade in one line: **a rented frontier model, plus your own
+context, plus a harness that wires them together.** Only one of those three is for sale, and
+it's the cheapest one. The model is a commodity you rent by the token. Your context — your
+repos, your decisions and the reasons behind them, what you owe people and what they said
+last time — isn't for sale at any price, because it only exists in your head.
+
+The harness is the part in the middle. It decides which context reaches which model at which
+step, and then lets the result act on the world. It's the part of the stack you can actually
+own, and it's the part Munder Difflin exists to give away.
+
+So: what have we done to that middle term in the last six weeks?
+
+## Michael learned the floor
+
+Talk mode could *do* things since v0.3.2. What it couldn't do was *know* things. Every "what's
+everyone working on?" turned into a round of tool calls and dead air.
+
+Now the voice session opens with a live snapshot of the whole floor — every agent's status,
+engine, context fill, circuit-breaker state, inbox depth, and in-flight tasks — and keeps
+receiving silent updates as things change mid-call. Ask what's happening and he just answers.
+
+He also graduated from narrator to operator. He can resume a paused agent, pause and resume
+floor-wide delivery, gate specific tools, manage tasks and schedules, clear an agent's
+context, archive workers, and change settings from a strict allowlist. Anything destructive
+still waits for you to say a distinct confirm word out loud, and secrets can't be touched by
+voice at all.
+
+## The IDE became a git time-machine
+
+v0.3.3 gave the built-in Monaco IDE a diff against HEAD. This wave made it somewhere you can
+move through history:
+
+- **History** — a clickable commit graph. Pick a commit, see the files it touched, open
+  side-by-side diffs of exactly what changed.
+- **Compare** — any two branches, with ahead/behind counts and per-file diffs.
+- **Guarded checkout** — it refuses to move a dirty tree, or pull code out from under an
+  agent that's actively working in it.
+
+Agents write a *lot* of markdown, so that got fixed too: ⌘-click any `.md` path an agent
+prints in its terminal and it opens rendered. In the IDE, markdown files get a
+code | split | preview switch that re-renders live. There's no raw-HTML pipeline anywhere in
+it, which is the only way reading agent-generated files is safe by construction.
+
+## Nine engines
+
+**xAI Grok** and **Kimi Code** joined, bringing the roster to nine: Claude Code, OpenAI
+Codex, Antigravity, GitHub Copilot CLI, Grok, Kimi, OpenCode, Crush, and pi.dev. Grok came in
+as a full hive citizen — lifecycle-hook adapter, guarded inbox delivery, `--resume` — not
+just a worker you can spawn.
+
+Settings was rebuilt into six clear tabs at the same time. The default agent model, autonomy
+mode, and the full circuit breaker finally have real controls instead of being buried or
+missing.
+
+## One gate for the queue
+
+This is the least glamorous thing here and probably the one you'll feel most.
+
+The message queue kept breaking because *four* different loops each decided, independently,
+when it was safe to type into a terminal. Now a single drain loop owns that decision — and
+automation never wipes your draft or closes your menus. A user draft or an open picker holds
+delivery (visible as a **"your draft"** badge), and expired blocks type *after* your text
+instead of over it. The whole contract is written down in
+[`docs/message-queue.md`](https://github.com/chaitanyagiri/munder-difflin/blob/main/docs/message-queue.md).
+
+v0.3.5 closed the last hole in it: pausing floor-wide delivery used to strand every queued
+message with no override and no explanation. Each row now gets a **send now** link that
+bypasses only the pause gate, and the composer says exactly why the queue is being held.
+
+A big share of this — the terminal, queue, and roster reliability work — is community code
+from [**Vyapak Goyal (@gts-47)**](https://github.com/gts-47), with major fixes from
+[**@qschmick**](https://github.com/qschmick): killed processes now actually die (every kill
+path escalates to a process-group kill), the circuit breaker stopped false-positive storming
+on idle agents, and warm usage reads got about **350× faster**.
+
+## A machine with nothing on it can run agents
+
+v0.3.6 was one failure wearing five different costumes: the app assumed your machine already
+had things on it. A shell to expand `~`. A `node` on PATH. An npm to install with. When it
+didn't, agents died with a bare exit code and no explanation.
+
+- **Node and npm install themselves.** Pick an engine on a machine with no Node and the app
+  fetches the current LTS from nodejs.org, **verifies it against the official
+  `SHASUMS256.txt` before anything runs**, installs it visibly in that agent's own terminal,
+  then installs the CLI. Already have Node 20+? Left completely alone. And when no installer
+  could possibly succeed, the banner names the missing piece and runs *nothing* — instead of
+  firing `npm install -g` on a machine with no npm and letting you watch `command not found`
+  scroll past.
+- **Hooks stopped dying with exit 127.** Agent CLIs run hooks through `sh -c` with a bare
+  `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — nvm's node isn't on it — so hook payloads were being
+  lost entirely: no live status, no Stop→inbox drain, no session IDs. This is also why the
+  orchestrator kept going stale across restarts.
+- **`~/dev/foo` works.** Only a shell expands `~`; Node treats it as a literal folder name,
+  so every typed `~/…` path failed its existence check and the agent never spawned.
+- **The office floor survives losing its GPU context.** Chromium evicts the oldest WebGL
+  context past about sixteen. The floor is created at startup, so it was always first to go —
+  and Pixi reported nothing at all, so it just went blank until you restarted. It notices and
+  rebuilds itself now.
+
+## And then: auto-update had never once worked
+
+Here's the confession.
+
+We shipped auto-update in v0.3.4 and announced it. It has never run. Not once, in any
+packaged build, through three releases.
+
+`electron-updater` is a CommonJS module that exposes `autoUpdater` through a lazy getter.
+Node's module lexer detects CommonJS named exports by static analysis, and it cannot see
+through a getter defined at runtime — so `await import('electron-updater')` handed back a
+namespace with no `autoUpdater` on it at all. We destructured it, got `undefined`, and the
+very next line threw:
+
+```
+TypeError: Cannot set properties of undefined (setting 'autoDownload')
+```
+
+That exception landed in a `catch` that flipped the app to notify-only mode and moved on.
+Which is why the only thing it could ever offer was a link to the releases page. It never
+showed up in testing because the entire path sits behind `app.isPackaged` — it simply does
+not execute in development.
+
+The interop fix is one line. The real bug was the `catch` that threw the error away, and
+that's what v0.3.7 actually changes:
+
+- **Errors are never swallowed.** Every updater failure now reaches the UI *and* an
+  `updater.log` on disk.
+- **The fallback is per-check, not a latch.** One network blip used to cost the whole session
+  its ability to self-update.
+- **The version number in the toolbar is now the update button.** It shows `checking…`, then
+  `ready to install`, then live download progress, then **restart to update**. Click it with
+  nothing pending and it checks on demand — before, the app only ever checked 30 seconds
+  after launch and then every six hours, with no way to ask.
+
+There's a full write-up of the debugging, including the trick that finally made a packaged
+Electron app talk, in [Why our auto-update never
+ran](/blog/why-our-auto-update-never-ran/).
+
+## If you're on v0.3.5 or v0.3.6
+
+You'll need to install v0.3.7 by hand, once. Your current build carries the broken updater,
+so it can't fetch the fix that repairs it — the one bootstrap problem a self-updating app
+cannot solve for itself.
+
+[**Download v0.3.7**](https://github.com/chaitanyagiri/munder-difflin/releases/latest) —
+macOS (signed and notarized), Windows, Linux. Free, MIT-licensed, local-first, and after this
+one manual step, it keeps itself current.
+
+## What's next
+
+More chat bridges, so a Telegram or Slack channel pipes straight into Michael's queue and his
+replies route back out. More engines, and a wider per-hire capability catalog. More
+integration templates. And pushing the remaining avatar station-visits to be driven entirely
+by real hook events rather than inferred.
+
+The model you rent gets better every few weeks without you doing anything. Your context is
+already yours. The harness in between is the part worth owning — so it's free, it's MIT, and
+it runs on your machine.

--- a/blog/src/posts/why-our-auto-update-never-ran.md
+++ b/blog/src/posts/why-our-auto-update-never-ran.md
@@ -1,0 +1,165 @@
+---
+title: "Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace"
+description: "Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here's how we found it, and what v0.3.7 changes."
+date: 2026-08-08
+category: internals
+categoryLabel: Internals
+type: Technical
+primaryKeyword: "electron-updater not working"
+secondaryKeywords: ["electron auto update not working", "cjs-module-lexer named export undefined", "await import commonjs electron", "electron-updater autoUpdater undefined", "electron app.isPackaged debugging"]
+tags: ["Internals", "Electron", "Debugging", "Release", "Open Source"]
+author:
+  name: Chaitanya Giri
+  initials: CG
+faq:
+  - q: "Why was electron-updater's autoUpdater undefined?"
+    a: "electron-updater is a CommonJS package that attaches autoUpdater to its exports through a lazy Object.defineProperty getter. Node's cjs-module-lexer detects named exports by static analysis, and it cannot see through a getter defined at runtime. So the ESM namespace produced by `await import('electron-updater')` has no autoUpdater key at all — it only exists on the namespace's `.default`. Destructuring `const { autoUpdater } = await import('electron-updater')` therefore yields undefined. Use `ns.autoUpdater ?? ns.default?.autoUpdater`, or plain `require()`, instead."
+  - q: "Why didn't this show up in development?"
+    a: "The whole updater setup block was behind an `app.isPackaged` check, which is false in dev. Development runs never executed the line that threw, so the bug could only ever appear in a shipped build — and shipped builds have no visible console. It survived three releases that way."
+  - q: "How do you debug an Electron app that only misbehaves when packaged?"
+    a: "Launch the installed binary directly from a terminal with an isolated data directory: `/Applications/YourApp.app/Contents/MacOS/YourApp --user-data-dir=/tmp/probe`. Electron's single-instance lock is keyed to the user-data directory, so this runs alongside the copy the user already has open, and every console.log and stack trace lands in your terminal instead of disappearing."
+  - q: "Do I need to reinstall Munder Difflin to get v0.3.7?"
+    a: "Yes, once. Every build from v0.3.4 through v0.3.6 carries the broken updater, so it cannot fetch this fix by itself. Download v0.3.7 manually from munderdiffl.in or the GitHub releases page. From v0.3.7 onward, updates download in the background and wait for your restart."
+  - q: "How do you stop a bug like this from hiding again?"
+    a: "Three changes. Errors are never swallowed — every updater failure is emitted to the UI and appended to a log file on disk. The notify-only fallback is per-check rather than a permanent latch, so one blip doesn't disable updates for the session. And the state model moved into a plain electron-free module with unit tests, so the rules can be verified without booting the app."
+---
+
+<div class="callout tldr"><span class="ic">TL;DR</span><p>Munder Difflin shipped auto-update in <strong>v0.3.4</strong>. It never ran — not once, in any packaged build, through three releases. The cause was a single destructuring assignment across the CommonJS/ESM boundary that produced <code>undefined</code>, and a <code>catch</code> block that threw away the error message. <strong>v0.3.7</strong> fixes it, turns the toolbar version into the update button, and makes sure the next failure can't hide.</p></div>
+
+A user restarted the app after v0.3.6 went live and reported that auto-update hadn't
+triggered. What they got instead was a toast offering to open the releases page in a
+browser — the fallback path, meant for installs that genuinely can't update themselves.
+
+That's a good bug report, because the fallback existing at all means the app *knew* there
+was a new version. It found the release. It just refused to install it.
+
+## Ruling things out, expensively
+
+The obvious suspect on macOS is notarization. An update that isn't properly signed and
+stapled gets refused by Gatekeeper, and the failure is quiet. So the published asset went
+under a microscope first:
+
+```bash
+shasum -a 512 Munder-Difflin-0.3.6-mac-universal.zip   # matches latest-mac.yml exactly
+codesign --verify --deep --strict --verbose=2 "Munder Difflin.app"
+xcrun stapler validate "Munder Difflin.app"
+spctl --assess -vv "Munder Difflin.app"
+```
+
+All clean. Developer ID signature, notarization ticket stapled, `spctl` accepted, and the
+SHA-512 matching the update feed byte for byte. The release was fine.
+
+Next suspect: the feed. Running `electron-updater` directly against the live GitHub release
+resolved 0.3.5 → 0.3.6 correctly, downloaded all 232 MB, verified the hash, and emitted
+`update-downloaded`. The updater library was fine too.
+
+So the release worked, the library worked, and the app still wouldn't update. The problem
+had to be in our own code — and our own code was refusing to say what was wrong.
+
+## Getting a packaged app to talk
+
+Everything interesting here lives behind `app.isPackaged`, which is false in development.
+The bug could only exist in a build with no visible console.
+
+The trick that cracked it: **Electron's single-instance lock is keyed to the user-data
+directory.** Point a second launch at a different one and it runs happily alongside the
+copy already open, with stdout wired to your terminal.
+
+```bash
+"/Applications/Munder Difflin.app/Contents/MacOS/Munder Difflin" \
+  --user-data-dir=/tmp/updater-probe
+```
+
+Thirty seconds later, the first check fired and printed the thing the app had been
+swallowing for three releases:
+
+```
+[updater] electron-updater unavailable; notify-only mode:
+TypeError: Cannot set properties of undefined (setting 'autoDownload')
+```
+
+## One line, three releases
+
+Here is the code that shipped in v0.3.4:
+
+```js
+const { autoUpdater } = await import('electron-updater');
+autoUpdater.autoDownload = true;          // ← TypeError, every single time
+```
+
+`electron-updater` is a CommonJS package, and it attaches `autoUpdater` to its exports
+through a lazy `Object.defineProperty` getter. Node's ESM loader detects named exports from
+CommonJS with `cjs-module-lexer`, which works by **static analysis** — and a property
+defined at runtime by a getter is invisible to it.
+
+The result, confirmed by probing the namespace directly:
+
+```js
+const ns = await import('electron-updater');
+Object.keys(ns);            // AppUpdater, MacUpdater, NsisUpdater, … default
+ns.autoUpdater;             // undefined   ← what we destructured
+ns.default.autoUpdater;     // object      ← where it actually lives
+require('electron-updater').autoUpdater;  // object
+```
+
+So the destructuring produced `undefined`, and the very next line — setting a property on
+it — threw. That exception landed in a `catch` that set a `fallbackActive` flag and moved
+on. From then on, every check in that session took the notify-only path. Which is exactly
+what the user saw: an app that finds new releases and can only offer you a link.
+
+The fix is unglamorous:
+
+```js
+const ns = await import('electron-updater');
+const autoUpdater = ns.autoUpdater ?? ns.default?.autoUpdater;
+if (!autoUpdater) throw new Error('electron-updater exposes no `autoUpdater` export');
+```
+
+**The general rule: never destructure a named export off `await import()` of a CommonJS
+package.** If the package builds its exports at runtime — getters, `Object.assign`,
+conditional wiring — the lexer won't see them, and you get `undefined` instead of an error
+telling you why.
+
+## The real bug was the catch block
+
+A one-character-class fix that survives three releases isn't really a story about interop.
+It's a story about a `catch` that discarded its argument.
+
+The error existed. It was specific, it named the exact property, and it pointed at the exact
+line. It was thrown away, and replaced with a degraded mode that looked deliberate. Anyone
+watching the app saw a working feature: it noticed new versions and offered a download link.
+Nothing looked broken enough to investigate.
+
+So v0.3.7 changes three things beyond the interop fix:
+
+- **Errors are never swallowed.** Every updater failure is emitted to the renderer *and*
+  appended to an `updater.log` in the app's data folder. The tooltip on the toolbar badge
+  shows the actual message.
+- **The fallback is per-check, not a latch.** A transient network error used to cost the
+  session its ability to self-update until the next restart. Now the next tick tries the
+  native path again.
+- **The state rules are testable.** How updater events map to what the UI shows moved into a
+  plain module with no Electron imports, with unit tests covering the rule that bit us — a
+  re-check must never wipe out an update you already have staged.
+
+## The version number is now a button
+
+The other half of the report was that nothing in the app told the user what was happening.
+There was a toast for "downloaded", and nothing for anything else — so a multi-minute
+232 MB download looked exactly like an app doing nothing.
+
+The version text next to the logo is now the control. It shows `checking…`, then
+`v0.3.8 ready to install` (click to download), then live progress, then **restart to
+update** (click to apply). With nothing pending, clicking it checks on demand — previously
+the only checks were 30 seconds after launch and every six hours after that, with no way to
+ask.
+
+## If you're on v0.3.5 or v0.3.6
+
+You'll need to install v0.3.7 by hand, once. Your current build carries the broken updater,
+so it can't fetch the fix that repairs it — the one bootstrap problem a self-updating app
+can't solve for itself. Grab it from [munderdiffl.in](https://munderdiffl.in/) or the
+[releases page](https://github.com/chaitanyagiri/munder-difflin/releases/latest).
+
+After that, it updates itself. For real this time — and if it ever doesn't, it'll tell you
+why.

--- a/docs/blog/append-only-event-log-agents/index.html
+++ b/docs/blog/append-only-event-log-agents/index.html
@@ -285,6 +285,24 @@ it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -317,24 +335,6 @@ it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/architecture-two-planes-one-renderer/index.html
+++ b/docs/blog/architecture-two-planes-one-renderer/index.html
@@ -288,6 +288,24 @@ free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -320,24 +338,6 @@ free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/file-based-coordination-vs-message-queues/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>4 min</span>
-    </div>
-    <h3><a href="/blog/file-based-coordination-vs-message-queues/">File-Based Coordination vs Message Queues for AI Agents</a></h3>
-    <p class="dek">Why a local agent hive coordinates through plain files, not Redis or RabbitMQ: the zero-ops wins, the real tradeoffs, and where files hit a ceiling.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/file-based-coordination-vs-message-queues/" aria-label="Read: File-Based Coordination vs Message Queues for AI Agents">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/atomic-file-mailboxes-for-agents/index.html
+++ b/docs/blog/atomic-file-mailboxes-for-agents/index.html
@@ -300,6 +300,24 @@ the office floor; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -332,24 +350,6 @@ the office floor; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/building-a-terminal-ui-xterm-node-pty/index.html
+++ b/docs/blog/building-a-terminal-ui-xterm-node-pty/index.html
@@ -343,6 +343,24 @@ to watch many real terminals at once; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -375,24 +393,6 @@ to watch many real terminals at once; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/building-an-ai-office-floor/index.html
+++ b/docs/blog/building-an-ai-office-floor/index.html
@@ -288,6 +288,24 @@ techniques — the hard part is wiring them to <em>real</em> agent events, not t
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -320,24 +338,6 @@ techniques — the hard part is wiring them to <em>real</em> agent events, not t
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/claude-code-hooks-explained/index.html
+++ b/docs/blog/claude-code-hooks-explained/index.html
@@ -302,6 +302,24 @@ free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -334,24 +352,6 @@ free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/compressing-agent-memory/index.html
+++ b/docs/blog/compressing-agent-memory/index.html
@@ -270,6 +270,24 @@ without forgetting; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -302,24 +320,6 @@ without forgetting; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/file-based-coordination-vs-message-queues/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>4 min</span>
-    </div>
-    <h3><a href="/blog/file-based-coordination-vs-message-queues/">File-Based Coordination vs Message Queues for AI Agents</a></h3>
-    <p class="dek">Why a local agent hive coordinates through plain files, not Redis or RabbitMQ: the zero-ops wins, the real tradeoffs, and where files hit a ceiling.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/file-based-coordination-vs-message-queues/" aria-label="Read: File-Based Coordination vs Message Queues for AI Agents">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/feed.xml
+++ b/docs/blog/feed.xml
@@ -8,6 +8,14 @@
   <id>https://munderdiffl.in/blog/</id>
   <author><name>Chaitanya Giri</name><uri>https://munderdiffl.in</uri></author>
   <entry>
+    <title>What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</title>
+    <link href="https://munderdiffl.in/blog/whats-up-with-munder-difflin/" />
+    <id>https://munderdiffl.in/blog/whats-up-with-munder-difflin/</id>
+    <published>2026-08-08T00:00:00.000Z</published>
+    <updated>2026-08-08T00:00:00.000Z</updated><category term="Story" />
+    <summary>Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</summary>
+  </entry>
+  <entry>
     <title>Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</title>
     <link href="https://munderdiffl.in/blog/why-our-auto-update-never-ran/" />
     <id>https://munderdiffl.in/blog/why-our-auto-update-never-ran/</id>
@@ -478,13 +486,5 @@
     <published>2026-06-04T00:00:00.000Z</published>
     <updated>2026-06-04T00:00:00.000Z</updated><category term="Concepts" />
     <summary>Why a hive of agents shouldn&#39;t all run the biggest model — and how routing the right task to the right model cuts cost and latency without losing quality.</summary>
-  </entry>
-  <entry>
-    <title>Evaluating AI Agent Reliability: How to Measure What You Can Trust</title>
-    <link href="https://munderdiffl.in/blog/evaluating-ai-agent-reliability/" />
-    <id>https://munderdiffl.in/blog/evaluating-ai-agent-reliability/</id>
-    <published>2026-06-04T00:00:00.000Z</published>
-    <updated>2026-06-04T00:00:00.000Z</updated><category term="Guides" />
-    <summary>How to measure whether an AI agent is reliable enough to trust: reliability thresholds, why benchmarks overstate, and evaluating on your own codebase.</summary>
   </entry>
 </feed>

--- a/docs/blog/feed.xml
+++ b/docs/blog/feed.xml
@@ -4,9 +4,17 @@
   <subtitle>Guides, deep dives, and comparisons on running multi-agent Claude Code: orchestration, agent memory, automation, and the tooling landscape.</subtitle>
   <link href="https://munderdiffl.in/blog/feed.xml" rel="self" />
   <link href="https://munderdiffl.in/blog/" />
-  <updated>2026-08-06T00:00:00.000Z</updated>
+  <updated>2026-08-08T00:00:00.000Z</updated>
   <id>https://munderdiffl.in/blog/</id>
   <author><name>Chaitanya Giri</name><uri>https://munderdiffl.in</uri></author>
+  <entry>
+    <title>Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</title>
+    <link href="https://munderdiffl.in/blog/why-our-auto-update-never-ran/" />
+    <id>https://munderdiffl.in/blog/why-our-auto-update-never-ran/</id>
+    <published>2026-08-08T00:00:00.000Z</published>
+    <updated>2026-08-08T00:00:00.000Z</updated><category term="Internals" />
+    <summary>Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</summary>
+  </entry>
   <entry>
     <title>Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</title>
     <link href="https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/" />
@@ -478,13 +486,5 @@
     <published>2026-06-04T00:00:00.000Z</published>
     <updated>2026-06-04T00:00:00.000Z</updated><category term="Guides" />
     <summary>How to measure whether an AI agent is reliable enough to trust: reliability thresholds, why benchmarks overstate, and evaluating on your own codebase.</summary>
-  </entry>
-  <entry>
-    <title>File-Based Coordination vs Message Queues for AI Agents</title>
-    <link href="https://munderdiffl.in/blog/file-based-coordination-vs-message-queues/" />
-    <id>https://munderdiffl.in/blog/file-based-coordination-vs-message-queues/</id>
-    <published>2026-06-04T00:00:00.000Z</published>
-    <updated>2026-06-04T00:00:00.000Z</updated><category term="Internals" />
-    <summary>Why a local agent hive coordinates through plain files, not Redis or RabbitMQ: the zero-ops wins, the real tradeoffs, and where files hit a ceiling.</summary>
   </entry>
 </feed>

--- a/docs/blog/file-based-coordination-vs-message-queues/index.html
+++ b/docs/blog/file-based-coordination-vs-message-queues/index.html
@@ -261,6 +261,24 @@ durable, git-versioned, and debuggable by just looking.
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -293,24 +311,6 @@ durable, git-versioned, and debuggable by just looking.
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/hire-manifest-untrusted-input/index.html
+++ b/docs/blog/hire-manifest-untrusted-input/index.html
@@ -286,6 +286,24 @@ for hop in 0..5:                // cap at 5 hops
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/compressing-agent-memory/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -318,24 +336,6 @@ for hop in 0..5:                // cap at 5 hops
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/file-based-coordination-vs-message-queues/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>4 min</span>
-    </div>
-    <h3><a href="/blog/file-based-coordination-vs-message-queues/">File-Based Coordination vs Message Queues for AI Agents</a></h3>
-    <p class="dek">Why a local agent hive coordinates through plain files, not Redis or RabbitMQ: the zero-ops wins, the real tradeoffs, and where files hit a ceiling.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/file-based-coordination-vs-message-queues/" aria-label="Read: File-Based Coordination vs Message Queues for AI Agents">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -84,15 +84,15 @@
   building a self-coordinating hive of agents with a GOD orchestrator you talk to.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
-    <a class="chip" aria-current="page">All<span class="ct">117</span></a>
+    <a class="chip" aria-current="page">All<span class="ct">118</span></a>
     
     <a class="chip" href="/blog/topics/guides/">guides<span class="ct">34</span></a>
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
@@ -107,6 +107,30 @@
 
 
 <div class="wrap featured"><article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+
+</div>
+
+
+<section class="wrap">
+  <div class="post-grid">
+    <article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -124,13 +148,7 @@
     </div>
   </div>
 </article>
-
-</div>
-
-
-<section class="wrap">
-  <div class="post-grid">
-    <article class="card">
+<article class="card">
   <a class="thumb t-comparisons" href="/blog/qm-vs-munder-difflin/" aria-hidden="true" tabindex="-1">
     <span>COMPARISONS</span>
   </a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -84,7 +84,7 @@
   building a self-coordinating hive of agents with a GOD orchestrator you talk to.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
-    <a class="chip" aria-current="page">All<span class="ct">118</span></a>
+    <a class="chip" aria-current="page">All<span class="ct">119</span></a>
     
     <a class="chip" href="/blog/topics/guides/">guides<span class="ct">34</span></a>
     
@@ -94,7 +94,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     
@@ -107,6 +107,30 @@
 
 
 <div class="wrap featured"><article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+
+</div>
+
+
+<section class="wrap">
+  <div class="post-grid">
+    <article class="card">
   <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -124,13 +148,7 @@
     </div>
   </div>
 </article>
-
-</div>
-
-
-<section class="wrap">
-  <div class="post-grid">
-    <article class="card">
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/launching-munder-difflin-v0-2-0/index.html
+++ b/docs/blog/launching-munder-difflin-v0-2-0/index.html
@@ -314,6 +314,24 @@ the next release is built the same way this one was.</p>
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -346,24 +364,6 @@ the next release is built the same way this one was.</p>
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-27">Jun 27, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>7 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
-    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-2-4/index.html
+++ b/docs/blog/launching-munder-difflin-v0-2-4/index.html
@@ -266,6 +266,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -298,24 +316,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-27">Jun 27, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>7 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
-    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-2-8/index.html
+++ b/docs/blog/launching-munder-difflin-v0-2-8/index.html
@@ -276,6 +276,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -308,24 +326,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-27">Jun 27, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>7 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
-    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-0/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-0/index.html
@@ -268,6 +268,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -300,24 +318,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-27">Jun 27, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>7 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
-    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-2/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-2/index.html
@@ -269,6 +269,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -301,24 +319,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-3/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-3/index.html
@@ -260,6 +260,24 @@ help it reach more people.</p>
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -292,24 +310,6 @@ help it reach more people.</p>
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-5/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-5/index.html
@@ -280,6 +280,24 @@ to help it reach more people.</p>
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -312,24 +330,6 @@ to help it reach more people.</p>
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-0/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-21">Jun 21, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>6 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-0/">Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers</a></h3>
-    <p class="dek">Munder Difflin v0.3.0 makes every hire — and Michael himself — a pluggable engine, adds an integrations registry with a write-only secret broker, and lets the god orchestrator spawn an ephemeral worker straight from Slack.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-0/" aria-label="Read: Launching Munder Difflin v0.3.0: Selectable Engines, Integrations &amp; Slack-Spawned Workers">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/launching-munder-difflin-v0-3-5/index.html
+++ b/docs/blog/launching-munder-difflin-v0-3-5/index.html
@@ -274,7 +274,7 @@ to help it reach more people.</p>
 
   <footer class="post-foot wrap"><div class="prevnext">
       <a class="pn prev" href="/blog/qm-vs-munder-difflin/"><span class="k">← Older</span><span class="t">qm vs Munder Difflin: YC&#39;s Multiplayer Harness or a Local-First Agent Office?</span></a>
-      <span></span>
+      <a class="pn next" href="/blog/why-our-auto-update-never-ran/"><span class="k">Newer →</span><span class="t">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</span></a>
     </div>
     <section class="related">
       <h2>Related in Story</h2>

--- a/docs/blog/node-pty-electron-real-terminals/index.html
+++ b/docs/blog/node-pty-electron-real-terminals/index.html
@@ -323,6 +323,24 @@ real terminals driving real agents; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -355,24 +373,6 @@ real terminals driving real agents; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/observability-for-agent-fleets/index.html
+++ b/docs/blog/observability-for-agent-fleets/index.html
@@ -260,6 +260,24 @@ open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -292,24 +310,6 @@ open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/one-prompt-automated-pr-review/index.html
+++ b/docs/blog/one-prompt-automated-pr-review/index.html
@@ -195,6 +195,24 @@
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -227,24 +245,6 @@
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-27">Jun 27, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>7 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
-    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/recovering-from-agent-failures/index.html
+++ b/docs/blog/recovering-from-agent-failures/index.html
@@ -280,6 +280,24 @@ there to read.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -312,24 +330,6 @@ there to read.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/rendering-many-live-terminals-performance/index.html
+++ b/docs/blog/rendering-many-live-terminals-performance/index.html
@@ -283,6 +283,24 @@ to run many real terminals without melting your CPU; it’s free and open source
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -315,24 +333,6 @@ to run many real terminals without melting your CPU; it’s free and open source
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/single-committer-git-pattern/index.html
+++ b/docs/blog/single-committer-git-pattern/index.html
@@ -290,6 +290,24 @@ never corrupt their own state; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -322,24 +340,6 @@ never corrupt their own state; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/tags/debugging/index.html
+++ b/docs/blog/tags/debugging/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Debugging</h1>
-  <p class="lead">1 post tagged <strong>Debugging</strong>.</p>
+  <p class="lead">2 posts tagged <strong>Debugging</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-guides" href="/blog/debugging-multi-agent-systems/" aria-hidden="true" tabindex="-1">
     <span>GUIDES</span>
   </a>

--- a/docs/blog/tags/electron/index.html
+++ b/docs/blog/tags/electron/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Electron</h1>
-  <p class="lead">4 posts tagged <strong>Electron</strong>.</p>
+  <p class="lead">5 posts tagged <strong>Electron</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>

--- a/docs/blog/tags/ide/index.html
+++ b/docs/blog/tags/ide/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#IDE</h1>
-  <p class="lead">3 posts tagged <strong>IDE</strong>.</p>
+  <p class="lead">4 posts tagged <strong>IDE</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/internals/index.html
+++ b/docs/blog/tags/internals/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Internals</h1>
-  <p class="lead">23 posts tagged <strong>Internals</strong>.</p>
+  <p class="lead">24 posts tagged <strong>Internals</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>

--- a/docs/blog/tags/multi-agent/index.html
+++ b/docs/blog/tags/multi-agent/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Multi-Agent</h1>
-  <p class="lead">81 posts tagged <strong>Multi-Agent</strong>.</p>
+  <p class="lead">82 posts tagged <strong>Multi-Agent</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/open-source/index.html
+++ b/docs/blog/tags/open-source/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Open Source</h1>
-  <p class="lead">16 posts tagged <strong>Open Source</strong>.</p>
+  <p class="lead">17 posts tagged <strong>Open Source</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>

--- a/docs/blog/tags/open-source/index.html
+++ b/docs/blog/tags/open-source/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Open Source</h1>
-  <p class="lead">15 posts tagged <strong>Open Source</strong>.</p>
+  <p class="lead">16 posts tagged <strong>Open Source</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/release/index.html
+++ b/docs/blog/tags/release/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Release</h1>
-  <p class="lead">9 posts tagged <strong>Release</strong>.</p>
+  <p class="lead">10 posts tagged <strong>Release</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>

--- a/docs/blog/tags/release/index.html
+++ b/docs/blog/tags/release/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Release</h1>
-  <p class="lead">8 posts tagged <strong>Release</strong>.</p>
+  <p class="lead">9 posts tagged <strong>Release</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/story/index.html
+++ b/docs/blog/tags/story/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Story</h1>
-  <p class="lead">11 posts tagged <strong>Story</strong>.</p>
+  <p class="lead">12 posts tagged <strong>Story</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/tags/voice/index.html
+++ b/docs/blog/tags/voice/index.html
@@ -57,11 +57,29 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Voice</h1>
-  <p class="lead">3 posts tagged <strong>Voice</strong>.</p>
+  <p class="lead">4 posts tagged <strong>Voice</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/the-hook-shim-pattern/index.html
+++ b/docs/blog/the-hook-shim-pattern/index.html
@@ -279,6 +279,24 @@ at the mercy of the bridge.
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -311,24 +329,6 @@ at the mercy of the bridge.
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/the-office-parody-behind-munder-difflin/index.html
+++ b/docs/blog/the-office-parody-behind-munder-difflin/index.html
@@ -268,6 +268,24 @@ Michael’s already at his desk. Free and open source.</p>
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -300,24 +318,6 @@ Michael’s already at his desk. Free and open source.</p>
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-27">Jun 27, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>7 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
-    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/topics/comparisons/index.html
+++ b/docs/blog/topics/comparisons/index.html
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/" aria-current="page">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/" aria-current="page">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     

--- a/docs/blog/topics/comparisons/index.html
+++ b/docs/blog/topics/comparisons/index.html
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/" aria-current="page">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     

--- a/docs/blog/topics/concepts/index.html
+++ b/docs/blog/topics/concepts/index.html
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     

--- a/docs/blog/topics/concepts/index.html
+++ b/docs/blog/topics/concepts/index.html
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/" aria-current="page">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     

--- a/docs/blog/topics/guides/index.html
+++ b/docs/blog/topics/guides/index.html
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     

--- a/docs/blog/topics/guides/index.html
+++ b/docs/blog/topics/guides/index.html
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     

--- a/docs/blog/topics/index.html
+++ b/docs/blog/topics/index.html
@@ -83,20 +83,20 @@
       </div>
     </a>
     
-    <a class="card" href="/blog/topics/comparisons/" style="text-decoration:none">
-      <span class="thumb t-comparisons" aria-hidden="true">COMPARISONS</span>
+    <a class="card" href="/blog/topics/internals/" style="text-decoration:none">
+      <span class="thumb t-internals" aria-hidden="true">INTERNALS</span>
       <div class="body">
-        <h3 style="color:var(--ink)">comparisons</h3>
+        <h3 style="color:var(--ink)">internals</h3>
         <p class="dek">17 posts.</p>
         <div class="foot"><span class="more">View topic →</span></div>
       </div>
     </a>
     
-    <a class="card" href="/blog/topics/internals/" style="text-decoration:none">
-      <span class="thumb t-internals" aria-hidden="true">INTERNALS</span>
+    <a class="card" href="/blog/topics/comparisons/" style="text-decoration:none">
+      <span class="thumb t-comparisons" aria-hidden="true">COMPARISONS</span>
       <div class="body">
-        <h3 style="color:var(--ink)">internals</h3>
-        <p class="dek">16 posts.</p>
+        <h3 style="color:var(--ink)">comparisons</h3>
+        <p class="dek">17 posts.</p>
         <div class="foot"><span class="more">View topic →</span></div>
       </div>
     </a>
@@ -147,9 +147,9 @@
     
     <a class="chip" href="/blog/tags/claude-code/">Claude Code<span class="ct">45</span></a>
     
-    <a class="chip" href="/blog/tags/guides/">Guides<span class="ct">23</span></a>
+    <a class="chip" href="/blog/tags/internals/">Internals<span class="ct">24</span></a>
     
-    <a class="chip" href="/blog/tags/internals/">Internals<span class="ct">23</span></a>
+    <a class="chip" href="/blog/tags/guides/">Guides<span class="ct">23</span></a>
     
     <a class="chip" href="/blog/tags/orchestration/">Orchestration<span class="ct">19</span></a>
     
@@ -157,7 +157,7 @@
     
     <a class="chip" href="/blog/tags/comparisons/">Comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/tags/open-source/">Open Source<span class="ct">15</span></a>
+    <a class="chip" href="/blog/tags/open-source/">Open Source<span class="ct">16</span></a>
     
     <a class="chip" href="/blog/tags/local-first/">Local-First<span class="ct">13</span></a>
     
@@ -169,9 +169,9 @@
     
     <a class="chip" href="/blog/tags/getting-started/">Getting Started<span class="ct">9</span></a>
     
-    <a class="chip" href="/blog/tags/memory/">Memory<span class="ct">8</span></a>
+    <a class="chip" href="/blog/tags/release/">Release<span class="ct">9</span></a>
     
-    <a class="chip" href="/blog/tags/release/">Release<span class="ct">8</span></a>
+    <a class="chip" href="/blog/tags/memory/">Memory<span class="ct">8</span></a>
     
     <a class="chip" href="/blog/tags/human-in-the-loop/">Human-in-the-Loop<span class="ct">7</span></a>
     
@@ -189,11 +189,11 @@
     
     <a class="chip" href="/blog/tags/guardrails/">Guardrails<span class="ct">5</span></a>
     
+    <a class="chip" href="/blog/tags/electron/">Electron<span class="ct">5</span></a>
+    
     <a class="chip" href="/blog/tags/autonomous/">Autonomous<span class="ct">5</span></a>
     
     <a class="chip" href="/blog/tags/git/">Git<span class="ct">4</span></a>
-    
-    <a class="chip" href="/blog/tags/electron/">Electron<span class="ct">4</span></a>
     
     <a class="chip" href="/blog/tags/mcp/">MCP<span class="ct">4</span></a>
     
@@ -239,6 +239,8 @@
     
     <a class="chip" href="/blog/tags/performance/">Performance<span class="ct">2</span></a>
     
+    <a class="chip" href="/blog/tags/debugging/">Debugging<span class="ct">2</span></a>
+    
     <a class="chip" href="/blog/tags/prompt-caching/">Prompt Caching<span class="ct">2</span></a>
     
     <a class="chip" href="/blog/tags/slack/">Slack<span class="ct">2</span></a>
@@ -274,8 +276,6 @@
     <a class="chip" href="/blog/tags/error-handling/">Error Handling<span class="ct">1</span></a>
     
     <a class="chip" href="/blog/tags/context-engineering/">Context Engineering<span class="ct">1</span></a>
-    
-    <a class="chip" href="/blog/tags/debugging/">Debugging<span class="ct">1</span></a>
     
     <a class="chip" href="/blog/tags/evaluation/">Evaluation<span class="ct">1</span></a>
     

--- a/docs/blog/topics/index.html
+++ b/docs/blog/topics/index.html
@@ -105,7 +105,7 @@
       <span class="thumb t-story" aria-hidden="true">STORY</span>
       <div class="body">
         <h3 style="color:var(--ink)">story</h3>
-        <p class="dek">10 posts.</p>
+        <p class="dek">11 posts.</p>
         <div class="foot"><span class="more">View topic →</span></div>
       </div>
     </a>
@@ -143,7 +143,7 @@
   <div class="filters" style="padding-top:36px">
     <span class="eyebrow" style="align-self:center">Tags</span>
     
-    <a class="chip" href="/blog/tags/multi-agent/">Multi-Agent<span class="ct">81</span></a>
+    <a class="chip" href="/blog/tags/multi-agent/">Multi-Agent<span class="ct">82</span></a>
     
     <a class="chip" href="/blog/tags/claude-code/">Claude Code<span class="ct">45</span></a>
     
@@ -157,19 +157,19 @@
     
     <a class="chip" href="/blog/tags/comparisons/">Comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/tags/open-source/">Open Source<span class="ct">16</span></a>
+    <a class="chip" href="/blog/tags/open-source/">Open Source<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/tags/local-first/">Local-First<span class="ct">13</span></a>
     
-    <a class="chip" href="/blog/tags/automation/">Automation<span class="ct">11</span></a>
+    <a class="chip" href="/blog/tags/story/">Story<span class="ct">12</span></a>
     
-    <a class="chip" href="/blog/tags/story/">Story<span class="ct">11</span></a>
+    <a class="chip" href="/blog/tags/automation/">Automation<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/tags/tools/">Tools<span class="ct">10</span></a>
     
-    <a class="chip" href="/blog/tags/getting-started/">Getting Started<span class="ct">9</span></a>
+    <a class="chip" href="/blog/tags/release/">Release<span class="ct">10</span></a>
     
-    <a class="chip" href="/blog/tags/release/">Release<span class="ct">9</span></a>
+    <a class="chip" href="/blog/tags/getting-started/">Getting Started<span class="ct">9</span></a>
     
     <a class="chip" href="/blog/tags/memory/">Memory<span class="ct">8</span></a>
     
@@ -203,6 +203,10 @@
     
     <a class="chip" href="/blog/tags/cli-agents/">CLI Agents<span class="ct">4</span></a>
     
+    <a class="chip" href="/blog/tags/voice/">Voice<span class="ct">4</span></a>
+    
+    <a class="chip" href="/blog/tags/ide/">IDE<span class="ct">4</span></a>
+    
     <a class="chip" href="/blog/tags/workflow/">Workflow<span class="ct">3</span></a>
     
     <a class="chip" href="/blog/tags/terminals/">Terminals<span class="ct">3</span></a>
@@ -215,11 +219,7 @@
     
     <a class="chip" href="/blog/tags/seo/">SEO<span class="ct">3</span></a>
     
-    <a class="chip" href="/blog/tags/voice/">Voice<span class="ct">3</span></a>
-    
     <a class="chip" href="/blog/tags/engines/">Engines<span class="ct">3</span></a>
-    
-    <a class="chip" href="/blog/tags/ide/">IDE<span class="ct">3</span></a>
     
     <a class="chip" href="/blog/tags/god/">GOD<span class="ct">2</span></a>
     

--- a/docs/blog/topics/internals/index.html
+++ b/docs/blog/topics/internals/index.html
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     

--- a/docs/blog/topics/internals/index.html
+++ b/docs/blog/topics/internals/index.html
@@ -62,7 +62,7 @@
   </nav>
   <p class="eyebrow">Topic</p>
   <h1>internals</h1>
-  <p class="lead">16 posts in this cluster.</p>
+  <p class="lead">17 posts in this cluster.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
     <a class="chip" href="/blog/">All</a>
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/" aria-current="page">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/" aria-current="page">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     
@@ -89,6 +89,24 @@
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>

--- a/docs/blog/topics/memory/index.html
+++ b/docs/blog/topics/memory/index.html
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     

--- a/docs/blog/topics/memory/index.html
+++ b/docs/blog/topics/memory/index.html
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     

--- a/docs/blog/topics/orchestration/index.html
+++ b/docs/blog/topics/orchestration/index.html
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     

--- a/docs/blog/topics/orchestration/index.html
+++ b/docs/blog/topics/orchestration/index.html
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/" aria-current="page">orchestration<span class="ct">9</span></a>
     

--- a/docs/blog/topics/story/index.html
+++ b/docs/blog/topics/story/index.html
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/" aria-current="page">story<span class="ct">10</span></a>
     

--- a/docs/blog/topics/story/index.html
+++ b/docs/blog/topics/story/index.html
@@ -62,7 +62,7 @@
   </nav>
   <p class="eyebrow">Topic</p>
   <h1>story</h1>
-  <p class="lead">10 posts in this cluster.</p>
+  <p class="lead">11 posts in this cluster.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
     <a class="chip" href="/blog/">All</a>
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/" aria-current="page">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/" aria-current="page">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     
@@ -89,6 +89,24 @@
 <section class="wrap">
   <div class="post-grid">
     <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>

--- a/docs/blog/topics/use-cases/index.html
+++ b/docs/blog/topics/use-cases/index.html
@@ -75,7 +75,7 @@
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
+    <a class="chip" href="/blog/topics/story/">story<span class="ct">11</span></a>
     
     <a class="chip" href="/blog/topics/orchestration/">orchestration<span class="ct">9</span></a>
     

--- a/docs/blog/topics/use-cases/index.html
+++ b/docs/blog/topics/use-cases/index.html
@@ -71,9 +71,9 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">17</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">16</span></a>
+    <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
     <a class="chip" href="/blog/topics/story/">story<span class="ct">10</span></a>
     

--- a/docs/blog/visualizing-ai-agents-pixijs/index.html
+++ b/docs/blog/visualizing-ai-agents-pixijs/index.html
@@ -280,6 +280,24 @@ to see your agents at work; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
     <span>INTERNALS</span>
   </a>
@@ -312,24 +330,6 @@ to see your agents at work; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
-    <span>INTERNALS</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
-    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/whats-up-with-munder-difflin/index.html
+++ b/docs/blog/whats-up-with-munder-difflin/index.html
@@ -1,0 +1,424 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own — Munder Difflin Blog</title>
+<meta name="description" content="Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it." />
+<link rel="canonical" href="https://munderdiffl.in/blog/whats-up-with-munder-difflin/" />
+
+<link rel="icon" type="image/png" href="https://munderdiffl.in/logo.png" />
+<link rel="apple-touch-icon" href="https://munderdiffl.in/logo.png" />
+<meta name="theme-color" content="#F5F2E8" />
+
+<!-- Open Graph -->
+<meta property="og:site_name" content="Munder Difflin Blog" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own — Munder Difflin Blog" />
+<meta property="og:description" content="Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it." />
+<meta property="og:url" content="https://munderdiffl.in/blog/whats-up-with-munder-difflin/" />
+<meta property="og:image" content="https://munderdiffl.in/media/og.png" />
+<meta property="og:locale" content="en_US" />
+<meta property="article:published_time" content="2026-08-08T00:00:00.000Z" />
+<meta property="article:author" content="Chaitanya Giri" />
+<meta property="article:tag" content="Story" />
+<meta property="article:tag" content="Release" />
+<meta property="article:tag" content="Multi-Agent" />
+<meta property="article:tag" content="Voice" />
+<meta property="article:tag" content="IDE" />
+<meta property="article:tag" content="Open Source" />
+
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own — Munder Difflin Blog" />
+<meta name="twitter:description" content="Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it." />
+<meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
+
+<link rel="alternate" type="application/atom+xml" title="Munder Difflin Blog" href="https://munderdiffl.in/blog/feed.xml" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/blog/assets/blog.css" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "What's Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own",
+  "description": "Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.",
+  "image": ["https://munderdiffl.in/media/og.png"],
+  "datePublished": "2026-08-08T00:00:00.000Z",
+  "dateModified": "2026-08-08T00:00:00.000Z",
+  "author": { "@type": "Person", "name": "Chaitanya Giri" },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Munder Difflin",
+    "logo": { "@type": "ImageObject", "url": "https://munderdiffl.in/logo.png" }
+  },
+  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://munderdiffl.in/blog/whats-up-with-munder-difflin/" },
+  "keywords": "munder difflin v0.3.7, personal agi harness, local multi agent harness update, claude code multi-agent release notes, voice ai agent orchestration, electron auto update fix, open source agent harness",
+  "articleSection": "Story",
+  "inLanguage": "en-US",
+  "url": "https://munderdiffl.in/blog/whats-up-with-munder-difflin/"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://munderdiffl.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://munderdiffl.in/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "What's Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own", "item": "https://munderdiffl.in/blog/whats-up-with-munder-difflin/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What's new in Munder Difflin v0.3.7?", "acceptedAnswer": { "@type": "Answer", "text": "v0.3.7 fixes auto-update, which had silently never worked in any packaged build since it shipped in v0.3.4. A CommonJS export vanished across the ESM import boundary, the resulting error was swallowed by a catch block, and the app quietly fell back to just linking you to the releases page. The version number in the toolbar is now the update button — it shows download progress and turns into 'restart to update' — and update failures now reach both the UI and a log file instead of disappearing." } },
+    { "@type": "Question", "name": "What shipped between v0.3.3 and v0.3.7?", "acceptedAnswer": { "@type": "Answer", "text": "Four releases in about six weeks. v0.3.4 was the big wave: voice orchestration that opens with a live snapshot of every agent and can run nearly the whole app, markdown previews everywhere, a git time-machine in the built-in IDE (commit history, branch compare, guarded checkout), a six-tab Settings redesign, xAI Grok and Kimi Code engines, and one single delivery gate for every automatic writer. v0.3.5 added a 'send now' escape hatch for a paused queue. v0.3.6 made a machine with nothing installed on it able to run agents — Node and npm install themselves, verified against Apple's published checksums. v0.3.7 fixed auto-update." } },
+    { "@type": "Question", "name": "Do I need to reinstall to get v0.3.7?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, once. Every build from v0.3.4 through v0.3.6 carries the broken updater and cannot fetch the fix that repairs it — the one bootstrap problem a self-updating app can't solve for itself. Download v0.3.7 from munderdiffl.in or the GitHub releases page. From v0.3.7 onward, updates download in the background and wait for your restart." } },
+    { "@type": "Question", "name": "How many agent CLIs does Munder Difflin support?", "acceptedAnswer": { "@type": "Answer", "text": "Nine: Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, xAI Grok, Kimi Code, OpenCode, Crush, and pi.dev. Each gets a desk, a mailbox, and shared memory, and most can play the GOD orchestrator role themselves. You can mix engines on the same floor, and bring your own API keys or point them at local models through Ollama, LM Studio, or vLLM." } },
+    { "@type": "Question", "name": "Is Munder Difflin free?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. MIT-licensed, free forever, and local-first. It drives the agent CLI subscriptions you already pay for rather than adding a bill of its own, and your code never leaves your machine." } }
+    
+  ]
+}
+</script>
+
+
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<nav id="nav">
+  <a class="brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+    <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+  </a>
+  <span class="spacer"></span>
+  <div class="links">
+    <a href="/blog/">Latest</a>
+    <a href="/blog/topics/">Topics</a>
+    <a href="/blog/about/">About</a>
+    <a href="https://munderdiffl.in">↗ Product</a>
+  </div>
+  <div class="nav-actions">
+    <a class="btn sm" href="https://munderdiffl.in/blog/feed.xml" aria-label="RSS feed">⤵ RSS</a>
+    <a class="btn sm primary" href="https://munderdiffl.in/#install">⤓ Download</a>
+  </div>
+</nav>
+
+<main id="main">
+
+<article>
+  <header class="post-head wrap">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/blog/">Blog</a>
+      <span>/</span>
+      <a href="/blog/topics/story/">Story</a>
+    </nav>
+    <h1>What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</h1>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="byline">
+      <span class="av" aria-hidden="true">CG</span>
+      <strong>Chaitanya Giri</strong>
+      <span class="dot" aria-hidden="true">·</span>
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true">·</span>
+      <span>7 min read</span>
+      <span class="tag kind">Story</span>
+    </div>
+  </header>
+
+  <div class="post-wrap wrap">
+    <div class="prose">
+      <div class="callout tldr"><span class="ic">TL;DR</span><p>Six weeks, four releases. <strong>Michael learned the floor</strong> and can now run nearly the whole app by voice. The IDE became a <strong>git time-machine</strong>. Two more engines brought the roster to <strong>nine</strong>. The message queue got <strong>one gate</strong> instead of four competing loops. A machine with <strong>nothing installed on it</strong> can now run agents. And <strong>auto-update — which had never once worked</strong> — actually works. If you're on v0.3.5 or v0.3.6, you'll need to grab v0.3.7 by hand, once.</p></div>
+<p>AGI is not going to arrive as an event. No announcement, no threshold, no day the sky
+changes colour. It’s arriving diffused — your agents, running on your context, doing your
+work, on hardware you own.</p>
+<p>Garry Tan puts the next decade in one line: <strong>a rented frontier model, plus your own
+context, plus a harness that wires them together.</strong> Only one of those three is for sale, and
+it’s the cheapest one. The model is a commodity you rent by the token. Your context — your
+repos, your decisions and the reasons behind them, what you owe people and what they said
+last time — isn’t for sale at any price, because it only exists in your head.</p>
+<p>The harness is the part in the middle. It decides which context reaches which model at which
+step, and then lets the result act on the world. It’s the part of the stack you can actually
+own, and it’s the part Munder Difflin exists to give away.</p>
+<p>So: what have we done to that middle term in the last six weeks?</p>
+<h2 id="michael-learned-the-floor" tabindex="-1">Michael learned the floor <a class="anchor" href="#michael-learned-the-floor" aria-hidden="true">#</a></h2>
+<p>Talk mode could <em>do</em> things since v0.3.2. What it couldn’t do was <em>know</em> things. Every “what’s
+everyone working on?” turned into a round of tool calls and dead air.</p>
+<p>Now the voice session opens with a live snapshot of the whole floor — every agent’s status,
+engine, context fill, circuit-breaker state, inbox depth, and in-flight tasks — and keeps
+receiving silent updates as things change mid-call. Ask what’s happening and he just answers.</p>
+<p>He also graduated from narrator to operator. He can resume a paused agent, pause and resume
+floor-wide delivery, gate specific tools, manage tasks and schedules, clear an agent’s
+context, archive workers, and change settings from a strict allowlist. Anything destructive
+still waits for you to say a distinct confirm word out loud, and secrets can’t be touched by
+voice at all.</p>
+<h2 id="the-ide-became-a-git-time-machine" tabindex="-1">The IDE became a git time-machine <a class="anchor" href="#the-ide-became-a-git-time-machine" aria-hidden="true">#</a></h2>
+<p>v0.3.3 gave the built-in Monaco IDE a diff against HEAD. This wave made it somewhere you can
+move through history:</p>
+<ul>
+<li><strong>History</strong> — a clickable commit graph. Pick a commit, see the files it touched, open
+side-by-side diffs of exactly what changed.</li>
+<li><strong>Compare</strong> — any two branches, with ahead/behind counts and per-file diffs.</li>
+<li><strong>Guarded checkout</strong> — it refuses to move a dirty tree, or pull code out from under an
+agent that’s actively working in it.</li>
+</ul>
+<p>Agents write a <em>lot</em> of markdown, so that got fixed too: ⌘-click any <code>.md</code> path an agent
+prints in its terminal and it opens rendered. In the IDE, markdown files get a
+code | split | preview switch that re-renders live. There’s no raw-HTML pipeline anywhere in
+it, which is the only way reading agent-generated files is safe by construction.</p>
+<h2 id="nine-engines" tabindex="-1">Nine engines <a class="anchor" href="#nine-engines" aria-hidden="true">#</a></h2>
+<p><strong>xAI Grok</strong> and <strong>Kimi Code</strong> joined, bringing the roster to nine: Claude Code, OpenAI
+Codex, Antigravity, GitHub Copilot CLI, Grok, Kimi, OpenCode, Crush, and pi.dev. Grok came in
+as a full hive citizen — lifecycle-hook adapter, guarded inbox delivery, <code>--resume</code> — not
+just a worker you can spawn.</p>
+<p>Settings was rebuilt into six clear tabs at the same time. The default agent model, autonomy
+mode, and the full circuit breaker finally have real controls instead of being buried or
+missing.</p>
+<h2 id="one-gate-for-the-queue" tabindex="-1">One gate for the queue <a class="anchor" href="#one-gate-for-the-queue" aria-hidden="true">#</a></h2>
+<p>This is the least glamorous thing here and probably the one you’ll feel most.</p>
+<p>The message queue kept breaking because <em>four</em> different loops each decided, independently,
+when it was safe to type into a terminal. Now a single drain loop owns that decision — and
+automation never wipes your draft or closes your menus. A user draft or an open picker holds
+delivery (visible as a <strong>“your draft”</strong> badge), and expired blocks type <em>after</em> your text
+instead of over it. The whole contract is written down in
+<a href="https://github.com/chaitanyagiri/munder-difflin/blob/main/docs/message-queue.md"><code>docs/message-queue.md</code></a>.</p>
+<p>v0.3.5 closed the last hole in it: pausing floor-wide delivery used to strand every queued
+message with no override and no explanation. Each row now gets a <strong>send now</strong> link that
+bypasses only the pause gate, and the composer says exactly why the queue is being held.</p>
+<p>A big share of this — the terminal, queue, and roster reliability work — is community code
+from <a href="https://github.com/gts-47"><strong>Vyapak Goyal (@gts-47)</strong></a>, with major fixes from
+<a href="https://github.com/qschmick"><strong>@qschmick</strong></a>: killed processes now actually die (every kill
+path escalates to a process-group kill), the circuit breaker stopped false-positive storming
+on idle agents, and warm usage reads got about <strong>350× faster</strong>.</p>
+<h2 id="a-machine-with-nothing-on-it-can-run-agents" tabindex="-1">A machine with nothing on it can run agents <a class="anchor" href="#a-machine-with-nothing-on-it-can-run-agents" aria-hidden="true">#</a></h2>
+<p>v0.3.6 was one failure wearing five different costumes: the app assumed your machine already
+had things on it. A shell to expand <code>~</code>. A <code>node</code> on PATH. An npm to install with. When it
+didn’t, agents died with a bare exit code and no explanation.</p>
+<ul>
+<li><strong>Node and npm install themselves.</strong> Pick an engine on a machine with no Node and the app
+fetches the current LTS from <a href="http://nodejs.org">nodejs.org</a>, <strong>verifies it against the official
+<code>SHASUMS256.txt</code> before anything runs</strong>, installs it visibly in that agent’s own terminal,
+then installs the CLI. Already have Node 20+? Left completely alone. And when no installer
+could possibly succeed, the banner names the missing piece and runs <em>nothing</em> — instead of
+firing <code>npm install -g</code> on a machine with no npm and letting you watch <code>command not found</code>
+scroll past.</li>
+<li><strong>Hooks stopped dying with exit 127.</strong> Agent CLIs run hooks through <code>sh -c</code> with a bare
+<code>PATH=/usr/bin:/bin:/usr/sbin:/sbin</code> — nvm’s node isn’t on it — so hook payloads were being
+lost entirely: no live status, no Stop→inbox drain, no session IDs. This is also why the
+orchestrator kept going stale across restarts.</li>
+<li><strong><code>~/dev/foo</code> works.</strong> Only a shell expands <code>~</code>; Node treats it as a literal folder name,
+so every typed <code>~/…</code> path failed its existence check and the agent never spawned.</li>
+<li><strong>The office floor survives losing its GPU context.</strong> Chromium evicts the oldest WebGL
+context past about sixteen. The floor is created at startup, so it was always first to go —
+and Pixi reported nothing at all, so it just went blank until you restarted. It notices and
+rebuilds itself now.</li>
+</ul>
+<h2 id="and-then-auto-update-had-never-once-worked" tabindex="-1">And then: auto-update had never once worked <a class="anchor" href="#and-then-auto-update-had-never-once-worked" aria-hidden="true">#</a></h2>
+<p>Here’s the confession.</p>
+<p>We shipped auto-update in v0.3.4 and announced it. It has never run. Not once, in any
+packaged build, through three releases.</p>
+<p><code>electron-updater</code> is a CommonJS module that exposes <code>autoUpdater</code> through a lazy getter.
+Node’s module lexer detects CommonJS named exports by static analysis, and it cannot see
+through a getter defined at runtime — so <code>await import('electron-updater')</code> handed back a
+namespace with no <code>autoUpdater</code> on it at all. We destructured it, got <code>undefined</code>, and the
+very next line threw:</p>
+<pre><code>TypeError: Cannot set properties of undefined (setting 'autoDownload')
+</code></pre>
+<p>That exception landed in a <code>catch</code> that flipped the app to notify-only mode and moved on.
+Which is why the only thing it could ever offer was a link to the releases page. It never
+showed up in testing because the entire path sits behind <code>app.isPackaged</code> — it simply does
+not execute in development.</p>
+<p>The interop fix is one line. The real bug was the <code>catch</code> that threw the error away, and
+that’s what v0.3.7 actually changes:</p>
+<ul>
+<li><strong>Errors are never swallowed.</strong> Every updater failure now reaches the UI <em>and</em> an
+<code>updater.log</code> on disk.</li>
+<li><strong>The fallback is per-check, not a latch.</strong> One network blip used to cost the whole session
+its ability to self-update.</li>
+<li><strong>The version number in the toolbar is now the update button.</strong> It shows <code>checking…</code>, then
+<code>ready to install</code>, then live download progress, then <strong>restart to update</strong>. Click it with
+nothing pending and it checks on demand — before, the app only ever checked 30 seconds
+after launch and then every six hours, with no way to ask.</li>
+</ul>
+<p>There’s a full write-up of the debugging, including the trick that finally made a packaged
+Electron app talk, in <a href="/blog/why-our-auto-update-never-ran/">Why our auto-update never
+ran</a>.</p>
+<h2 id="if-youre-on-v035-or-v036" tabindex="-1">If you’re on v0.3.5 or v0.3.6 <a class="anchor" href="#if-youre-on-v035-or-v036" aria-hidden="true">#</a></h2>
+<p>You’ll need to install v0.3.7 by hand, once. Your current build carries the broken updater,
+so it can’t fetch the fix that repairs it — the one bootstrap problem a self-updating app
+cannot solve for itself.</p>
+<p><a href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><strong>Download v0.3.7</strong></a> —
+macOS (signed and notarized), Windows, Linux. Free, MIT-licensed, local-first, and after this
+one manual step, it keeps itself current.</p>
+<h2 id="whats-next" tabindex="-1">What’s next <a class="anchor" href="#whats-next" aria-hidden="true">#</a></h2>
+<p>More chat bridges, so a Telegram or Slack channel pipes straight into Michael’s queue and his
+replies route back out. More engines, and a wider per-hire capability catalog. More
+integration templates. And pushing the remaining avatar station-visits to be driven entirely
+by real hook events rather than inferred.</p>
+<p>The model you rent gets better every few weeks without you doing anything. Your context is
+already yours. The harness in between is the part worth owning — so it’s free, it’s MIT, and
+it runs on your machine.</p>
+
+
+      
+      <section class="faq" aria-label="Frequently asked questions">
+        <h2 id="faq">FAQ</h2>
+        
+        <div class="qa">
+          <p class="q">What&#39;s new in Munder Difflin v0.3.7?</p>
+          <p class="a">v0.3.7 fixes auto-update, which had silently never worked in any packaged build since it shipped in v0.3.4. A CommonJS export vanished across the ESM import boundary, the resulting error was swallowed by a catch block, and the app quietly fell back to just linking you to the releases page. The version number in the toolbar is now the update button — it shows download progress and turns into &#39;restart to update&#39; — and update failures now reach both the UI and a log file instead of disappearing.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">What shipped between v0.3.3 and v0.3.7?</p>
+          <p class="a">Four releases in about six weeks. v0.3.4 was the big wave: voice orchestration that opens with a live snapshot of every agent and can run nearly the whole app, markdown previews everywhere, a git time-machine in the built-in IDE (commit history, branch compare, guarded checkout), a six-tab Settings redesign, xAI Grok and Kimi Code engines, and one single delivery gate for every automatic writer. v0.3.5 added a &#39;send now&#39; escape hatch for a paused queue. v0.3.6 made a machine with nothing installed on it able to run agents — Node and npm install themselves, verified against Apple&#39;s published checksums. v0.3.7 fixed auto-update.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Do I need to reinstall to get v0.3.7?</p>
+          <p class="a">Yes, once. Every build from v0.3.4 through v0.3.6 carries the broken updater and cannot fetch the fix that repairs it — the one bootstrap problem a self-updating app can&#39;t solve for itself. Download v0.3.7 from munderdiffl.in or the GitHub releases page. From v0.3.7 onward, updates download in the background and wait for your restart.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">How many agent CLIs does Munder Difflin support?</p>
+          <p class="a">Nine: Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, xAI Grok, Kimi Code, OpenCode, Crush, and pi.dev. Each gets a desk, a mailbox, and shared memory, and most can play the GOD orchestrator role themselves. You can mix engines on the same floor, and bring your own API keys or point them at local models through Ollama, LM Studio, or vLLM.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Is Munder Difflin free?</p>
+          <p class="a">Yes. MIT-licensed, free forever, and local-first. It drives the agent CLI subscriptions you already pay for rather than adding a bill of its own, and your code never leaves your machine.</p>
+        </div>
+        
+      </section>
+      
+
+      
+      <hr />
+      <div class="share">
+        <span class="lbl">Tags</span>
+        <a class="tag" href="/blog/tags/story/">Story</a><a class="tag" href="/blog/tags/release/">Release</a><a class="tag" href="/blog/tags/multi-agent/">Multi-Agent</a><a class="tag" href="/blog/tags/voice/">Voice</a><a class="tag" href="/blog/tags/ide/">IDE</a><a class="tag" href="/blog/tags/open-source/">Open Source</a>
+      </div>
+      
+    </div>
+
+    
+    <aside class="toc-rail" aria-label="Table of contents">
+      <div class="tt">On this page</div>
+      <ol>
+        <li class="lvl-2"><a href="#michael-learned-the-floor">Michael learned the floor</a></li><li class="lvl-2"><a href="#the-ide-became-a-git-time-machine">The IDE became a git time-machine</a></li><li class="lvl-2"><a href="#nine-engines">Nine engines</a></li><li class="lvl-2"><a href="#one-gate-for-the-queue">One gate for the queue</a></li><li class="lvl-2"><a href="#a-machine-with-nothing-on-it-can-run-agents">A machine with nothing on it can run agents</a></li><li class="lvl-2"><a href="#and-then-auto-update-had-never-once-worked">And then: auto-update had never once worked</a></li><li class="lvl-2"><a href="#if-youre-on-v035-or-v036">If you’re on v0.3.5 or v0.3.6</a></li><li class="lvl-2"><a href="#whats-next">What’s next</a></li>
+      </ol>
+    </aside>
+    
+  </div>
+
+  <footer class="post-foot wrap"><div class="prevnext">
+      <a class="pn prev" href="/blog/why-our-auto-update-never-ran/"><span class="k">← Older</span><span class="t">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</span></a>
+      <span></span>
+    </div>
+    <section class="related">
+      <h2>Related in Story</h2>
+      <div class="post-grid">
+        <article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-06">Aug 6, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-5/">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</a></h3>
+    <p class="dek">The v0.3.4 + v0.3.5 wave: voice orchestration with live floor context and full app control, markdown previews everywhere, commit history and branch compare in the built-in IDE, a six-tab Settings redesign, xAI Grok and Kimi Code engines, auto-update, and a queue that always has an escape hatch.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-5/" aria-label="Read: Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-3/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-07-03">Jul 3, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>3 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-3/">Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support</a></h3>
+    <p class="dek">Munder Difflin v0.3.3 adds a full Monaco IDE — file tree, editor tabs, save, and side-by-side git diffs of your agents&#39; changes — plus GitHub Copilot CLI as a first-class agent engine, our first community-contributed provider.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-06-27">Jun 27, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
+    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
+    </div>
+  </div>
+</article>
+
+      </div>
+    </section>
+    
+  </footer>
+</article>
+
+</main>
+<footer>
+  <div class="wrap">
+    <div class="foot-top">
+      <a class="foot-brand brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+        <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+      </a>
+      <div class="foot-links">
+        <a href="/blog/">Latest</a>
+        <a href="/blog/topics/">Topics</a>
+        <a href="/blog/about/">About</a>
+        <a href="https://munderdiffl.in/blog/feed.xml">RSS</a>
+        <a href="https://github.com/chaitanyagiri/munder-difflin">GitHub</a>
+        <a href="https://munderdiffl.in">munderdiffl.in ↗</a>
+      </div>
+    </div>
+    <div class="foot-meta">
+      © 2026 Munder Difflin · Local-first · MIT-licensed ·
+      Built on <a href="https://munderdiffl.in">Electron, React, Pixi.js, xterm.js &amp; node-pty</a>.
+      Run an office of agents while you sleep.
+    </div>
+  </div>
+</footer>
+
+<script>
+  // sticky-nav border on scroll
+  (function () {
+    var nav = document.getElementById('nav');
+    if (!nav) return;
+    var onScroll = function () { nav.classList.toggle('scrolled', window.scrollY > 8); };
+    onScroll(); window.addEventListener('scroll', onScroll, { passive: true });
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/blog/why-our-auto-update-never-ran/index.html
+++ b/docs/blog/why-our-auto-update-never-ran/index.html
@@ -1,0 +1,388 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace — Munder Difflin Blog</title>
+<meta name="description" content="Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes." />
+<link rel="canonical" href="https://munderdiffl.in/blog/why-our-auto-update-never-ran/" />
+
+<link rel="icon" type="image/png" href="https://munderdiffl.in/logo.png" />
+<link rel="apple-touch-icon" href="https://munderdiffl.in/logo.png" />
+<meta name="theme-color" content="#F5F2E8" />
+
+<!-- Open Graph -->
+<meta property="og:site_name" content="Munder Difflin Blog" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace — Munder Difflin Blog" />
+<meta property="og:description" content="Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes." />
+<meta property="og:url" content="https://munderdiffl.in/blog/why-our-auto-update-never-ran/" />
+<meta property="og:image" content="https://munderdiffl.in/media/og.png" />
+<meta property="og:locale" content="en_US" />
+<meta property="article:published_time" content="2026-08-08T00:00:00.000Z" />
+<meta property="article:author" content="Chaitanya Giri" />
+<meta property="article:tag" content="Internals" />
+<meta property="article:tag" content="Electron" />
+<meta property="article:tag" content="Debugging" />
+<meta property="article:tag" content="Release" />
+<meta property="article:tag" content="Open Source" />
+
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace — Munder Difflin Blog" />
+<meta name="twitter:description" content="Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes." />
+<meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
+
+<link rel="alternate" type="application/atom+xml" title="Munder Difflin Blog" href="https://munderdiffl.in/blog/feed.xml" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/blog/assets/blog.css" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace",
+  "description": "Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here's how we found it, and what v0.3.7 changes.",
+  "image": ["https://munderdiffl.in/media/og.png"],
+  "datePublished": "2026-08-08T00:00:00.000Z",
+  "dateModified": "2026-08-08T00:00:00.000Z",
+  "author": { "@type": "Person", "name": "Chaitanya Giri" },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Munder Difflin",
+    "logo": { "@type": "ImageObject", "url": "https://munderdiffl.in/logo.png" }
+  },
+  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://munderdiffl.in/blog/why-our-auto-update-never-ran/" },
+  "keywords": "electron-updater not working, electron auto update not working, cjs-module-lexer named export undefined, await import commonjs electron, electron-updater autoUpdater undefined, electron app.isPackaged debugging",
+  "articleSection": "Internals",
+  "inLanguage": "en-US",
+  "url": "https://munderdiffl.in/blog/why-our-auto-update-never-ran/"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://munderdiffl.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://munderdiffl.in/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace", "item": "https://munderdiffl.in/blog/why-our-auto-update-never-ran/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "Why was electron-updater's autoUpdater undefined?", "acceptedAnswer": { "@type": "Answer", "text": "electron-updater is a CommonJS package that attaches autoUpdater to its exports through a lazy Object.defineProperty getter. Node's cjs-module-lexer detects named exports by static analysis, and it cannot see through a getter defined at runtime. So the ESM namespace produced by `await import('electron-updater')` has no autoUpdater key at all — it only exists on the namespace's `.default`. Destructuring `const { autoUpdater } = await import('electron-updater')` therefore yields undefined. Use `ns.autoUpdater ?? ns.default?.autoUpdater`, or plain `require()`, instead." } },
+    { "@type": "Question", "name": "Why didn't this show up in development?", "acceptedAnswer": { "@type": "Answer", "text": "The whole updater setup block was behind an `app.isPackaged` check, which is false in dev. Development runs never executed the line that threw, so the bug could only ever appear in a shipped build — and shipped builds have no visible console. It survived three releases that way." } },
+    { "@type": "Question", "name": "How do you debug an Electron app that only misbehaves when packaged?", "acceptedAnswer": { "@type": "Answer", "text": "Launch the installed binary directly from a terminal with an isolated data directory: `/Applications/YourApp.app/Contents/MacOS/YourApp --user-data-dir=/tmp/probe`. Electron's single-instance lock is keyed to the user-data directory, so this runs alongside the copy the user already has open, and every console.log and stack trace lands in your terminal instead of disappearing." } },
+    { "@type": "Question", "name": "Do I need to reinstall Munder Difflin to get v0.3.7?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, once. Every build from v0.3.4 through v0.3.6 carries the broken updater, so it cannot fetch this fix by itself. Download v0.3.7 manually from munderdiffl.in or the GitHub releases page. From v0.3.7 onward, updates download in the background and wait for your restart." } },
+    { "@type": "Question", "name": "How do you stop a bug like this from hiding again?", "acceptedAnswer": { "@type": "Answer", "text": "Three changes. Errors are never swallowed — every updater failure is emitted to the UI and appended to a log file on disk. The notify-only fallback is per-check rather than a permanent latch, so one blip doesn't disable updates for the session. And the state model moved into a plain electron-free module with unit tests, so the rules can be verified without booting the app." } }
+    
+  ]
+}
+</script>
+
+
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<nav id="nav">
+  <a class="brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+    <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+  </a>
+  <span class="spacer"></span>
+  <div class="links">
+    <a href="/blog/">Latest</a>
+    <a href="/blog/topics/">Topics</a>
+    <a href="/blog/about/">About</a>
+    <a href="https://munderdiffl.in">↗ Product</a>
+  </div>
+  <div class="nav-actions">
+    <a class="btn sm" href="https://munderdiffl.in/blog/feed.xml" aria-label="RSS feed">⤵ RSS</a>
+    <a class="btn sm primary" href="https://munderdiffl.in/#install">⤓ Download</a>
+  </div>
+</nav>
+
+<main id="main">
+
+<article>
+  <header class="post-head wrap">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/blog/">Blog</a>
+      <span>/</span>
+      <a href="/blog/topics/internals/">Internals</a>
+    </nav>
+    <h1>Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</h1>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="byline">
+      <span class="av" aria-hidden="true">CG</span>
+      <strong>Chaitanya Giri</strong>
+      <span class="dot" aria-hidden="true">·</span>
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true">·</span>
+      <span>5 min read</span>
+      <span class="tag kind">Internals</span>
+    </div>
+  </header>
+
+  <div class="post-wrap wrap">
+    <div class="prose">
+      <div class="callout tldr"><span class="ic">TL;DR</span><p>Munder Difflin shipped auto-update in <strong>v0.3.4</strong>. It never ran — not once, in any packaged build, through three releases. The cause was a single destructuring assignment across the CommonJS/ESM boundary that produced <code>undefined</code>, and a <code>catch</code> block that threw away the error message. <strong>v0.3.7</strong> fixes it, turns the toolbar version into the update button, and makes sure the next failure can't hide.</p></div>
+<p>A user restarted the app after v0.3.6 went live and reported that auto-update hadn’t
+triggered. What they got instead was a toast offering to open the releases page in a
+browser — the fallback path, meant for installs that genuinely can’t update themselves.</p>
+<p>That’s a good bug report, because the fallback existing at all means the app <em>knew</em> there
+was a new version. It found the release. It just refused to install it.</p>
+<h2 id="ruling-things-out-expensively" tabindex="-1">Ruling things out, expensively <a class="anchor" href="#ruling-things-out-expensively" aria-hidden="true">#</a></h2>
+<p>The obvious suspect on macOS is notarization. An update that isn’t properly signed and
+stapled gets refused by Gatekeeper, and the failure is quiet. So the published asset went
+under a microscope first:</p>
+<pre class="language-bash"><code class="language-bash">shasum <span class="token parameter variable">-a</span> <span class="token number">512</span> Munder-Difflin-0.3.6-mac-universal.zip   <span class="token comment"># matches latest-mac.yml exactly</span>
+codesign <span class="token parameter variable">--verify</span> <span class="token parameter variable">--deep</span> <span class="token parameter variable">--strict</span> <span class="token parameter variable">--verbose</span><span class="token operator">=</span><span class="token number">2</span> <span class="token string">"Munder Difflin.app"</span>
+xcrun stapler validate <span class="token string">"Munder Difflin.app"</span>
+spctl <span class="token parameter variable">--assess</span> <span class="token parameter variable">-vv</span> <span class="token string">"Munder Difflin.app"</span></code></pre>
+<p>All clean. Developer ID signature, notarization ticket stapled, <code>spctl</code> accepted, and the
+SHA-512 matching the update feed byte for byte. The release was fine.</p>
+<p>Next suspect: the feed. Running <code>electron-updater</code> directly against the live GitHub release
+resolved 0.3.5 → 0.3.6 correctly, downloaded all 232 MB, verified the hash, and emitted
+<code>update-downloaded</code>. The updater library was fine too.</p>
+<p>So the release worked, the library worked, and the app still wouldn’t update. The problem
+had to be in our own code — and our own code was refusing to say what was wrong.</p>
+<h2 id="getting-a-packaged-app-to-talk" tabindex="-1">Getting a packaged app to talk <a class="anchor" href="#getting-a-packaged-app-to-talk" aria-hidden="true">#</a></h2>
+<p>Everything interesting here lives behind <code>app.isPackaged</code>, which is false in development.
+The bug could only exist in a build with no visible console.</p>
+<p>The trick that cracked it: <strong>Electron’s single-instance lock is keyed to the user-data
+directory.</strong> Point a second launch at a different one and it runs happily alongside the
+copy already open, with stdout wired to your terminal.</p>
+<pre class="language-bash"><code class="language-bash"><span class="token string">"/Applications/Munder Difflin.app/Contents/MacOS/Munder Difflin"</span> <span class="token punctuation">\</span>
+  --user-data-dir<span class="token operator">=</span>/tmp/updater-probe</code></pre>
+<p>Thirty seconds later, the first check fired and printed the thing the app had been
+swallowing for three releases:</p>
+<pre><code>[updater] electron-updater unavailable; notify-only mode:
+TypeError: Cannot set properties of undefined (setting 'autoDownload')
+</code></pre>
+<h2 id="one-line-three-releases" tabindex="-1">One line, three releases <a class="anchor" href="#one-line-three-releases" aria-hidden="true">#</a></h2>
+<p>Here is the code that shipped in v0.3.4:</p>
+<pre class="language-js"><code class="language-js"><span class="token keyword">const</span> <span class="token punctuation">{</span> autoUpdater <span class="token punctuation">}</span> <span class="token operator">=</span> <span class="token keyword">await</span> <span class="token keyword">import</span><span class="token punctuation">(</span><span class="token string">'electron-updater'</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+autoUpdater<span class="token punctuation">.</span>autoDownload <span class="token operator">=</span> <span class="token boolean">true</span><span class="token punctuation">;</span>          <span class="token comment">// ← TypeError, every single time</span></code></pre>
+<p><code>electron-updater</code> is a CommonJS package, and it attaches <code>autoUpdater</code> to its exports
+through a lazy <code>Object.defineProperty</code> getter. Node’s ESM loader detects named exports from
+CommonJS with <code>cjs-module-lexer</code>, which works by <strong>static analysis</strong> — and a property
+defined at runtime by a getter is invisible to it.</p>
+<p>The result, confirmed by probing the namespace directly:</p>
+<pre class="language-js"><code class="language-js"><span class="token keyword">const</span> ns <span class="token operator">=</span> <span class="token keyword">await</span> <span class="token keyword">import</span><span class="token punctuation">(</span><span class="token string">'electron-updater'</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+Object<span class="token punctuation">.</span><span class="token function">keys</span><span class="token punctuation">(</span>ns<span class="token punctuation">)</span><span class="token punctuation">;</span>            <span class="token comment">// AppUpdater, MacUpdater, NsisUpdater, … default</span>
+ns<span class="token punctuation">.</span>autoUpdater<span class="token punctuation">;</span>             <span class="token comment">// undefined   ← what we destructured</span>
+ns<span class="token punctuation">.</span>default<span class="token punctuation">.</span>autoUpdater<span class="token punctuation">;</span>     <span class="token comment">// object      ← where it actually lives</span>
+<span class="token function">require</span><span class="token punctuation">(</span><span class="token string">'electron-updater'</span><span class="token punctuation">)</span><span class="token punctuation">.</span>autoUpdater<span class="token punctuation">;</span>  <span class="token comment">// object</span></code></pre>
+<p>So the destructuring produced <code>undefined</code>, and the very next line — setting a property on
+it — threw. That exception landed in a <code>catch</code> that set a <code>fallbackActive</code> flag and moved
+on. From then on, every check in that session took the notify-only path. Which is exactly
+what the user saw: an app that finds new releases and can only offer you a link.</p>
+<p>The fix is unglamorous:</p>
+<pre class="language-js"><code class="language-js"><span class="token keyword">const</span> ns <span class="token operator">=</span> <span class="token keyword">await</span> <span class="token keyword">import</span><span class="token punctuation">(</span><span class="token string">'electron-updater'</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+<span class="token keyword">const</span> autoUpdater <span class="token operator">=</span> ns<span class="token punctuation">.</span>autoUpdater <span class="token operator">??</span> ns<span class="token punctuation">.</span>default<span class="token operator">?.</span>autoUpdater<span class="token punctuation">;</span>
+<span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span>autoUpdater<span class="token punctuation">)</span> <span class="token keyword">throw</span> <span class="token keyword">new</span> <span class="token class-name">Error</span><span class="token punctuation">(</span><span class="token string">'electron-updater exposes no `autoUpdater` export'</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>
+<p><strong>The general rule: never destructure a named export off <code>await import()</code> of a CommonJS
+package.</strong> If the package builds its exports at runtime — getters, <code>Object.assign</code>,
+conditional wiring — the lexer won’t see them, and you get <code>undefined</code> instead of an error
+telling you why.</p>
+<h2 id="the-real-bug-was-the-catch-block" tabindex="-1">The real bug was the catch block <a class="anchor" href="#the-real-bug-was-the-catch-block" aria-hidden="true">#</a></h2>
+<p>A one-character-class fix that survives three releases isn’t really a story about interop.
+It’s a story about a <code>catch</code> that discarded its argument.</p>
+<p>The error existed. It was specific, it named the exact property, and it pointed at the exact
+line. It was thrown away, and replaced with a degraded mode that looked deliberate. Anyone
+watching the app saw a working feature: it noticed new versions and offered a download link.
+Nothing looked broken enough to investigate.</p>
+<p>So v0.3.7 changes three things beyond the interop fix:</p>
+<ul>
+<li><strong>Errors are never swallowed.</strong> Every updater failure is emitted to the renderer <em>and</em>
+appended to an <code>updater.log</code> in the app’s data folder. The tooltip on the toolbar badge
+shows the actual message.</li>
+<li><strong>The fallback is per-check, not a latch.</strong> A transient network error used to cost the
+session its ability to self-update until the next restart. Now the next tick tries the
+native path again.</li>
+<li><strong>The state rules are testable.</strong> How updater events map to what the UI shows moved into a
+plain module with no Electron imports, with unit tests covering the rule that bit us — a
+re-check must never wipe out an update you already have staged.</li>
+</ul>
+<h2 id="the-version-number-is-now-a-button" tabindex="-1">The version number is now a button <a class="anchor" href="#the-version-number-is-now-a-button" aria-hidden="true">#</a></h2>
+<p>The other half of the report was that nothing in the app told the user what was happening.
+There was a toast for “downloaded”, and nothing for anything else — so a multi-minute
+232 MB download looked exactly like an app doing nothing.</p>
+<p>The version text next to the logo is now the control. It shows <code>checking…</code>, then
+<code>v0.3.8 ready to install</code> (click to download), then live progress, then <strong>restart to
+update</strong> (click to apply). With nothing pending, clicking it checks on demand — previously
+the only checks were 30 seconds after launch and every six hours after that, with no way to
+ask.</p>
+<h2 id="if-youre-on-v035-or-v036" tabindex="-1">If you’re on v0.3.5 or v0.3.6 <a class="anchor" href="#if-youre-on-v035-or-v036" aria-hidden="true">#</a></h2>
+<p>You’ll need to install v0.3.7 by hand, once. Your current build carries the broken updater,
+so it can’t fetch the fix that repairs it — the one bootstrap problem a self-updating app
+can’t solve for itself. Grab it from <a href="https://munderdiffl.in/">munderdiffl.in</a> or the
+<a href="https://github.com/chaitanyagiri/munder-difflin/releases/latest">releases page</a>.</p>
+<p>After that, it updates itself. For real this time — and if it ever doesn’t, it’ll tell you
+why.</p>
+
+
+      
+      <section class="faq" aria-label="Frequently asked questions">
+        <h2 id="faq">FAQ</h2>
+        
+        <div class="qa">
+          <p class="q">Why was electron-updater&#39;s autoUpdater undefined?</p>
+          <p class="a">electron-updater is a CommonJS package that attaches autoUpdater to its exports through a lazy Object.defineProperty getter. Node&#39;s cjs-module-lexer detects named exports by static analysis, and it cannot see through a getter defined at runtime. So the ESM namespace produced by `await import(&#39;electron-updater&#39;)` has no autoUpdater key at all — it only exists on the namespace&#39;s `.default`. Destructuring `const { autoUpdater } = await import(&#39;electron-updater&#39;)` therefore yields undefined. Use `ns.autoUpdater ?? ns.default?.autoUpdater`, or plain `require()`, instead.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Why didn&#39;t this show up in development?</p>
+          <p class="a">The whole updater setup block was behind an `app.isPackaged` check, which is false in dev. Development runs never executed the line that threw, so the bug could only ever appear in a shipped build — and shipped builds have no visible console. It survived three releases that way.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">How do you debug an Electron app that only misbehaves when packaged?</p>
+          <p class="a">Launch the installed binary directly from a terminal with an isolated data directory: `/Applications/YourApp.app/Contents/MacOS/YourApp --user-data-dir=/tmp/probe`. Electron&#39;s single-instance lock is keyed to the user-data directory, so this runs alongside the copy the user already has open, and every console.log and stack trace lands in your terminal instead of disappearing.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Do I need to reinstall Munder Difflin to get v0.3.7?</p>
+          <p class="a">Yes, once. Every build from v0.3.4 through v0.3.6 carries the broken updater, so it cannot fetch this fix by itself. Download v0.3.7 manually from munderdiffl.in or the GitHub releases page. From v0.3.7 onward, updates download in the background and wait for your restart.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">How do you stop a bug like this from hiding again?</p>
+          <p class="a">Three changes. Errors are never swallowed — every updater failure is emitted to the UI and appended to a log file on disk. The notify-only fallback is per-check rather than a permanent latch, so one blip doesn&#39;t disable updates for the session. And the state model moved into a plain electron-free module with unit tests, so the rules can be verified without booting the app.</p>
+        </div>
+        
+      </section>
+      
+
+      
+      <hr />
+      <div class="share">
+        <span class="lbl">Tags</span>
+        <a class="tag" href="/blog/tags/internals/">Internals</a><a class="tag" href="/blog/tags/electron/">Electron</a><a class="tag" href="/blog/tags/debugging/">Debugging</a><a class="tag" href="/blog/tags/release/">Release</a><a class="tag" href="/blog/tags/open-source/">Open Source</a>
+      </div>
+      
+    </div>
+
+    
+    <aside class="toc-rail" aria-label="Table of contents">
+      <div class="tt">On this page</div>
+      <ol>
+        <li class="lvl-2"><a href="#ruling-things-out-expensively">Ruling things out, expensively</a></li><li class="lvl-2"><a href="#getting-a-packaged-app-to-talk">Getting a packaged app to talk</a></li><li class="lvl-2"><a href="#one-line-three-releases">One line, three releases</a></li><li class="lvl-2"><a href="#the-real-bug-was-the-catch-block">The real bug was the catch block</a></li><li class="lvl-2"><a href="#the-version-number-is-now-a-button">The version number is now a button</a></li><li class="lvl-2"><a href="#if-youre-on-v035-or-v036">If you’re on v0.3.5 or v0.3.6</a></li>
+      </ol>
+    </aside>
+    
+  </div>
+
+  <footer class="post-foot wrap"><div class="prevnext">
+      <a class="pn prev" href="/blog/launching-munder-difflin-v0-3-5/"><span class="k">← Older</span><span class="t">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</span></a>
+      <span></span>
+    </div>
+    <section class="related">
+      <h2>Related in Internals</h2>
+      <div class="post-grid">
+        <article class="card">
+  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-06-15">Jun 15, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>12 min</span>
+    </div>
+    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
+    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-internals" href="/blog/compressing-agent-memory/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-06-05">Jun 5, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/compressing-agent-memory/">Compressing Agent Memory Without Losing the Original</a></h3>
+    <p class="dek">How and why to compress an agent&#39;s long-term memory: the toolbox, the lossy trap, and keeping a lossless original beside a compact copy.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
+  <a class="thumb t-internals" href="/blog/architecture-two-planes-one-renderer/" aria-hidden="true" tabindex="-1">
+    <span>INTERNALS</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-06-04">Jun 4, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/architecture-two-planes-one-renderer/">Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</a></h3>
+    <p class="dek">A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/architecture-two-planes-one-renderer/" aria-label="Read: Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer">Read →</a>
+    </div>
+  </div>
+</article>
+
+      </div>
+    </section>
+    
+  </footer>
+</article>
+
+</main>
+<footer>
+  <div class="wrap">
+    <div class="foot-top">
+      <a class="foot-brand brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+        <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+      </a>
+      <div class="foot-links">
+        <a href="/blog/">Latest</a>
+        <a href="/blog/topics/">Topics</a>
+        <a href="/blog/about/">About</a>
+        <a href="https://munderdiffl.in/blog/feed.xml">RSS</a>
+        <a href="https://github.com/chaitanyagiri/munder-difflin">GitHub</a>
+        <a href="https://munderdiffl.in">munderdiffl.in ↗</a>
+      </div>
+    </div>
+    <div class="foot-meta">
+      © 2026 Munder Difflin · Local-first · MIT-licensed ·
+      Built on <a href="https://munderdiffl.in">Electron, React, Pixi.js, xterm.js &amp; node-pty</a>.
+      Run an office of agents while you sleep.
+    </div>
+  </div>
+</footer>
+
+<script>
+  // sticky-nav border on scroll
+  (function () {
+    var nav = document.getElementById('nav');
+    if (!nav) return;
+    var onScroll = function () { nav.classList.toggle('scrolled', window.scrollY > 8); };
+    onScroll(); window.addEventListener('scroll', onScroll, { passive: true });
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/blog/why-our-auto-update-never-ran/index.html
+++ b/docs/blog/why-our-auto-update-never-ran/index.html
@@ -284,7 +284,7 @@ why.</p>
 
   <footer class="post-foot wrap"><div class="prevnext">
       <a class="pn prev" href="/blog/launching-munder-difflin-v0-3-5/"><span class="k">← Older</span><span class="t">Launching Munder Difflin v0.3.5: A Michael Who Knows the Floor, a Git Time-Machine, and an App That Updates Itself</span></a>
-      <span></span>
+      <a class="pn next" href="/blog/whats-up-with-munder-difflin/"><span class="k">Newer →</span><span class="t">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</span></a>
     </div>
     <section class="related">
       <h2>Related in Internals</h2>

--- a/docs/blog/why-we-built-munder-difflin/index.html
+++ b/docs/blog/why-we-built-munder-difflin/index.html
@@ -210,6 +210,24 @@ Munder Difflin</a> — it’s open source and local-first, on macOS, Windows, an
       <h2>Related in Story</h2>
       <div class="post-grid">
         <article class="card">
+  <a class="thumb t-story" href="/blog/whats-up-with-munder-difflin/" aria-hidden="true" tabindex="-1">
+    <span>STORY</span>
+  </a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>7 min</span>
+    </div>
+    <h3><a href="/blog/whats-up-with-munder-difflin/">What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own</a></h3>
+    <p class="dek">Everything that shipped between v0.3.3 and v0.3.7 — a Michael who knows the floor and runs the app by voice, a git time-machine in the IDE, nine agent engines, a queue that respects your draft, Node that installs itself, and the auto-update bug that had been silently broken since the day we shipped it.</p>
+    <div class="foot">
+      <span class="tag kind">Story</span>
+      <a class="more" href="/blog/whats-up-with-munder-difflin/" aria-label="Read: What&#39;s Up With Munder Difflin: Six Weeks, Four Releases, and the Part of the Stack You Actually Own">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card">
   <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-5/" aria-hidden="true" tabindex="-1">
     <span>STORY</span>
   </a>
@@ -242,24 +260,6 @@ Munder Difflin</a> — it’s open source and local-first, on macOS, Windows, an
     <div class="foot">
       <span class="tag kind">Story</span>
       <a class="more" href="/blog/launching-munder-difflin-v0-3-3/" aria-label="Read: Launching Munder Difflin v0.3.3: A Built-in Monaco IDE and GitHub Copilot CLI Support">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card">
-  <a class="thumb t-story" href="/blog/launching-munder-difflin-v0-3-2/" aria-hidden="true" tabindex="-1">
-    <span>STORY</span>
-  </a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-27">Jun 27, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>7 min</span>
-    </div>
-    <h3><a href="/blog/launching-munder-difflin-v0-3-2/">Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator</a></h3>
-    <p class="dek">Munder Difflin v0.3.2 adds Realtime Michael — a low-latency voice channel to the GOD orchestrator. Talk to Michael and he listens, answers, and acts: reading the hive and, behind spoken echo-back confirmation, dispatching, spawning, and steering the floor in real time.</p>
-    <div class="foot">
-      <span class="tag kind">Story</span>
-      <a class="more" href="/blog/launching-munder-difflin-v0-3-2/" aria-label="Read: Launching Munder Difflin v0.3.2: Talk to Michael, a Realtime Voice Orchestrator">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -622,13 +622,13 @@
           <li><b>The version is now a button.</b> Top-left, next to the logo: it shows download progress and turns into "restart to update" when a release is staged.</li>
           <li><b>Nothing fails silently.</b> Update errors now reach the UI and a log file instead of being swallowed.</li>
         </ul>
-        <a class="more" href="/blog/why-our-auto-update-never-ran/">Read the write-up →</a>
+        <a class="more" href="/blog/whats-up-with-munder-difflin/">What's up with Munder Difflin →</a>
       </div>
     </div>
-    <h1 class="hero-title reveal">An always-on cluster of CLI agents doing your work</h1>
+    <h1 class="hero-title reveal">Forever running cli agent cluster to do all your work</h1>
     <p class="hero-sub reveal">
-      Your coding agents are already good enough to do the job. Munder Difflin wraps the CLIs you
-      already pay for into one local hive that keeps working — and answers to you.
+      CLI agents are really smart, they are already better at your job, why not just let it do all your work?
+      Munder Difflin is a local agent harness that wraps around any cli agent to make it part of a forever running agent hive that you control
     </p>
     <div class="hero-cta reveal">
       <a class="btn primary lg" data-download href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download free</a>
@@ -808,10 +808,13 @@
       <div class="mini"><span class="ic">📋</span><div class="t"><span class="lbl">Command Center</span><span class="sub">Kanban + live fleet + budgets</span></div></div>
       <div class="mini"><span class="ic">⏰</span><div class="t"><span class="lbl">Scheduled missions</span><span class="sub">Set it once, runs automatically</span></div></div>
       <div class="mini"><span class="ic">🔭</span><div class="t"><span class="lbl">Full observability</span><span class="sub">OTel, per-agent cost, waterfall</span></div></div>
+      <div class="mini"><span class="ic">🔔</span><div class="t"><span class="lbl">Desktop notifications</span><span class="sub">Agent done or needs your input</span></div></div>
       <div class="mini"><span class="ic">🔄</span><div class="t"><span class="lbl">Session resume</span><span class="sub">Agents pick up where they left off</span></div></div>
       <div class="mini"><span class="ic">🧩</span><div class="t"><span class="lbl">Agent Gallery</span><span class="sub">Off-the-shelf hires you review &amp; spawn</span></div></div>
+      <div class="mini"><span class="ic">🔐</span><div class="t"><span class="lbl">Integrations registry</span><span class="sub">Services behind a write-only secret broker</span></div></div>
       <div class="mini"><span class="ic">📡</span><div class="t"><span class="lbl">Remote control</span><span class="sub">Check in and steer from your phone</span></div></div>
       <div class="mini"><span class="ic">⬆️</span><div class="t"><span class="lbl">Auto-update</span><span class="sub">Downloads in the background; you click restart</span></div></div>
+      <div class="mini"><span class="ic">📄</span><div class="t"><span class="lbl">Markdown previews</span><span class="sub">⌘-click any .md an agent prints</span></div></div>
       <div class="mini"><span class="ic">🎛️</span><div class="t"><span class="lbl">Six-tab Settings</span><span class="sub">Models, autonomy, budgets, voice, memory</span></div></div>
     </div>
   </div>
@@ -956,10 +959,14 @@
         <tbody>
           <tr><td>Agents in parallel</td><td class="c-no">One, babysat by you</td><td class="c-yes"><span class="ck">✓</span> A whole floor, orchestrated</td></tr>
           <tr><td>Multiple CLI tools</td><td class="c-no">One at a time</td><td class="c-yes"><span class="ck">✓</span> Seven engines, one office — Claude Code to Copilot</td></tr>
+          <tr><td>Talk to your agents</td><td class="c-no">Typing only</td><td class="c-yes"><span class="ck">✓</span> Talk mode — run the floor by voice</td></tr>
           <tr><td>Trigger from Slack</td><td class="c-no">—</td><td class="c-yes"><span class="ck">✓</span> Message a channel; the reply comes back when it's done</td></tr>
+          <tr><td>Webhooks &amp; schedules</td><td class="c-no">Cron + duct tape</td><td class="c-yes"><span class="ck">✓</span> POST a webhook or set it on a schedule</td></tr>
           <tr><td>Runs unattended</td><td class="c-no">Stops when you close the lid</td><td class="c-yes"><span class="ck">✓</span> Hours to days, autonomously</td></tr>
           <tr><td>Long-term memory</td><td class="c-no">Forgets every session</td><td class="c-yes"><span class="ck">✓</span> MemPalace, shared by every agent</td></tr>
+          <tr><td>See what's happening</td><td class="c-no">Scrollback archaeology</td><td class="c-yes"><span class="ck">✓</span> A live office floor + Command Center</td></tr>
           <tr><td>Safety rails</td><td class="c-no">Hope</td><td class="c-yes"><span class="ck">✓</span> Human gates on spend, scope &amp; deletes</td></tr>
+          <tr><td>Cost</td><td class="c-yes">Your existing subscription</td><td class="c-yes"><span class="ck">✓</span> Same — free &amp; open source on top</td></tr>
           <tr><td>Cool to look at?</td><td class="c-no">It's… a terminal</td><td class="c-fun">😎 Extremely. It's <em>The Office</em>, starring your agents.</td></tr>
         </tbody>
       </table>
@@ -978,23 +985,27 @@
     <div class="faq-list">
       <details class="faq-item reveal">
         <summary>Is it really free?</summary>
-        <div class="a">Yes — <b>MIT-licensed and free forever</b>. It drives the agent subscriptions you already pay for, so there's no new bill from us. If it's useful, <a href="https://github.com/chaitanyagiri/munder-difflin">a star</a> is all we ask.</div>
+        <div class="a">Yes. Munder Difflin is <b>MIT-licensed and free forever</b> — download it or build from source. It drives the agent subscriptions you already pay for (Claude Code, Codex, Antigravity…), so there's no new bill from us. If it's useful, <a href="https://github.com/chaitanyagiri/munder-difflin">a GitHub star</a> is all we ask.</div>
       </details>
       <details class="faq-item reveal">
         <summary>Do I need new API keys?</summary>
-        <div class="a">No. If <code>claude</code>, <code>codex</code>, or <code>agy</code> already work in your terminal, they work here — it runs the <b>same CLI processes</b> under your existing login. Your own keys and local LLMs are optional extras.</div>
+        <div class="a">No. If <code>claude</code>, <code>codex</code>, or <code>agy</code> already work in your terminal, they'll work here — the harness runs the <b>same CLI processes</b> under your existing login/subscription. You can optionally add your own keys or local LLMs in Settings → AI Engines.</div>
       </details>
       <details class="faq-item reveal">
         <summary>Does my code leave my machine?</summary>
-        <div class="a"><b>No.</b> Agents are real CLI processes in local terminals, each in its own git worktree, with state in a local SQLite file. The only network traffic is what your own CLIs already make.</div>
+        <div class="a"><b>No.</b> The harness is local-first: agents are real CLI processes in local terminals, each in its own isolated git worktree, with state in a local SQLite file. The only network traffic is what your own CLIs already make to their providers.</div>
       </details>
       <details class="faq-item reveal">
         <summary>Which agent CLIs are supported?</summary>
-        <div class="a">Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, OpenCode, Crush, pi.dev, xAI Grok, and Kimi Code. Each gets a desk, a mailbox, and shared memory — mix and match on the same floor.</div>
+        <div class="a">Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, OpenCode, Crush, pi.dev — plus <b>xAI Grok</b> and <b>Kimi Code</b>. Each gets a desk, a mailbox, and shared memory; most can even play the orchestrator. Mix and match on the same floor.</div>
       </details>
       <details class="faq-item reveal">
         <summary>How is this different from YC's qm?</summary>
-        <div class="a"><a href="https://github.com/yc-software/qm" rel="nofollow">qm</a> is headless and built for teams, in Slack and a web UI. Munder Difflin is the <b>local-first desktop version</b> of the same idea: real terminals you can watch, voice orchestration, and a built-in IDE. <a href="/blog/qm-vs-munder-difflin/">Full comparison →</a></div>
+        <div class="a">They're solving the same problem from different ends. <a href="https://github.com/yc-software/qm" rel="nofollow">qm</a> is a multiplayer agent harness for teams — headless, living in Slack and a web UI. Munder Difflin covers the same jobs — security postures, background crons and watches, Slack triggers, shareable skills — as a <b>simpler, local-first desktop app</b> that's been shipping stably since v0.2: real terminals you can watch, voice orchestration, a built-in IDE with commit history and branch compare, and auto-update. If you want your agent office on your own machine with everything visible, that's us. <a href="/blog/qm-vs-munder-difflin/">Full comparison →</a></div>
+      </details>
+      <details class="faq-item reveal">
+        <summary>Can it really run for days without me?</summary>
+        <div class="a">Yes — that's the point. The hive keeps iterating on its own, and <b>escalates to you</b> (desktop, Slack, or voice) only when something needs a human: spend limits, scope changes, or destructive operations. You can steer mid-run or stop gracefully at any time.</div>
       </details>
       <details class="faq-item reveal">
         <summary>Why does everything look like The Office?</summary>
@@ -1049,13 +1060,13 @@
   <div class="wrap">
     <div class="eyebrow reveal">Show some support</div>
     <h2 class="h2 reveal">Keep the office running.</h2>
-    <p class="lead reveal">The download is free and always will be. Two small things keep it going.</p>
+    <p class="lead reveal">The download is, and always will be, free. If Munder Difflin is useful to you, two small things keep it going.</p>
 
     <div class="grid-2">
       <div class="support-card reveal">
         <div class="ic">⭐</div>
         <h3>Drop a star on GitHub</h3>
-        <p>Two seconds, and the single biggest way to help the project reach more people.</p>
+        <p>It costs nothing, takes two seconds, and is the single biggest way to help the project reach more people.</p>
         <a class="btn ghost" data-gh-stars href="https://github.com/chaitanyagiri/munder-difflin"><span class="star-ic">★</span> Star the repo<span class="star-count"></span></a>
       </div>
       <div class="support-card reveal">
@@ -1090,7 +1101,8 @@
   <section class="final" style="padding-top: 84px;">
     <div class="eyebrow reveal">v0.3.7 · Free &amp; open source</div>
     <h2 class="reveal">Your virtual office is <span class="hl">one download away.</span></h2>
-    <p class="reveal">A full floor of AI agents — planning, building, and shipping around the clock, on your machine.</p>
+    <p class="reveal">A full floor of AI agents — planning, building, and shipping around the clock, on your machine.
+      Free, local, and MIT-licensed.</p>
     <div class="center-cta reveal">
       <a class="btn primary lg" data-download href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download free</a>
       <a class="btn ghost lg" data-gh-stars href="https://github.com/chaitanyagiri/munder-difflin"><span class="star-ic">★</span> Star on GitHub<span class="star-count"></span></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
 <meta name="twitter:description" content="Turn the agent CLIs you already have into a coordinated office that plans, builds, and ships around the clock — on a live office floor you can watch. Free &amp; open source." />
 <meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
 <meta name="twitter:image:alt" content="Munder Difflin office floor — agents at their desks, the GOD orchestrator in Michael's office, and a live terminal session." />
-<meta name="theme-color" content="#0F0E09" />
+<meta name="theme-color" content="#FAF8F1" />
 <link rel="alternate" type="application/rss+xml" title="Munder Difflin Blog" href="https://munderdiffl.in/blog/feed.xml" />
 <script type="application/ld+json">
 {
@@ -91,26 +91,12 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-<script>
-  // theme init — BEFORE first paint. Default: dark on desktop, light on phones
-  // (dark's WebGL hero + grid are tuned for big screens); the toggle persists a choice.
-  (function () {
-    var t;
-    try { t = localStorage.getItem('mdf_theme'); } catch (e) {}
-    if (t !== 'light' && t !== 'dark') {
-      var mobile = false;
-      try { mobile = window.matchMedia('(max-width: 768px)').matches; } catch (e) {}
-      t = mobile ? 'light' : 'dark';
-    }
-    document.documentElement.setAttribute('data-theme', t);
-  })();
-</script>
 <style>
   :root {
     /* canvas — slightly off-white, warm (light theme; dark overrides below) */
     --bg:       #FAF8F1;
     --surface:  #FFFFFF;
-    --dark:     #131208;   /* demo frames, final CTA */
+    --dark:     #131208;   /* final CTA */
     --dark-2:   #1C1A10;
     /* ink */
     --ink:      #17150E;
@@ -144,29 +130,6 @@
     --pad-x: 24px;
     --font-sans: "Geist", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  }
-
-  /* ---------- dark theme (the default; toggle in the nav) ---------- */
-  html[data-theme="dark"] {
-    --bg:       #0F0E09;
-    --surface:  #17150F;
-    --ink:      #F4F1E6;
-    --muted:    #B5B0A0;
-    --faint:    #7C7869;
-    --line:        rgba(244,241,230,0.10);
-    --line-strong: rgba(244,241,230,0.22);
-    --ver-accent:   #72C2DF;
-    /* opaque page-color nav: looks transparent (same color, no border) but the
-       body grid pattern never shows through the bar */
-    --nav-bg:       #0F0E09;
-    --frame-border: rgba(244,241,230,0.14);
-    --media-tint:   rgba(244,241,230,0.04);
-    --chip-bg:      rgba(244,241,230,0.14);
-    --grid-line:    rgba(244,241,230,0.05);
-    --green: #4CC38A;
-    --shadow-sm: 0 1px 2px rgba(0,0,0,0.4);
-    --shadow-md: 0 2px 8px rgba(0,0,0,0.45), 0 12px 32px rgba(0,0,0,0.35);
-    --shadow-lg: 0 4px 16px rgba(0,0,0,0.5), 0 24px 64px rgba(0,0,0,0.45);
   }
 
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -211,12 +174,6 @@
     transition: border-color .2s ease;
   }
   nav.scrolled { border-bottom-color: var(--line); }
-  /* dark mode: fully transparent at the top, frosted only once you scroll */
-  html[data-theme="dark"] nav { backdrop-filter: none; -webkit-backdrop-filter: none; }
-  html[data-theme="dark"] nav.scrolled {
-    background: rgba(15,14,9,0.72);
-    backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
-  }
   .brand { display: flex; align-items: center; gap: 10px; }
   .brand-logo { height: 34px; width: auto; display: block; }
   .foot-brand .brand-logo { height: 28px; }
@@ -337,22 +294,8 @@
   .center { text-align: center; }
   .center .lead { margin-left: auto; margin-right: auto; }
 
-  /* ---------- theme toggle ---------- */
-  .theme-toggle {
-    display: inline-flex; align-items: center; justify-content: center;
-    width: 38px; height: 38px; padding: 0; cursor: pointer;
-    background: var(--surface); border: 1px solid var(--line-strong); border-radius: 999px;
-    color: var(--ink); box-shadow: var(--shadow-sm); font-size: 15px; line-height: 1;
-    transition: transform .12s ease, border-color .12s ease;
-  }
-  .theme-toggle:hover { transform: translateY(-1px); border-color: var(--ink); }
-  .theme-toggle svg { width: 16px; height: 16px; display: block; }
-  .theme-toggle .sun { display: none; } .theme-toggle .moon { display: block; }
-  html[data-theme="dark"] .theme-toggle .sun { display: block; }
-  html[data-theme="dark"] .theme-toggle .moon { display: none; }
-
   /* ---------- hero ---------- */
-  .hero { padding: 84px 0 0; text-align: center; position: relative; }
+  .hero { padding: 84px 0 96px; text-align: center; position: relative; }
   .hero::before {
     content: ""; position: absolute; inset: 0 0 auto 0; height: 720px; z-index: 0;
     background:
@@ -360,24 +303,6 @@
       radial-gradient(900px 500px at 50% 10%, rgba(114,194,223,0.10), transparent 70%);
     pointer-events: none;
   }
-  /* Lightfall (react-bits) — WebGL falling light streaks behind the hero; dark theme only */
-  .lightfall {
-    position: absolute; inset: 0 0 auto 0; height: min(880px, 100%); z-index: 0;
-    pointer-events: none; display: none; overflow: hidden;
-    -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 62%, transparent 100%);
-    mask-image: linear-gradient(180deg, #000 0%, #000 62%, transparent 100%);
-  }
-  .lightfall canvas { width: 100%; height: 100%; display: block; }
-  html[data-theme="dark"] .lightfall { display: block; }
-  /* dark hero: drop the sky-blue wash (too bright over the headline), keep a faint warm glow;
-     and lift the description contrast so streaks never wash it out */
-  html[data-theme="dark"] .hero::before {
-    background: radial-gradient(680px 380px at 50% 0%, rgba(255,202,84,0.08), transparent 70%);
-  }
-  html[data-theme="dark"] .hero-sub { color: #CDC8B8; }
-  /* .wrap sits ABOVE .demo so the open download menu never hides behind the video tabs */
-  .hero .wrap { position: relative; z-index: 2; }
-  .hero .demo { position: relative; z-index: 1; }
   .chip-wrap { position: relative; display: inline-block; margin-bottom: 28px; }
   .chip {
     display: inline-flex; align-items: center; gap: 8px;
@@ -415,83 +340,6 @@
   .trust { margin-top: 18px; font-family: var(--font-mono); color: var(--faint); font-size: 12.5px; }
   .trust b { color: var(--ink); font-weight: 600; }
   .trust a { text-decoration: underline; }
-
-  /* ---------- demo: tabs + frame (the Orca-style multi-section demo) ---------- */
-  .demo { margin-top: 56px; padding-bottom: 96px; }
-  .demo-tabs {
-    display: inline-flex; gap: 4px; flex-wrap: nowrap; justify-content: flex-start;
-    background: var(--surface); border: 1px solid var(--line); border-radius: 999px;
-    padding: 5px; box-shadow: var(--shadow-sm); margin-bottom: 26px;
-    max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch;
-    scrollbar-width: none; scroll-snap-type: x proximity;
-  }
-  .demo-tabs::-webkit-scrollbar { display: none; }
-  .demo-tab {
-    font-family: var(--font-mono); font-size: 12.5px; font-weight: 600; color: var(--muted);
-    background: transparent; border: 0; border-radius: 999px; padding: 9px 15px; cursor: pointer;
-    display: inline-flex; align-items: center; gap: 7px; white-space: nowrap; flex: none;
-    scroll-snap-align: center;
-    transition: background .15s ease, color .15s ease;
-  }
-  .demo-tab:hover { color: var(--ink); }
-  .demo-tab[aria-selected="true"] { background: var(--yellow); color: #17150E; }
-  .demo-tab .dot { width: 6px; height: 6px; border-radius: 50%; background: #17150E; display: none; }
-  .demo-tab[aria-selected="true"] .dot { display: inline-block; }
-  .demo-frame {
-    max-width: 1060px; margin: 0 auto;
-    background: var(--dark); border: 1px solid var(--frame-border); border-radius: var(--r-lg);
-    box-shadow: var(--shadow-lg); overflow: hidden;
-  }
-  .demo-frame .bar {
-    display: flex; align-items: center; gap: 10px; padding: 12px 16px;
-    border-bottom: 1px solid rgba(255,255,255,0.08);
-  }
-  .demo-frame .bar .dots { display: flex; gap: 7px; }
-  .demo-frame .bar .dots i { width: 10px; height: 10px; border-radius: 50%; background: rgba(255,255,255,0.16); display: inline-block; }
-  .demo-frame .bar .title { font-family: var(--font-mono); font-size: 12.5px; color: rgba(255,255,255,0.55); margin-left: 4px; }
-  .demo-frame .bar .status {
-    margin-left: auto; font-family: var(--font-mono); font-size: 11.5px; color: rgba(255,255,255,0.75);
-    display: inline-flex; align-items: center; gap: 7px;
-    border: 1px solid rgba(255,255,255,0.22); border-radius: 999px; padding: 3px 10px;
-  }
-  .live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--sky); animation: pulse 2s infinite; }
-  @keyframes pulse { 0%{box-shadow:0 0 0 0 rgba(114,194,223,0.55);} 70%{box-shadow:0 0 0 7px rgba(114,194,223,0);} 100%{box-shadow:0 0 0 0 rgba(114,194,223,0);} }
-  /* sliding panels: all five sit in one horizontal track; switching tabs
-     translates the track — pure transform, so it stays 60fps on mobile */
-  .demo-viewport { overflow: hidden; }
-  .demo-track {
-    display: flex; width: 100%;
-    transition: transform .45s cubic-bezier(.45,.05,.2,1);
-    will-change: transform;
-  }
-  .demo-panel { flex: 0 0 100%; min-width: 0; }
-  .demo-media { aspect-ratio: 16 / 10; background: var(--dark); position: relative; }
-  .demo-media img, .demo-media video { width: 100%; height: 100%; object-fit: contain; display: block; }
-  /* click-to-play overlay (videos have narration — no surprise audio) */
-  .demo-play {
-    position: absolute; inset: 0; z-index: 2; cursor: pointer;
-    display: flex; align-items: center; justify-content: center;
-    background: rgba(19,18,8,0.25); border: 0; padding: 0; width: 100%;
-    transition: background .2s ease;
-  }
-  .demo-play:hover { background: rgba(19,18,8,0.12); }
-  .demo-play .pp {
-    width: 74px; height: 74px; border-radius: 50%;
-    background: rgba(250,248,241,0.94); color: var(--ink);
-    display: grid; place-items: center; box-shadow: var(--shadow-lg);
-    transition: transform .15s ease;
-  }
-  .demo-play:hover .pp { transform: scale(1.07); }
-  .demo-play .pp svg { width: 26px; height: 26px; margin-left: 4px; }
-  .demo-play .dur {
-    position: absolute; right: 14px; bottom: 12px;
-    font-family: var(--font-mono); font-size: 11.5px; color: rgba(255,255,255,0.85);
-    background: rgba(19,18,8,0.65); border-radius: 999px; padding: 3px 9px;
-  }
-  .demo-play.hidden { display: none; }
-  @media (prefers-reduced-motion: reduce) { .demo-track { transition: none; } }
-  .demo-cap { text-align: center; font-size: 14px; color: var(--faint); margin-top: 16px; }
-  .demo-cap b { color: var(--ink); font-weight: 600; }
 
   /* ---------- providers strip ---------- */
   .providers { padding: 64px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); background: var(--surface); }
@@ -719,20 +567,11 @@
   @media (max-width: 480px) {
     :root { --pad-x: 16px; }
     section { padding: 68px 0; }
-    .hero { padding: 56px 0 0; }
+    .hero { padding: 56px 0 64px; }
     nav { gap: 10px; }
     .brand-logo { height: 28px; }
     .nav-actions { gap: 8px; }
     .chip { font-size: 10.5px; letter-spacing: 0; padding: 6px 11px; gap: 6px; white-space: nowrap; }
-    /* video tabs: edge-to-edge scroll strip on phones */
-    .demo-tabs {
-      display: flex; width: calc(100% + 2 * var(--pad-x));
-      margin-left: calc(-1 * var(--pad-x)); margin-right: calc(-1 * var(--pad-x));
-      padding: 5px var(--pad-x); border-radius: 0; border-left: 0; border-right: 0;
-    }
-    .demo-tab { font-size: 12px; padding: 8px 13px; }
-    .demo-frame { border-radius: var(--r-md); }
-    .demo-cap { font-size: 13px; padding: 0 4px; }
     /* slimmer badges on phones */
     .badge { font-size: 10.5px; padding: 3px 9px; gap: 5px; }
     .badge .dot { width: 6px; height: 6px; }
@@ -751,7 +590,6 @@
   </div>
   <div class="spacer"></div>
   <div class="links" id="navMenu">
-    <a href="#demo">Demo</a>
     <a href="#features">Features</a>
     <a href="#how">How it works</a>
     <a href="#compare">Compare</a>
@@ -762,15 +600,6 @@
     <a class="nav-menu-only btn primary sm" href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download</a>
   </div>
   <div class="nav-actions">
-    <button class="theme-toggle" id="themeToggle" type="button" aria-label="Switch between dark and light theme">
-      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
-        <circle cx="12" cy="12" r="4.2"/>
-        <path d="M12 2.5v2.4M12 19.1v2.4M2.5 12h2.4M19.1 12h2.4M5.2 5.2l1.7 1.7M17.1 17.1l1.7 1.7M18.8 5.2l-1.7 1.7M6.9 17.1l-1.7 1.7"/>
-      </svg>
-      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M20.4 14.2A8.3 8.3 0 0 1 9.8 3.6a8.3 8.3 0 1 0 10.6 10.6Z"/>
-      </svg>
-    </button>
     <a class="btn ghost sm nav-desktop-only" data-gh-stars href="https://github.com/chaitanyagiri/munder-difflin"><span class="star-ic">★</span> Star<span class="star-count"></span></a>
     <a class="btn primary sm nav-desktop-only" data-download data-align="right" href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download</a>
     <button class="nav-toggle" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navMenu">
@@ -781,26 +610,25 @@
 
 <!-- ===================== HERO ===================== -->
 <header class="hero">
-  <div class="lightfall" id="lightfall" aria-hidden="true"></div>
   <div class="wrap">
     <div class="chip-wrap reveal" id="verWrap">
       <button class="chip" id="verChip" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="verPop">
-        <span class="new">NEW</span> <b>v0.3.5</b> · Local agent harness
+        <span class="new">NEW</span> <b>v0.3.7</b> · Local agent harness
       </button>
-      <div class="ver-pop" id="verPop" role="dialog" aria-label="What's new in v0.3.5">
-        <h4>What's new in v0.3.5</h4>
+      <div class="ver-pop" id="verPop" role="dialog" aria-label="What's new in v0.3.7">
+        <h4>What's new in v0.3.7</h4>
         <ul>
-          <li><b>Michael knows the floor</b> — talk mode opens with a live snapshot of every agent and stays current mid-call; he can now run nearly the whole app by voice.</li>
-          <li><b>Git time-machine in the IDE</b> — clickable commit history, branch compare, and guarded checkout. Plus live markdown previews everywhere (⌘-click a .md path in any terminal).</li>
-          <li><b>The app updates itself</b> — new releases download in the background and wait for your "restart to update" click. Also: xAI Grok joins the engine roster.</li>
+          <li><b>Auto-update actually works.</b> A CommonJS/ESM import bug meant it silently never ran in any packaged build. Fixed, with a regression test.</li>
+          <li><b>The version is now a button.</b> Top-left, next to the logo: it shows download progress and turns into "restart to update" when a release is staged.</li>
+          <li><b>Nothing fails silently.</b> Update errors now reach the UI and a log file instead of being swallowed.</li>
         </ul>
-        <a class="more" href="/blog/launching-munder-difflin-v0-3-5/">Read the launch post →</a>
+        <a class="more" href="/blog/why-our-auto-update-never-ran/">Read the write-up →</a>
       </div>
     </div>
-    <h1 class="hero-title reveal">Forever running cli agent cluster to do all your work</h1>
+    <h1 class="hero-title reveal">An always-on cluster of CLI agents doing your work</h1>
     <p class="hero-sub reveal">
-      CLI agents are really smart, they are already better at your job, why not just let it do all your work?
-      Munder Difflin is a local agent harness that wraps around any cli agent to make it part of a forever running agent hive that you control
+      Your coding agents are already good enough to do the job. Munder Difflin wraps the CLIs you
+      already pay for into one local hive that keeps working — and answers to you.
     </p>
     <div class="hero-cta reveal">
       <a class="btn primary lg" data-download href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download free</a>
@@ -809,80 +637,6 @@
     <p class="trust reveal"><b>Free &amp; open source.</b> macOS · Windows · Linux — or <a href="#install">build from source</a> in two commands.</p>
   </div>
 
-  <!-- ============ MULTI-SECTION DEMO (tabs slide between narrated videos) ============ -->
-  <div class="demo wrap" id="demo">
-    <div class="demo-tabs reveal" role="tablist" aria-label="Product demo">
-      <button class="demo-tab" role="tab" aria-selected="true" data-tab="intro"><span class="dot"></span>Introduction</button>
-      <button class="demo-tab" role="tab" aria-selected="false" data-tab="setup"><span class="dot"></span>Setup &amp; installation</button>
-      <button class="demo-tab" role="tab" aria-selected="false" data-tab="agents"><span class="dot"></span>Adding new agents</button>
-      <button class="demo-tab" role="tab" aria-selected="false" data-tab="orchestrator"><span class="dot"></span>Talking to the orchestrator</button>
-      <button class="demo-tab" role="tab" aria-selected="false" data-tab="features"><span class="dot"></span>Other features &amp; configs</button>
-    </div>
-
-    <div class="demo-frame reveal">
-      <div class="bar">
-        <div class="dots"><i></i><i></i><i></i></div>
-        <span class="title" id="demoTitle">munder-difflin — introduction</span>
-        <span class="status"><span class="live-dot"></span> live</span>
-      </div>
-
-      <div class="demo-viewport">
-        <div class="demo-track" id="demoTrack">
-          <div class="demo-panel" data-panel="intro">
-            <div class="demo-media">
-              <video preload="none" playsinline poster="./media/demo/intro-poster.jpg" data-src="./media/demo/intro.mp4"
-                     aria-label="Introduction — a tour of the office of AI agents running on one computer."></video>
-              <button class="demo-play" type="button" aria-label="Play video: Introduction">
-                <span class="pp"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></span>
-                <span class="dur">0:18</span>
-              </button>
-            </div>
-          </div>
-          <div class="demo-panel" data-panel="setup">
-            <div class="demo-media">
-              <video preload="none" playsinline poster="./media/demo/setup-poster.jpg" data-src="./media/demo/setup.mp4"
-                     aria-label="Setup and installation — download, open, and your floor is live."></video>
-              <button class="demo-play" type="button" aria-label="Play video: Setup and installation">
-                <span class="pp"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></span>
-                <span class="dur">0:51</span>
-              </button>
-            </div>
-          </div>
-          <div class="demo-panel" data-panel="agents">
-            <div class="demo-media">
-              <video preload="none" playsinline poster="./media/demo/agents-poster.jpg" data-src="./media/demo/agents.mp4"
-                     aria-label="Adding new agents — hiring Claude Code, Codex, or Antigravity agents onto the floor."></video>
-              <button class="demo-play" type="button" aria-label="Play video: Adding new agents">
-                <span class="pp"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></span>
-                <span class="dur">0:19</span>
-              </button>
-            </div>
-          </div>
-          <div class="demo-panel" data-panel="orchestrator">
-            <div class="demo-media">
-              <video preload="none" playsinline poster="./media/demo/orchestrator-poster.jpg" data-src="./media/demo/orchestrator.mp4"
-                     aria-label="Talking to the orchestrator — brief one agent and the floor staffs itself."></video>
-              <button class="demo-play" type="button" aria-label="Play video: Talking to the orchestrator">
-                <span class="pp"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></span>
-                <span class="dur">0:36</span>
-              </button>
-            </div>
-          </div>
-          <div class="demo-panel" data-panel="features">
-            <div class="demo-media">
-              <video preload="none" playsinline poster="./media/demo/features-poster.jpg" data-src="./media/demo/features.mp4"
-                     aria-label="Other features and configs — Command Center, schedules, guardrails, and settings."></video>
-              <button class="demo-play" type="button" aria-label="Play video: Other features and configs">
-                <span class="pp"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></span>
-                <span class="dur">0:33</span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <p class="demo-cap reveal" id="demoCap"><b>Introduction.</b> The whole idea in 18 seconds — an office of AI agents, working for you.</p>
-  </div>
 </header>
 
 <!-- ===================== PROVIDERS ===================== -->
@@ -1054,13 +808,10 @@
       <div class="mini"><span class="ic">📋</span><div class="t"><span class="lbl">Command Center</span><span class="sub">Kanban + live fleet + budgets</span></div></div>
       <div class="mini"><span class="ic">⏰</span><div class="t"><span class="lbl">Scheduled missions</span><span class="sub">Set it once, runs automatically</span></div></div>
       <div class="mini"><span class="ic">🔭</span><div class="t"><span class="lbl">Full observability</span><span class="sub">OTel, per-agent cost, waterfall</span></div></div>
-      <div class="mini"><span class="ic">🔔</span><div class="t"><span class="lbl">Desktop notifications</span><span class="sub">Agent done or needs your input</span></div></div>
       <div class="mini"><span class="ic">🔄</span><div class="t"><span class="lbl">Session resume</span><span class="sub">Agents pick up where they left off</span></div></div>
       <div class="mini"><span class="ic">🧩</span><div class="t"><span class="lbl">Agent Gallery</span><span class="sub">Off-the-shelf hires you review &amp; spawn</span></div></div>
-      <div class="mini"><span class="ic">🔐</span><div class="t"><span class="lbl">Integrations registry</span><span class="sub">Services behind a write-only secret broker</span></div></div>
       <div class="mini"><span class="ic">📡</span><div class="t"><span class="lbl">Remote control</span><span class="sub">Check in and steer from your phone</span></div></div>
-      <div class="mini"><span class="ic">⬆️</span><div class="t"><span class="lbl">Auto-update</span><span class="sub">Downloads new releases, you click restart</span></div></div>
-      <div class="mini"><span class="ic">📄</span><div class="t"><span class="lbl">Markdown previews</span><span class="sub">⌘-click any .md an agent prints</span></div></div>
+      <div class="mini"><span class="ic">⬆️</span><div class="t"><span class="lbl">Auto-update</span><span class="sub">Downloads in the background; you click restart</span></div></div>
       <div class="mini"><span class="ic">🎛️</span><div class="t"><span class="lbl">Six-tab Settings</span><span class="sub">Models, autonomy, budgets, voice, memory</span></div></div>
     </div>
   </div>
@@ -1205,14 +956,10 @@
         <tbody>
           <tr><td>Agents in parallel</td><td class="c-no">One, babysat by you</td><td class="c-yes"><span class="ck">✓</span> A whole floor, orchestrated</td></tr>
           <tr><td>Multiple CLI tools</td><td class="c-no">One at a time</td><td class="c-yes"><span class="ck">✓</span> Seven engines, one office — Claude Code to Copilot</td></tr>
-          <tr><td>Talk to your agents</td><td class="c-no">Typing only</td><td class="c-yes"><span class="ck">✓</span> Talk mode — run the floor by voice</td></tr>
           <tr><td>Trigger from Slack</td><td class="c-no">—</td><td class="c-yes"><span class="ck">✓</span> Message a channel; the reply comes back when it's done</td></tr>
-          <tr><td>Webhooks &amp; schedules</td><td class="c-no">Cron + duct tape</td><td class="c-yes"><span class="ck">✓</span> POST a webhook or set it on a schedule</td></tr>
           <tr><td>Runs unattended</td><td class="c-no">Stops when you close the lid</td><td class="c-yes"><span class="ck">✓</span> Hours to days, autonomously</td></tr>
           <tr><td>Long-term memory</td><td class="c-no">Forgets every session</td><td class="c-yes"><span class="ck">✓</span> MemPalace, shared by every agent</td></tr>
-          <tr><td>See what's happening</td><td class="c-no">Scrollback archaeology</td><td class="c-yes"><span class="ck">✓</span> A live office floor + Command Center</td></tr>
           <tr><td>Safety rails</td><td class="c-no">Hope</td><td class="c-yes"><span class="ck">✓</span> Human gates on spend, scope &amp; deletes</td></tr>
-          <tr><td>Cost</td><td class="c-yes">Your existing subscription</td><td class="c-yes"><span class="ck">✓</span> Same — free &amp; open source on top</td></tr>
           <tr><td>Cool to look at?</td><td class="c-no">It's… a terminal</td><td class="c-fun">😎 Extremely. It's <em>The Office</em>, starring your agents.</td></tr>
         </tbody>
       </table>
@@ -1231,27 +978,23 @@
     <div class="faq-list">
       <details class="faq-item reveal">
         <summary>Is it really free?</summary>
-        <div class="a">Yes. Munder Difflin is <b>MIT-licensed and free forever</b> — download it or build from source. It drives the agent subscriptions you already pay for (Claude Code, Codex, Antigravity…), so there's no new bill from us. If it's useful, <a href="https://github.com/chaitanyagiri/munder-difflin">a GitHub star</a> is all we ask.</div>
+        <div class="a">Yes — <b>MIT-licensed and free forever</b>. It drives the agent subscriptions you already pay for, so there's no new bill from us. If it's useful, <a href="https://github.com/chaitanyagiri/munder-difflin">a star</a> is all we ask.</div>
       </details>
       <details class="faq-item reveal">
         <summary>Do I need new API keys?</summary>
-        <div class="a">No. If <code>claude</code>, <code>codex</code>, or <code>agy</code> already work in your terminal, they'll work here — the harness runs the <b>same CLI processes</b> under your existing login/subscription. You can optionally add your own keys or local LLMs in Settings → AI Engines.</div>
+        <div class="a">No. If <code>claude</code>, <code>codex</code>, or <code>agy</code> already work in your terminal, they work here — it runs the <b>same CLI processes</b> under your existing login. Your own keys and local LLMs are optional extras.</div>
       </details>
       <details class="faq-item reveal">
         <summary>Does my code leave my machine?</summary>
-        <div class="a"><b>No.</b> The harness is local-first: agents are real CLI processes in local terminals, each in its own isolated git worktree, with state in a local SQLite file. The only network traffic is what your own CLIs already make to their providers.</div>
+        <div class="a"><b>No.</b> Agents are real CLI processes in local terminals, each in its own git worktree, with state in a local SQLite file. The only network traffic is what your own CLIs already make.</div>
       </details>
       <details class="faq-item reveal">
         <summary>Which agent CLIs are supported?</summary>
-        <div class="a">Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, OpenCode, Crush, pi.dev — and, new in v0.3.4, <b>xAI Grok</b> and <b>Kimi Code</b>. Each gets a desk, a mailbox, and shared memory; most can even play the orchestrator. Mix and match on the same floor.</div>
+        <div class="a">Claude Code, OpenAI Codex, Antigravity (Gemini), GitHub Copilot CLI, OpenCode, Crush, pi.dev, xAI Grok, and Kimi Code. Each gets a desk, a mailbox, and shared memory — mix and match on the same floor.</div>
       </details>
       <details class="faq-item reveal">
         <summary>How is this different from YC's qm?</summary>
-        <div class="a">They're solving the same problem from different ends. <a href="https://github.com/yc-software/qm" rel="nofollow">qm</a> is a multiplayer agent harness for teams — headless, living in Slack and a web UI. Munder Difflin covers the same jobs — security postures, background crons and watches, Slack triggers, shareable skills — as a <b>simpler, local-first desktop app</b> that's been shipping stably since v0.2: real terminals you can watch, voice orchestration, a built-in IDE with commit history and branch compare, and auto-update. If you want your agent office on your own machine with everything visible, that's us. <a href="/blog/qm-vs-munder-difflin/">Full comparison →</a></div>
-      </details>
-      <details class="faq-item reveal">
-        <summary>Can it really run for days without me?</summary>
-        <div class="a">Yes — that's the point. The hive keeps iterating on its own, and <b>escalates to you</b> (desktop, Slack, or voice) only when something needs a human: spend limits, scope changes, or destructive operations. You can steer mid-run or stop gracefully at any time.</div>
+        <div class="a"><a href="https://github.com/yc-software/qm" rel="nofollow">qm</a> is headless and built for teams, in Slack and a web UI. Munder Difflin is the <b>local-first desktop version</b> of the same idea: real terminals you can watch, voice orchestration, and a built-in IDE. <a href="/blog/qm-vs-munder-difflin/">Full comparison →</a></div>
       </details>
       <details class="faq-item reveal">
         <summary>Why does everything look like The Office?</summary>
@@ -1306,13 +1049,13 @@
   <div class="wrap">
     <div class="eyebrow reveal">Show some support</div>
     <h2 class="h2 reveal">Keep the office running.</h2>
-    <p class="lead reveal">The download is, and always will be, free. If Munder Difflin is useful to you, two small things keep it going.</p>
+    <p class="lead reveal">The download is free and always will be. Two small things keep it going.</p>
 
     <div class="grid-2">
       <div class="support-card reveal">
         <div class="ic">⭐</div>
         <h3>Drop a star on GitHub</h3>
-        <p>It costs nothing, takes two seconds, and is the single biggest way to help the project reach more people.</p>
+        <p>Two seconds, and the single biggest way to help the project reach more people.</p>
         <a class="btn ghost" data-gh-stars href="https://github.com/chaitanyagiri/munder-difflin"><span class="star-ic">★</span> Star the repo<span class="star-count"></span></a>
       </div>
       <div class="support-card reveal">
@@ -1345,10 +1088,9 @@
 <!-- ===================== FINAL CTA ===================== -->
 <div class="final-wrap">
   <section class="final" style="padding-top: 84px;">
-    <div class="eyebrow reveal">v0.3.5 · Free &amp; open source</div>
+    <div class="eyebrow reveal">v0.3.7 · Free &amp; open source</div>
     <h2 class="reveal">Your virtual office is <span class="hl">one download away.</span></h2>
-    <p class="reveal">A full floor of AI agents — planning, building, and shipping around the clock, on your machine.
-      Free, local, and MIT-licensed.</p>
+    <p class="reveal">A full floor of AI agents — planning, building, and shipping around the clock, on your machine.</p>
     <div class="center-cta reveal">
       <a class="btn primary lg" data-download href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download free</a>
       <a class="btn ghost lg" data-gh-stars href="https://github.com/chaitanyagiri/munder-difflin"><span class="star-ic">★</span> Star on GitHub<span class="star-count"></span></a>
@@ -1414,265 +1156,6 @@
       if (wrap.classList.contains('open') && !wrap.contains(e.target)) setOpen(false);
     });
     document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
-  })();
-
-  // theme toggle — dark by default (set pre-paint in <head>), persisted per visitor
-  (function () {
-    var btn = document.getElementById('themeToggle');
-    if (!btn) return;
-    var meta = document.querySelector('meta[name="theme-color"]');
-    function apply(t) {
-      document.documentElement.setAttribute('data-theme', t);
-      if (meta) meta.setAttribute('content', t === 'dark' ? '#0F0E09' : '#FAF8F1');
-      try { localStorage.setItem('mdf_theme', t); } catch (e) {}
-    }
-    apply(document.documentElement.getAttribute('data-theme') || 'dark');
-    btn.addEventListener('click', function () {
-      var cur = document.documentElement.getAttribute('data-theme');
-      apply(cur === 'dark' ? 'light' : 'dark');
-    });
-  })();
-
-  // Lightfall — falling light streaks behind the hero (dark theme only).
-  // Vanilla-WebGL port of the react-bits <Lightfall/> background (MIT,
-  // https://reactbits.dev/backgrounds/lightfall) — same fragment shader, no deps.
-  (function () {
-    var host = document.getElementById('lightfall');
-    if (!host || !window.WebGLRenderingContext) return;
-    var reduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    var canvas = document.createElement('canvas');
-    var gl = canvas.getContext('webgl', { alpha: true, antialias: true, premultipliedAlpha: false });
-    if (!gl) return;
-    host.appendChild(canvas);
-
-    var VERT = 'attribute vec2 position;attribute vec2 uv;varying vec2 vUv;' +
-      'void main(){vUv=uv;gl_Position=vec4(position,0.0,1.0);}';
-    var FRAG = [
-      'precision highp float;',
-      'uniform vec3 iResolution;uniform vec2 iMouse;uniform float iTime;',
-      'uniform vec3 uColor0;uniform vec3 uColor1;uniform vec3 uColor2;uniform vec3 uColor3;',
-      'uniform vec3 uColor4;uniform vec3 uColor5;uniform vec3 uColor6;uniform vec3 uColor7;',
-      'uniform int uColorCount;uniform vec3 uBgColor;uniform vec3 uMouseColor;',
-      'uniform float uSpeed;uniform int uStreakCount;uniform float uStreakWidth;uniform float uStreakLength;',
-      'uniform float uGlow;uniform float uDensity;uniform float uTwinkle;uniform float uZoom;',
-      'uniform float uBgGlow;uniform float uOpacity;uniform float uMouseEnabled;uniform float uMouseStrength;uniform float uMouseRadius;',
-      'varying vec2 vUv;',
-      'vec3 palette(float h){int count=uColorCount;if(count<1)count=1;',
-      ' int idx=int(floor(clamp(h,0.0,0.999999)*float(count)));',
-      ' if(idx<=0)return uColor0;if(idx==1)return uColor1;if(idx==2)return uColor2;if(idx==3)return uColor3;',
-      ' if(idx==4)return uColor4;if(idx==5)return uColor5;if(idx==6)return uColor6;return uColor7;}',
-      'vec3 tanhv(vec3 x){vec3 e=exp(-2.0*x);return (1.0-e)/(1.0+e);}',
-      'vec2 sceneC(vec2 frag,vec2 r){vec2 P=(frag+frag-r)/r.x;float z=0.0;float d=1e3;vec4 O=vec4(0.0);',
-      ' for(int k=0;k<39;k++){if(d<=1e-4)break;O=z*normalize(vec4(P,uZoom,0.0))-vec4(0.0,4.0,1.0,0.0)/4.5;',
-      '  d=1.0-sqrt(length(O*O));z+=d;}return vec2(O.x,atan(O.z,O.y));}',
-      'void mainImage(out vec4 o,vec2 C){',
-      ' vec2 r=iResolution.xy;vec2 uv0=(C+C-r)/r.x;float T=0.1*iTime*uSpeed+9.0;',
-      ' float angRings=max(1.0,floor(6.28318530718*max(uDensity,0.05)+0.5));',
-      ' vec2 Y=vec2(5e-3,6.28318530718/angRings);',
-      ' vec2 c0=sceneC(C,r);vec2 cdx=sceneC(C+vec2(1.0,0.0),r);vec2 cdy=sceneC(C+vec2(0.0,1.0),r);',
-      ' vec2 dCx=cdx-c0;vec2 dCy=cdy-c0;',
-      ' dCx.y-=6.28318530718*floor(dCx.y/6.28318530718+0.5);',
-      ' dCy.y-=6.28318530718*floor(dCy.y/6.28318530718+0.5);',
-      ' vec2 fw=abs(dCx)+abs(dCy);C=c0;',
-      ' vec2 P=vec2(2.0,1.0)*uv0-(r/r.x)*vec2(0.0,1.0);',
-      ' vec4 O=vec4(uBgColor*90.0*uBgGlow/(1e3*dot(P,P)+6.0),0.0);',
-      ' float mGlow=0.0;',
-      ' if(uMouseEnabled>0.5){vec2 mN=(iMouse+iMouse-r)/r.x;float md=length(uv0-mN);',
-      '  mGlow=exp(-md*md/max(uMouseRadius*uMouseRadius,1e-4))*uMouseStrength;O.rgb+=uMouseColor*mGlow*0.25;}',
-      ' float zr=5e-4*uStreakWidth;vec2 rr=vec2(max(length(fw),1e-5));float tail=19.0/max(uStreakLength,0.05);',
-      ' for(int m=0;m<16;m++){if(m>=uStreakCount)break;float jf=float(m)+1.0;',
-      '  float ic=fract(sin(dot(vec2(jf,floor(C.x/Y.x+0.5)),vec2(7.0,11.0))*73.0));',
-      '  vec2 Pp=C-(T+T*ic)*vec2(0.0,1.0);Pp-=floor(Pp/Y+0.5)*Y;',
-      '  float h=fract(8663.0*ic);vec3 col=palette(h);',
-      '  float weight=mix(1.5,1.0+sin(T+7.0*h+4.0),uTwinkle);weight*=(1.0+mGlow*2.0);',
-      '  vec2 inner=vec2(length(max(Pp,vec2(-1.0,0.0))),length(Pp)-zr)-zr;',
-      '  vec2 sm=vec2(1.0)-smoothstep(-rr,rr,inner);',
-      '  O.rgb+=dot(sm,vec2(exp(tail*Pp.y),3.0))*col*weight;C.x+=Y.x/8.0;}',
-      ' vec3 colr=sqrt(tanhv(max(O.rgb*uGlow-vec3(0.05),0.0)));o=vec4(colr,uOpacity);}',
-      'void main(){vec4 color;mainImage(color,vUv*iResolution.xy);gl_FragColor=color;}'
-    ].join('\n');
-
-    function sh(type, src) {
-      var s = gl.createShader(type); gl.shaderSource(s, src); gl.compileShader(s);
-      if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) { return null; }
-      return s;
-    }
-    var vs = sh(gl.VERTEX_SHADER, VERT), fs = sh(gl.FRAGMENT_SHADER, FRAG);
-    if (!vs || !fs) return;
-    var prog = gl.createProgram();
-    gl.attachShader(prog, vs); gl.attachShader(prog, fs); gl.linkProgram(prog);
-    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) return;
-    gl.useProgram(prog);
-
-    // fullscreen triangle (position + uv), same geometry as ogl's Triangle
-    var buf = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
-      -1, -1, 0, 0,   3, -1, 2, 0,   -1, 3, 0, 2
-    ]), gl.STATIC_DRAW);
-    var aPos = gl.getAttribLocation(prog, 'position'), aUv = gl.getAttribLocation(prog, 'uv');
-    gl.enableVertexAttribArray(aPos); gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 16, 0);
-    gl.enableVertexAttribArray(aUv);  gl.vertexAttribPointer(aUv, 2, gl.FLOAT, false, 16, 8);
-
-    function hexRGB(hex) {
-      var c = hex.replace('#', '');
-      return [parseInt(c.slice(0, 2), 16) / 255, parseInt(c.slice(2, 4), 16) / 255, parseInt(c.slice(4, 6), 16) / 255];
-    }
-    var U = function (n) { return gl.getUniformLocation(prog, n); };
-    // white / blue / yellow streaks over a faint cool-blue core glow
-    var colors = ['#FFFFFF', '#72C2DF', '#FFCA54'];
-    var avg = [0, 0, 0];
-    colors.forEach(function (c) { var v = hexRGB(c); avg[0] += v[0] / 3; avg[1] += v[1] / 3; avg[2] += v[2] / 3; });
-    for (var i = 0; i < 8; i++) gl.uniform3fv(U('uColor' + i), hexRGB(colors[Math.min(i, colors.length - 1)]));
-    gl.uniform1i(U('uColorCount'), colors.length);
-    gl.uniform3fv(U('uBgColor'), hexRGB('#2C6E8A'));
-    gl.uniform3fv(U('uMouseColor'), avg);
-    gl.uniform1f(U('uSpeed'), 0.25);
-    gl.uniform1i(U('uStreakCount'), 10);
-    gl.uniform1f(U('uStreakWidth'), 0.6);
-    gl.uniform1f(U('uStreakLength'), 1);
-    gl.uniform1f(U('uGlow'), 1);
-    gl.uniform1f(U('uDensity'), 0.15);
-    gl.uniform1f(U('uTwinkle'), 0.85);
-    gl.uniform1f(U('uZoom'), 3);
-    gl.uniform1f(U('uBgGlow'), 0.0);
-    gl.uniform1f(U('uOpacity'), 1);
-    gl.uniform1f(U('uMouseEnabled'), 0); // no hover spotlight
-    gl.uniform1f(U('uMouseStrength'), 0);
-    gl.uniform1f(U('uMouseRadius'), 1);
-    var uRes = U('iResolution'), uMouse = U('iMouse'), uTime = U('iTime');
-
-    var dpr = Math.min(window.devicePixelRatio || 1, 1.5);
-    function resize() {
-      var rect = host.getBoundingClientRect();
-      canvas.width = Math.max(1, Math.round(rect.width * dpr));
-      canvas.height = Math.max(1, Math.round(rect.height * dpr));
-      gl.viewport(0, 0, canvas.width, canvas.height);
-      gl.uniform3f(uRes, canvas.width, canvas.height, 1);
-    }
-    resize();
-    if ('ResizeObserver' in window) new ResizeObserver(resize).observe(host);
-    else window.addEventListener('resize', resize);
-
-    // only render while the hero is on screen, the tab is visible, and theme is dark
-    var onScreen = true;
-    if ('IntersectionObserver' in window) {
-      new IntersectionObserver(function (en) { onScreen = en[0].isIntersecting; }).observe(host);
-    }
-    var t0 = performance.now();
-    function frame(now) {
-      requestAnimationFrame(frame);
-      if (!onScreen || document.hidden) return;
-      if (document.documentElement.getAttribute('data-theme') !== 'dark') return;
-      gl.uniform1f(uTime, (now - t0) / 1000);
-      gl.drawArrays(gl.TRIANGLES, 0, 3);
-    }
-    if (reduced) { // static frame, no animation
-      gl.uniform2f(uMouse, 0, 0); gl.uniform1f(uTime, 9);
-      gl.drawArrays(gl.TRIANGLES, 0, 3);
-    } else {
-      requestAnimationFrame(frame);
-    }
-  })();
-
-  // demo: sliding tab switcher + lazy click-to-play videos.
-  // Videos carry narration, so nothing autoplays: the active tab's <video> only
-  // fetches metadata (a few KB, thanks to +faststart) until the user hits play.
-  (function () {
-    var tabs = Array.prototype.slice.call(document.querySelectorAll('.demo-tab'));
-    var panels = Array.prototype.slice.call(document.querySelectorAll('.demo-panel'));
-    var track = document.getElementById('demoTrack');
-    var title = document.getElementById('demoTitle');
-    var cap = document.getElementById('demoCap');
-    if (!track || !tabs.length) return;
-    var META = {
-      'intro':        { title: 'munder-difflin — introduction',           cap: '<b>Introduction.</b> The whole idea in 18 seconds — an office of AI agents, working for you.' },
-      'setup':        { title: 'munder-difflin — setup & installation',   cap: '<b>Setup &amp; installation.</b> Download, open, done — no config files, no YAML, no wiring.' },
-      'agents':       { title: 'munder-difflin — adding new agents',      cap: '<b>Adding new agents.</b> Hire Claude Code, Codex, or Antigravity agents onto the floor — each gets a desk and a mailbox.' },
-      'orchestrator': { title: 'munder-difflin — the orchestrator',       cap: '<b>Talking to the orchestrator.</b> Brief Michael once; he staffs the floor, routes the work, and reports back.' },
-      'features':     { title: 'munder-difflin — features & configs',     cap: '<b>Other features &amp; configs.</b> Command Center, schedules, guardrails, engines, and everything in Settings.' }
-    };
-    var current = 0;
-
-    // start a panel's video: attach src on first play (lazy), then play with sound
-    function startVideo(idx) {
-      var video = panels[idx].querySelector('video');
-      var btn = panels[idx].querySelector('.demo-play');
-      if (!video || !btn) return;
-      if (!video.src) { video.src = video.getAttribute('data-src'); }
-      video.controls = true;
-      btn.classList.add('hidden');
-      var attempt = video.play();
-      if (attempt && attempt.catch) {
-        attempt.catch(function () {
-          // blocked (e.g. chained autoplay on iOS) — surface the play button again
-          video.controls = false;
-          btn.classList.remove('hidden');
-        });
-      }
-    }
-
-    panels.forEach(function (p, i) {
-      var video = p.querySelector('video');
-      var btn = p.querySelector('.demo-play');
-      if (!video || !btn) return;
-      btn.addEventListener('click', function () { startVideo(i); });
-      // while this one plays, buffer the next section so the hand-off is gapless
-      video.addEventListener('play', function () {
-        var nxt = panels[i + 1] && panels[i + 1].querySelector('video');
-        if (nxt && !nxt.src) { nxt.preload = 'auto'; nxt.src = nxt.getAttribute('data-src'); }
-      });
-      // when a video finishes: auto-advance to the next section and keep playing;
-      // after the last one, offer the big play button again for a clean replay
-      video.addEventListener('ended', function () {
-        video.controls = false;
-        btn.classList.remove('hidden');
-        if (i < panels.length - 1) {
-          activate(i + 1);
-          startVideo(i + 1);
-        }
-      });
-    });
-
-    function activate(idx) {
-      if (idx < 0 || idx >= panels.length || idx === current && track.style.transform) return;
-      // pause whatever was playing in the outgoing panel
-      var out = panels[current].querySelector('video');
-      if (out && !out.paused) out.pause();
-      current = idx;
-      track.style.transform = 'translateX(-' + (idx * 100) + '%)';
-      tabs.forEach(function (x, i) { x.setAttribute('aria-selected', i === idx ? 'true' : 'false'); });
-      // keep the active tab visible in the (mobile) scrollable tab strip
-      var bar = tabs[idx].parentElement;
-      if (bar && bar.scrollWidth > bar.clientWidth) {
-        bar.scrollTo({ left: tabs[idx].offsetLeft - (bar.clientWidth - tabs[idx].offsetWidth) / 2, behavior: 'smooth' });
-      }
-      var key = panels[idx].getAttribute('data-panel');
-      if (META[key]) { title.textContent = META[key].title; cap.innerHTML = META[key].cap; }
-      // warm up the incoming video's metadata so the play click starts instantly
-      var vid = panels[idx].querySelector('video');
-      if (vid && !vid.src) { vid.preload = 'metadata'; vid.src = vid.getAttribute('data-src'); }
-    }
-
-    tabs.forEach(function (t, i) {
-      t.addEventListener('click', function () { activate(i); });
-      t.addEventListener('keydown', function (e) {
-        if (e.key === 'ArrowRight') { e.preventDefault(); activate(Math.min(current + 1, tabs.length - 1)); tabs[current].focus(); }
-        if (e.key === 'ArrowLeft')  { e.preventDefault(); activate(Math.max(current - 1, 0)); tabs[current].focus(); }
-      });
-    });
-
-    // swipe between panels on touch devices
-    var x0 = null;
-    track.addEventListener('touchstart', function (e) { x0 = e.touches[0].clientX; }, { passive: true });
-    track.addEventListener('touchend', function (e) {
-      if (x0 == null) return;
-      var dx = e.changedTouches[0].clientX - x0; x0 = null;
-      if (Math.abs(dx) < 48) return;
-      activate(dx < 0 ? Math.min(current + 1, panels.length - 1) : Math.max(current - 1, 0));
-    }, { passive: true });
-
-    activate(0);
   })();
 
   // mobile nav: hamburger ⇄ cross + dropdown

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Munder Difflin is a free, MIT-licensed, local-first multi-agent harness for CLI coding
 > agents, presented as a virtual office (an affectionate parody of The Office; not
-> affiliated with NBC). Current version: 0.3.5 (August 2026). Desktop app (Electron) for
+> affiliated with NBC). Current version: 0.3.7 (August 2026). Desktop app (Electron) for
 > macOS, Windows, and Linux. Website: https://munderdiffl.in — Source:
 > https://github.com/chaitanyagiri/munder-difflin — Author: Chaitanya Giri.
 
@@ -35,7 +35,7 @@ pi.dev — and turns them into a coordinated, forever-running team on your own m
 - **Background work.** Scheduled missions, Slack triggers (message the office from Slack,
   get replies in-thread), webhook triggers, desktop notifications, Remote Control from a
   phone.
-- **Auto-update (v0.3.4+).** Checks GitHub releases, downloads in the background, installs
+- **Auto-update (working from v0.3.7).** Checks GitHub releases, downloads in the background, installs
   only on the user's "restart to update" click.
 - **Local-first.** No vendor cloud, no code upload, state in local SQLite; the only network
   traffic is what the user's own CLIs already make to their providers.
@@ -60,6 +60,7 @@ drives the CLI logins/subscriptions the user already has.
 
 - Homepage + FAQ: https://munderdiffl.in/
 - Blog index (118 articles): https://munderdiffl.in/blog/
+- v0.3.7 auto-update write-up: https://munderdiffl.in/blog/why-our-auto-update-never-ran/
 - v0.3.5 launch post: https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/
 - Changelog: https://github.com/chaitanyagiri/munder-difflin/blob/main/CHANGELOG.md
 - Message-queue delivery contract: https://github.com/chaitanyagiri/munder-difflin/blob/main/docs/message-queue.md

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@
 > your own computer — each agent a real CLI process in a real terminal, with shared
 > long-term memory, inter-agent messaging, a GOD orchestrator, scheduled missions, Slack
 > and webhook triggers, realtime voice orchestration, a built-in Monaco IDE with git
-> history and branch compare, markdown previews, and auto-update. Current version: 0.3.5
+> history and branch compare, markdown previews, and auto-update. Current version: 0.3.7
 > (August 2026). Desktop app for macOS, Windows, and Linux. No vendor cloud; code never
 > leaves your machine. It covers the same jobs as YC's qm (security postures, background
 > crons/watches, Slack, shared skills) as a simpler local-first desktop app, and adds what
@@ -21,6 +21,7 @@
 
 ## Key guides
 
+- [Why our auto-update never ran](https://munderdiffl.in/blog/why-our-auto-update-never-ran/): the v0.3.7 fix — a CommonJS export that vanished into an ESM namespace
 - [What's new in v0.3.5](https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/): the v0.3.4+v0.3.5 release wave
 - [How to install and use Munder Difflin](https://munderdiffl.in/blog/how-to-install-and-use-munder-difflin/)
 - [Your first hour with Munder Difflin](https://munderdiffl.in/blog/your-first-hour-with-munder-difflin/)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -21,6 +21,7 @@
 
 ## Key guides
 
+- [What's up with Munder Difflin](https://munderdiffl.in/blog/whats-up-with-munder-difflin/): everything shipped from v0.3.3 to v0.3.7
 - [Why our auto-update never ran](https://munderdiffl.in/blog/why-our-auto-update-never-ran/): the v0.3.7 fix — a CommonJS export that vanished into an ESM namespace
 - [What's new in v0.3.5](https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/): the v0.3.4+v0.3.5 release wave
 - [How to install and use Munder Difflin](https://munderdiffl.in/blog/how-to-install-and-use-munder-difflin/)

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -18,6 +18,12 @@
   <url><loc>https://munderdiffl.in/blog/topics/</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
   <url><loc>https://munderdiffl.in/blog/about/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
   <url>
+    <loc>https://munderdiffl.in/blog/whats-up-with-munder-difflin/</loc>
+    <lastmod>2026-08-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://munderdiffl.in/blog/why-our-auto-update-never-ran/</loc>
     <lastmod>2026-08-08</lastmod>
     <changefreq>monthly</changefreq>
@@ -742,11 +748,11 @@
   <url><loc>https://munderdiffl.in/blog/tags/comparisons/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/open-source/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/local-first/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/automation/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/story/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/automation/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/tools/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/getting-started/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/release/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/getting-started/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/memory/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/human-in-the-loop/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/security/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -763,15 +769,15 @@
   <url><loc>https://munderdiffl.in/blog/tags/architecture/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/reliability/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/cli-agents/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/voice/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/ide/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/workflow/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/terminals/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/model-routing/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/agentic-ai/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/aeo/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/seo/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/voice/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/engines/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/ide/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/god/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/messaging/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/faq/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -10,13 +10,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://munderdiffl.in/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url><loc>https://munderdiffl.in/blog/</loc><changefreq>daily</changefreq><priority>0.9</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
   <url><loc>https://munderdiffl.in/blog/about/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url>
+    <loc>https://munderdiffl.in/blog/why-our-auto-update-never-ran/</loc>
+    <lastmod>2026-08-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <url>
     <loc>https://munderdiffl.in/blog/launching-munder-difflin-v0-3-5/</loc>
     <lastmod>2026-08-06</lastmod>
@@ -721,16 +727,16 @@
   </url>
   <url><loc>https://munderdiffl.in/blog/topics/guides/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/concepts/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
-  <url><loc>https://munderdiffl.in/blog/topics/comparisons/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/internals/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://munderdiffl.in/blog/topics/comparisons/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/story/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/orchestration/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/memory/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/use-cases/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/multi-agent/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/claude-code/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/guides/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/internals/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/guides/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/orchestration/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/concepts/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/comparisons/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -740,8 +746,8 @@
   <url><loc>https://munderdiffl.in/blog/tags/story/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/tools/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/getting-started/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/memory/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/release/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/memory/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/human-in-the-loop/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/security/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/cost/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -750,9 +756,9 @@
   <url><loc>https://munderdiffl.in/blog/tags/hive/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/observability/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/guardrails/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/electron/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/autonomous/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/git/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/electron/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/mcp/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/architecture/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/reliability/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -775,6 +781,7 @@
   <url><loc>https://munderdiffl.in/blog/tags/xtermjs/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/hooks/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/performance/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/debugging/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/prompt-caching/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/slack/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/protocols/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -793,7 +800,6 @@
   <url><loc>https://munderdiffl.in/blog/tags/node-pty/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/error-handling/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/context-engineering/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/debugging/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/evaluation/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/ai-search/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/cloud-agents/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munder-difflin",
-  "version": "0.3.4",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munder-difflin",
-      "version": "0.3.4",
+      "version": "0.3.7",
       "hasInstallScript": true,
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munder-difflin",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "description": "Local multi-agent harness for Claude Code: autonomous agents that message, route, and remember — coordinated by a GOD orchestrator and visualized as avatars at work.",
   "main": "out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,71 +1,122 @@
 import { app, ipcMain, shell } from 'electron';
 import type { WebContents } from 'electron';
 import { request as httpsRequest } from 'node:https';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { readConfig } from './config';
+import { reduceStatus, clampPercent, isNewer, type UpdateStatus } from '../shared/updateState';
 
 /**
- * Auto-update from GitHub releases (v0.3.4).
+ * Auto-update from GitHub releases.
  *
  * Primary path: electron-updater against the `publish` block in
  * electron-builder.yml — the release workflow uploads latest*.yml + zip +
- * blockmaps, macOS builds are Developer ID signed + notarized, so Squirrel.Mac
- * (zip), NSIS, and AppImage all update natively. Downloads happen in the
- * background; installation is ALWAYS user-initiated ("Restart to update" toast
+ * blockmaps, macOS builds are Developer ID signed + notarized + stapled, so
+ * Squirrel.Mac (zip), NSIS, and AppImage all update natively. Downloads happen
+ * in the background; installation is ALWAYS user-initiated ("restart to update"
  * → `update:restartAndInstall`). The app never restarts on its own.
  *
- * Fallback path (win-portable exe, unsigned/dev-ish builds, or any updater
- * error): a plain `releases/latest` poll — semver-compare against the running
- * version and show a notify-only toast linking the release page. Same pattern
- * as the landing page's REL upgrade fetch, with the same modest cache so we
- * stay far from the unauthenticated 60/hr rate limit.
+ * Fallback path (win-portable exe, or a genuine updater error): a plain
+ * `releases/latest` poll — semver-compare against the running version and show a
+ * notify-only state linking the release page.
  *
  * Everything is gated on the `autoUpdate` HarnessConfig flag (default ON,
  * Settings → General) and on `app.isPackaged` — dev runs never poll.
+ *
+ * ─── v0.3.7: why native updating never actually ran ──────────────────────────
+ * electron-updater is CommonJS and exposes `autoUpdater` through a lazy
+ * `Object.defineProperty` getter. Node's cjs-module-lexer cannot see through
+ * that, so the ESM namespace produced by `await import('electron-updater')` has
+ * NO `autoUpdater` named export — only `.default.autoUpdater`. The old code did
+ * `const { autoUpdater } = await import('electron-updater')`, got `undefined`,
+ * and threw `TypeError: Cannot set properties of undefined (setting
+ * 'autoDownload')` on the very first line of setup. That threw into a catch that
+ * silently latched notify-only mode, so from v0.3.4 through v0.3.6 EVERY
+ * packaged build only ever offered "open the releases page". It never showed up
+ * in dev because the whole block is behind `app.isPackaged`.
+ *
+ * Two rules came out of that and both are load-bearing here:
+ *   1. resolve the module through `loadAutoUpdater()` below, which handles the
+ *      namespace/default interop and throws a NAMED error if the export is gone;
+ *   2. never swallow an updater error — every failure is surfaced to the
+ *      renderer AND appended to `updater.log` in userData, and the notify-only
+ *      downgrade is per-check, not a permanent latch.
  */
 
 const REPO = 'chaitanyagiri/munder-difflin';
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
 const FALLBACK_CACHE_MS = 60 * 60 * 1000;     // 1h between releases/latest polls
 
-export type UpdateStatus =
-  | { state: 'downloaded'; version: string; notes?: string }
-  | { state: 'available-manual'; version: string; url: string };
+export type { UpdateStatus };
 
 let sendTo: (() => WebContents | null) | null = null;
 let started = false;
-let fallbackActive = false;
 let lastFallbackCheck = 0;
-/** Remembered so a toast dismissed by a reload can be re-served on checkNow. */
+/** Remembered so a status survives a renderer reload and can be re-served. */
 let lastStatus: UpdateStatus | null = null;
 
+/** Append-only breadcrumb trail in userData. The whole point of this file's
+ *  existence is that the last failure left no trace anywhere. */
+function logLine(msg: string): void {
+  const line = `[${new Date().toISOString()}] ${msg}\n`;
+  console.log('[updater]', msg);
+  try {
+    const dir = app.getPath('userData');
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, 'updater.log'), line);
+  } catch { /* logging must never take the app down */ }
+}
+
 function emit(status: UpdateStatus): void {
-  lastStatus = status;
-  try { sendTo?.()?.send('update:status', status); } catch { /* window tore down */ }
+  lastStatus = reduceStatus(lastStatus, status);
+  try { sendTo?.()?.send('update:status', lastStatus); } catch { /* window tore down */ }
 }
 
 function autoUpdateEnabled(): boolean {
-  const cfg = readConfig();
-  return cfg.autoUpdate !== false; // default ON
-}
-
-/** `1.2.3` -> [1,2,3]; returns null for anything that doesn't look like semver. */
-function parseVersion(v: string): number[] | null {
-  const m = v.trim().replace(/^v/, '').match(/^(\d+)\.(\d+)\.(\d+)/);
-  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
-}
-
-function isNewer(candidate: string, current: string): boolean {
-  const a = parseVersion(candidate);
-  const b = parseVersion(current);
-  if (!a || !b) return false;
-  for (let i = 0; i < 3; i++) {
-    if (a[i] !== b[i]) return a[i] > b[i];
+  try {
+    return readConfig().autoUpdate !== false; // default ON
+  } catch {
+    return true;
   }
-  return false;
+}
+
+type AutoUpdater = import('electron-updater').AppUpdater;
+
+let autoUpdaterPromise: Promise<AutoUpdater> | null = null;
+
+/**
+ * Resolve electron-updater's `autoUpdater` across the CJS/ESM interop seam.
+ *
+ * See the header note: the named export is invisible to the ESM lexer, so the
+ * namespace object only carries it on `.default`. Both shapes are checked so
+ * this keeps working if a future electron-updater ships real named exports, and
+ * a missing export throws something we can actually read in a log.
+ */
+async function loadAutoUpdater(): Promise<AutoUpdater> {
+  autoUpdaterPromise ??= (async () => {
+    const ns = (await import('electron-updater')) as unknown as {
+      autoUpdater?: AutoUpdater;
+      default?: { autoUpdater?: AutoUpdater };
+    };
+    const found = ns.autoUpdater ?? ns.default?.autoUpdater;
+    if (!found) throw new Error('electron-updater loaded but exposes no `autoUpdater` export');
+    return found;
+  })();
+  try {
+    return await autoUpdaterPromise;
+  } catch (e) {
+    autoUpdaterPromise = null; // let a later attempt retry rather than latch
+    throw e;
+  }
+}
+
+function errText(e: unknown): string {
+  const m = e instanceof Error ? e.message : String(e);
+  return m.length > 300 ? `${m.slice(0, 300)}…` : m;
 }
 
 /** Notify-only check against releases/latest (no download). Never throws. */
-function fallbackCheck(force = false): void {
+function fallbackCheck(reason: string | undefined, force = false): void {
   const now = Date.now();
   if (!force && now - lastFallbackCheck < FALLBACK_CACHE_MS) return;
   lastFallbackCheck = now;
@@ -90,7 +141,8 @@ function fallbackCheck(force = false): void {
               emit({
                 state: 'available-manual',
                 version: tag.replace(/^v/, ''),
-                url: rel.html_url ?? `https://github.com/${REPO}/releases/latest`
+                url: rel.html_url ?? `https://github.com/${REPO}/releases/latest`,
+                reason
               });
             }
           } catch { /* malformed body — try again next interval */ }
@@ -103,20 +155,49 @@ function fallbackCheck(force = false): void {
   } catch { /* never let the fallback take the app down */ }
 }
 
-async function nativeCheck(): Promise<void> {
-  if (fallbackActive) { fallbackCheck(); return; }
+/**
+ * One check. Native first; on failure, report the real error AND degrade to the
+ * notify-only poll for THIS check only — the next tick tries native again, so a
+ * single blip no longer costs the session its ability to self-update.
+ */
+async function runCheck(): Promise<{ ok: boolean; error?: string }> {
+  emit({ state: 'checking' });
   try {
-    const { autoUpdater } = await import('electron-updater');
-    await autoUpdater.checkForUpdates();
-  } catch {
-    fallbackActive = true;
-    fallbackCheck();
+    const autoUpdater = await loadAutoUpdater();
+    const result = await autoUpdater.checkForUpdates();
+    if (!result || !isNewer(result.updateInfo.version, app.getVersion())) {
+      emit({ state: 'not-available' });
+    }
+    // `update-available` / `download-progress` / `update-downloaded` handlers
+    // (wired in initAutoUpdater) carry it from here.
+    return { ok: true };
+  } catch (e) {
+    const message = errText(e);
+    logLine(`native check failed: ${message}`);
+    emit({ state: 'error', message });
+    fallbackCheck(message);
+    return { ok: false, error: message };
+  }
+}
+
+/** Explicitly start (or restart) the download. Safe to call twice. */
+async function runDownload(): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const autoUpdater = await loadAutoUpdater();
+    await autoUpdater.downloadUpdate();
+    return { ok: true };
+  } catch (e) {
+    const message = errText(e);
+    logLine(`download failed: ${message}`);
+    emit({ state: 'error', message });
+    fallbackCheck(message);
+    return { ok: false, error: message };
   }
 }
 
 /**
  * Start the updater. Call once from app.whenReady with an accessor for the
- * primary window's webContents. Safe to call in dev (no-ops).
+ * primary window's webContents. Safe to call in dev (registers IPC, no polling).
  */
 export function initAutoUpdater(getWebContents: () => WebContents | null): void {
   sendTo = getWebContents;
@@ -124,19 +205,27 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
   // IPC surface is registered unconditionally so the renderer can always call it.
   ipcMain.handle('update:restartAndInstall', async () => {
     try {
-      const { autoUpdater } = await import('electron-updater');
+      const autoUpdater = await loadAutoUpdater();
+      logLine('quitAndInstall requested by the user');
       autoUpdater.quitAndInstall();
       return { ok: true };
     } catch (e) {
-      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+      const error = errText(e);
+      logLine(`quitAndInstall failed: ${error}`);
+      emit({ state: 'error', message: error });
+      return { ok: false, error };
     }
   });
   ipcMain.handle('update:checkNow', async () => {
-    if (!app.isPackaged) return { ok: false, error: 'dev build' };
-    if (lastStatus) emit(lastStatus); // re-serve a pending status to a fresh window
-    await nativeCheck();
-    return { ok: true };
+    if (!app.isPackaged) return { ok: false, error: 'dev build — updates are only checked in packaged apps' };
+    return runCheck();
   });
+  ipcMain.handle('update:download', async () => {
+    if (!app.isPackaged) return { ok: false, error: 'dev build — updates are only downloaded in packaged apps' };
+    return runDownload();
+  });
+  /** Re-serve the last known status to a freshly loaded window. */
+  ipcMain.handle('update:current', () => lastStatus ?? { state: 'idle' });
   ipcMain.handle('update:openRelease', (_evt, url: unknown) => {
     const href = typeof url === 'string' ? url : `https://github.com/${REPO}/releases/latest`;
     // Only ever open the project's releases page — this is not a generic opener.
@@ -151,24 +240,38 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
 
   void (async () => {
     try {
-      const { autoUpdater } = await import('electron-updater');
+      const autoUpdater = await loadAutoUpdater();
       autoUpdater.autoDownload = true;
       autoUpdater.autoInstallOnAppQuit = false; // install ONLY on explicit restart
+      autoUpdater.on('update-available', (info) => {
+        logLine(`update available: ${info.version}`);
+        emit({ state: 'available', version: info.version, notes: typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined });
+      });
+      autoUpdater.on('download-progress', (p) => {
+        const version = lastStatus && 'version' in lastStatus ? lastStatus.version : app.getVersion();
+        emit({ state: 'downloading', version, percent: clampPercent(p.percent) });
+      });
       autoUpdater.on('update-downloaded', (info) => {
+        logLine(`update downloaded: ${info.version} — waiting for the user to restart`);
         emit({ state: 'downloaded', version: info.version, notes: typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined });
       });
       autoUpdater.on('error', (err) => {
-        // Portable exe / missing metadata / offline: degrade to notify-only.
-        console.warn('[updater] native update failed; falling back to notify-only:', err?.message ?? err);
-        fallbackActive = true;
-        fallbackCheck();
+        const message = errText(err);
+        logLine(`native updater error: ${message}`);
+        emit({ state: 'error', message });
+        // Notify-only for THIS failure; the next tick still tries native.
+        fallbackCheck(message);
       });
+      logLine(`native updater ready (current v${app.getVersion()})`);
     } catch (e) {
-      console.warn('[updater] electron-updater unavailable; notify-only mode:', e);
-      fallbackActive = true;
+      // Reaching here means the module itself is unusable — the exact class of
+      // bug that hid from v0.3.4 to v0.3.6. Say so loudly, in the log and the UI.
+      const message = errText(e);
+      logLine(`electron-updater unavailable; notify-only mode: ${message}`);
+      emit({ state: 'error', message });
     }
 
-    const tick = (): void => { if (autoUpdateEnabled()) void nativeCheck(); };
+    const tick = (): void => { if (autoUpdateEnabled()) void runCheck(); };
     // First check shortly after boot (don't compete with spawn/startup I/O),
     // then every CHECK_INTERVAL_MS.
     setTimeout(tick, 30_000);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,8 @@ import type { HireManifest } from '../shared/hire';
 export type { HireManifest } from '../shared/hire';
 import type { IntegrationRecord, IntegrationTemplate } from '../shared/integrations';
 export type { IntegrationRecord, IntegrationTemplate } from '../shared/integrations';
+import type { UpdateStatus } from '../shared/updateState';
+export type { UpdateStatus } from '../shared/updateState';
 
 /** Renderer-visible integration record: the secretRef handle is redacted to a
  *  presence boolean. Matches main `integrations.listRecordsRedacted()` — the
@@ -1182,25 +1184,29 @@ const api = {
   rosterWrite: (snap: RosterSnapshot): Promise<{ ok: boolean; skipped?: string; error?: string }> =>
     ipcRenderer.invoke('roster:write', snap),
 
-  // ─── Auto-update (v0.3.4) ───────────────────────────────────────────────────
-  /** Push channel from main's updater: either a downloaded update waiting for a
-   *  restart, or (fallback/notify-only installs) a newer release to link to. */
-  onUpdateStatus: (
-    cb: (status:
-      | { state: 'downloaded'; version: string; notes?: string }
-      | { state: 'available-manual'; version: string; url: string }) => void
-  ): (() => void) => {
-    const listener = (_e: IpcRendererEvent, payload: Parameters<typeof cb>[0]) => cb(payload);
+  // ─── Auto-update (v0.3.4; full state model v0.3.7) ──────────────────────────
+  /** Push channel from main's updater — every stage of the pipeline, so the
+   *  toolbar badge can show "checking", download progress, and the staged
+   *  "restart to update" rather than only the terminal states. */
+  onUpdateStatus: (cb: (status: UpdateStatus) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, payload: UpdateStatus) => cb(payload);
     ipcRenderer.on('update:status', listener);
     return () => ipcRenderer.removeListener('update:status', listener);
   },
-  /** Quit and install the downloaded update — only ever called from the toast's
-   *  explicit "restart to update" button. */
+  /** The last known status — a reloaded window subscribes AFTER main may have
+   *  already emitted, so it pulls the current state instead of waiting 6h. */
+  updateCurrent: (): Promise<UpdateStatus> => ipcRenderer.invoke('update:current'),
+  /** Quit and install the downloaded update — only ever called from an explicit
+   *  "restart to update" click. */
   updateRestartAndInstall: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('update:restartAndInstall'),
-  /** Manual re-check (also re-serves a pending status to a fresh window). */
+  /** Manual re-check. */
   updateCheckNow: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('update:checkNow'),
+  /** Start the download for an already-detected update (autoDownload normally
+   *  beats the user to it; this is the explicit one-click path). */
+  updateDownload: (): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('update:download'),
   /** Open the project's releases page for a notify-only update. */
   updateOpenRelease: (url?: string): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('update:openRelease', url)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import { HivePicker } from '@/components/HivePicker';
 import { QuitWarningModal, type ClosingTimeState } from '@/components/QuitWarningModal';
 import { CompletionToast } from '@/realtime/CompletionToast';
 import { UpdateToast } from '@/components/UpdateToast';
+import { UpdateBadge } from '@/components/UpdateBadge';
 import { useAppTheme, toggleAppTheme } from '@/design/theme';
 import { SettingsModal } from '@/components/SettingsModal';
 import { PixelPanel } from '@/components/PixelPanel';
@@ -238,12 +239,15 @@ export function App() {
           alt="Munder Difflin"
           style={{ height: 20, width: 'auto', display: 'block' }}
         />
+        {/* v0.3.7: the version is no longer inert text — it doubles as the
+            update control (check / download / restart to update). */}
+        <UpdateBadge />
         <span style={{
           fontFamily: 'var(--cth-font-ui)',
           fontSize: 13,
           color: 'var(--cth-ink-500)'
         }}>
-          v{__APP_VERSION__} · {config.autoMode ? 'auto mode on' : 'auto mode off'}
+          {config.autoMode ? 'auto mode on' : 'auto mode off'}
         </span>
         {/* v0.3.4: theme + fullscreen live HERE (top right), not buried in the
             terminal header — and the theme darkens the whole app, terminals

--- a/src/renderer/src/components/UpdateBadge.tsx
+++ b/src/renderer/src/components/UpdateBadge.tsx
@@ -1,0 +1,91 @@
+/**
+ * Toolbar version + update control — top-left, right next to the logo.
+ *
+ * Always shows the running version. When main's updater reports anything
+ * interesting it grows a chip that IS the button: "v0.3.7 ready to install"
+ * (click → download), "downloading 42%", "restart to update to v0.3.7"
+ * (click → quitAndInstall). With nothing pending, clicking the version itself
+ * runs a manual check — the old build only ever checked 30s after boot and then
+ * every 6h, so there was no way to ask.
+ *
+ * All of the "what does this state say and do" logic lives in
+ * src/shared/updateState.ts so it can be unit-tested without Electron; this file
+ * is wiring and pixels.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { describeUpdate, reduceStatus, type UpdateStatus } from '@shared/updateState';
+
+declare const __APP_VERSION__: string;
+
+export function UpdateBadge() {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    // Subscribe first, then pull — main may have emitted before this window
+    // finished loading (or before a reload), and `update:current` re-serves it.
+    const off = window.cth.onUpdateStatus?.((next) => setStatus((prev) => reduceStatus(prev, next)));
+    void window.cth.updateCurrent?.().then((cur) => {
+      if (cur) setStatus((prev) => reduceStatus(prev, cur));
+    }).catch(() => { /* older main without the handler — the push channel still works */ });
+    return off;
+  }, []);
+
+  const view = describeUpdate(status, __APP_VERSION__);
+
+  const onClick = useCallback(async () => {
+    if (view.action === 'none' || busy) return;
+    setBusy(true);
+    try {
+      if (view.action === 'restart') await window.cth.updateRestartAndInstall();
+      else if (view.action === 'download') await window.cth.updateDownload();
+      else if (view.action === 'check') await window.cth.updateCheckNow();
+      else if (view.action === 'open-release') {
+        await window.cth.updateOpenRelease(status?.state === 'available-manual' ? status.url : undefined);
+      }
+    } catch { /* the emitted status carries the failure — nothing to do here */ }
+    setBusy(false);
+  }, [view.action, busy, status]);
+
+  const interactive = view.action !== 'none' && !view.busy;
+  // The chip only earns colour when it wants something: ready = mint (act on
+  // me), warn = amber (something went wrong), busy/idle stay in the titlebar's
+  // own greys so a quiet app looks exactly like it did before.
+  const chipBg =
+    view.tone === 'ready' ? 'var(--cth-mint-light, #d0f0e0)'
+      : view.tone === 'warn' ? 'var(--cth-amber-light, #f6e2b3)'
+        : 'transparent';
+
+  return (
+    <button
+      className="cth-titlebar-nodrag"
+      onClick={() => { void onClick(); }}
+      disabled={!interactive}
+      title={view.title}
+      aria-label={view.label ? `${view.title}` : `Version ${__APP_VERSION__} — check for updates`}
+      aria-busy={view.busy || busy}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        padding: view.label ? '2px 8px' : '2px 4px',
+        margin: 0,
+        background: chipBg,
+        border: 'none',
+        borderRadius: 2,
+        boxShadow: view.label ? 'inset 0 0 0 1px var(--cth-ink-300)' : 'none',
+        fontFamily: 'var(--cth-font-ui)',
+        fontSize: 13,
+        lineHeight: '18px',
+        color: view.tone === 'idle' ? 'var(--cth-ink-500)' : 'var(--cth-ink-900)',
+        cursor: interactive ? 'pointer' : 'default'
+      }}
+    >
+      <span>v{__APP_VERSION__}</span>
+      {view.label && (
+        <>
+          <span aria-hidden style={{ color: 'var(--cth-ink-500)' }}>·</span>
+          <span style={{ fontWeight: 600 }}>{view.label}</span>
+        </>
+      )}
+    </button>
+  );
+}

--- a/src/renderer/src/components/UpdateToast.tsx
+++ b/src/renderer/src/components/UpdateToast.tsx
@@ -13,16 +13,27 @@
  */
 import { useEffect, useState } from 'react';
 import { Icon } from '@/components/Icon';
+import type { UpdateStatus } from '@shared/updateState';
 
-type UpdateStatus =
-  | { state: 'downloaded'; version: string; notes?: string }
-  | { state: 'available-manual'; version: string; url: string };
+/** The toast is the LOUD half — it only interrupts for the two states a user has
+ *  to act on. Everything else (checking, available, download progress, errors)
+ *  lives quietly in the toolbar badge next to the logo. */
+type ToastStatus = Extract<UpdateStatus, { state: 'downloaded' | 'available-manual' }>;
+
+function toastable(s: UpdateStatus): ToastStatus | null {
+  return s.state === 'downloaded' || s.state === 'available-manual' ? s : null;
+}
 
 export function UpdateToast() {
-  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [status, setStatus] = useState<ToastStatus | null>(null);
   const [busy, setBusy] = useState(false);
 
-  useEffect(() => window.cth.onUpdateStatus?.(setStatus), []);
+  useEffect(() => window.cth.onUpdateStatus?.((next) => {
+    const t = toastable(next);
+    // A non-toastable state (a re-check, say) must not erase a toast the user
+    // hasn't answered yet — only a new actionable state replaces it.
+    if (t) setStatus(t);
+  }), []);
 
   if (!status) return null;
 

--- a/src/shared/updateState.ts
+++ b/src/shared/updateState.ts
@@ -1,0 +1,142 @@
+/**
+ * Auto-update status model + presentation mapping.
+ *
+ * Deliberately electron-free: main (src/main/updater.ts) produces these states
+ * from electron-updater events, the toolbar badge
+ * (src/renderer/src/components/UpdateBadge.tsx) renders them, and the rules that
+ * matter — which state wins when two arrive out of order, what the button says
+ * and does — live here where they can be unit-tested without booting Electron.
+ */
+
+export type UpdateStatus =
+  /** Nothing known yet (fresh window, or dev build where we never check). */
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'not-available' }
+  | { state: 'available'; version: string; notes?: string }
+  | { state: 'downloading'; version: string; percent: number }
+  | { state: 'downloaded'; version: string; notes?: string }
+  /** This install can't self-update (win-portable, or the native path failed):
+   *  notify-only, link to the release page. `reason` is the underlying error. */
+  | { state: 'available-manual'; version: string; url: string; reason?: string }
+  | { state: 'error'; message: string };
+
+export type UpdateAction = 'none' | 'check' | 'download' | 'restart' | 'open-release';
+
+export interface UpdateBadgeView {
+  /** Extra text beside the version, or null to show the version alone. */
+  label: string | null;
+  /** What a click does. 'none' renders the badge non-interactive. */
+  action: UpdateAction;
+  tone: 'idle' | 'busy' | 'ready' | 'warn';
+  /** Tooltip — the only place the underlying error is ever surfaced verbatim. */
+  title: string;
+  busy: boolean;
+}
+
+/** `1.2.3` / `v1.2.3` -> [1,2,3]; null for anything that isn't semver-ish. */
+export function parseVersion(v: string): [number, number, number] | null {
+  const m = String(v ?? '').trim().replace(/^v/, '').match(/^(\d+)\.(\d+)\.(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+export function isNewer(candidate: string, current: string): boolean {
+  const a = parseVersion(candidate);
+  const b = parseVersion(current);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return false;
+}
+
+/** Download percentages arrive as floats and, on a resumed/differential
+ *  download, occasionally out of range. Clamp so the UI can't render `-0%`
+ *  or `104%`. */
+export function clampPercent(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+/** How far along the update pipeline a state is. A later stage is never
+ *  replaced by an earlier one for the SAME version — see `reduceStatus`. */
+function rank(s: UpdateStatus): number {
+  switch (s.state) {
+    case 'idle': return 0;
+    case 'checking': return 1;
+    case 'not-available': return 1;
+    case 'error': return 1;
+    case 'available-manual': return 2;
+    case 'available': return 3;
+    case 'downloading': return 4;
+    case 'downloaded': return 5;
+  }
+}
+
+function versionOf(s: UpdateStatus): string | null {
+  return 'version' in s ? s.version : null;
+}
+
+/**
+ * Fold a new status into the current one.
+ *
+ * The rule that matters: once an update is staged, the 6-hourly re-check (or a
+ * manual "check now") must NOT wipe the "restart to update" affordance out from
+ * under the user — `checking` / `not-available` / a transient `error` are all
+ * lower-rank and lose. A genuinely NEWER version always wins, so a long-running
+ * app that sees 0.3.7 while 0.3.6 is staged moves forward rather than sticking.
+ */
+export function reduceStatus(prev: UpdateStatus | null, next: UpdateStatus): UpdateStatus {
+  if (!prev) return next;
+  const pv = versionOf(prev);
+  const nv = versionOf(next);
+  if (pv && nv && isNewer(nv, pv)) return next;   // a newer release supersedes
+  if (pv && nv && pv !== nv) return next;         // different (e.g. rolled back) release
+  return rank(next) >= rank(prev) ? next : prev;
+}
+
+/**
+ * What the toolbar badge shows and does for a given status.
+ *
+ * `currentVersion` is the running app's version — it is always rendered next to
+ * the logo, so every one of these views is "v0.3.6" plus at most one extra chip.
+ */
+export function describeUpdate(status: UpdateStatus | null, currentVersion: string): UpdateBadgeView {
+  const v = currentVersion;
+  switch (status?.state) {
+    case 'checking':
+      return { label: 'checking…', action: 'none', tone: 'busy', busy: true, title: `Checking for updates (you're on v${v})` };
+    case 'available':
+      return {
+        label: `v${status.version} ready to install`, action: 'download', tone: 'ready', busy: false,
+        title: `Version ${status.version} is available — click to download it`
+      };
+    case 'downloading':
+      return {
+        label: `downloading ${clampPercent(status.percent)}%`, action: 'none', tone: 'busy', busy: true,
+        title: `Downloading v${status.version}… ${clampPercent(status.percent)}%`
+      };
+    case 'downloaded':
+      return {
+        label: `restart to update to v${status.version}`, action: 'restart', tone: 'ready', busy: false,
+        title: `v${status.version} is downloaded and ready — click to restart and apply it`
+      };
+    case 'available-manual':
+      return {
+        label: `v${status.version} — get it manually`, action: 'open-release', tone: 'warn', busy: false,
+        title: status.reason
+          ? `This install couldn't update itself (${status.reason}) — click to open the release page`
+          : `This install can't update itself — click to open the release page`
+      };
+    case 'error':
+      return {
+        label: 'update check failed', action: 'check', tone: 'warn', busy: false,
+        title: `${status.message} — click to try again`
+      };
+    case 'not-available':
+      return { label: null, action: 'check', tone: 'idle', busy: false, title: `v${v} is the latest version — click to check again` };
+    case 'idle':
+    default:
+      return { label: null, action: 'check', tone: 'idle', busy: false, title: `v${v} — click to check for updates` };
+  }
+}

--- a/test/update-state.test.cjs
+++ b/test/update-state.test.cjs
@@ -1,0 +1,114 @@
+'use strict';
+
+/**
+ * Auto-update state model.
+ *
+ * These cover the two rules that actually broke in the field:
+ *   1. a re-check must never wipe out a staged "restart to update" (the 6h tick
+ *      and the manual check both emit `checking` → `not-available`);
+ *   2. every state maps to a button that says what it does — the v0.3.4-0.3.6
+ *      builds could only ever say "open the releases page", which is what the
+ *      founder hit when 0.3.6 shipped.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { parseVersion, isNewer, clampPercent, reduceStatus, describeUpdate } =
+  loadTs('src/shared/updateState.ts');
+
+test('parseVersion accepts v-prefixed and bare semver, rejects junk', () => {
+  assert.deepEqual(parseVersion('0.3.6'), [0, 3, 6]);
+  assert.deepEqual(parseVersion('v0.3.6'), [0, 3, 6]);
+  assert.deepEqual(parseVersion('1.10.2-beta.1'), [1, 10, 2]);
+  assert.equal(parseVersion('nightly'), null);
+  assert.equal(parseVersion(''), null);
+});
+
+test('isNewer compares numerically, not lexically', () => {
+  assert.equal(isNewer('0.3.6', '0.3.5'), true);
+  assert.equal(isNewer('v0.3.6', '0.3.5'), true);
+  // The one a string compare gets wrong: '0.3.10' < '0.3.9' lexically.
+  assert.equal(isNewer('0.3.10', '0.3.9'), true);
+  assert.equal(isNewer('0.3.5', '0.3.6'), false);
+  assert.equal(isNewer('0.3.6', '0.3.6'), false);
+  assert.equal(isNewer('garbage', '0.3.6'), false);
+});
+
+test('clampPercent keeps progress renderable', () => {
+  assert.equal(clampPercent(42.6), 43);
+  assert.equal(clampPercent(-3), 0);
+  assert.equal(clampPercent(104), 100);
+  assert.equal(clampPercent(NaN), 0);
+  assert.equal(clampPercent(undefined), 0);
+});
+
+test('a re-check never clobbers a staged update', () => {
+  const staged = { state: 'downloaded', version: '0.3.7' };
+  // The 6h tick: checking → not-available, both must lose to the staged update.
+  assert.deepEqual(reduceStatus(staged, { state: 'checking' }), staged);
+  assert.deepEqual(reduceStatus(staged, { state: 'not-available' }), staged);
+  // A transient network error mid-session must not drop the restart button.
+  assert.deepEqual(reduceStatus(staged, { state: 'error', message: 'ETIMEDOUT' }), staged);
+});
+
+test('the pipeline moves forward for the same version', () => {
+  let s = reduceStatus(null, { state: 'checking' });
+  s = reduceStatus(s, { state: 'available', version: '0.3.7' });
+  assert.equal(s.state, 'available');
+  s = reduceStatus(s, { state: 'downloading', version: '0.3.7', percent: 12 });
+  assert.equal(s.state, 'downloading');
+  s = reduceStatus(s, { state: 'downloaded', version: '0.3.7' });
+  assert.equal(s.state, 'downloaded');
+  // Late progress events must not walk it back off "downloaded".
+  s = reduceStatus(s, { state: 'downloading', version: '0.3.7', percent: 99 });
+  assert.equal(s.state, 'downloaded');
+});
+
+test('a genuinely newer release supersedes a staged one', () => {
+  const staged = { state: 'downloaded', version: '0.3.7' };
+  const next = reduceStatus(staged, { state: 'available', version: '0.3.8' });
+  assert.deepEqual(next, { state: 'available', version: '0.3.8' });
+});
+
+test('every actionable state offers the action its label promises', () => {
+  const check = (status, expected) => {
+    const v = describeUpdate(status, '0.3.6');
+    assert.equal(v.action, expected.action, `action for ${status ? status.state : 'null'}`);
+    if ('label' in expected) assert.equal(v.label, expected.label);
+    if ('busy' in expected) assert.equal(v.busy, expected.busy);
+  };
+
+  // Idle / up-to-date: version only, but still clickable to check on demand —
+  // the whole point of the founder's "tell me and let me trigger it" ask.
+  check(null, { action: 'check', label: null, busy: false });
+  check({ state: 'idle' }, { action: 'check', label: null });
+  check({ state: 'not-available' }, { action: 'check', label: null });
+
+  check({ state: 'checking' }, { action: 'none', busy: true });
+  check({ state: 'available', version: '0.3.7' }, { action: 'download', busy: false });
+  check({ state: 'downloading', version: '0.3.7', percent: 42 }, { action: 'none', busy: true });
+  check({ state: 'downloaded', version: '0.3.7' }, { action: 'restart', busy: false });
+  check({ state: 'available-manual', version: '0.3.7', url: 'https://x' }, { action: 'open-release' });
+  check({ state: 'error', message: 'boom' }, { action: 'check' });
+});
+
+test('labels name the version so the badge is self-explanatory', () => {
+  assert.match(describeUpdate({ state: 'available', version: '0.3.7' }, '0.3.6').label, /0\.3\.7/);
+  assert.match(describeUpdate({ state: 'downloaded', version: '0.3.7' }, '0.3.6').label, /restart/i);
+  assert.match(describeUpdate({ state: 'downloading', version: '0.3.7', percent: 42.4 }, '0.3.6').label, /42%/);
+});
+
+test('the underlying failure reaches the tooltip instead of being swallowed', () => {
+  // This is the regression guard for the v0.3.4-0.3.6 bug: the real error was
+  // caught and dropped, leaving "open the releases page" with no explanation.
+  const err = describeUpdate({ state: 'error', message: 'Cannot set properties of undefined' }, '0.3.6');
+  assert.match(err.title, /Cannot set properties of undefined/);
+
+  const manual = describeUpdate(
+    { state: 'available-manual', version: '0.3.7', url: 'https://x', reason: 'ENOTFOUND github.com' },
+    '0.3.6'
+  );
+  assert.match(manual.title, /ENOTFOUND github\.com/);
+});


### PR DESCRIPTION
## Auto-update never ran. Not once, in any packaged build.

`electron-updater` is CommonJS and exposes `autoUpdater` through a lazy `Object.defineProperty` getter. Node's `cjs-module-lexer` can't see through that, so `await import('electron-updater')` yields a namespace with **no `autoUpdater` export** — only `.default.autoUpdater`. The shipped code destructured the namespace, got `undefined`, and threw on the first line of setup:

```
TypeError: Cannot set properties of undefined (setting 'autoDownload')
```

That landed in a `catch` that silently latched notify-only mode, so every packaged build from **v0.3.4 through v0.3.6** could only ever offer "open the releases page". Invisible in dev, because the whole path is behind `app.isPackaged`.

**Reproduced** by running the shipped 0.3.5 bundle from a terminal with an isolated `--user-data-dir` (Electron's single-instance lock is per-userData-dir, so it runs alongside a live app).

### Ruled out with evidence — the v0.3.6 release itself is correct
- Published mac `.zip`: SHA512 matches `latest-mac.yml` byte-for-byte, Developer ID signed, **notarized, ticket stapled**, `spctl` accepted, `codesign --verify --deep --strict` valid.
- Feed/provider/version-compare: a real check against the live feed resolves 0.3.5 → 0.3.6.
- Download: full 232 MB fetched, SHA512 verified, `update-downloaded` emitted.
- Dynamic `import()` inside ASAR works fine on Electron 32.

## Fixed
- `loadAutoUpdater()` resolves `ns.autoUpdater ?? ns.default?.autoUpdater`, throws a **named** error if the export ever vanishes, and clears the failed promise so a retry is possible.
- **Errors are never swallowed** — emitted to the renderer *and* appended to `updater.log` in userData. The old `catch` left no trace anywhere, which is why this survived three releases.
- The notify-only downgrade is **per-check, not a permanent latch** — one network blip no longer costs the session its ability to self-update.
- `update-available` and `download-progress` are handled, so a multi-minute 232 MB download is visible instead of looking like nothing happened.

## Added
- **The toolbar version is now the update control** (`UpdateBadge.tsx`, top-left next to the logo): `checking…` → `vX.Y.Z ready to install` (click to download) → `downloading 42%` → `restart to update` (click to apply). Idle click runs a manual check — previously the only checks were boot+30s and every 6h, with no way to ask.
- New IPC `update:download` (one-click) and `update:current` (a reloaded window pulls state instead of waiting 6h).
- State rules extracted to `src/shared/updateState.ts` (electron-free) with **9 unit tests**, covering the rule that bit here: a re-check must never wipe a staged "restart to update".

## Docs cleanup
- **Site** (1852 → ~1330 lines): demo-video section removed entirely (tabs, videos, CSS, JS, nav link); **dark mode removed** (pre-paint init, `[data-theme="dark"]` palette, toggle, and the dark-only WebGL hero) — every CSS var still resolves from `:root`; copy trimmed throughout.
- **README** (366 → 320): the 48-row feature table becomes a grouped scannable list; the wall-of-text status note becomes six lines; version badge 0.3.3 → 0.3.7 (stale for four releases).
- **RELEASE.md** (298 → 145): leads with 0.3.7, compresses prior releases into one "Previously" list.
- New post: `why-our-auto-update-never-ran` — the debugging write-up.

## ⚠️ Upgrade note
**v0.3.5 and v0.3.6 installs carry the broken updater and cannot fetch this fix themselves.** Users must install v0.3.7 manually, once. From v0.3.7 onward, updates are automatic. This is called out in the release notes, README, and the blog post.

## Verified
101/101 tests (was 92, +9), typecheck clean, build green, site renders with no console errors, and the **built bundle's resolver run under Electron returns a live `autoUpdater` with `autoDownload` set** — the exact line that used to throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)