### PR TITLE
fix(transcript): never resolve a root cwd to the projects directory itself

### DIFF
--- a/src/main/transcript.ts
+++ b/src/main/transcript.ts
@@ -44,7 +44,14 @@ export function projectDir(cwd: string): string {
   const root = path.join(os.homedir(), '.claude/projects');
   const current = path.join(root, projectKey(cwd));
   if (existsSync(current)) return current;
-  const legacy = path.join(root, legacyProjectKey(cwd));
+  // For cwd '/' the legacy key is the empty string, and path.join(root, '')
+  // collapses to the projects ROOT — which always exists, so the fallback would
+  // hand back a directory holding every project rather than one, and callers
+  // would read/seed `~/.claude/projects/<session>.jsonl`. An empty key is not a
+  // project name; treat it as no legacy candidate at all.
+  const legacyKey = legacyProjectKey(cwd);
+  if (!legacyKey) return current;
+  const legacy = path.join(root, legacyKey);
   return existsSync(legacy) ? legacy : current;
 }
 

--- a/test/transcript-project-dir.test.cjs
+++ b/test/transcript-project-dir.test.cjs
@@ -119,3 +119,14 @@ test('the real failing path resolves to the dir Claude Code actually writes', ()
     );
   });
 });
+
+test('a root cwd never resolves to the projects directory itself', () => {
+  withHome((home, _mkProject) => {
+    // legacyProjectKey('/') is the empty string, and path.join(root, '') is the
+    // projects ROOT — which always exists, so an unguarded fallback would hand
+    // back the directory holding EVERY project and seed the session file there.
+    const resolved = projectDir('/');
+    assert.notEqual(resolved, path.join(home, '.claude/projects'));
+    assert.equal(path.basename(resolved), '-');
+  });
+});


### PR DESCRIPTION
For cwd `/` the legacy key is the empty string, and `path.join(root, '')` collapses to `~/.claude/projects` — the directory holding **every** project, which always exists. The legacy fallback therefore returns it, and callers go on to read and seed `~/.claude/projects/<session>.jsonl` instead of the real per-project location.

An empty key is not a project name; treat it as no legacy candidate at all. Covered by a new test.

Found by an independent review pass over my branch. Typecheck clean, 131/131 focused tests pass.