### PR TITLE
fix(paste): paste what was just dictated, not the clipboard's previous text

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2269,7 +2269,34 @@ function installAppMenu(): void {
         ? [newFloorItem, { type: 'separator' as const }, { role: 'close' as const }]
         : [newFloorItem, { type: 'separator' as const }, { role: 'quit' as const }]
     },
-    { role: 'editMenu' },
+    // The Edit menu is spelled out rather than `{ role: 'editMenu' }` for one
+    // reason: `registerAccelerator: false` on the clipboard items.
+    //
+    // A registered accelerator is claimed by the MENU, which then replays the
+    // action through `webContents.paste()` — an async hop that runs a beat after
+    // the keystroke. Dictation tools (Muesli, Wispr Flow, …) insert text by
+    // stashing the clipboard, writing the transcript, sending the paste key, and
+    // restoring the old clipboard immediately; the menu's late paste therefore
+    // read the RESTORED clipboard and typed the user's previous copy instead of
+    // what they had just said. It hit the terminal and the composer alike,
+    // because both were downstream of the same replay.
+    //
+    // With registerAccelerator false the item still shows its shortcut, but the
+    // key is left for the focused element to handle inline — xterm's own paste
+    // handler and the textarea's native paste event both read the clipboard
+    // synchronously, inside the keystroke, before any restore can land.
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' as const, registerAccelerator: false },
+        { role: 'redo' as const, registerAccelerator: false },
+        { type: 'separator' as const },
+        { role: 'cut' as const, registerAccelerator: false },
+        { role: 'copy' as const, registerAccelerator: false },
+        { role: 'paste' as const, registerAccelerator: false },
+        { role: 'selectAll' as const, registerAccelerator: false }
+      ]
+    },
     { role: 'viewMenu' },
     { role: 'windowMenu' }
   ];
@@ -2752,6 +2779,17 @@ ipcMain.handle('app:copyToClipboard', (_evt, text: unknown) => {
 });
 ipcMain.handle('app:readClipboard', () => {
   try { return clipboard.readText(); } catch { return ''; }
+});
+// Same read, SYNCHRONOUS, for the terminal's paste shortcut.
+//
+// Dictation tools (muesli.works, Wispr Flow, …) type by stashing the user's
+// clipboard, writing the transcript, sending the paste key, then restoring the
+// old clipboard immediately. An `invoke` read returns a tick or two later — by
+// which point the restore has already landed and we paste the PREVIOUS text.
+// A `sendSync` read completes inside the keydown handler, before the tool gets
+// a chance to put the old contents back.
+ipcMain.on('app:readClipboardSync', (evt) => {
+  try { evt.returnValue = clipboard.readText(); } catch { evt.returnValue = ''; }
 });
 // NOTE: the terminal theme is mirrored into each agent's per-session Claude
 // settings at spawn (hive.ensureAgent theme option) — deliberately NOT via

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -615,6 +615,12 @@ const api = {
   /** Read the system clipboard as plain text ('' when empty/unreadable). */
   readClipboard: (): Promise<string> =>
     ipcRenderer.invoke('app:readClipboard'),
+  /** Clipboard text, read SYNCHRONOUSLY. Only for the terminal's paste shortcut,
+   *  where an async read loses a race against dictation tools that restore the
+   *  previous clipboard right after sending the paste key. */
+  readClipboardSync: (): string => {
+    try { return ipcRenderer.sendSync('app:readClipboardSync') ?? ''; } catch { return ''; }
+  },
 
   // ─── Config ──────────────────────────────────────────────────────────────
   getConfig: (): Promise<HarnessConfig> =>

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -184,8 +184,24 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     void window.cth.copyToClipboard(term.getSelection());
     return true;
   };
+  /** Paste the clipboard into the terminal.
+   *
+   *  The read is SYNCHRONOUS on purpose. Dictation tools (muesli.works, Wispr
+   *  Flow, …) "type" by stashing the clipboard, writing the transcript, sending
+   *  the paste key, and restoring the old clipboard immediately after. The async
+   *  read this used to do came back a tick or two later — after the restore — so
+   *  the terminal pasted the text that had been on the clipboard BEFORE, and the
+   *  words the user had just spoken were dropped. Reading inside the keydown
+   *  handler closes that window entirely.
+   *
+   *  Falls back to the async read if the sync bridge is unavailable (an older
+   *  preload), so this degrades to the previous behaviour rather than to nothing. */
   const pasteClipboard = (): void => {
     if (entry.exited) return;
+    try {
+      const text = window.cth.readClipboardSync?.();
+      if (typeof text === 'string') { if (text) term.paste(text); return; }
+    } catch { /* fall through to the async path */ }
     void window.cth.readClipboard().then((t) => { if (t) term.paste(t); });
   };
   term.attachCustomKeyEventHandler((ev) => {


### PR DESCRIPTION
Dictation tools (Muesli, Wispr Flow, etc.) work by stashing the clipboard, writing the transcript into it, sending a paste, then **restoring the old clipboard immediately**. Anything that reads the clipboard asynchronously loses that race and pastes the previous text.

Two independent late reads, both fixed:

1. **Terminal paste** — `pasteClipboard` awaited `window.cth.readClipboard()`, an async IPC round-trip. By the time it resolved the tool had already restored the old text. Added a synchronous `app:readClipboardSync` (`ipcMain.on` + `event.returnValue`) and read through it, keeping the async path as a fallback.
2. **The app-wide Cmd+V** — `{ role: 'editMenu' }` registers Cmd+V as a **menu accelerator**, and Electron replays it via `webContents.paste()` on the next tick. That fires app-wide, including over the Queue composer, and loses the same race. Replaced with an explicit Edit submenu whose clipboard items carry `registerAccelerator: false`, so the keystroke is left to the focused element and the menu items still work from the menu bar.

Typecheck clean, 130/130 focused tests pass.