### PR TITLE
fix(terminal): strip the CLI's quote rail from copied selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs",
+    "test:focused": "node --test test/codex-remote.test.cjs test/control.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs test/queue-delivery.test.cjs test/terminal-automation.test.cjs test/terminal-recovery.test.cjs test/terminal-selection.test.cjs test/roster.test.cjs test/proc-kill.test.cjs test/expand-tilde.test.cjs test/hive-cwd.test.cjs test/hive-hook-node.test.cjs test/hive-roster-injection.test.cjs test/hive-runtime-path.test.cjs test/cli-install-ladder.test.cjs test/node-install.test.cjs test/office-gl-recovery.test.cjs test/update-state.test.cjs test/transcript-project-dir.test.cjs test/commit-graph.test.cjs",
     "check:links": "node tools/check-release-links.cjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -32,6 +32,7 @@ import {
   terminalAutomationBlock,
   type TerminalAutomationBlock
 } from './terminalAutomation';
+import { sanitizeTerminalSelection } from './terminalSelection';
 import '@xterm/xterm/css/xterm.css';
 
 export interface TerminalEntry {
@@ -181,7 +182,13 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
   //   right-click                 → copy the selection, else paste (console style)
   const copySelection = (): boolean => {
     if (!term.hasSelection()) return false;
-    void window.cth.copyToClipboard(term.getSelection());
+    // Selections come off the character GRID, so any gutter the CLI painted
+    // there (Claude Code renders a blockquote as `▎ text`) is part of the
+    // copied cells. Strip it — see terminalSelection.ts.
+    const text = sanitizeTerminalSelection(term.getSelection());
+    // Still `true` when a rail-only selection sanitizes to nothing: the gesture
+    // was a copy and must stay one, or right-click would fall through to paste.
+    if (text) void window.cth.copyToClipboard(text);
     return true;
   };
   const pasteClipboard = (): void => {

--- a/src/renderer/src/components/terminalSelection.ts
+++ b/src/renderer/src/components/terminalSelection.ts
@@ -1,0 +1,47 @@
+/**
+ * Copy hygiene for terminal selections.
+ *
+ * Agent CLIs paint their decoration INTO the character grid. Claude Code draws
+ * a markdown blockquote as `▎ text`, so the rail is a real cell on that line —
+ * not a border drawn beside it. Selecting the line (which is exactly what a
+ * triple-click or a full-width drag does) therefore copies the rail with the
+ * prose, and the paste lands as:
+ *
+ *     ▎ Munder Difflin — clones for you and your team, working 24/7.
+ *
+ * Nothing downstream wants that glyph, so strip it on the way to the clipboard.
+ *
+ * The guard that stops this from eating real content: a rail only counts when a
+ * space follows it or it ends the line — the shape a quote gutter always has. A
+ * bar chart (`▌▌▌▌ 40%`) or block art keeps its bars because they run together.
+ *
+ * Deliberately narrow. Only the left/right BLOCK elements CLIs use as a gutter
+ * are in the set; box-drawing verticals (`│`, `┃`) are not. `tree`, `git log
+ * --graph` and every framed table indent continuation lines with `│   `, and
+ * stripping that would corrupt far more copies than it would fix.
+ */
+
+/** ▌ ▍ ▎ ▏ (left half → left one-eighth) and ▐ ▕ (right half, right eighth). */
+const RAIL_CHARS = '▌▍▎▏▐▕';
+
+/** Leading indent, then one or more `rail + space` / `rail + end-of-line` runs.
+ *  Nested quotes render as `▎ ▎ text`, hence the repeat. */
+const LEADING_RAIL = new RegExp(`^([ \\t]*)(?:[${RAIL_CHARS}](?: |(?=\\r?$)))+`);
+
+const ANY_RAIL = new RegExp(`[${RAIL_CHARS}]`);
+
+/** Drop a quote/gutter rail from the start of a single line, keeping its indent. */
+export function stripLeadingRail(line: string): string {
+  return line.replace(LEADING_RAIL, '$1');
+}
+
+/**
+ * Clean a terminal selection for the clipboard: per line, drop the gutter rail
+ * the CLI painted into column 0. Everything else — indentation, box drawing,
+ * inline glyphs — is left byte-for-byte alone.
+ */
+export function sanitizeTerminalSelection(text: string): string {
+  // The overwhelming majority of copies contain no rail at all; skip the split.
+  if (!text || !ANY_RAIL.test(text)) return text;
+  return text.split('\n').map(stripLeadingRail).join('\n');
+}

--- a/test/terminal-selection.test.cjs
+++ b/test/terminal-selection.test.cjs
@@ -1,0 +1,76 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  sanitizeTerminalSelection,
+  stripLeadingRail
+} = loadTs('src/renderer/src/components/terminalSelection.ts');
+
+test('the reported paste: Claude Code blockquote rail is dropped', () => {
+  assert.equal(
+    sanitizeTerminalSelection('▎ Munder Difflin — clones for you and your team, working 24/7.'),
+    'Munder Difflin — clones for you and your team, working 24/7.'
+  );
+});
+
+test('every line of a multi-line quote loses its rail', () => {
+  const copied = [
+    '▎ Munder Difflin is live on Product Hunt today.',
+    '▎',
+    '▎ Free, open source, local-first.'
+  ].join('\n');
+  assert.equal(sanitizeTerminalSelection(copied), [
+    'Munder Difflin is live on Product Hunt today.',
+    '',
+    'Free, open source, local-first.'
+  ].join('\n'));
+});
+
+test('indent survives, nested rails do not', () => {
+  assert.equal(stripLeadingRail('  ▎ indented quote'), '  indented quote');
+  assert.equal(stripLeadingRail('▎ ▎ nested quote'), 'nested quote');
+  assert.equal(stripLeadingRail('\t▏ tab-indented'), '\ttab-indented');
+});
+
+test('CRLF selections keep their carriage return', () => {
+  assert.equal(sanitizeTerminalSelection('▎ line one\r\n▎\r\n▎ line two\r\n'),
+    'line one\r\n\r\nline two\r\n');
+});
+
+test('block art and bar charts are left alone (bars run together)', () => {
+  assert.equal(sanitizeTerminalSelection('▌▌▌▌ 40%'), '▌▌▌▌ 40%');
+  assert.equal(sanitizeTerminalSelection('█▉▊▋▌ gradient'), '█▉▊▋▌ gradient');
+});
+
+test('box drawing is never touched — tree/graph output must paste intact', () => {
+  const tree = ['├── src', '│   └── main', '└── test'].join('\n');
+  assert.equal(sanitizeTerminalSelection(tree), tree);
+  assert.equal(sanitizeTerminalSelection('┃ heavy vertical'), '┃ heavy vertical');
+  assert.equal(sanitizeTerminalSelection('| pipe table |'), '| pipe table |');
+});
+
+test('a mixed selection strips only the rail, never the tree indent', () => {
+  // The tree lines must survive even though the selection DOES contain a rail,
+  // so this walks the regex instead of the "no rail anywhere" fast path.
+  const copied = ['▎ the layout is:', '├── src', '│   └── main', '└── test'].join('\n');
+  assert.equal(sanitizeTerminalSelection(copied),
+    ['the layout is:', '├── src', '│   └── main', '└── test'].join('\n'));
+});
+
+test('a rail in the middle of a line is content, not a gutter', () => {
+  assert.equal(sanitizeTerminalSelection('press ▎ to quit'), 'press ▎ to quit');
+});
+
+test('ordinary prose is returned byte-for-byte', () => {
+  const prose = 'npm run test:focused   # 154 passing\n  indented line\n';
+  assert.equal(sanitizeTerminalSelection(prose), prose);
+  assert.equal(sanitizeTerminalSelection(''), '');
+});
+
+test('a rail-only selection sanitizes to nothing', () => {
+  assert.equal(sanitizeTerminalSelection('▎'), '');
+  assert.equal(sanitizeTerminalSelection('▎ '), '');
+});


### PR DESCRIPTION
## The bug

Copying a line of agent output from a terminal pastes a stray block glyph with it:

```
▎ Munder Difflin — clones for you and your team, working 24/7.
```

Claude Code paints a markdown blockquote **into the character grid** — the `▎` rail is a real cell in column 0, not a border drawn beside the text. A triple-click or a full-width drag therefore selects it along with the prose, and xterm's `getSelection()` hands it straight to the clipboard.

## The fix

Sanitize on the way out, in `copySelection()` — the single place every copy path already funnels through (Ctrl/Cmd+C with a selection, Ctrl/Cmd+Shift+C, right-click). Per line: drop a leading run of gutter rails, keep the indent.

New `src/renderer/src/components/terminalSelection.ts` (pure string module, electron-free, unit-testable).

Kept deliberately narrow so it can't corrupt legitimate copies:

- **A rail only counts when a space follows it, or it ends the line** — the shape a quote gutter always has. Bar charts and block art (`▌▌▌▌ 40%`) keep their bars, because those run together.
- **Only the left/right BLOCK elements are in the set** (`▌▍▎▏▐▕`). Box-drawing verticals (`│`, `┃`) are *not*: `tree`, `git log --graph` and every framed table indent continuation lines with `│   `, and stripping that would break far more copies than it fixes.
- **No rail anywhere → returned byte-for-byte unchanged** (fast path, no split).
- A rail-only selection sanitizes to empty but still **counts as a copy**, so right-click doesn't fall through to paste and inject clipboard text into the agent's prompt.

## Verification

- 10 new tests in `test/terminal-selection.test.cjs`, added to `test:focused`.
- **Mutation-checked both directions:** 4 fail against a no-op sanitizer (the fix does something); 3 of the guard tests fail against a naive strip that also eats box drawing (the guards have teeth).
- `npm run test:focused` → **140/140**; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)