### PR TITLE
fix(hive): stop codex hooks timing out after 1s

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1538,6 +1538,21 @@ export class HiveManager {
       // each spawn (idempotent). A single-quoted TOML literal avoids path escaping
       // (hive roots are space/quote-free). NOTE: hooks fire in INTERACTIVE codex
       // sessions (how hive workers run), not in headless `codex exec`.
+      //
+      // `timeout` IS SECONDS HERE — do NOT copy Claude's `timeout: 0` sentinel into
+      // this file. Codex parses the key as `timeout_sec` and normalizes it with
+      // `timeout_sec.unwrap_or(600).max(1)`, so 0 does not mean "no timeout": it is
+      // floored to ONE SECOND, the shortest budget there is. That shipped through
+      // v0.3.7 and made every codex worker log `SessionStart hook (failed) — hook
+      // timed out after 1s` (same for UserPromptSubmit), because each hook cold-starts
+      // the Electron binary via hive-node and then waits on hooks.sock — measured
+      // 0.08-0.16s idle but 0.6-0.7s under 8 concurrent spawns, which is exactly what
+      // session start and prompt dispatch look like. 30s clears that by two orders of
+      // magnitude while still capping a wedged shim well before its own 5s internal
+      // cap stops mattering; bare omission (600s) would leave a hang looking like a
+      // freeze. Verify any change with codex's own resolver, no model spend:
+      // `codex app-server` → initialize → `hooks/list` reports the normalized
+      // timeoutSec per event.
       const shim = this.shimPath();
       let config = existsSync(join(userHome, 'config.toml'))
         ? readFileSync(join(userHome, 'config.toml'), 'utf8') : '';
@@ -1546,7 +1561,7 @@ export class HiveManager {
           'SessionStart', 'UserPromptSubmit', 'PreCompact', 'PostCompact'];
         config += '\n# --- munder-hive lifecycle hooks (auto-generated; do not edit) ---\n';
         for (const ev of events) {
-          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = '${this.nodeRunUnquoted(shim)}'\ntimeout = 0\n`;
+          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = '${this.nodeRunUnquoted(shim)}'\ntimeout = 30\n`;
         }
       }
       writeFileSync(join(home, 'config.toml'), config, 'utf8');


### PR DESCRIPTION
## What was happening

Every codex worker logged this on v0.3.7:

```
• SessionStart hook (failed)
  error: hook timed out after 1s

• UserPromptSubmit hook (failed)
  error: hook timed out after 1s
```

The cause was ours. `installCodexHooks` wrote `timeout = 0` into each per-agent `CODEX_HOME/config.toml` — Claude Code's "no timeout" sentinel.

Codex does not read it that way:

- `codex-rs/config/src/hook_config.rs` maps the TOML key `timeout` to `timeout_sec`, in **seconds**
- `codex-rs/hooks/src/engine/discovery.rs` normalizes it with `timeout_sec.unwrap_or(600).max(1)` — so `0` is **floored to one second**, the shortest budget available, the exact opposite of the intent
- `codex-rs/hooks/src/engine/command_runner.rs` prints `format!("hook timed out after {}s", handler.timeout_sec)` — the `1s` in the error *is* that resolved value

One second was never survivable. Each hook cold-starts the Electron binary through `hive-node` and then waits on `hooks.sock`:

| condition | per-hook wall time |
|---|---|
| idle, warm | 0.08–0.16s |
| first spawn (cold) | 0.43s |
| 8 concurrent spawns | 0.59–0.68s each |

That last row is what session start and prompt dispatch actually look like — and those are exactly the two events that failed.

## The change

One line: `timeout = 0` → `timeout = 30`, plus a comment explaining the trap so nobody re-copies the Claude sentinel.

30s rather than deleting the line: bare omission inherits codex's 600s default, which would turn a wedged shim into an apparent freeze. 30s clears real latency by two orders of magnitude and still fails eventually.

## Verification

Asked codex's own resolver, no model spend — `codex app-server` → `initialize` → `hooks/list` reports the normalized `timeoutSec` per event. Fed it the byte-identical config MD generates:

```
before (timeout = 0)  → all 8 events resolve to timeoutSec=1
after  (timeout = 30) → all 8 events resolve to timeoutSec=30
```

`npm run typecheck` clean (node + web).

## Notes

- **Not a codex regression.** `.max(1)` has been in place since at least 2026-06-11 — this path never worked.
- **Claude agents unaffected.** Their hook entries set no timeout and use Claude's default.
- **Left alone deliberately:** the same `timeout: 0` sentinel is still written for gemini/antigravity `hooks.json` (`hive.ts:1462,1465`). Those semantics are unverified; worth a follow-up rather than a blind edit here.
- **No migration needed.** Existing agent `CODEX_HOME`s keep the stale file until their next spawn; the config is regenerated per spawn.
- **Follow-up worth considering:** `hooks/list` reports `trustStatus: untrusted` for our entries — hook trust is a second codex gate MD never explicitly satisfies. Also, pointing `hive-node` at a plain `node` when one is on PATH would remove the Electron cold start entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)