### PR TITLE
Sandbox integrations: keep the OS sandbox on, close the tunnel, run agent code off-machine

### DIFF
--- a/examples/sandbox-worker/Dockerfile
+++ b/examples/sandbox-worker/Dockerfile
@@ -1,0 +1,9 @@
+# Container image for the sandbox exec service. The base image ships the agent
+# @cloudflare/sandbox talks to; add whatever toolchain your agents need on top.
+FROM docker.io/cloudflare/sandbox:0.7.0
+
+# Example: give agent code a Python as well as the bundled Node.
+# RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+#     && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 3000

--- a/examples/sandbox-worker/README.md
+++ b/examples/sandbox-worker/README.md
@@ -1,0 +1,75 @@
+# Sandbox exec service (reference)
+
+The other half of the **Sandbox exec (Cloudflare)** integration template. It gives a
+hive worker one capability: *run this code somewhere that isn't the user's laptop.*
+
+Agents in Munder Difflin run as real CLI processes on the user's machine. Sandboxed
+autonomy (Settings → Autonomy & Budgets) bounds what those processes can touch, but the
+riskiest thing an agent does isn't its own file writes — it's executing code the model
+just **wrote** and nobody has read. That belongs off-machine.
+
+## How a worker reaches it
+
+The worker never holds this service's token and never calls it directly. It calls the
+app's loopback broker, which injects the credential and forwards the request:
+
+```
+worker ──▶ $MD_BROKER_URL/i/sandbox-exec/exec                    (capability token)
+              └──▶ broker (Electron main) ──▶ https://<your worker>/exec
+                                                Authorization: Bearer <AUTH_TOKEN>
+```
+
+```bash
+curl -s -X POST "$MD_BROKER_URL/i/sandbox-exec/exec" \
+  -H "Authorization: Bearer $MD_BROKER_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"source":"python3 -c \"print(sum(range(10)))\"","backend":"shell"}'
+# → {"ok":true,"stdout":"45\n","stderr":"","exitCode":0}
+```
+
+## Routes
+
+| Route | Body | Returns |
+| --- | --- | --- |
+| `POST /exec` | `{"source": "...", "backend": "shell" \| "js", "timeoutMs"?: number}` | `{"ok":true,"stdout","stderr","exitCode"}` |
+| `GET /health` | — | `{"ok":true,"backend":"sandbox-sdk"}` |
+
+Both require `Authorization: Bearer <AUTH_TOKEN>`. Source is capped at 256 KB and the
+timeout at 120 s, whatever the caller asks for.
+
+## Deploy
+
+```bash
+cd examples/sandbox-worker
+npm install
+wrangler secret put AUTH_TOKEN      # any long random string
+wrangler deploy
+```
+
+Then in Munder Difflin: **Settings → Integrations → Sandbox exec (Cloudflare)**, set the
+base URL to your Worker origin (`https://md-sandbox-exec.<you>.workers.dev`) and paste
+the same token as the secret. Enable it, and it appears in every worker's capability
+catalog.
+
+## Which Cloudflare sandbox?
+
+This implementation uses [`@cloudflare/sandbox`](https://github.com/cloudflare/sandbox-sdk)
+(**beta**): a real container per sandbox id, with streaming exec, background processes,
+git clone, `/workspace` file APIs, and `sleepAfter` lifetimes. It needs Workers +
+Containers, and Docker locally for `wrangler dev`.
+
+[`@cloudflare/computer`](https://github.com/cloudflare/computer) (**preview**, MIT) is
+the other option — a virtual filesystem plus `workspace.runtime.exec(source, {backend})`
+inside Durable Objects, with the authoritative state in SQLite and container /
+isolate-bash / isolate-JS backends. The isolate backends need no container at all, so
+they start faster and cost less for small snippets, at the price of a much smaller
+userland. `runInSandbox()` in `src/index.ts` is the single function to swap; upstream
+calls its APIs unstable, so pin a version if you go that way.
+
+Neither is required by the app: anything that answers these two routes works, including
+a service on your own infrastructure.
+
+## Not production code
+
+One bearer token, no tenancy, no quotas, no audit log. It is deliberately small enough
+to read in one sitting before you trust it with anything.

--- a/examples/sandbox-worker/package.json
+++ b/examples/sandbox-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "md-sandbox-exec",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Reference sandbox exec service for the Munder Difflin 'Sandbox exec (Cloudflare)' integration. Deployed separately; not part of the app build.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "^0.7.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260801.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/examples/sandbox-worker/src/index.ts
+++ b/examples/sandbox-worker/src/index.ts
@@ -1,0 +1,146 @@
+/**
+ * Sandbox exec service — the other half of the "Sandbox exec (Cloudflare)" integration
+ * template in Munder Difflin (src/shared/integrations.ts).
+ *
+ * A hive worker never calls this Worker directly and never holds its token. It calls
+ * the app's loopback broker, which injects the credential and forwards:
+ *
+ *     worker ──▶ $MD_BROKER_URL/i/sandbox-exec/exec
+ *                  │  (capability token — a handle, not a secret)
+ *                  ▼
+ *              broker (Electron main) ──▶ https://<this worker>/exec
+ *                                            Authorization: Bearer <AUTH_TOKEN>
+ *
+ * ROUTES
+ *   POST /exec    {"source": "<code>", "backend": "shell"|"js", "timeoutMs"?: number}
+ *                 → 200 {"ok":true,"stdout","stderr","exitCode"}
+ *   GET  /health  → 200 {"ok":true,"backend":"..."}
+ *
+ * Auth is a single bearer token compared in constant time. There is no multi-tenancy
+ * and no user data here: this exists so an agent can run code it just WROTE somewhere
+ * that isn't the user's laptop.
+ *
+ * NOT PRODUCTION CODE. It is a reference small enough to read in one sitting; deploy it
+ * to your own account, or replace it with any service that speaks the same two routes.
+ */
+
+/// <reference types="@cloudflare/workers-types" />
+
+import { getSandbox } from '@cloudflare/sandbox';
+
+export interface Env {
+  /** Bearer token the broker sends. `wrangler secret put AUTH_TOKEN`. */
+  AUTH_TOKEN: string;
+  /** Durable Object namespace for the container-backed sandbox (see wrangler.jsonc). */
+  Sandbox: DurableObjectNamespace;
+}
+
+export { Sandbox } from '@cloudflare/sandbox';
+
+/** Hard ceiling regardless of what the caller asks for. */
+const MAX_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+/** Refuse oversized payloads before doing any work. */
+const MAX_SOURCE_BYTES = 256 * 1024;
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+/** Constant-time compare, length-guarded — a length mismatch is answered in the same
+ *  shape as a wrong token so the endpoint leaks nothing about the secret. */
+function tokenOk(presented: string, expected: string): boolean {
+  if (!expected || presented.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < presented.length; i++) diff |= presented.charCodeAt(i) ^ expected.charCodeAt(i);
+  return diff === 0;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    const presented = (request.headers.get('authorization') ?? '').replace(/^Bearer\s+/i, '');
+    if (!tokenOk(presented, env.AUTH_TOKEN)) return json({ ok: false, error: 'unauthorized' }, 401);
+
+    if (request.method === 'GET' && url.pathname === '/health') {
+      return json({ ok: true, backend: 'sandbox-sdk' });
+    }
+    if (request.method !== 'POST' || url.pathname !== '/exec') {
+      return json({ ok: false, error: 'not found' }, 404);
+    }
+
+    let body: { source?: unknown; backend?: unknown; timeoutMs?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return json({ ok: false, error: 'body must be JSON' }, 400);
+    }
+
+    const source = typeof body.source === 'string' ? body.source : '';
+    if (!source) return json({ ok: false, error: 'source is required' }, 400);
+    if (new TextEncoder().encode(source).length > MAX_SOURCE_BYTES) {
+      return json({ ok: false, error: 'source too large' }, 413);
+    }
+    const backend = body.backend === 'js' ? 'js' : 'shell';
+    const timeoutMs = Math.min(
+      typeof body.timeoutMs === 'number' && body.timeoutMs > 0 ? body.timeoutMs : DEFAULT_TIMEOUT_MS,
+      MAX_TIMEOUT_MS
+    );
+
+    try {
+      const result = await runInSandbox(env, source, backend, timeoutMs);
+      return json({ ok: true, ...result });
+    } catch (e) {
+      // The message can carry the sandbox's own stderr, which is the useful part for
+      // the agent. It never carries the token: that is only ever read above.
+      return json({ ok: false, error: e instanceof Error ? e.message : String(e) }, 502);
+    }
+  }
+};
+
+/**
+ * Run `source` in a fresh sandbox and return its output.
+ *
+ * Uses @cloudflare/sandbox (beta): a real container per sandbox id, with streaming
+ * exec, background processes and `/workspace` file APIs. `sleepAfter` is what stops an
+ * idle container from billing forever — an agent's one-shot exec has no reason to
+ * outlive the request by more than a minute.
+ *
+ * ALTERNATIVE — @cloudflare/computer (github.com/cloudflare/computer, PREVIEW, MIT):
+ * a virtual filesystem + exec runtime inside Durable Objects, with the authoritative
+ * state in SQLite and pluggable backends (container / isolate-bash / isolate-JS):
+ *
+ *     const workspace = getWorkspace(env.WORKSPACE, 'agent-exec');
+ *     const out = await workspace.runtime.exec(source, { backend: 'isolate-shell' });
+ *
+ * The isolate backends need no container at all, so they are cheaper and start faster
+ * for small "run this snippet" jobs — at the cost of a much smaller userland. Its APIs
+ * are explicitly unstable, so pin a version if you switch.
+ */
+async function runInSandbox(
+  env: Env,
+  source: string,
+  backend: 'shell' | 'js',
+  timeoutMs: number
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  // One sandbox id per request → no state carries between two agents' code. Reuse a
+  // stable id instead if you WANT a warm container with a persistent /workspace.
+  const id = `exec-${crypto.randomUUID()}`;
+  const sandbox = getSandbox(env.Sandbox, id, {
+    // Reap the container shortly after the job; an agent exec is one-shot.
+    sleepAfter: '1m',
+    labels: { source: 'munder-difflin' }
+  });
+
+  const command =
+    backend === 'js'
+      ? `node -e ${JSON.stringify(source)}`
+      : source;
+
+  const result = await sandbox.exec(command, { timeout: timeoutMs });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: typeof result.exitCode === 'number' ? result.exitCode : 0
+  };
+}

--- a/examples/sandbox-worker/wrangler.jsonc
+++ b/examples/sandbox-worker/wrangler.jsonc
@@ -1,0 +1,27 @@
+{
+  // Sandbox exec service — see ./README.md. Deploy to YOUR account; the app never
+  // deploys this for you and nothing in the main build compiles this directory.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "md-sandbox-exec",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-01",
+  "compatibility_flags": ["nodejs_compat"],
+
+  // The container image the sandbox runs. @cloudflare/sandbox ships one; point
+  // `image` at your own Dockerfile when your agents need extra tooling preinstalled.
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      "max_instances": 4
+    }
+  ],
+
+  "durable_objects": {
+    "bindings": [{ "name": "Sandbox", "class_name": "Sandbox" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Sandbox"] }]
+
+  // AUTH_TOKEN is a SECRET, never a var — set it with:
+  //   wrangler secret put AUTH_TOKEN
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs test/sandbox-mode.test.cjs test/tunnel.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs test/sandbox-mode.test.cjs test/tunnel.test.cjs test/integration-templates.test.cjs",
     "check:links": "node tools/check-release-links.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs test/sandbox-mode.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs test/sandbox-mode.test.cjs test/tunnel.test.cjs",
     "check:links": "node tools/check-release-links.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs test/sandbox-mode.test.cjs",
     "check:links": "node tools/check-release-links.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",

--- a/resources/skills/capabilities/SKILL.md
+++ b/resources/skills/capabilities/SKILL.md
@@ -27,6 +27,9 @@ The harness injects these env vars (use them; don't hard-code paths):
   `outbox/`, and `.claude/skills/`). Your bundled skills live under
   `$AGENT_DIR/.claude/skills/`.
 - `HIVE_ROOT` — the shared hive (`PROTOCOL.md`, the kanban, other agents).
+- `MD_BROKER_URL`, `MD_BROKER_TOKEN` — the loopback integration broker and your
+  per-worker capability token (a handle, never a credential). Present only when
+  integrations are enabled for you; see §3.
 
 At boot you also have `identity.md` (who you are) and `HIVE_ROOT/PROTOCOL.md`
 (the full coordination protocol). To message god or another agent, write ONE
@@ -96,6 +99,20 @@ on one):
 - **Enterprise Knowledge Graph.** If enabled: `node "$KG_CLI" search "<query>"`
   for ranked passages, `node "$KG_CLI" list`, `node "$KG_CLI" get <id>` — use it
   for company-specific facts instead of guessing.
+- **Sandbox exec.** If a `sandbox-exec` integration is enabled: POST through the
+  broker to run code somewhere that is not the user's machine.
+
+  ```bash
+  curl -s -X POST "$MD_BROKER_URL/i/sandbox-exec/exec" \
+    -H "Authorization: Bearer $MD_BROKER_TOKEN" \
+    -H 'content-type: application/json' \
+    -d '{"source":"<code>","backend":"shell"}'   # → {ok,stdout,stderr,exitCode}
+  ```
+
+  Reach for it whenever you are about to execute something you WROTE and have not
+  read back, an unfamiliar script, or an install that would touch the machine
+  outside your working directory. A one-shot container, torn down after the call —
+  so a bad command costs you an error message instead of the user's files.
 - **MCP integrations** (filesystem, git, and others) come pre-wired into your
   session settings when enabled; invoke them as normal tools. The set is gated
   by the hive's consent configuration.
@@ -109,6 +126,9 @@ then pass those concrete ISO bounds to the integration query.
 
 - Temporal skills are **read-only** helpers — they never write or reach the
   network. The broker mediates all external calls; you hold no credentials.
+- Code **you wrote and have not read back** belongs in `sandbox-exec`, not in a
+  local `Bash` call — when that integration is available to you, prefer it over
+  running the snippet on the user's machine.
 - Do **not** push or tag to any remote. Commit locally; **god** is the sole
   integrator. Pause only for high-severity actions (remote push, paid/infra
   changes, deleting something you didn't create) — otherwise work autonomously.

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -183,6 +183,12 @@ export interface HarnessConfig {
   registeredRepos: string[];
   /** When true, new agents are spawned with --permission-mode bypassPermissions. */
   autoMode: boolean;
+  /** When true, auto mode keeps each engine's OS SANDBOX on instead of dropping it.
+   *  Agents stay prompt-free, but a runaway one can only write inside its cwd and the
+   *  roots we declare for it (its `$AGENT_DIR`, the MemPalace). Off by default: the
+   *  scoped posture is only available on engines that expose a `sandboxedAutoFlag`
+   *  (Claude, Codex), and it's a behaviour change for existing floors. */
+  sandboxedAutoMode?: boolean;
   /** The command we run when spawning a new agent. */
   defaultCommand: string;
   /** Default model for newly spawned agents (e.g. 'claude-sonnet-4-6[1m]'); unset = CLI default. */
@@ -406,6 +412,7 @@ const DEFAULTS: HarnessConfig = {
   recentHives: [],
   registeredRepos: [],
   autoMode: true,
+  sandboxedAutoMode: false,
   defaultCommand: 'claude',
   godProvider: 'claude',
   godModel: 'claude-opus-4-8',
@@ -667,7 +674,7 @@ export function commandForAutoMode(
     ? config.defaultCommand
     : defaultCommandForProvider(p, config.defaultCommand);
   if (!config.autoMode) return base;
-  const flag = autoModeFlagForProvider(p);
+  const flag = autoModeFlagForProvider(p, { sandboxed: !!config.sandboxedAutoMode });
   return flag ? `${base} ${flag}` : base;
 }
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -322,6 +322,11 @@ export interface HarnessConfig {
   slackChannelId?: string;
   /** Local HTTP port the webhook server binds to (default 3847). */
   slackPort?: number;
+  /** Which public-tunnel provider the Slack + webhook servers open. 'auto' (default)
+   *  prefers a cloudflared quick tunnel — an ordinary child process we can actually
+   *  kill on stop — and falls back to tunnelmole when cloudflared isn't installed.
+   *  Pin it to force one provider. See src/main/tunnel.ts. */
+  tunnelProvider?: 'auto' | 'cloudflared' | 'tunnelmole';
   /** Opt-in: allow APP/VOICE-INITIATED proactive posting into Slack (e.g. the
    *  renderer's "queued" acknowledgement). DEFAULT OFF per the human directive
    *  "stop posting into Slack by default". This does NOT gate the Slack-ORIGIN

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -21,7 +21,7 @@ import {
   existsSync, mkdirSync, readFileSync, writeFileSync, renameSync,
   readdirSync, statSync, rmSync, appendFileSync, symlinkSync, copyFileSync, chmodSync
 } from 'node:fs';
-import { join, dirname, isAbsolute } from 'node:path';
+import { join, dirname, isAbsolute, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync, spawn, type ChildProcess } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
@@ -521,6 +521,33 @@ export class HiveManager {
     }
   }
 
+  /** The paths a hive worker legitimately writes OUTSIDE its PTY cwd, in the order
+   *  a policy file should list them. This is the whole reason auto mode used to drop
+   *  the sandbox: the PROTOCOL makes every worker write to `$AGENT_DIR` (inbox→.done,
+   *  memory.md, outbox JSON, and the per-agent `.claude`/`.codex` config we author
+   *  there), which lives in a different path tree from cwd. Declaring these as
+   *  writable roots is what lets the sandbox stay ON.
+   *
+   *  Absolute-only — a relative or `~/…` entry would be silently ignored (Codex) or
+   *  rejected (Claude), so it is dropped here rather than shipped into a policy file
+   *  that then reads as broader than it is. Entries already covered by an ancestor in
+   *  the list are collapsed away, so the file states the real grant once (god gets
+   *  HIVE_ROOT, which subsumes its own agent dir) instead of implying two. */
+  private sandboxWritableRoots(dir: string, extra: string[] = []): string[] {
+    const covers = (parent: string, child: string): boolean =>
+      child === parent || child.startsWith(parent.endsWith(sep) ? parent : parent + sep);
+    const out: string[] = [];
+    for (const p of [dir, ...extra]) {
+      if (!p || typeof p !== 'string') continue;
+      const abs = expandTilde(p);
+      if (!isAbsolute(abs)) continue;
+      if (out.some((have) => covers(have, abs))) continue; // already granted
+      for (let i = out.length - 1; i >= 0; i--) if (covers(abs, out[i])) out.splice(i, 1);
+      out.push(abs);
+    }
+    return out;
+  }
+
   /**
    * Ensure an agent's workspace + registry entry, returning the spawn injection
    * (provider-specific args + env) that makes the process hive-aware.
@@ -538,6 +565,15 @@ export class HiveManager {
        *  copied into the agent's `.claude/skills/` per spawn; undefined or missing
        *  is a no-op (tolerated until Kevin populates the resource dir). */
       skillsDir?: string;
+      /** config.sandboxedAutoMode — keep the engine's OS sandbox ON in auto mode.
+       *  When set, the injection declares the WRITABLE ROOTS a hive worker needs
+       *  outside its cwd (its own `$AGENT_DIR`, the shared MemPalace) so PROTOCOL
+       *  housekeeping still works with the sandbox enforcing everything else. */
+      sandboxedAutoMode?: boolean;
+      /** Extra absolute paths a worker legitimately writes outside cwd/AGENT_DIR —
+       *  today just the MemPalace, threaded in by the caller because hive.ts has no
+       *  handle on the memory manager. Only consulted in sandboxed auto mode. */
+      extraWritableRoots?: string[];
     } = {}
   ): Promise<SpawnInjection> {
     const root = this.root();
@@ -614,6 +650,20 @@ export class HiveManager {
     // written as `"$HIVE_NODE" <script>` unconditionally and never expand to "".
     env.HIVE_NODE = this.nodeLauncher() ?? 'node';
 
+    // Sandboxed auto mode (config.sandboxedAutoMode) — the writable roots this agent
+    // gets on top of its cwd, consumed below by BOTH the Claude settings file and the
+    // Codex `--add-dir` args. Empty unless the mode is on, so the default spawn is
+    // byte-identical to before. god is the one agent that legitimately writes OUTSIDE
+    // its own folder: it is the sole scribe of board.md/tasks.json and drops worker
+    // spawn-requests, all at HIVE_ROOT — which subsumes its agent dir, so the helper
+    // collapses the two into one honest grant.
+    const writableRoots = opts.sandboxedAutoMode
+      ? this.sandboxWritableRoots(dir, [
+          ...(meta.isGod ? [root] : []),
+          ...(opts.extraWritableRoots ?? [])
+        ])
+      : [];
+
     const claudeProvider = isClaudeProvider(meta.provider ?? 'claude');
 
     // Non-hive-aware providers (Antigravity's `agy`, OpenAI's `codex`, xAI's
@@ -666,6 +716,12 @@ export class HiveManager {
               // that already vets hook sources"). Without it the hooks silently
               // never fire. Must precede the positional prompt.
               preArgs.push('--dangerously-bypass-hook-trust');
+              // Sandboxed auto mode: the command already carries
+              // `-a never -s workspace-write` (the preset's sandboxedAutoFlag), which
+              // confines writes to the PTY cwd. Widen it by exactly the roots the
+              // PROTOCOL needs — nothing else — so hive housekeeping works with the
+              // sandbox ON. argv, not a shell string, so paths with spaces are safe.
+              for (const writable of writableRoots) preArgs.push('--add-dir', writable);
             }
             else if (desc.shim === 'pi') {
               // Pi (earendil-works) has a rich pi.on(event) lifecycle. We drop a
@@ -764,7 +820,13 @@ export class HiveManager {
     if (sock && shim) {
       env.HIVE_SOCK = sock;
       const settingsPath = join(dir, 'settings.json');
-      this.writeJson(settingsPath, this.hookSettings(shim, meta.cwd, opts.mcpDefaults, opts.theme));
+      this.writeJson(
+        settingsPath,
+        // `writableRoots` is empty unless sandboxed auto mode is on, in which case
+        // hookSettings omits the sandbox keys entirely — an existing floor's settings
+        // file is unchanged.
+        this.hookSettings(shim, meta.cwd, opts.mcpDefaults, opts.theme, { writableRoots })
+      );
       args.push('--settings', settingsPath);
     }
     return { args, env };
@@ -823,7 +885,13 @@ export class HiveManager {
    *  (W3) the default MCP bundle merged into this PER-SESSION settings file. cwd
    *  scopes the filesystem/git servers; cfg (the consent map) gates which servers
    *  are written. Claude-only — this is invoked solely on the Claude spawn path. */
-  private hookSettings(shim: string, cwd: string, cfg: McpDefaultsMap, theme?: 'light' | 'dark'): unknown {
+  private hookSettings(
+    shim: string,
+    cwd: string,
+    cfg: McpDefaultsMap,
+    theme?: 'light' | 'dark',
+    sandbox?: { writableRoots?: string[] }
+  ): unknown {
     // Bundled node, NOT bare `node` — see nodeLauncherPath(). Claude runs each of
     // these through `sh -c` with a stripped PATH, where `node` is often absent.
     const cmd = this.nodeRun(shim);
@@ -832,7 +900,29 @@ export class HiveManager {
       hooks: [{ type: 'command', command: cmd }]
     });
     const mcpServers = this.buildDefaultMcpServers(cwd, cfg);
+    // Sandboxed auto mode (config.sandboxedAutoMode). Two DIFFERENT layers have to
+    // agree or an agent deadlocks halfway through the protocol:
+    //   - `permissions.additionalDirectories` — what the Edit/Write TOOLS may touch
+    //     outside cwd. Without it `--permission-mode acceptEdits` prompts on
+    //     memory.md and the whole point of auto mode is lost.
+    //   - `sandbox.filesystem.allowWrite` — what a BASH SUBPROCESS may write. The
+    //     sandbox otherwise allows only cwd + the session temp dir, so `mv` of an
+    //     inbox message into .done/ would fail even though the tool was allowed.
+    // `sandbox.enabled` is what actually turns the OS sandbox (Seatbelt on macOS,
+    // bubblewrap on Linux/WSL2) on. `autoAllowBashIfSandboxed` defaults to true, so
+    // sandboxed commands still run without prompts — autonomy is preserved.
+    // Native Windows has no sandbox; the keys are harmless there (Claude Code warns
+    // and runs unsandboxed) and the worker keeps its bypass posture via the preset
+    // fallback, so nothing hangs.
+    const roots = sandbox?.writableRoots ?? [];
+    const sandboxKeys = roots.length
+      ? {
+          permissions: { additionalDirectories: roots },
+          sandbox: { enabled: true, filesystem: { allowWrite: roots } }
+        }
+      : {};
     return {
+      ...sandboxKeys,
       // Match the TUI's truecolor palette to the harness terminal theme —
       // PER SESSION, so the user's global Claude theme (their own terminals
       // outside the app) is never touched.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1487,6 +1487,7 @@ async function startSlackServer(): Promise<{ ok: boolean; url?: string; error?: 
     port: cfg.slackPort && cfg.slackPort > 0 ? cfg.slackPort : 3847,
     signingSecret: cfg.slackSigningSecret,
     channelId: cfg.slackChannelId,
+    tunnelProvider: cfg.tunnelProvider ?? 'auto',
     // Fires from the HTTP server's event loop (not the IPC thread); route through
     // liveWebContents() so a message arriving during window teardown can't throw.
     // Downloads any file attachments (bot token stays in main; local paths go to IPC).
@@ -1893,7 +1894,8 @@ async function startWebhookServer(): Promise<{ ok: boolean; url?: string; error?
     port: cfg.webhookPort && cfg.webhookPort > 0 ? cfg.webhookPort : WEBHOOK_DEFAULT_PORT,
     endpoints,
     onMessage: handleWebhookMessage,
-    lookupStatus: lookupWebhookStatus
+    lookupStatus: lookupWebhookStatus,
+    tunnelProvider: cfg.tunnelProvider ?? 'auto'
   });
   webhookServer = server;
   const res = await server.start();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2504,7 +2504,15 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
           theme: readConfig().terminalTheme ?? 'light',
           // W3 — default-MCP consent state + the bundled skills source dir.
           mcpDefaults: readConfig().mcpDefaults,
-          skillsDir: skillsResourceDir()
+          skillsDir: skillsResourceDir(),
+          // Sandboxed auto mode: keep the engine's OS sandbox on and declare the
+          // roots a worker still needs. The MemPalace is the one write target
+          // outside the agent's own folder that a NON-god worker has (`mempalace`
+          // writes the shared palace); hive.ts has no handle on the memory manager,
+          // so it is threaded in here. The KG is read-only for agents, so it is not
+          // granted — a worker that only searches it needs no write access.
+          sandboxedAutoMode: !!readConfig().sandboxedAutoMode,
+          extraWritableRoots: memory.active() ? [memory.palacePath() ?? ''] : []
         }
       );
       opts.args = [...(opts.args ?? []), ...inj.args];

--- a/src/main/slack.ts
+++ b/src/main/slack.ts
@@ -10,7 +10,8 @@
  *   - on a plain `message` event, strips a leading bot mention and emits the
  *     text via `onMessage`.
  *
- * It also opens a `tunnelmole` tunnel so the local port is reachable from Slack's
+ * It also opens a public tunnel (src/main/tunnel.ts — a cloudflared quick tunnel when
+ * available, tunnelmole otherwise) so the local port is reachable from Slack's
  * servers; the tunnel URL is what the user pastes into their Slack app's Event
  * Subscriptions → Request URL. The tunnel is best-effort: the local handler is
  * the security boundary and stays up even if the tunnel can't be established.
@@ -21,11 +22,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { createHmac, timingSafeEqual } from 'node:crypto';
-// NOTE: `tunnelmole` is an ESM-only package. The Electron main process is bundled
-// as CommonJS, so a static `import` gets externalized into `require('tunnelmole')`
-// and throws ERR_REQUIRE_ESM at load. It is imported dynamically inside
-// `openTunnel()` instead — Rollup preserves dynamic import() in CJS output, which
-// can load ESM. Do not hoist this back to a top-level import.
+// The public tunnel (and the ESM-only `tunnelmole` fallback's dynamic import) lives in
+// src/main/tunnel.ts, shared with WebhookServer, so both get a real close handle.
+import { openTunnel, type TunnelHandle, type TunnelProviderId } from './tunnel';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const {
@@ -79,6 +78,9 @@ export interface SlackWebhookServerOptions {
    *  coordinates needed to reply back in the originating thread. May be async
    *  (e.g. to download file attachments before forwarding via IPC). */
   onMessage: (m: SlackInboundMessage) => void | Promise<void>;
+  /** Which public-tunnel provider to open (default 'auto' → cloudflared when
+   *  installed, tunnelmole otherwise). See src/main/tunnel.ts. */
+  tunnelProvider?: TunnelProviderId;
 }
 
 /** A verified, de-mentioned inbound Slack message plus the coordinates needed to
@@ -112,6 +114,11 @@ const TUNNEL_START_TIMEOUT_MS = 10_000;
 export class SlackWebhookServer {
   private server: Server | null = null;
   private tunnelUrl: string | null = null;
+  /** The live tunnel, kept so `stop()` can actually take it down. Before this the
+   *  tunnel outlived the server it pointed at until the whole app quit. */
+  private tunnel: TunnelHandle | null = null;
+  /** Which tunnel provider to use ('auto' → cloudflared when installed). */
+  private readonly tunnelProvider: TunnelProviderId;
   private readonly port: number;
   private readonly signingSecret: string;
   private readonly channelId?: string;
@@ -133,6 +140,7 @@ export class SlackWebhookServer {
     this.signingSecret = opts.signingSecret;
     this.channelId = opts.channelId?.trim() || undefined;
     this.onMessage = opts.onMessage;
+    this.tunnelProvider = opts.tunnelProvider ?? 'auto';
   }
 
   /**
@@ -152,21 +160,26 @@ export class SlackWebhookServer {
       return { ok: false, error: `failed to bind port ${this.port}: ${errMsg(e)}` };
     }
     try {
-      const url = await this.openTunnel();
-      if (!url) throw new Error('tunnelmole returned empty URL');
-      this.tunnelUrl = url;
-      // tunnelmole runs in the background; there is no close handle to wire here.
-      return { ok: true, url };
+      const tunnel = await openTunnel(this.port, {
+        provider: this.tunnelProvider,
+        timeoutMs: TUNNEL_START_TIMEOUT_MS
+      });
+      this.tunnel = tunnel;
+      this.tunnelUrl = tunnel.url;
+      return { ok: true, url: tunnel.url };
     } catch (e) {
       // Surface the tunnel failure rather than silently returning ok:true with no url.
       return { ok: false, error: `tunnel unavailable: ${errMsg(e)}` };
     }
   }
 
-  /** Close the HTTP server. Idempotent and best-effort.
-   *  Note: tunnelmole has no documented close handle; teardown is best-effort. */
+  /** Close the HTTP server AND the public tunnel. Idempotent and best-effort.
+   *  The tunnel teardown is real for cloudflared (the child is killed); it remains a
+   *  no-op for the tunnelmole fallback, which exposes no close API. */
   stop(): void {
     this.tunnelUrl = null;
+    try { this.tunnel?.close(); } catch { /* noop */ }
+    this.tunnel = null;
     try { this.server?.close(); } catch { /* noop */ }
     this.server = null;
   }
@@ -181,18 +194,6 @@ export class SlackWebhookServer {
         this.server = server;
         resolve();
       });
-    });
-  }
-
-  private async openTunnel(): Promise<string> {
-    // TODO: optional persistent domain — pass `domain` here when config carries one.
-    // Dynamic import keeps the ESM-only `tunnelmole` out of the CJS require graph.
-    const { tunnelmole } = await import('tunnelmole');
-    return new Promise<string>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('timed out')), TUNNEL_START_TIMEOUT_MS);
-      tunnelmole({ port: this.port })
-        .then((url) => { clearTimeout(timer); resolve(url); })
-        .catch((e) => { clearTimeout(timer); reject(e); });
     });
   }
 

--- a/src/main/tunnel.ts
+++ b/src/main/tunnel.ts
@@ -1,0 +1,201 @@
+/**
+ * Public-tunnel provider — the one place the app turns a loopback port into a URL an
+ * outside service (Slack, a webhook caller) can reach.
+ *
+ * WHY THIS EXISTS. `SlackWebhookServer` and `WebhookServer` each had their own private
+ * `openTunnel()` calling `tunnelmole`, and both carried the same admission in a comment:
+ * *"tunnelmole has no documented close handle; teardown is best-effort."* Stopping the
+ * bridge closed our HTTP server but left the tunnel process running, so the public URL
+ * outlived the thing it pointed at until the app quit. This module fixes that by making
+ * the tunnel a HANDLE with a real `close()`, and by defaulting to a provider we can
+ * actually kill: a `cloudflared` quick tunnel, which is an ordinary child process.
+ *
+ * Providers:
+ *   - 'cloudflared' — `cloudflared tunnel --url http://127.0.0.1:<port>` prints a
+ *     `https://<sub>.trycloudflare.com` URL on stderr. No account, no config, no login.
+ *     `close()` kills the child through the same `ensureKilled` ladder the PTYs use.
+ *   - 'tunnelmole'  — the previous behaviour, unchanged, as the fallback for a machine
+ *     with no `cloudflared`. Its `close()` is a documented no-op.
+ *   - 'auto'        — cloudflared when the binary resolves, else tunnelmole.
+ *
+ * Deliberately free of any `electron` import, and the process-level dependencies
+ * (binary resolution, spawn) are injectable, so the URL parsing and provider selection
+ * are unit-testable without a network or a real tunnel — the same posture as
+ * `integrationBroker.ts`.
+ */
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { resolveCommand } from './shellEnv';
+import { ensureKilled } from './procKill';
+
+export type TunnelProviderId = 'auto' | 'cloudflared' | 'tunnelmole';
+
+export interface TunnelHandle {
+  /** The public https URL forwarding to the local port. */
+  url: string;
+  /** Which provider actually produced it (never 'auto'). */
+  provider: Exclude<TunnelProviderId, 'auto'>;
+  /** Tear the tunnel down. Idempotent; never throws. A no-op for tunnelmole, which
+   *  exposes no handle — callers should still always call it. */
+  close(): void;
+}
+
+/** How long to wait for a provider to hand back a URL before giving up. */
+export const TUNNEL_START_TIMEOUT_MS = 10_000;
+
+/** The quick-tunnel hostname cloudflared prints. Anchored to the real domain so a
+ *  hostile-looking line in the log can't be mistaken for the tunnel URL. */
+const QUICK_TUNNEL_RE = /https:\/\/[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)*\.trycloudflare\.com/i;
+
+/**
+ * Pull the quick-tunnel URL out of a chunk of cloudflared output. It arrives inside a
+ * box-drawn banner, padded with spaces and a trailing `|`, and split across lines that
+ * may not align with stream chunks — so match on the accumulated buffer, not per line.
+ * Returns null when the buffer doesn't (yet) contain a URL.
+ */
+export function extractQuickTunnelUrl(buffer: string): string | null {
+  const m = QUICK_TUNNEL_RE.exec(buffer);
+  return m ? m[0] : null;
+}
+
+export interface TunnelDeps {
+  /** Absolute path for a binary name, or '' when it isn't installed. Injected for tests. */
+  resolve?: (cmd: string) => string;
+  /** Child spawner. Injected for tests. */
+  spawn?: typeof nodeSpawn;
+  /** Process killer. Injected for tests so a fake child's pid is never signalled for
+   *  real — an arbitrary test pid could belong to something else on the machine. */
+  kill?: (pid: number | undefined) => void;
+}
+
+/** Is a cloudflared binary present on this machine? */
+export function cloudflaredAvailable(deps: TunnelDeps = {}): boolean {
+  const resolve = deps.resolve ?? resolveCommand;
+  try { return !!resolve('cloudflared'); } catch { return false; }
+}
+
+/** Which provider `openTunnel` will actually use for the requested setting. */
+export function selectProvider(
+  requested: TunnelProviderId = 'auto',
+  deps: TunnelDeps = {}
+): Exclude<TunnelProviderId, 'auto'> {
+  if (requested === 'cloudflared' || requested === 'tunnelmole') return requested;
+  return cloudflaredAvailable(deps) ? 'cloudflared' : 'tunnelmole';
+}
+
+/**
+ * Open a public tunnel to `port`. Rejects (never hangs) when the provider fails, exits,
+ * or produces no URL inside the timeout — the caller decides whether that is fatal.
+ *
+ * An explicit `provider: 'cloudflared'` is honoured even when the binary doesn't
+ * resolve, so a misconfiguration surfaces as a clear error instead of silently falling
+ * back to the provider the user turned off.
+ */
+export async function openTunnel(
+  port: number,
+  opts: { provider?: TunnelProviderId; timeoutMs?: number; deps?: TunnelDeps } = {}
+): Promise<TunnelHandle> {
+  const timeoutMs = opts.timeoutMs ?? TUNNEL_START_TIMEOUT_MS;
+  const provider = selectProvider(opts.provider ?? 'auto', opts.deps);
+  return provider === 'cloudflared'
+    ? openCloudflaredTunnel(port, timeoutMs, opts.deps ?? {})
+    : openTunnelmoleTunnel(port, timeoutMs);
+}
+
+function openCloudflaredTunnel(
+  port: number,
+  timeoutMs: number,
+  deps: TunnelDeps
+): Promise<TunnelHandle> {
+  const resolve = deps.resolve ?? resolveCommand;
+  const spawn = deps.spawn ?? nodeSpawn;
+  return new Promise<TunnelHandle>((resolveP, reject) => {
+    const bin = resolve('cloudflared') || 'cloudflared';
+    let child: ChildProcess;
+    try {
+      child = spawn(
+        bin,
+        // 127.0.0.1, never localhost: the servers bind IPv4 loopback and a
+        // localhost→::1 resolution would forward into a closed port.
+        ['tunnel', '--no-autoupdate', '--url', `http://127.0.0.1:${port}`],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+    } catch (e) {
+      reject(new Error(`cloudflared failed to start: ${e instanceof Error ? e.message : String(e)}`));
+      return;
+    }
+
+    let settled = false;
+    // Keep only the tail: the banner is early, and an unbounded buffer would grow for
+    // the whole life of a long-running tunnel.
+    let buf = '';
+    const done = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.stdout?.removeAllListeners('data');
+      child.stderr?.removeAllListeners('data');
+      child.removeAllListeners('exit');
+      child.removeAllListeners('error');
+      fn();
+    };
+    const killer = deps.kill ?? ((pid?: number) => ensureKilled(pid));
+    // One-shot: `stop()` is idempotent and callers may retry it, and after the first
+    // kill the pid can have been recycled by the OS — signalling it twice would be
+    // signalling somebody else's process.
+    let killed = false;
+    const kill = (): void => {
+      if (killed) return;
+      killed = true;
+      try { killer(child.pid ?? undefined); } catch { /* noop */ }
+    };
+
+    const timer = setTimeout(() => {
+      done(() => { kill(); reject(new Error(`cloudflared timed out after ${timeoutMs}ms`)); });
+    }, timeoutMs);
+
+    const onChunk = (c: Buffer | string): void => {
+      buf = (buf + String(c)).slice(-8192);
+      const url = extractQuickTunnelUrl(buf);
+      if (!url) return;
+      done(() => resolveP({
+        url,
+        provider: 'cloudflared',
+        // The whole point of this module: a tunnel you can actually take down.
+        close: () => kill()
+      }));
+    };
+    child.stdout?.on('data', onChunk);
+    child.stderr?.on('data', onChunk); // cloudflared logs the banner to stderr
+    child.on('error', (e) => done(() => reject(new Error(`cloudflared failed: ${e.message}`))));
+    child.on('exit', (code) => done(() => reject(
+      new Error(`cloudflared exited (${code ?? 'signal'}) before printing a URL${buf ? `: ${buf.trim().slice(-300)}` : ''}`)
+    )));
+  });
+}
+
+function openTunnelmoleTunnel(port: number, timeoutMs: number): Promise<TunnelHandle> {
+  return new Promise<TunnelHandle>((resolveP, reject) => {
+    const timer = setTimeout(() => reject(new Error('timed out')), timeoutMs);
+    // `tunnelmole` is ESM-only and the main process is bundled as CJS, so a static
+    // import would be externalized into require() and throw ERR_REQUIRE_ESM at load.
+    // Rollup preserves dynamic import() in CJS output, which can load ESM. Do not
+    // hoist this to a top-level import.
+    import('tunnelmole')
+      .then(({ tunnelmole }) => tunnelmole({ port }))
+      .then((url: string) => {
+        clearTimeout(timer);
+        if (!url) { reject(new Error('tunnelmole returned empty URL')); return; }
+        resolveP({
+          url,
+          provider: 'tunnelmole',
+          // tunnelmole exposes no close handle — documented, and the reason
+          // cloudflared is preferred whenever it is installed.
+          close: () => { /* no-op: tunnelmole has no teardown API */ }
+        });
+      })
+      .catch((e: unknown) => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      });
+  });
+}

--- a/src/main/webhook.ts
+++ b/src/main/webhook.ts
@@ -42,11 +42,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { validateAgainstSchema, type InboundKind } from '../shared/triggers';
-// NOTE: `tunnelmole` is an ESM-only package. The Electron main process is bundled
-// as CommonJS, so a static `import` gets externalized into `require('tunnelmole')`
-// and throws ERR_REQUIRE_ESM at load. It is imported dynamically inside
-// `openTunnel()` instead — Rollup preserves dynamic import() in CJS output, which
-// can load ESM. Do not hoist this back to a top-level import.
+// The public tunnel (and the ESM-only `tunnelmole` fallback's dynamic import) lives in
+// src/main/tunnel.ts, shared with SlackWebhookServer, so both get a real close handle.
+import { openTunnel, type TunnelHandle, type TunnelProviderId } from './tunnel';
 
 /** One servable endpoint — the structural subset of `WebhookTrigger` this class
  *  needs. A whole `WebhookTrigger` is assignable, so callers pass config rows
@@ -110,6 +108,9 @@ export interface WebhookServerOptions {
    * returns is the ONLY thing echoed to the caller; no secret ever reaches here.
    */
   onMessage: (msg: WebhookInbound, endpoint: WebhookEndpointRef) => WebhookDispatch | null;
+  /** Which public-tunnel provider to open (default 'auto' → cloudflared when
+   *  installed, tunnelmole otherwise). See src/main/tunnel.ts. */
+  tunnelProvider?: TunnelProviderId;
   /**
    * Resolve a capability token to its task's public status, or null when the
    * token maps to nothing (→ 404). MUST be scoped to the one token — it must
@@ -143,6 +144,11 @@ const UNKNOWN_BUCKET = ':unknown';
 export class WebhookServer {
   private server: Server | null = null;
   private tunnelUrl: string | null = null;
+  /** The live tunnel, kept so `stop()` can actually take it down. Before this the
+   *  tunnel outlived the server it pointed at until the whole app quit. */
+  private tunnel: TunnelHandle | null = null;
+  /** Which tunnel provider to use ('auto' → cloudflared when installed). */
+  private readonly tunnelProvider: TunnelProviderId;
   private readonly port: number;
   private endpoints = new Map<string, WebhookEndpoint>();
   private readonly onMessage: (msg: WebhookInbound, endpoint: WebhookEndpointRef) => WebhookDispatch | null;
@@ -152,13 +158,14 @@ export class WebhookServer {
    *  never exported, so it cannot be matched even by accident. */
   private readonly decoySecret = randomBytes(32).toString('hex');
   // Fixed-window rate limiters keyed by bucket ('' = global, else the endpoint id).
-  // The remote IP is the tunnel's, so per-IP would be meaningless behind tunnelmole.
+  // The remote IP is the tunnel's, so per-IP would be meaningless behind a tunnel.
   private windows = new Map<string, { start: number; count: number }>();
 
   constructor(opts: WebhookServerOptions) {
     this.port = opts.port;
     this.onMessage = opts.onMessage;
     this.lookupStatus = opts.lookupStatus;
+    this.tunnelProvider = opts.tunnelProvider ?? 'auto';
     this.setEndpoints(opts.endpoints);
   }
 
@@ -217,21 +224,26 @@ export class WebhookServer {
       return { ok: false, error: `failed to bind port ${this.port}: ${errMsg(e)}` };
     }
     try {
-      const url = await this.openTunnel();
-      if (!url) throw new Error('tunnelmole returned empty URL');
-      this.tunnelUrl = url;
-      // tunnelmole runs in the background; there is no close handle to wire here.
-      return { ok: true, url };
+      const tunnel = await openTunnel(this.port, {
+        provider: this.tunnelProvider,
+        timeoutMs: TUNNEL_START_TIMEOUT_MS
+      });
+      this.tunnel = tunnel;
+      this.tunnelUrl = tunnel.url;
+      return { ok: true, url: tunnel.url };
     } catch (e) {
       // Surface the tunnel failure rather than silently returning ok:true with no url.
       return { ok: false, error: `tunnel unavailable: ${errMsg(e)}` };
     }
   }
 
-  /** Close the HTTP server. Idempotent and best-effort.
-   *  Note: tunnelmole has no documented close handle; teardown is best-effort. */
+  /** Close the HTTP server AND the public tunnel. Idempotent and best-effort.
+   *  The tunnel teardown is real for cloudflared (the child is killed); it remains a
+   *  no-op for the tunnelmole fallback, which exposes no close API. */
   stop(): void {
     this.tunnelUrl = null;
+    try { this.tunnel?.close(); } catch { /* noop */ }
+    this.tunnel = null;
     try { this.server?.close(); } catch { /* noop */ }
     this.server = null;
   }
@@ -246,18 +258,6 @@ export class WebhookServer {
         this.server = server;
         resolve();
       });
-    });
-  }
-
-  private async openTunnel(): Promise<string> {
-    // TODO: optional persistent domain — pass `domain` here when config carries one.
-    // Dynamic import keeps the ESM-only `tunnelmole` out of the CJS require graph.
-    const { tunnelmole } = await import('tunnelmole');
-    return new Promise<string>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('timed out')), TUNNEL_START_TIMEOUT_MS);
-      tunnelmole({ port: this.port })
-        .then((url) => { clearTimeout(timer); resolve(url); })
-        .catch((e) => { clearTimeout(timer); reject(e); });
     });
   }
 

--- a/src/renderer/src/components/AiEnginesSettings.tsx
+++ b/src/renderer/src/components/AiEnginesSettings.tsx
@@ -210,8 +210,10 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
       }}>
         ⚠ In <strong>auto mode</strong> these engines run with full filesystem + shell access
         (no sandbox) — like Claude's bypass mode. Turn auto mode off (General) to make them
-        ask first. Live end-to-end verification with real model calls is pending your keys / a
-        local LLM.
+        ask first, or turn on <strong>sandboxed autonomy</strong> (Autonomy &amp; Budgets) —
+        though that only binds engines that expose a scoped sandbox (Claude, Codex); the
+        engines on this page keep full access either way. Live end-to-end verification with
+        real model calls is pending your keys / a local LLM.
       </div>
     </div>
   );

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -186,6 +186,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
   const cfgX = config as HarnessConfig & {
     strongKeepalive?: boolean; audience?: string; autoMode?: boolean;
     defaultModel?: string; maxTurns?: number; semanticMemory?: boolean;
+    sandboxedAutoMode?: boolean;
   };
   const [keepAwake, setKeepAwake] = useState<boolean>(cfgX.strongKeepalive === true);
   const toggleKeepAwake = async () => {
@@ -207,6 +208,16 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     setAutoModeOn(next);
     try { await window.cth.updateConfig({ autoMode: next } as Partial<HarnessConfig>); }
     catch { setAutoModeOn(!next); }
+  };
+  // Sandboxed auto mode — autonomy WITHOUT dropping each engine's OS sandbox. Only
+  // meaningful while auto mode is on (ask-first agents are already gated), so the row
+  // renders disabled below when autonomy is off.
+  const [sandboxedOn, setSandboxedOn] = useState<boolean>(cfgX.sandboxedAutoMode === true);
+  const toggleSandboxed = async () => {
+    const next = !sandboxedOn;
+    setSandboxedOn(next);
+    try { await window.cth.updateConfig({ sandboxedAutoMode: next } as Partial<HarnessConfig>); }
+    catch { setSandboxedOn(!next); }
   };
   const [defaultModelSel, setDefaultModelSel] = useState<string>(cfgX.defaultModel ?? 'claude-fable-5');
   const [defaultModelNote, setDefaultModelNote] = useState('');
@@ -1114,6 +1125,36 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                           </div>
                           <PixelButton variant={autoModeOn ? 'primary' : 'secondary'} size="sm" onClick={toggleAutoMode}>
                             {autoModeOn ? 'autonomous' : 'ask-first'}
+                          </PixelButton>
+                        </div>
+
+                        {/* Sandboxed autonomy. Autonomous mode normally DROPS the sandbox
+                            each engine ships (claude bypassPermissions, codex
+                            --dangerously-bypass-approvals-and-sandbox) so a worker can
+                            write to its hive folder outside the project. This keeps the
+                            sandbox on and declares those folders as writable roots
+                            instead — same autonomy, bounded blast radius. */}
+                        <div style={{
+                          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                          gap: 12, marginTop: 10, opacity: autoModeOn ? 1 : 0.5
+                        }}>
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                            <span style={{ fontSize: 13, lineHeight: '20px', color: 'var(--cth-ink-900)' }}>
+                              {sandboxedOn ? 'Sandboxed — writes confined to the workspace' : 'Unsandboxed — full filesystem + shell access'}
+                            </span>
+                            <span style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-500)' }}>
+                              Keeps each engine&apos;s own sandbox on in autonomous mode (Claude, Codex;
+                              other engines are unaffected). Agents can still write their project folder
+                              and their hive folder — nothing else.
+                            </span>
+                          </div>
+                          <PixelButton
+                            variant={sandboxedOn ? 'primary' : 'secondary'}
+                            size="sm"
+                            onClick={toggleSandboxed}
+                            disabled={!autoModeOn}
+                          >
+                            {sandboxedOn ? 'sandboxed' : 'unsandboxed'}
                           </PixelButton>
                         </div>
                       </div>

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -62,6 +62,9 @@ export interface HarnessConfig {
   recentHives?: string[];
   registeredRepos: string[];
   autoMode: boolean;
+  /** Auto mode keeps each engine's OS sandbox on instead of dropping it. Mirrors
+   *  src/main/config.ts. Off by default. */
+  sandboxedAutoMode?: boolean;
   defaultCommand: string;
   /** Default model for newly spawned agents (e.g. 'claude-sonnet-4-6[1m]'); unset = CLI default. */
   defaultModel?: string;
@@ -358,7 +361,7 @@ export function decodeProviderModel(value: string): {
  *  configured `defaultCommand`; other providers use their preset binary so the
  *  app works without Claude installed. */
 export function buildSpawnCommand(
-  config: Pick<HarnessConfig, 'defaultCommand' | 'autoMode'>,
+  config: Pick<HarnessConfig, 'defaultCommand' | 'autoMode'> & Partial<Pick<HarnessConfig, 'sandboxedAutoMode'>>,
   model?: string,
   provider: AgentProvider = inferAgentProvider(config.defaultCommand)
 ): string {
@@ -381,7 +384,13 @@ export function buildSpawnCommand(
   }
   // Auto (skip-permissions) mode appends each provider's own flag — Claude's
   // bypassPermissions, Codex's dangerous bypass, Grok's always-approve, Kimi's
-  // auto, or agy's skip flag.
-  if (config.autoMode && preset.autoFlag) cmd = `${cmd} ${preset.autoFlag}`;
+  // auto, or agy's skip flag. With `sandboxedAutoMode` on, an engine that has a
+  // SCOPED equivalent uses that instead, so the agent keeps working prompt-free
+  // but under its CLI's own sandbox (the extra writable roots a hive worker needs
+  // are declared by hive.ts, not here). Engines with no scoped mode keep their
+  // bypass flag rather than silently losing autonomy.
+  const autoFlag =
+    config.sandboxedAutoMode && preset.sandboxedAutoFlag ? preset.sandboxedAutoFlag : preset.autoFlag;
+  if (config.autoMode && autoFlag) cmd = `${cmd} ${autoFlag}`;
   return cmd;
 }

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -77,6 +77,21 @@ export interface AgentProviderPreset {
   /** Flag appended when the floor is in auto (skip-permissions) mode.
    *  PR #54 consumers read this; mirrors `autoModeFlag`. */
   autoFlag?: string;
+  /** The SCOPED-SANDBOX equivalent of `autoFlag`, used instead of it when the user
+   *  turns on `config.sandboxedAutoMode`. Autonomy is preserved (no approval
+   *  prompts) but the CLI keeps the OS sandbox its vendor ships, so a runaway
+   *  agent cannot write outside the roots we declare for it.
+   *
+   *  Only set for CLIs that expose BOTH halves — "never prompt" AND "confine
+   *  writes" — as separate knobs. The reason this used to be impossible for a
+   *  hive worker is that a worker must also write to `$AGENT_DIR` (inbox→.done,
+   *  memory.md, outbox JSON), a different path tree from the PTY cwd. That is
+   *  solved on the config-file side: hive.ts declares those extra WRITABLE ROOTS
+   *  in the per-agent config it already authors (`settings.json` for Claude,
+   *  `$CODEX_HOME/config.toml` for Codex), so the sandbox stays on and the
+   *  protocol still works. Providers that offer no scoped mode leave this unset
+   *  and keep `autoFlag` — never silently losing autonomy. */
+  sandboxedAutoFlag?: string;
   /** Claude Code accepts the hive identity injection (`--append-system-prompt`
    *  + hook `--settings`). Other CLIs don't — they spawn with the shared AGENT_*
    *  env only. Gates the Claude-specific spawn injection in hive.ensureAgent.
@@ -172,6 +187,15 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     supportsModel: true,
     modelFlag: '--model',
     autoFlag: '--permission-mode bypassPermissions',
+    // Sandboxed auto mode: `acceptEdits` auto-approves file edits (inside cwd +
+    // `permissions.additionalDirectories`) while Bash runs under Claude Code's
+    // OS sandbox — Seatbelt on macOS, bubblewrap on Linux/WSL2 — which we turn on
+    // in the per-agent settings.json hive.ts already writes. Bash still needs no
+    // prompt because `autoAllowBashIfSandboxed` defaults to true, so the worker
+    // stays autonomous while losing the ability to write outside its declared
+    // roots. NOT `--permission-mode auto`: that mode is account/plan/org gated and
+    // is REJECTED at startup where it isn't available, which would break the spawn.
+    sandboxedAutoFlag: '--permission-mode acceptEdits',
     hiveAware: true,
     canReceiveInbox: true,
     // Longest-context Claude variant — matches the "give Michael a bigger model"
@@ -204,6 +228,12 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     // alongside it). The app already runs claude/agy in this same full-access posture.
     autoModeFlag: '--dangerously-bypass-approvals-and-sandbox',
     autoFlag: '--dangerously-bypass-approvals-and-sandbox',
+    // Sandboxed auto mode: the exact `-a never -s workspace-write` posture the
+    // comment above says had to be abandoned. It is viable again because hive.ts
+    // now passes `--add-dir <AGENT_DIR>` alongside it, so the worker can still do
+    // its PROTOCOL housekeeping (inbox→.done, memory.md, outbox JSON) in a path
+    // tree outside cwd while every other write stays inside the sandbox.
+    sandboxedAutoFlag: '-a never -s workspace-write',
     // Suppresses first-run interactive prompts (directory-trust gate, installer).
     nonInteractiveEnv: { CODEX_NON_INTERACTIVE: '1' },
     supportsModel: true,
@@ -562,9 +592,24 @@ export function defaultCommandForProvider(provider: AgentProvider, fallback = ''
   return providerPreset(provider).defaultCommand || fallback;
 }
 
-/** Returns the preset's auto-mode CLI flag for the given provider. Empty string = no flag. */
-export function autoModeFlagForProvider(provider: AgentProvider): string {
-  return providerPreset(provider).autoModeFlag ?? '';
+/** Returns the preset's auto-mode CLI flag for the given provider. Empty string = no flag.
+ *  With `{ sandboxed: true }` (config.sandboxedAutoMode) the SCOPED-sandbox flag wins
+ *  where the CLI has one; providers without one fall back to the bypass flag so a floor
+ *  never loses autonomy just because one of its engines can't be confined. Callers that
+ *  want to TELL the user which happened should use `providerIsSandboxable`. */
+export function autoModeFlagForProvider(
+  provider: AgentProvider,
+  opts?: { sandboxed?: boolean }
+): string {
+  const preset = providerPreset(provider);
+  if (opts?.sandboxed && preset.sandboxedAutoFlag) return preset.sandboxedAutoFlag;
+  return preset.autoModeFlag ?? '';
+}
+
+/** Whether this provider's CLI can stay autonomous with its sandbox ON — i.e. whether
+ *  `sandboxedAutoMode` actually changes anything for it. Drives the settings copy. */
+export function providerIsSandboxable(provider: AgentProvider): boolean {
+  return !!providerPreset(provider).sandboxedAutoFlag;
 }
 
 /** Returns any env vars the provider needs for non-interactive / first-run suppression. */

--- a/src/shared/codexCommands.ts
+++ b/src/shared/codexCommands.ts
@@ -45,8 +45,8 @@ export const CODEX_COMMAND_GROUPS: CmdGroup[] = [
   {
     title: 'APPROVALS & PERMISSIONS',
     items: [
-      { cmd: 'codex --dangerously-bypass-approvals-and-sandbox', kind: 'cli', desc: 'Auto mode: skip ALL approval prompts AND drop the OS sandbox (full filesystem access). Used by Munder Difflin when auto mode is on — full parity with Claude bypassPermissions, and required so a hive worker can write to its agent folder outside the project cwd.' },
-      { cmd: 'codex -a never -s workspace-write', kind: 'cli', desc: 'Never prompt for approval (-a never) but scope the sandbox to the project workspace (-s workspace-write). Safer, but blocks writes outside cwd (e.g. a hive agent folder in another path tree).' },
+      { cmd: 'codex --dangerously-bypass-approvals-and-sandbox', kind: 'cli', desc: 'Auto mode: skip ALL approval prompts AND drop the OS sandbox (full filesystem access). Used by Munder Difflin when auto mode is on and sandboxed autonomy is off — full parity with Claude bypassPermissions.' },
+      { cmd: 'codex -a never -s workspace-write --add-dir <agent-dir>', kind: 'cli', desc: 'Sandboxed auto mode: never prompt (-a never) but keep the sandbox scoped to the workspace (-s workspace-write), with --add-dir widening it by exactly the hive agent folder a worker must write to. This is what Munder Difflin spawns when "sandboxed autonomy" is on (Settings → Autonomy & Budgets).' },
       { cmd: 'codex -a untrusted', kind: 'cli', desc: 'Only run trusted commands without asking; escalate to the user for anything else.' },
       { cmd: 'codex -s danger-full-access', kind: 'cli', desc: 'Remove all sandbox restrictions (fine-grained flag — pair with -a for full control).' }
     ]

--- a/src/shared/integrations.ts
+++ b/src/shared/integrations.ts
@@ -334,5 +334,25 @@ export const INTEGRATION_TEMPLATES: IntegrationTemplate[] = [
     secretHelp: 'HubSpot → Settings → Integrations → Private Apps → create app → Access token (scopes crm.objects.*).',
     docsUrl: 'https://developers.hubspot.com/docs/api/crm/understanding-the-crm',
     idSuggestion: 'hubspot'
+  },
+  {
+    // The one template whose baseUrl the user MUST supply: it points at their own
+    // deployed sandbox service, not a vendor's public API. `examples/sandbox-worker/`
+    // in this repo is a ~90-line Cloudflare Worker that implements the two routes.
+    //
+    // Why this is a template and not a feature: a worker already reaches registered
+    // integrations through the loopback broker, which holds the credential and makes
+    // the outbound call. So "run this code somewhere that isn't the user's laptop"
+    // needs no new machinery — only a registered endpoint. It is the mitigation for
+    // the one thing an agent sandbox can't help with: code the model WROTE and hasn't
+    // read, which is exactly what shouldn't execute next to the user's ssh keys.
+    kind: 'custom-rest',
+    label: 'Sandbox exec (Cloudflare)',
+    baseUrl: '',
+    authType: 'bearer',
+    secretLabel: 'Sandbox service bearer token',
+    secretHelp: 'The token your deployed sandbox Worker checks (wrangler secret put AUTH_TOKEN). Base URL is your Worker origin, e.g. https://sandbox.<you>.workers.dev. POST /exec {"source","backend"} runs code; GET /health checks it. See examples/sandbox-worker/.',
+    docsUrl: 'https://github.com/cloudflare/computer',
+    idSuggestion: 'sandbox-exec'
   }
 ];

--- a/test/integration-templates.test.cjs
+++ b/test/integration-templates.test.cjs
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * The integration template catalog (src/shared/integrations.ts).
+ *
+ * A template is what the user clicks to register a REST endpoint the loopback broker
+ * will call on a worker's behalf. Every template therefore has to survive the SAME
+ * upsert gate a hand-typed record does — a catalog entry that can't validate is a dead
+ * button in the UI, and nothing else in the suite covered the catalog as a whole.
+ *
+ * Plus the specifics of the `sandbox-exec` entry: it is the one template whose baseUrl
+ * the user must supply (their own deployed service, not a vendor's public API), and it
+ * is the route agent-written code is meant to take instead of a local Bash call.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  INTEGRATION_TEMPLATES,
+  INTEGRATION_SLUG_RE,
+  validateIntegrationRecord,
+  resolveUpstreamUrl,
+  secretRefFor,
+  authTypeNeedsSecret
+} = loadTs('src/shared/integrations.ts');
+
+/** The record the UI builds from a template once the user fills in the blanks. */
+function recordFrom(tpl, baseUrl) {
+  return {
+    id: tpl.idSuggestion,
+    label: tpl.label,
+    kind: tpl.kind,
+    baseUrl: baseUrl ?? tpl.baseUrl,
+    authType: tpl.authType,
+    ...(tpl.authHeader ? { authHeader: tpl.authHeader } : {}),
+    ...(authTypeNeedsSecret(tpl.authType) ? { secretRef: secretRefFor(tpl.idSuggestion) } : {}),
+    enabled: true
+  };
+}
+
+test('every template yields a record that passes the upsert gate', () => {
+  for (const tpl of INTEGRATION_TEMPLATES) {
+    // Templates with no baseUrl expect the user to supply one; stand in for that here.
+    const res = validateIntegrationRecord(recordFrom(tpl, tpl.baseUrl || 'https://example.test'));
+    assert.equal(res.ok, true, `${tpl.label}: ${res.ok ? '' : res.error}`);
+  }
+});
+
+test('template ids are unique and slug-shaped', () => {
+  const seen = new Set();
+  for (const tpl of INTEGRATION_TEMPLATES) {
+    assert.match(tpl.idSuggestion, INTEGRATION_SLUG_RE, `${tpl.label} has a bad id`);
+    assert.equal(seen.has(tpl.idSuggestion), false, `duplicate id ${tpl.idSuggestion}`);
+    seen.add(tpl.idSuggestion);
+  }
+});
+
+test('sandbox-exec ships with no baseUrl — it points at the user\'s own service', () => {
+  const tpl = INTEGRATION_TEMPLATES.find((t) => t.idSuggestion === 'sandbox-exec');
+  assert.ok(tpl, 'the sandbox-exec template should be in the catalog');
+  assert.equal(tpl.baseUrl, '');
+  assert.equal(tpl.authType, 'bearer');
+  // A blank baseUrl must NOT validate: the user has to supply their Worker origin.
+  assert.equal(validateIntegrationRecord(recordFrom(tpl)).ok, false);
+});
+
+test('a worker cannot escape the sandbox service origin through the broker path', () => {
+  const base = 'https://md-sandbox-exec.example.workers.dev';
+  assert.equal(resolveUpstreamUrl(base, 'exec').href, `${base}/exec`);
+  // The broker forwards a worker-supplied path, so the traversal guards matter here as
+  // much as for any other integration.
+  assert.equal(resolveUpstreamUrl(base, '../../admin'), null);
+  assert.equal(resolveUpstreamUrl(base, '%2e%2e/admin'), null);
+  assert.equal(resolveUpstreamUrl(base, '//evil.test/exec'), null);
+  assert.equal(resolveUpstreamUrl(base, 'https://evil.test/exec'), null);
+});

--- a/test/sandbox-mode.test.cjs
+++ b/test/sandbox-mode.test.cjs
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Sandboxed auto mode (config.sandboxedAutoMode).
+ *
+ * Auto mode historically DROPPED the OS sandbox each engine ships — Claude's
+ * `bypassPermissions`, Codex's `--dangerously-bypass-approvals-and-sandbox` — for one
+ * concrete reason: the HIVE PROTOCOL makes every worker write to `$AGENT_DIR`
+ * (inbox→.done, memory.md, outbox JSON), a different path tree from its PTY cwd, and a
+ * workspace-scoped sandbox blocks that.
+ *
+ * These tests pin the fix: the scoped flag is selected, and the extra WRITABLE ROOTS are
+ * declared in the per-agent config we already author for each engine — so autonomy is
+ * kept and the blast radius is bounded. They also pin the two ways this could silently
+ * regress: a provider with no scoped mode must NOT lose its auto flag, and with the mode
+ * off nothing may be written at all.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  providerPreset,
+  autoModeFlagForProvider,
+  providerIsSandboxable
+} = loadTs('src/shared/agentProvider.ts');
+const { buildSpawnCommand } = loadTs('src/renderer/src/store/config.ts');
+const { HiveManager } = loadTs('src/main/hive.ts');
+
+const auto = { defaultCommand: 'claude', autoMode: true };
+const autoSandboxed = { ...auto, sandboxedAutoMode: true };
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-sandbox-mode-'));
+}
+
+// ─── flag selection ──────────────────────────────────────────────────────────
+
+test('claude swaps bypassPermissions for a scoped mode when sandboxed', () => {
+  assert.equal(buildSpawnCommand(auto, undefined, 'claude'), 'claude --permission-mode bypassPermissions');
+  assert.equal(buildSpawnCommand(autoSandboxed, undefined, 'claude'), 'claude --permission-mode acceptEdits');
+});
+
+test('codex swaps the dangerous bypass for -a never -s workspace-write', () => {
+  assert.equal(
+    buildSpawnCommand(auto, undefined, 'codex'),
+    'codex --dangerously-bypass-approvals-and-sandbox'
+  );
+  assert.equal(buildSpawnCommand(autoSandboxed, undefined, 'codex'), 'codex -a never -s workspace-write');
+});
+
+test('claude never gets --permission-mode auto: it is account-gated and rejected at startup', () => {
+  // Spawning into a rejected flag would fail the whole agent, so the scoped mode has to
+  // be one every account can use.
+  assert.equal(providerPreset('claude').sandboxedAutoFlag.includes('auto'), false);
+});
+
+test('an engine with no scoped sandbox keeps its auto flag rather than losing autonomy', () => {
+  const grok = providerPreset('grok');
+  assert.equal(grok.sandboxedAutoFlag, undefined);
+  assert.equal(providerIsSandboxable('grok'), false);
+  assert.equal(buildSpawnCommand(autoSandboxed, undefined, 'grok'), buildSpawnCommand(auto, undefined, 'grok'));
+  assert.equal(autoModeFlagForProvider('grok', { sandboxed: true }), grok.autoModeFlag);
+});
+
+test('sandboxedAutoMode is inert while auto mode is off', () => {
+  const off = { defaultCommand: 'claude', autoMode: false, sandboxedAutoMode: true };
+  assert.equal(buildSpawnCommand(off, undefined, 'claude'), 'claude');
+  assert.equal(buildSpawnCommand(off, undefined, 'codex'), 'codex');
+});
+
+// ─── writable roots: Claude (per-agent settings.json) ────────────────────────
+
+function settingsOf(home, id) {
+  const p = path.join(home, 'hive', 'agents', id, 'settings.json');
+  return fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : null;
+}
+
+test('claude: the agent dir is declared to BOTH the tool layer and the bash sandbox', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  await hive.ensureAgent(
+    { id: 'c1', name: 'C', provider: 'claude', cwd: home },
+    { sandboxedAutoMode: true }
+  );
+
+  const s = settingsOf(home, 'c1');
+  assert.ok(s, 'the per-agent settings file should exist');
+  const dir = path.join(home, 'hive', 'agents', 'c1');
+  // additionalDirectories governs the Edit/Write TOOLS; sandbox.filesystem.allowWrite
+  // governs BASH SUBPROCESSES. Only one of the two and the agent deadlocks halfway
+  // through the protocol (e.g. the tool is allowed but `mv … .done/` is denied).
+  assert.deepEqual(s.permissions.additionalDirectories, [dir]);
+  assert.equal(s.sandbox.enabled, true);
+  assert.deepEqual(s.sandbox.filesystem.allowWrite, [dir]);
+});
+
+test('claude: with the mode off the settings file carries no sandbox keys at all', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  await hive.ensureAgent({ id: 'c2', name: 'C', provider: 'claude', cwd: home }, {});
+
+  const s = settingsOf(home, 'c2');
+  assert.ok(s, 'the per-agent settings file should still exist (hooks live there)');
+  assert.equal('permissions' in s, false);
+  assert.equal('sandbox' in s, false);
+});
+
+// ─── writable roots: Codex (--add-dir on argv) ───────────────────────────────
+
+/** Every `--add-dir <path>` pair in a spawn injection's args, in order. */
+function addDirs(args) {
+  const out = [];
+  for (let i = 0; i < args.length; i++) if (args[i] === '--add-dir') out.push(args[i + 1]);
+  return out;
+}
+
+test('codex: the agent dir rides in as --add-dir, ahead of the positional prompt', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  const inj = await hive.ensureAgent(
+    { id: 'x1', name: 'X', provider: 'codex', cwd: home },
+    { sandboxedAutoMode: true }
+  );
+
+  const dir = path.join(home, 'hive', 'agents', 'x1');
+  assert.deepEqual(addDirs(inj.args), [dir]);
+  // Codex takes its initial prompt POSITIONALLY, so every flag must precede it.
+  const last = inj.args.indexOf('--add-dir');
+  assert.ok(last < inj.args.length - 2, 'flags must come before the positional prompt');
+});
+
+test('codex: no --add-dir when the mode is off', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  const inj = await hive.ensureAgent({ id: 'x2', name: 'X', provider: 'codex', cwd: home }, {});
+  assert.deepEqual(addDirs(inj.args), []);
+});
+
+// ─── which roots get granted ─────────────────────────────────────────────────
+
+test('god gets HIVE_ROOT — it writes board.md/tasks.json — collapsed to ONE grant', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  await hive.ensureAgent(
+    { id: 'g1', name: 'God', provider: 'claude', cwd: home, isGod: true },
+    { sandboxedAutoMode: true }
+  );
+
+  const roots = settingsOf(home, 'g1').sandbox.filesystem.allowWrite;
+  // HIVE_ROOT already contains agents/g1, so listing both would overstate the grant.
+  assert.deepEqual(roots, [path.join(home, 'hive')]);
+});
+
+test('a non-absolute extra root is dropped instead of shipped into the policy', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+
+  await hive.ensureAgent(
+    { id: 'c3', name: 'C', provider: 'claude', cwd: home },
+    { sandboxedAutoMode: true, extraWritableRoots: ['relative/palace', '', path.join(home, 'palace')] }
+  );
+
+  const roots = settingsOf(home, 'c3').sandbox.filesystem.allowWrite;
+  assert.deepEqual(roots, [path.join(home, 'hive', 'agents', 'c3'), path.join(home, 'palace')]);
+});

--- a/test/tunnel.test.cjs
+++ b/test/tunnel.test.cjs
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * Public-tunnel provider (src/main/tunnel.ts).
+ *
+ * The defect this module exists to fix: both SlackWebhookServer and WebhookServer used
+ * to call tunnelmole directly and carried the same comment — "no documented close
+ * handle; teardown is best-effort" — so stopping the bridge left the public URL alive
+ * until the app quit. A cloudflared quick tunnel is an ordinary child process, so the
+ * handle it returns can really close.
+ *
+ * The child is injected, so these run with no network, no cloudflared install, and no
+ * real tunnel.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  extractQuickTunnelUrl,
+  selectProvider,
+  cloudflaredAvailable,
+  openTunnel
+} = loadTs('src/main/tunnel.ts');
+
+/** The banner cloudflared actually prints, split the way a stream chunks it. */
+const BANNER_LINES = [
+  '2026-08-14T10:00:00Z INF Requesting new quick Tunnel on trycloudflare.com...\n',
+  '2026-08-14T10:00:01Z INF +----------------------------------------------------+\n',
+  '2026-08-14T10:00:01Z INF |  Your quick Tunnel has been created! Visit it at    |\n',
+  '2026-08-14T10:00:01Z INF |  (it may take some time to be reachable):           |\n',
+  '2026-08-14T10:00:01Z INF |  https://sour-pine-mercury-mars.trycloudflare.com   |\n',
+  '2026-08-14T10:00:01Z INF +----------------------------------------------------+\n'
+];
+const EXPECTED_URL = 'https://sour-pine-mercury-mars.trycloudflare.com';
+
+/** A stand-in for the cloudflared child process. */
+function fakeChild() {
+  const child = new EventEmitter();
+  child.pid = 4242;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+// ─── URL extraction ──────────────────────────────────────────────────────────
+
+test('the URL is found inside the box-drawn banner', () => {
+  assert.equal(extractQuickTunnelUrl(BANNER_LINES.join('')), EXPECTED_URL);
+});
+
+test('extraction works on a buffer split mid-URL across chunks', () => {
+  // The whole reason the parser matches the ACCUMULATED buffer rather than each chunk:
+  // a stream chunk boundary can land in the middle of the hostname.
+  let buf = '';
+  let found = null;
+  for (const piece of ['INF |  https://sour-pine-', 'mercury-mars.trycloudflare', '.com  |\n']) {
+    buf += piece;
+    found = found ?? extractQuickTunnelUrl(buf);
+  }
+  assert.equal(found, EXPECTED_URL);
+});
+
+test('no URL in ordinary log noise, and a look-alike domain is not matched', () => {
+  assert.equal(extractQuickTunnelUrl('INF Requesting new quick Tunnel...\n'), null);
+  assert.equal(extractQuickTunnelUrl('https://evil-trycloudflare.com.attacker.test/x'), null);
+});
+
+// ─── provider selection ──────────────────────────────────────────────────────
+
+const withCloudflared = { resolve: () => '/usr/local/bin/cloudflared' };
+const withoutCloudflared = { resolve: () => '' };
+
+test('auto prefers cloudflared and falls back to tunnelmole', () => {
+  assert.equal(selectProvider('auto', withCloudflared), 'cloudflared');
+  assert.equal(selectProvider('auto', withoutCloudflared), 'tunnelmole');
+  assert.equal(cloudflaredAvailable(withoutCloudflared), false);
+});
+
+test('an explicit provider is honoured even when the binary is missing', () => {
+  // A misconfiguration must surface as an error later, not silently fall back to the
+  // provider the user pinned away from.
+  assert.equal(selectProvider('cloudflared', withoutCloudflared), 'cloudflared');
+  assert.equal(selectProvider('tunnelmole', withCloudflared), 'tunnelmole');
+});
+
+// ─── the handle ──────────────────────────────────────────────────────────────
+
+test('a cloudflared tunnel resolves with a closable handle', async () => {
+  const child = fakeChild();
+  let spawned = null;
+  const killed = [];
+  const p = openTunnel(3847, {
+    deps: {
+      ...withCloudflared,
+      spawn: (bin, args) => { spawned = { bin, args }; return child; },
+      kill: (pid) => killed.push(pid)
+    }
+  });
+  for (const line of BANNER_LINES) child.stderr.emit('data', Buffer.from(line));
+
+  const handle = await p;
+  assert.equal(handle.url, EXPECTED_URL);
+  assert.equal(handle.provider, 'cloudflared');
+  assert.equal(typeof handle.close, 'function');
+  // 127.0.0.1, never localhost: the servers bind IPv4 loopback, and localhost can
+  // resolve to ::1 — which would forward into a closed port.
+  assert.deepEqual(spawned.args, ['tunnel', '--no-autoupdate', '--url', 'http://127.0.0.1:3847']);
+  assert.equal(spawned.bin, '/usr/local/bin/cloudflared');
+  // close() must be safe to call twice — stop() is idempotent and callers may retry —
+  // and must signal EXACTLY once: after the first kill the OS can recycle the pid, so
+  // a second signal would land on somebody else's process.
+  handle.close();
+  handle.close();
+  assert.deepEqual(killed, [4242]);
+});
+
+test('a child that exits before printing a URL rejects instead of hanging', async () => {
+  const child = fakeChild();
+  const p = openTunnel(3847, {
+    deps: { ...withCloudflared, spawn: () => child }
+  });
+  child.stderr.emit('data', Buffer.from('ERR failed to connect\n'));
+  child.emit('exit', 1);
+
+  await assert.rejects(p, (e) => {
+    assert.match(e.message, /cloudflared exited/);
+    assert.match(e.message, /failed to connect/, 'the tail of the log should be reported');
+    return true;
+  });
+});
+
+test('a silent child times out rather than blocking the bridge forever', async () => {
+  const child = fakeChild();
+  const killed = [];
+  const p = openTunnel(3847, {
+    timeoutMs: 30,
+    deps: { ...withCloudflared, spawn: () => child, kill: (pid) => killed.push(pid) }
+  });
+  await assert.rejects(p, /timed out/);
+  // The abandoned child must not be left running — that is the leak this module fixes.
+  assert.deepEqual(killed, [4242]);
+});
+
+test('late output after settling cannot resolve or throw a second time', async () => {
+  const child = fakeChild();
+  const p = openTunnel(3847, { deps: { ...withCloudflared, spawn: () => child } });
+  for (const line of BANNER_LINES) child.stderr.emit('data', Buffer.from(line));
+  await p;
+  // A long-running tunnel keeps logging after start; none of it may re-settle the
+  // promise or hit a removed listener.
+  child.stderr.emit('data', Buffer.from('INF connection established\n'));
+  child.emit('exit', 0);
+});


### PR DESCRIPTION
Three related pieces of the same story: agents in this app are real CLI processes on the user's machine, and today almost nothing bounds them.

Nothing here changes default behaviour — item 1 is off by default, item 2 falls back to today's provider, item 3 is inert until registered.

## 1 · Keep the engine's OS sandbox on in auto mode (`f3d2841`)

Auto mode drops the sandbox every engine ships (`bypassPermissions`, `codex --dangerously-bypass-approvals-and-sandbox`, `--yolo`). The only isolation left is a git worktree, which bounds nothing outside the repo.

The reason was never that autonomy requires it — it was a path layout. The PROTOCOL makes every worker write to `$AGENT_DIR`, a different path tree from its PTY cwd, which a workspace-scoped sandbox blocks (`src/shared/codexCommands.ts:45` says so). Both CLIs accept extra writable roots, so we declare them in the per-agent config we already author for each engine:

| | flag | writable roots declared in |
| --- | --- | --- |
| claude | `--permission-mode acceptEdits` | `settings.json` — `permissions.additionalDirectories` (Edit/Write tools) **and** `sandbox.filesystem.allowWrite` (bash subprocesses) |
| codex | `-a never -s workspace-write` | `--add-dir <root>` on argv |

Both Claude keys are required or an agent deadlocks mid-protocol: the tool is allowed but `mv … .done/` is denied. Mode is `acceptEdits`, **not** `auto` — `auto` is account/plan gated and rejected at startup where unavailable, which would break the spawn.

god is the one agent granted `HIVE_ROOT` (sole scribe of board.md/tasks.json, drops spawn-requests); that subsumes its own agent dir, so the two collapse into one grant.

**Verified against the installed CLIs, not just asserted.** Claude ran bash with no prompt, wrote the declared agent dir, and got `Operation not permitted` touching `$HOME`. Codex reports `sandbox: workspace-write [workdir, /tmp, $TMPDIR, <agent dir>]`. (Codex's behavioural write test couldn't finish — the account is out of API credits — so its half is verified at the flag/policy level only.)

Toggle: **Settings → Autonomy & Budgets**. Off ⇒ spawn and settings file are byte-identical to before. Engines with no scoped mode keep their bypass flag rather than silently losing autonomy.

## 2 · Give the public tunnel a close handle (`a931eab`)

`slack.ts` and `webhook.ts` each had their own `openTunnel()` and both carried the same admission — *"tunnelmole has no documented close handle; teardown is best-effort"*. Stopping the bridge left the public URL alive until the app quit.

New `src/main/tunnel.ts` returns a handle with a real `close()` and defaults to a cloudflared quick tunnel — an ordinary child process, killed through the same `ensureKilled` ladder the PTYs use. tunnelmole stays as the fallback, unchanged. Also fixes two ways the old code stranded a child: a silent cloudflared is killed on timeout, and an early exit rejects with the tail of its log instead of hanging.

## 3 · Brokered sandbox exec (`16d024f`)

Sandboxed autonomy bounds an agent's own writes; it does nothing about code the model just *wrote* and nobody has read. The loopback broker already forwards to a registered baseUrl with the credential injected in main, so this is a template, not machinery:

- one `INTEGRATION_TEMPLATES` entry (`sandbox-exec`) — the only template whose baseUrl the user must supply, since it points at their own service;
- the capability catalog gains the call plus the boundary that makes it matter, and documents `MD_BROKER_URL`/`MD_BROKER_TOKEN`, which were injected but never written down;
- `examples/sandbox-worker/` is the missing half: a ~90-line Worker over `@cloudflare/sandbox` behind a constant-time bearer check, with `runInSandbox()` as the single swap point for [`@cloudflare/computer`](https://github.com/cloudflare/computer)'s isolate backends. Not compiled by the app build (tsconfigs include only `src/**`).

## Tests

`npm run typecheck` clean; `npm run test:focused` **154 pass / 0 fail** (130 before, +24 across three new files, all registered in the focused suite).

`test/integration-templates.test.cjs` also closes a pre-existing gap: nothing covered the template catalog, so an entry that couldn't pass the upsert gate would have shipped as a dead button.

## Not in scope

Running agents *themselves* in a remote sandbox. Every engine here is a long-lived interactive TUI over a PTY; `@cloudflare/computer` documents no PTY or long-lived-process support and `@cloudflare/sandbox` needs a deployed Worker + Containers. That belongs behind an execution-backend seam, in the Cloud tier — not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)