### PR TITLE
perf(office): stop rendering the floor nobody is looking at

### DIFF
--- a/src/renderer/src/scene/office/OfficeFloor.tsx
+++ b/src/renderer/src/scene/office/OfficeFloor.tsx
@@ -168,6 +168,38 @@ export function OfficeFloor() {
   // tears down and rebuilds the whole scene on the new map/cast (see deps below).
   const officeTheme = useStore((s) => s.officeTheme);
 
+  // Is the floor actually on screen? A fullscreen terminal or file editor covers
+  // it completely, and a hidden window shows nothing at all — but the Pixi ticker
+  // went on running the whole scene regardless: every character, thought cloud,
+  // coffee run and envelope animating, and the renderer drawing every frame, into
+  // pixels nobody can see. On a floor of twenty agents that is the app's single
+  // largest continuous cost, and users who live in the fullscreen terminal (the
+  // normal way to work with one agent) paid it 100% of the time.
+  //
+  // Stop the ticker instead of unmounting: the WebGL context, textures and the
+  // whole scene graph stay alive, so coming back out of fullscreen is instant
+  // rather than a full theme reload. Nothing in the scene reads wall-clock time —
+  // every update is driven by the ticker's own delta — so a paused floor simply
+  // resumes where it left off.
+  const fullscreenAgentId = useStore((s) => s.fullscreenAgentId);
+  const fullscreenFilePath = useStore((s) => s.fullscreenFilePath);
+  const [docHidden, setDocHidden] = useState(() => document.hidden);
+  useEffect(() => {
+    const onVis = () => setDocHidden(document.hidden);
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  }, []);
+  const paused = !!fullscreenAgentId || !!fullscreenFilePath || docHidden;
+  // Read inside init(), which finishes asynchronously and would otherwise start a
+  // ticker the effect below had already been asked to stop.
+  const pausedRef = useRef(paused);
+  useEffect(() => {
+    pausedRef.current = paused;
+    const ticker = appRef.current?.ticker;
+    if (!ticker) return; // app.init() hasn't created it yet — init() applies it
+    if (paused) ticker.stop(); else ticker.start();
+  }, [paused]);
+
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -1653,6 +1685,9 @@ export function OfficeFloor() {
         }
       };
       app.ticker.add(onTick);
+      // init() is async: the floor may already be behind a fullscreen terminal by
+      // the time we get here, and app.init() starts the ticker itself.
+      if (pausedRef.current) app.ticker.stop();
 
       const resize = new ResizeObserver((entries) => {
         for (const e of entries) {


### PR DESCRIPTION
A fullscreen terminal or file editor covers the office floor completely, and a hidden window shows nothing at all — but the Pixi ticker goes on running the whole scene regardless: every character, thought cloud, coffee run and envelope animating, and the renderer drawing every frame, into pixels nobody can see.

On a floor of twenty agents that is the app's single largest continuous cost. Working the normal way with one agent — living in the fullscreen terminal — pays it 100% of the time, which is a real hit on a busy machine (I chase paste races that need the renderer to answer a keystroke inside 500ms, and this is what eats that budget).

**Stop the ticker rather than unmount.** The WebGL context, textures and the whole scene graph stay alive, so leaving fullscreen is instant instead of a full theme reload. Nothing in the scene reads wall-clock time — every update is driven by the ticker's own delta — so a paused floor resumes exactly where it left off.

Paused when `fullscreenAgentId` or `fullscreenFilePath` is set, or `document.hidden`. `init()` is async and starts the ticker itself, so it re-applies the paused state on the way out; otherwise a floor that went fullscreen mid-load would come back running.

Typecheck clean, focused tests pass.