### PR TITLE
fix(transcript): key project dirs the way Claude Code actually does

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",

--- a/src/main/transcript.ts
+++ b/src/main/transcript.ts
@@ -3,17 +3,49 @@ import os from 'node:os';
 import path from 'node:path';
 import { estimateCostUsd, normalizeModel } from './pricing';
 
-/** Resolve the Claude Code transcript directory for a given working directory.
- *  Claude Code stores per-project transcripts under ~/.claude/projects, keying
- *  each project by its absolute cwd with the leading slash dropped and every
- *  remaining slash turned into a dash (e.g. /Users/me/app → Users-me-app). On
- *  Windows EVERY non-alphanumeric character is dashed (drive colon and
- *  backslashes included): C:\Users\me\app → C--Users-me-app. */
-export function projectDir(cwd: string): string {
-  const key = process.platform === 'win32'
-    ? cwd.replace(/[^a-zA-Z0-9]/g, '-')
+/** Claude Code's project key: the absolute cwd with EVERY non-alphanumeric
+ *  character turned into a dash — the leading slash and any dots included.
+ *  /Users/me/app → -Users-me-app, /Users/me/MDv0.3.0 → -Users-me-MDv0-3-0,
+ *  C:\Users\me\app → C--Users-me-app.
+ *
+ *  One rule for every platform. The Windows branch always used it; POSIX had its
+ *  own narrower spelling, and that divergence is what broke — see projectDir. */
+function projectKey(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/** The pre-2026 POSIX key: leading slash DROPPED, only slashes dashed, so dots
+ *  survived (/Users/me/MDv0.3.0 → Users-me-MDv0.3.0). Kept solely so transcripts
+ *  written before the change stay readable. */
+function legacyProjectKey(cwd: string): string {
+  return process.platform === 'win32'
+    ? projectKey(cwd)
     : cwd.replace(/^\//, '').replaceAll('/', '-');
-  return path.join(os.homedir(), '.claude/projects', key);
+}
+
+/** Resolve the Claude Code transcript directory for a given working directory:
+ *  ~/.claude/projects keyed by cwd.
+ *
+ *  We used to emit the legacy key unconditionally on POSIX, which silently
+ *  stopped matching once Claude Code moved to dashing every non-alphanumeric.
+ *  Nothing errored — every caller reads an absent directory as "no transcripts
+ *  yet" — so the miss cost months of dead memory condensation (a long run of
+ *  `condense-abort`s with zero successes) and a usage reconciler quietly reading
+ *  nothing at all.
+ *
+ *  Prefer the CURRENT spelling; fall back to the legacy one only when it exists
+ *  and the current one does not, so pre-change installs stay readable. That order
+ *  is not cosmetic: this harness itself created legacy-named directories by
+ *  copying transcripts into them, so a fallback-first resolver would keep reading
+ *  our own stale copies forever. When neither exists we return the CURRENT
+ *  spelling, because callers that go on to create the directory must create the
+ *  one Claude Code will actually read. */
+export function projectDir(cwd: string): string {
+  const root = path.join(os.homedir(), '.claude/projects');
+  const current = path.join(root, projectKey(cwd));
+  if (existsSync(current)) return current;
+  const legacy = path.join(root, legacyProjectKey(cwd));
+  return existsSync(legacy) ? legacy : current;
 }
 
 /** Ensure session `<sessionId>.jsonl` exists in `cwd`'s Claude project dir so a

--- a/test/load-ts.cjs
+++ b/test/load-ts.cjs
@@ -24,7 +24,12 @@ function loadFile(filename) {
     compilerOptions: {
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES2022,
-      strict: true
+      strict: true,
+      // Match tsconfig.node/tsconfig.web. Without it a default import of a CJS
+      // builtin (`import path from 'node:path'`) compiles to `path_1.default`,
+      // which is undefined at run time — the module loads fine and then explodes
+      // on first use. Test harness only; no shipped code compiles through here.
+      esModuleInterop: true
     },
     fileName: filename,
     reportDiagnostics: true

--- a/test/transcript-project-dir.test.cjs
+++ b/test/transcript-project-dir.test.cjs
@@ -1,0 +1,121 @@
+'use strict';
+
+// Originally contributed by Vyapak Goyal (@gts-47) in #123, extended here with
+// the dotted-path cases that the first version's dot-free fixtures could not
+// catch.
+//
+// POSIX-only: projectDir() resolves against os.homedir(), which these cases
+// redirect via $HOME — a knob Windows does not honour.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { projectDir } = loadTs('src/main/transcript.ts');
+
+/** projectDir() resolves against os.homedir(), which POSIX reads from $HOME — so
+ *  each case gets a throwaway home and never touches the real ~/.claude. */
+function withHome(run) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-transcript-'));
+  const prev = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    return run(home, (key) => {
+      const dir = path.join(home, '.claude/projects', key);
+      fs.mkdirSync(dir, { recursive: true });
+      return dir;
+    });
+  } finally {
+    if (prev === undefined) delete process.env.HOME;
+    else process.env.HOME = prev;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test('an unseen cwd resolves to the CURRENT key, leading slash dashed', () => {
+  withHome(() => {
+    // The regression: this used to return 'Users-me-app', a directory Claude Code
+    // has not written to in months, so every read came back empty and every
+    // caller read empty as "no data yet".
+    assert.equal(path.basename(projectDir('/Users/me/app')), '-Users-me-app');
+  });
+});
+
+test('DOTS are dashed too, not just slashes', () => {
+  withHome(() => {
+    // The case a slash-only fix silently fails: Claude Code dashes EVERY
+    // non-alphanumeric, so a version-numbered project directory keys as
+    // MDv0-3-0. Dashing only the separators yields '-Users-me-MDv0.3.0', which
+    // Claude Code never writes to — and because the legacy fallback then finds
+    // the harness's own stale twin, the miss looks like a hit.
+    assert.equal(
+      path.basename(projectDir('/Users/me/Documents/MDv0.3.0')),
+      '-Users-me-Documents-MDv0-3-0'
+    );
+  });
+});
+
+test('every other non-alphanumeric is dashed as well', () => {
+  withHome(() => {
+    assert.equal(
+      path.basename(projectDir('/Users/me/my_proj (old)/v1.2')),
+      '-Users-me-my-proj--old--v1-2'
+    );
+  });
+});
+
+test('the current directory wins even when a legacy twin exists', () => {
+  withHome((_home, mkProject) => {
+    // Both spellings exist on a machine that ran the old code: the harness itself
+    // created the legacy twin by copying transcripts into it. Preferring the
+    // legacy one would mean reading our own stale copies forever.
+    const legacy = mkProject('Users-me-app');
+    const current = mkProject('-Users-me-app');
+    const resolved = projectDir('/Users/me/app');
+    assert.equal(resolved, current);
+    assert.notEqual(resolved, legacy);
+  });
+});
+
+test('the dotted legacy twin loses to the dotted current spelling', () => {
+  withHome((_home, mkProject) => {
+    const legacy = mkProject('Users-me-MDv0.3.0');
+    const current = mkProject('-Users-me-MDv0-3-0');
+    const resolved = projectDir('/Users/me/MDv0.3.0');
+    assert.equal(resolved, current);
+    assert.notEqual(resolved, legacy);
+  });
+});
+
+test('a legacy-only install still resolves, so old transcripts stay readable', () => {
+  withHome((_home, mkProject) => {
+    const legacy = mkProject('Users-me-app');
+    assert.equal(projectDir('/Users/me/app'), legacy);
+  });
+});
+
+test('a legacy-only install with dots resolves to its undashed twin', () => {
+  withHome((_home, mkProject) => {
+    // The legacy key kept dots, so the fallback has to keep them too — deriving
+    // it from the new key by stripping the leading dash would look for
+    // 'Users-me-MDv0-3-0' and find nothing.
+    const legacy = mkProject('Users-me-MDv0.3.0');
+    assert.equal(projectDir('/Users/me/MDv0.3.0'), legacy);
+  });
+});
+
+test('the real failing path resolves to the dir Claude Code actually writes', () => {
+  withHome((_home, mkProject) => {
+    // The exact cwd whose transcripts the condense step could not find (#123).
+    const cwd = '/Users/vyapakgoyal/Documents/HarnessAgents';
+    mkProject('-Users-vyapakgoyal-Documents-HarnessAgents');
+    mkProject('Users-vyapakgoyal-Documents-HarnessAgents');
+    assert.equal(
+      path.basename(projectDir(cwd)),
+      '-Users-vyapakgoyal-Documents-HarnessAgents'
+    );
+  });
+});


### PR DESCRIPTION
## Credit

**This bug was found, diagnosed and fixed by @gts-47 (Vyapak Goyal) in #123.** The
investigation, the root cause, the resolver design with its legacy fallback, the
`esModuleInterop` catch and the original test suite are all his work.

This PR is #123 rebased onto current `main`, narrowed to the transcript fix alone, with
one correction to the project key (below) and the extra test cases that cover it. #123
also carried five unrelated fixes on the same branch; those are still wanted and should
come back as their own PRs, not lost — see the end of this description.

---

## The bug

`projectDir()` encodes a project's cwd using an older Claude Code convention: the leading
slash is **dropped** and the remaining slashes dashed (`/Users/me/app` → `Users-me-app`).
Claude Code dashes **every non-alphanumeric character** (`/Users/me/app` → `-Users-me-app`)
— which is the same rule this file's own Windows branch already used.

So every consumer of `projectDir()` reads a directory Claude Code never writes to. Nothing
asserts the directory exists, so an empty read looks like "no data" rather than "wrong
path", and it fails silently.

## What it breaks

`MemoryReflector` calls `extractLastAssistantText`, which reads the transcript through
`projectDir()`, finds nothing, and aborts with `no assistant response found in transcript`.
Memory condensation has never once succeeded. The summarizer was never at fault: the hidden
Haiku session's own transcript is present, valid, and sitting in the dashed directory the
whole time. Every failed attempt still writes a full backup first, so the cost compounds.

Reproduced on the maintainer's machine, from `hive/log.jsonl`:

```json
{"kind":"condense-abort","agentId":"jim-msiupp4g","reason":"summarize-failed",
 "detail":"Error: no assistant response found in transcript"}
```

Zero `condense` successes on record. It also affects the offline usage reconciler
(`readAgentUsage`) and cross-cwd session-resume seeding, which writes into a directory
Claude Code never reads.

## The correction to #123

#123 dashed the leading slash but nothing else (`cwd.replaceAll('/', '-')`). That is not
the rule, and it fails in a way that hides itself.

Claude Code dashes **every** non-alphanumeric, dots included. Verified against
`~/.claude/projects` on the maintainer's machine: all 30 live Claude-Code-written
directories match `[a-zA-Z0-9-]` with **zero** dots, while the stale harness-written twins
keep theirs (`Users-chaitanya-Documents-MDv0.2.6xOG`). Running #123's own resolver against
real paths there:

| cwd | #123 returns | Claude Code writes | |
|---|---|---|---|
| `…/Documents/MDv0.3.0` | `Users-…-MDv0.3.0` | `-Users-…-MDv0-3-0` | ❌ |
| `…/MDv0.3.0/worktrees/jim-msiupp4g` | `Users-…-MDv0.3.0-worktrees-…` | `-Users-…-MDv0-3-0-worktrees-…` | ❌ |
| `/Users/vyapakgoyal/Documents/HarnessAgents` | matches | matches | ✅ |

It resolves correctly for `HarnessAgents` because that path has no dots. **Every** project
path on the maintainer's machine contains `MDv0.3.0`, so the slash-only fix would have
changed nothing there — and because the legacy fallback then finds the harness's own stale
twin, the miss returns a real directory and reads as a hit. A silent fix for a silent bug.

The original four tests all used dot-free fixtures, which is why they passed.

## The fix

- `projectKey()` — one rule on every platform: `cwd.replace(/[^a-zA-Z0-9]/g, '-')`. The
  POSIX/Windows divergence is what rotted; there is now nothing to diverge.
- `legacyProjectKey()` — the old POSIX spelling, **dots preserved**, so pre-change
  transcripts stay readable. Deriving it from the new key by stripping the leading dash
  would look for `Users-me-MDv0-3-0` and find nothing.
- `projectDir()` — prefers the current spelling; falls back to legacy **only** when legacy
  exists and current does not; returns the current spelling when neither exists, so callers
  that create the directory create the one Claude Code will actually read.

That preference order is load-bearing, not cosmetic: this harness created legacy-named
directories itself via `mkdirSync`/`copyFileSync` in `transcript.ts`, so a fallback-first
resolver would keep reading our own stale copies forever.

Windows behaviour is unchanged.

## Verification

Against the maintainer's real `~/.claude/projects`, the fixed resolver now lands on the
live directories — where `main` finds nothing:

```
-Users-chaitanya-Documents-MDv0-3-0                          EXISTS, 351 transcripts
-Users-chaitanya-Documents-MDv0-3-0-worktrees-jim-msiupp4g   EXISTS, 6 transcripts
-Users-chaitanya-dev-claudeTerminalHarness                   EXISTS, 1 transcripts
```

`test/transcript-project-dir.test.cjs` — eight cases, POSIX-only and hermetic (each gets a
throwaway `$HOME`, so the real `~/.claude` is never touched). #123's four, plus four that
cover the dot rule: dots dashed, mixed non-alphanumerics (`my_proj (old)/v1.2`), a dotted
legacy twin losing to the dotted current spelling, and a dotted legacy-only install still
resolving.

`test/load-ts.cjs` needed `esModuleInterop: true` to match `tsconfig.node`/`tsconfig.web`
— @gts-47's catch, and confirmed necessary here: without it `import path from 'node:path'`
compiles to `path_1.default`, and the new test dies with
`Cannot read properties of undefined (reading 'join')`. Test harness only; no shipped code
compiles through it. The full suite passes with it enabled.

`npm run typecheck` (node + web) exits 0. **116/116 tests pass.**

**Not verified:** I have not watched a condense cycle succeed end to end in a running app.
The resolver is proven against the real directories above, but the first live confirmation
will be a `{"kind":"condense"}` line appearing in `hive/log.jsonl` where there has never
been one.

## Still wanted from #123, not included here

#123's branch carried five unrelated fixes. None are superseded — all five are still absent
from `main` — and dropping them here is about scope, not merit. Worth reopening as separate
PRs:

1. **`.codex/` in `MINE_IGNORE_LINES`** — a Codex worker's `CODEX_HOME` sits inside the
   hive repo and was being versioned in full; twenty agents took `.git` to 7.5GB and git's
   auto-gc then OOMed the machine. Note the gitignore stops *future* commits but does not
   untrack what is already committed, so an already-bloated hive needs a
   `git rm -r --cached` alongside it.
2. **`Restart & Continue` tolerating `no pty:`** — a session that already died is the state
   the kill was trying to reach, so treating it as fatal broke the one button that exists
   for it. Matching on the error *string* is brittle; a structured code would be sturdier.
3. **Clipboard `sendSync`** and **4. the Edit-menu `registerAccelerator: false`** — both
   target the same dictation-paste race. Worth landing together, and worth checking what
   hand-spelling the Edit menu drops relative to `{ role: 'editMenu' }`: macOS supplies
   `pasteAndMatchStyle`, `delete`, and the Speech / Start Dictation / Emoji & Symbols items,
   none of which survive the replacement.
5. **Roster and composer font scaling** — a judgement call about proportional vs monospace
   faces at matched px, so it should land on its own where it can be argued on its merits.

Closes #123.
