### PR TITLE
fix(inbox): stop one odd message id from silencing an agent's wake nudge

### DIFF
--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -253,10 +253,20 @@ function passesContextPressure(a: Agent, rule: ContextRule): boolean {
  *      doesn't stall while an agent sits at its prompt.
  */
 export function useHive(config: HarnessConfig | null): void {
-  // Per-agent dedup key for the inbox-wake nudge: the newest inbox message id we
-  // last nudged about. Keyed by id (not count) so an oscillating count after a
-  // drain doesn't re-nudge for the same message set.
-  const nudged = useRef<Record<string, string>>({});
+  // Per-agent dedup for the inbox-wake nudge: every inbox message id we have
+  // already nudged this agent about. A SET, not a high-water mark.
+  //
+  // This used to hold one string — the lexicographically largest id in the inbox,
+  // read as "the newest". Message ids are usually `<timestamp>-<rand>`, so that
+  // held, but an agent may set its own `id` in the outbox JSON and the hive keeps
+  // it verbatim (hive.ts normalize: `partial.id ?? ...`). One such id in god's
+  // inbox — `dev15-progress-canvas-v4` — sorts above EVERY `2026-*` timestamp and
+  // never drains, so the "newest" id was frozen on it: Michael was nudged once per
+  // app launch and then never again, however much real mail piled up behind it.
+  // Tracking the ids we have seen has no such ordering assumption, and it keeps
+  // the property the high-water mark was there for — a set that only shrinks as
+  // messages drain contains nothing new, so it does not re-nudge.
+  const nudged = useRef<Record<string, Set<string>>>({});
   // Per-agent timestamp of the last queued-message we submitted. Guards against
   // re-sending the next message before the agent's hooks have flipped it to
   // 'working' (there's a short window where it still reads 'idle' right after we
@@ -603,19 +613,17 @@ export function useHive(config: HarnessConfig | null): void {
       for (const a of agents) {
         try {
           const inbox = await window.cth.hiveInbox(a.id);
-          // Dedup by the newest message id, not the count — a count can oscillate
-          // as messages drain and re-arrive, which would re-nudge for the same set.
-          const newest = inbox.length
-            ? inbox.map((m) => m.id).sort().slice(-1)[0]
-            : '';
-          if (newest && nudged.current[a.id] !== newest) {
+          // Nudge on any id we have not nudged for yet. Draining shrinks the set
+          // and introduces nothing new, so it stays quiet; a genuinely new message
+          // fires regardless of how its id happens to sort.
+          const seen = nudged.current[a.id] ?? (nudged.current[a.id] = new Set());
+          const fresh = inbox.filter((m) => m.id && !seen.has(m.id));
+          if (fresh.length) {
             useStore.getState().enqueueMessage(
               a.id,
               'You have new hive inbox message(s) — read your inbox, act on them now, and move handled ones to inbox/.done/. Act autonomously; only message god if you genuinely need a decision.'
             );
-            nudged.current[a.id] = newest;
-          } else if (!newest) {
-            nudged.current[a.id] = '';
+            for (const m of fresh) seen.add(m.id);
           }
         } catch { /* ignore */ }
       }


### PR DESCRIPTION
The inbox-wake nudge dedupes on the **lexicographically largest** id in an agent's inbox, read as "the newest". Ids are normally `<timestamp>-<rand>` so that holds — but an agent may set its own `id` in the outbox JSON and `normalize()` keeps it verbatim (`id: partial.id ?? …`, unchanged since inception).

My orchestrator's inbox has held `dev15-progress-canvas-v4` since Aug 10. Letters sort above digits, so that id outranks every `2026-*` timestamp and, because it never drains, it is permanently "the newest". Result: he was nudged once per app launch and then never again, while **45 real messages** piled up behind it unannounced. Agents finished work, reported back, and he never heard. Measured across his inbox: 34 of 1611 messages carry a hand-written id — 2%, which is all it takes.

It self-healed in the past only because the offending message eventually got moved to `.done`.

Track the ids already nudged for instead of a high-water mark. No ordering assumption, and it keeps what the high-water mark was there for: a set that only shrinks as messages drain contains nothing new, so a drain stays quiet.

Typecheck clean, 130/130 focused tests pass.