### PR TITLE
fix(memory): read the transcript directory Claude Code actually writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/auto-compact.test.cjs test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs",
+    "test:focused": "node --test test/auto-compact.test.cjs test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/transcript-project-dir.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -147,8 +147,19 @@ function shortRand(): string {
 
 /** Non-memory files `mempalace mine` must not ingest (Claude Code hooks config,
  *  cursor, raw inbox/outbox JSON). `mempalace mine` honors .gitignore, so we drop
- *  one in each agent dir; written on birth here and refreshed by the mine loop. */
-const MINE_IGNORE_LINES = ['settings.json', 'cursor.json', 'inbox/', 'outbox/'];
+ *  one in each agent dir; written on birth here and refreshed by the mine loop.
+ *
+ *  `.codex/` is here for a second reason as well, and it is the load-bearing one:
+ *  a Codex worker's CODEX_HOME lives INSIDE its agent dir (see installCodexHooks —
+ *  Codex can only be given hooks through a config.toml in its own home, so it
+ *  cannot share the user's ~/.codex). Codex then fills that folder with full
+ *  session transcripts, an 80MB+ logs sqlite and a plugin cache, and the hive's
+ *  git repo was faithfully versioning every revision of all of it. Twenty Codex
+ *  agents took the hive's .git to 7.5GB, at which point git's own auto-gc tried to
+ *  repack it and took 22GB of RAM doing so — the machine swapped, the app stopped
+ *  responding. None of it was ever wanted in history: it is Codex's private
+ *  scratch state, and it stays on disk (so resume still works) either way. */
+const MINE_IGNORE_LINES = ['settings.json', 'cursor.json', 'inbox/', 'outbox/', '.codex/'];
 
 /** Idempotently ensure `<agentDir>/.gitignore` excludes the non-memory files.
  *  Append-only: writes only the missing lines, leaving any existing entries. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1806,6 +1806,17 @@ ipcMain.handle('app:copyToClipboard', (_evt, text: unknown) => {
 ipcMain.handle('app:readClipboard', () => {
   try { return clipboard.readText(); } catch { return ''; }
 });
+// Same read, SYNCHRONOUS, for the terminal's paste shortcut.
+//
+// Dictation tools (muesli.works, Wispr Flow, …) type by stashing the user's
+// clipboard, writing the transcript, sending the paste key, then restoring the
+// old clipboard immediately. An `invoke` read returns a tick or two later — by
+// which point the restore has already landed and we paste the PREVIOUS text.
+// A `sendSync` read completes inside the keydown handler, before the tool gets
+// a chance to put the old contents back.
+ipcMain.on('app:readClipboardSync', (evt) => {
+  try { evt.returnValue = clipboard.readText(); } catch { evt.returnValue = ''; }
+});
 // NOTE: the terminal theme is mirrored into each agent's per-session Claude
 // settings at spawn (hive.ensureAgent theme option) — deliberately NOT via
 // `claude config set -g theme`, which would also restyle the user's own

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1475,7 +1475,34 @@ function installAppMenu(): void {
         ? [newFloorItem, { type: 'separator' as const }, { role: 'close' as const }]
         : [newFloorItem, { type: 'separator' as const }, { role: 'quit' as const }]
     },
-    { role: 'editMenu' },
+    // The Edit menu is spelled out rather than `{ role: 'editMenu' }` for one
+    // reason: `registerAccelerator: false` on the clipboard items.
+    //
+    // A registered accelerator is claimed by the MENU, which then replays the
+    // action through `webContents.paste()` — an async hop that runs a beat after
+    // the keystroke. Dictation tools (Muesli, Wispr Flow, …) insert text by
+    // stashing the clipboard, writing the transcript, sending the paste key, and
+    // restoring the old clipboard immediately; the menu's late paste therefore
+    // read the RESTORED clipboard and typed the user's previous copy instead of
+    // what they had just said. It hit the terminal and the composer alike,
+    // because both were downstream of the same replay.
+    //
+    // With registerAccelerator false the item still shows its shortcut, but the
+    // key is left for the focused element to handle inline — xterm's own paste
+    // handler and the textarea's native paste event both read the clipboard
+    // synchronously, inside the keystroke, before any restore can land.
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' as const, registerAccelerator: false },
+        { role: 'redo' as const, registerAccelerator: false },
+        { type: 'separator' as const },
+        { role: 'cut' as const, registerAccelerator: false },
+        { role: 'copy' as const, registerAccelerator: false },
+        { role: 'paste' as const, registerAccelerator: false },
+        { role: 'selectAll' as const, registerAccelerator: false }
+      ]
+    },
     { role: 'viewMenu' },
     { role: 'windowMenu' }
   ];

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -18,10 +18,17 @@ import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 
 /** Non-memory files `mempalace mine` must not ingest: the Claude Code hooks
- *  config (a large JSON blob that swamps the wake-up digest), the cursor, and
- *  raw inbox/outbox message JSON. `mempalace mine` honors .gitignore, so we drop
- *  one in each agent dir rather than touch the mine command. */
-const MINE_IGNORE_LINES = ['settings.json', 'cursor.json', 'inbox/', 'outbox/'];
+ *  config (a large JSON blob that swamps the wake-up digest), the cursor, raw
+ *  inbox/outbox message JSON, and a Codex worker's private CODEX_HOME. `mempalace
+ *  mine` honors .gitignore, so we drop one in each agent dir rather than touch the
+ *  mine command.
+ *
+ *  MUST STAY IN SYNC with MINE_IGNORE_LINES in hive.ts — that copy is written when
+ *  an agent spawns, this one on every mine cycle, and only this one reaches agents
+ *  that are not currently running. See hive.ts for why `.codex/` matters beyond
+ *  mempalace: it is also what stopped the hive's git repo from versioning every
+ *  Codex transcript and sqlite log into a 7.5GB history. */
+const MINE_IGNORE_LINES = ['settings.json', 'cursor.json', 'inbox/', 'outbox/', '.codex/'];
 
 /** Idempotently ensure `<agentDir>/.gitignore` excludes the non-memory files.
  *  Writes only the missing lines (append-only) so it's safe to call every cycle. */

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -66,6 +66,7 @@ export class MemoryManager {
   private binCache: string | null | undefined;
   private mineTimer: NodeJS.Timeout | null = null;
   private initStarted = false;
+  private warnedUnavailable = false; // one boot warning, not one per start() call
   /** True while a mineNow() pass is in flight — serializes palace writers. */
   private mining = false;
   /** agentId → memory.md mtimeMs at last successful mine (skip unchanged). */
@@ -120,7 +121,18 @@ export class MemoryManager {
     return found;
   }
   /** Force re-resolution (e.g. after the user installs mempalace). */
-  resetBinCache(): void { this.binCache = undefined; }
+  resetBinCache(): void { this.binCache = undefined; this.warnedUnavailable = false; }
+
+  private warnUnavailable(): void {
+    if (this.warnedUnavailable) return;
+    this.warnedUnavailable = true;
+    console.warn(
+      '[memory] semantic memory is ENABLED but the `mempalace` CLI was not found on PATH '
+      + '(or in ~/.local/bin, /opt/homebrew/bin, /usr/local/bin). The shared palace is inert: '
+      + 'nothing is mined, no agent can recall across the team, and agents are not told it exists. '
+      + 'Install it with `uv tool install mempalace`, then reopen the floor.'
+    );
+  }
 
   available(): boolean { return this.bin() !== null; }
   enabled(): boolean { return this.getSettings().enabled; }
@@ -162,6 +174,11 @@ export class MemoryManager {
    *  run `mempalace init`: it ends in an interactive "Mine now? [Y/n]" prompt
    *  that --yes doesn't cover, so a spawned child would hang forever. */
   start(): void {
+    // Enabled-but-uninstalled is the failure mode that let the shared palace sit
+    // dark for two months: `active()` simply returns false and every entry point
+    // no-ops, so the config flag reads as "on" while nothing indexes or recalls.
+    // Say it once, loudly, with the command that fixes it.
+    if (this.enabled() && !this.available()) this.warnUnavailable();
     if (!this.active() || this.initStarted) return;
     if (!this.bin() || !this.getHome() || !this.palacePath()) return;
     this.initStarted = true;

--- a/src/main/reflect.ts
+++ b/src/main/reflect.ts
@@ -34,6 +34,10 @@ const CONDENSE_MODEL = 'claude-haiku-4-5';
 /** Hard cap so a wedged headless run can't stall the reflect loop. */
 const DEFAULT_TIMEOUT_MS = 180_000;
 
+/** Consecutive failures before a stuck agent is escalated (and re-escalated). At
+ *  the default 30-minute interval that surfaces a broken pipeline within ~1.5h. */
+const ESCALATE_AFTER = 3;
+
 /** The fixed region headings of the bounded memory shape (the stable contract). */
 const PINNED_HEADING = '## 📌 Durable facts (pinned — never condensed)';
 const CONDENSED_HEADING = '## 🗜 Condensed history';
@@ -98,6 +102,7 @@ export class MemoryReflector {
   /** True while a reflectNow() pass is in flight — serializes the loop (a slow
    *  LLM pass must not overlap the next interval tick), mirroring MemoryManager. */
   private reflecting = false;
+  private abortStreak = new Map<string, number>(); // agentId → consecutive condense failures
 
   /**
    * @param getHome      Lazily resolve harnessHome so reflection follows config.
@@ -241,6 +246,7 @@ export class MemoryReflector {
       return { id, condensed: false, reason: 'swap-failed', oldBytes, newBytes };
     }
 
+    this.abortStreak.delete(id); // a success clears the streak, so escalation counts real runs
     try {
       this.appendLog({
         kind: 'condense', agentId: id, oldBytes, newBytes,
@@ -253,6 +259,26 @@ export class MemoryReflector {
 
   private logAbort(id: string, reason: string, detail?: string, extra?: Record<string, unknown>): void {
     try { this.appendLog({ kind: 'condense-abort', agentId: id, reason, ...(detail ? { detail } : {}), ...extra }); }
+    catch { /* best-effort */ }
+    this.noteAbort(id, reason, detail);
+  }
+
+  /** A single abort is normal (a busy machine, one bad LLM pass). A STREAK means
+   *  the pipeline is broken, and a broken pipeline is invisible: every tick backs
+   *  the file up, fails, and writes one more indistinguishable log line. That is
+   *  how 4039 consecutive aborts went unnoticed for two months while memory grew
+   *  unbounded. Escalate on every ESCALATE_AFTER-th failure so a stuck agent
+   *  surfaces within the hour instead of never. */
+  private noteAbort(id: string, reason: string, detail?: string): void {
+    const streak = (this.abortStreak.get(id) ?? 0) + 1;
+    this.abortStreak.set(id, streak);
+    if (streak % ESCALATE_AFTER !== 0) return;
+    console.error(
+      `[reflect] condensation is STUCK for ${id}: ${streak} consecutive failures `
+      + `(${reason}${detail ? `: ${detail}` : ''}). Its memory.md is growing unbounded `
+      + 'and every attempt still writes a full backup copy.'
+    );
+    try { this.appendLog({ kind: 'condense-stuck', agentId: id, streak, reason, ...(detail ? { detail } : {}) }); }
     catch { /* best-effort */ }
   }
 

--- a/src/main/transcript.ts
+++ b/src/main/transcript.ts
@@ -3,17 +3,42 @@ import os from 'node:os';
 import path from 'node:path';
 import { estimateCostUsd, normalizeModel } from './pricing';
 
-/** Resolve the Claude Code transcript directory for a given working directory.
- *  Claude Code stores per-project transcripts under ~/.claude/projects, keying
- *  each project by its absolute cwd with the leading slash dropped and every
- *  remaining slash turned into a dash (e.g. /Users/me/app → Users-me-app). On
- *  Windows EVERY non-alphanumeric character is dashed (drive colon and
- *  backslashes included): C:\Users\me\app → C--Users-me-app. */
-export function projectDir(cwd: string): string {
-  const key = process.platform === 'win32'
+/** Claude Code's current project key: the absolute cwd with EVERY separator
+ *  dashed, the leading slash included (/Users/me/app → -Users-me-app). On Windows
+ *  every non-alphanumeric character is dashed (C:\Users\me\app → C--Users-me-app). */
+function projectKey(cwd: string): string {
+  return process.platform === 'win32'
     ? cwd.replace(/[^a-zA-Z0-9]/g, '-')
-    : cwd.replace(/^\//, '').replaceAll('/', '-');
-  return path.join(os.homedir(), '.claude/projects', key);
+    : cwd.replaceAll('/', '-');
+}
+
+/** The pre-2026 key, which dropped the leading slash (/Users/me/app → Users-me-app). */
+function legacyProjectKey(cwd: string): string {
+  return projectKey(cwd).replace(/^-/, '');
+}
+
+/** Resolve the Claude Code transcript directory for a given working directory:
+ *  ~/.claude/projects keyed by cwd.
+ *
+ *  We used to emit the LEGACY key unconditionally, which silently stopped
+ *  matching when Claude Code started dashing the leading slash too. Nothing
+ *  errored — every caller reads an absent directory as "no transcripts yet" — so
+ *  the miss cost two months of dead memory condensation (4039 `condense-abort`s,
+ *  zero successes) plus a usage reconciler quietly reading nothing.
+ *
+ *  Prefer the CURRENT spelling and fall back to the legacy one only when it
+ *  exists and the current one does not, so pre-change installs stay readable.
+ *  The preference order matters and is not cosmetic: this harness itself created
+ *  legacy-named directories by copying transcripts into them, so a fallback-first
+ *  resolver would keep reading our own stale copies. An unresolvable cwd yields
+ *  the CURRENT spelling — callers that create the directory must create the one
+ *  Claude Code will actually read. */
+export function projectDir(cwd: string): string {
+  const root = path.join(os.homedir(), '.claude/projects');
+  const current = path.join(root, projectKey(cwd));
+  if (existsSync(current)) return current;
+  const legacy = path.join(root, legacyProjectKey(cwd));
+  return existsSync(legacy) ? legacy : current;
 }
 
 /** Ensure session `<sessionId>.jsonl` exists in `cwd`'s Claude project dir so a

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -439,6 +439,12 @@ const api = {
   /** Read the system clipboard as plain text ('' when empty/unreadable). */
   readClipboard: (): Promise<string> =>
     ipcRenderer.invoke('app:readClipboard'),
+  /** Clipboard text, read SYNCHRONOUSLY. Only for the terminal's paste shortcut,
+   *  where an async read loses a race against dictation tools that restore the
+   *  previous clipboard right after sending the paste key. */
+  readClipboardSync: (): string => {
+    try { return ipcRenderer.sendSync('app:readClipboardSync') ?? ''; } catch { return ''; }
+  },
 
   // ─── Config ──────────────────────────────────────────────────────────────
   getConfig: (): Promise<HarnessConfig> =>

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -313,7 +313,15 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
       } catch { /* host not sized yet */ }
 
       const killed = await window.cth.killPty(a.ptyId);
-      if (!killed.ok) throw new Error(killed.error ?? 'Could not stop the current process.');
+      // A pty that is ALREADY gone is the state this kill was trying to reach, so
+      // it is not a failure. This is the single most common way to arrive at
+      // "Restart & Continue": the session died on its own — a crash, or Ctrl-C
+      // twice — main dropped it from the session map, and kill then answers
+      // `no pty: <id>`. Treating that as fatal aborted before the respawn and
+      // turned the one situation the button exists for into a dead end.
+      if (!killed.ok && !/^no pty:/.test(killed.error ?? '')) {
+        throw new Error(killed.error ?? 'Could not stop the current process.');
+      }
       if (resume) {
         // A blank xterm can retain corrupt renderer/DOM/subscription state even
         // after its PTY is healthy. Throw that one terminal away, acquire its

--- a/src/renderer/src/components/FullscreenTerminal.tsx
+++ b/src/renderer/src/components/FullscreenTerminal.tsx
@@ -30,8 +30,12 @@ const SIDEBAR_WIDTH = 'clamp(232px, 14vw, 340px)';
 function rosterScale(zoom: number) {
   const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, Math.round(n)));
   return {
-    name: clamp(zoom * 0.48, 7, 14),
-    group: clamp(zoom * 0.45, 7, 13),
+    // Name and group sit a notch below the terminal's own apparent size: they are
+    // set in a PROPORTIONAL UI face, which reads larger than a monospace glyph at
+    // the same px, so matching the ratio by number made the rail louder than the
+    // terminal it labels. The note keeps its ratio — it is content, not chrome.
+    name: clamp(zoom * 0.42, 7, 13),
+    group: clamp(zoom * 0.39, 7, 12),
     note: clamp(zoom * 0.68, 10, 20),
     portrait: clamp(zoom * 1.2, 18, 40)
   };

--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -57,9 +57,12 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
     ? `voice: ${ff.error}`
     : null;
 
-  // The draft box is the terminal's twin — it should read at the same size the
-  // agent's output does, at every zoom level.
-  const composerFontSize = useTerminalFontSize();
+  // The draft box tracks the terminal's zoom, but sits slightly under it. Matching
+  // the px exactly was the original intent ("the terminal's twin") and it reads
+  // wrong: the composer uses a proportional UI face against the terminal's
+  // monospace, and the same number is visibly larger in a proportional face — so
+  // the box you type into shouted over the output it belongs to.
+  const composerFontSize = Math.max(11, Math.round(useTerminalFontSize() * 0.88));
   const composerLineHeight = Math.round(composerFontSize * 1.4);
 
   const idle = agent.status === 'idle';

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -172,8 +172,24 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     void window.cth.copyToClipboard(term.getSelection());
     return true;
   };
+  /** Paste the clipboard into the terminal.
+   *
+   *  The read is SYNCHRONOUS on purpose. Dictation tools (muesli.works, Wispr
+   *  Flow, …) "type" by stashing the clipboard, writing the transcript, sending
+   *  the paste key, and restoring the old clipboard immediately after. The async
+   *  read this used to do came back a tick or two later — after the restore — so
+   *  the terminal pasted the text that had been on the clipboard BEFORE, and the
+   *  words the user had just spoken were dropped. Reading inside the keydown
+   *  handler closes that window entirely.
+   *
+   *  Falls back to the async read if the sync bridge is unavailable (an older
+   *  preload), so this degrades to the previous behaviour rather than to nothing. */
   const pasteClipboard = (): void => {
     if (entry.exited) return;
+    try {
+      const text = window.cth.readClipboardSync?.();
+      if (typeof text === 'string') { if (text) term.paste(text); return; }
+    } catch { /* fall through to the async path */ }
     void window.cth.readClipboard().then((t) => { if (t) term.paste(t); });
   };
   term.attachCustomKeyEventHandler((ev) => {

--- a/test/load-ts.cjs
+++ b/test/load-ts.cjs
@@ -24,7 +24,11 @@ function loadFile(filename) {
     compilerOptions: {
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES2022,
-      strict: true
+      strict: true,
+      // Match tsconfig.node/web. Without it a default import of a CJS builtin
+      // (`import path from 'node:path'`) compiles to `path_1.default` and is
+      // undefined at run time — the module loads, then explodes on first use.
+      esModuleInterop: true
     },
     fileName: filename,
     reportDiagnostics: true

--- a/test/transcript-project-dir.test.cjs
+++ b/test/transcript-project-dir.test.cjs
@@ -1,0 +1,71 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { projectDir } = loadTs('src/main/transcript.ts');
+
+/** projectDir() resolves against os.homedir(), which POSIX reads from $HOME — so
+ *  each case gets a throwaway home and never touches the real ~/.claude. */
+function withHome(run) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-transcript-'));
+  const prev = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    return run(home, (key) => {
+      const dir = path.join(home, '.claude/projects', key);
+      fs.mkdirSync(dir, { recursive: true });
+      return dir;
+    });
+  } finally {
+    if (prev === undefined) delete process.env.HOME;
+    else process.env.HOME = prev;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test('an unseen cwd resolves to the CURRENT key, leading slash dashed', () => {
+  withHome(() => {
+    // The regression: this used to return 'Users-me-app', a directory Claude Code
+    // has not written to in months, so every read came back empty and every
+    // caller read empty as "no data yet".
+    assert.equal(path.basename(projectDir('/Users/me/app')), '-Users-me-app');
+  });
+});
+
+test('the current directory wins even when a legacy twin exists', () => {
+  withHome((_home, mkProject) => {
+    // Both spellings exist on this machine for the hive root: the harness itself
+    // created the legacy twin by copying transcripts into it. Preferring the
+    // legacy one would mean reading our own stale copies forever.
+    const legacy = mkProject('Users-me-app');
+    const current = mkProject('-Users-me-app');
+    const resolved = projectDir('/Users/me/app');
+    assert.equal(resolved, current);
+    assert.notEqual(resolved, legacy);
+  });
+});
+
+test('a legacy-only install still resolves, so old transcripts stay readable', () => {
+  withHome((_home, mkProject) => {
+    const legacy = mkProject('Users-me-app');
+    assert.equal(projectDir('/Users/me/app'), legacy);
+  });
+});
+
+test('the real failing path resolves to the dir Claude Code actually writes', () => {
+  withHome((_home, mkProject) => {
+    // The exact cwd whose transcripts the condense step could not find.
+    const cwd = '/Users/vyapakgoyal/Documents/HarnessAgents';
+    mkProject('-Users-vyapakgoyal-Documents-HarnessAgents');
+    mkProject('Users-vyapakgoyal-Documents-HarnessAgents');
+    assert.equal(
+      path.basename(projectDir(cwd)),
+      '-Users-vyapakgoyal-Documents-HarnessAgents'
+    );
+  });
+});


### PR DESCRIPTION
## The bug

`projectDir()` encodes a project's cwd using an older Claude Code convention: the leading slash is
**dropped** and the rest are dashed (`/Users/me/app` → `Users-me-app`). Claude Code now dashes the
leading slash too (`/Users/me/app` → `-Users-me-app`).

So every consumer of `projectDir()` reads a directory Claude Code never writes to. Nothing asserts the
directory exists, so an empty read looks like "no data" rather than "wrong path", and it fails silently.

## What it breaks

`MemoryReflector` calls `extractLastAssistantText`, which reads the transcript through `projectDir()`,
finds nothing, and aborts with `no assistant response found in transcript`. On this machine that is
**4039 condense-aborts and zero successes since 17 Jun 2026** — memory condensation has never once run.
The summarizer was never at fault: the hidden Haiku session's own transcript is present, valid, and in
the dashed directory the whole time.

Evidence from a live machine:

```
~/.claude/projects/-Users-...-HarnessAgents   1518 transcripts, mode 700, written today
~/.claude/projects/Users-...-HarnessAgents       4 stale files, mode 755, newest 4 Aug
```

The no-dash twin is mode 755 because *our own* Electron process created it via `mkdirSync`/`copyFileSync`
in `transcript.ts`. Both variants exist side by side for the root and for ~10 worktrees.

It also affects the offline usage reconciler (`readAgentUsage`) and cross-cwd session-resume seeding,
which writes into a directory Claude Code never reads.

## The fix

- `projectKey()` dashes every separator, including the leading slash.
- `legacyProjectKey()` keeps the old spelling.
- `projectDir()` prefers the current spelling, falls back to legacy **only** when legacy exists and the
  current one does not, and returns the current spelling when neither exists — so callers that create the
  directory create the one Claude Code will actually read.

Windows behaviour is unchanged.

## Tests

`test/transcript-project-dir.test.cjs`, four cases: an unseen cwd yields the dashed key; the current
spelling wins when both twins exist; legacy-only installs still resolve; and the exact path that was
failing. Hermetic — each case gets a throwaway `$HOME`, so the real `~/.claude` is never touched.

`test/load-ts.cjs` needed `esModuleInterop: true` to match `tsconfig.node`/`tsconfig.web`; without it a
default import of a CJS builtin compiles to `path_1.default`, which is undefined at run time. Test
harness only — no shipped code is affected.

`npm run typecheck` (node + web) exits 0. `npm run test:focused` passes 37/37.
