### PR TITLE
feat(grok): offer Grok 4.6 in the model picker

### DIFF
--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -282,6 +282,7 @@ export const GROK_MODELS: ModelOption[] = [
   // harness's `config.defaultModel`; the pickers mark that one separately, and
   // labelling both "default" is what made the two impossible to tell apart.
   { id: undefined, label: 'CLI default' },
+  { id: 'grok-4.6', label: 'Grok 4.6' },
   { id: 'grok-4.5', label: 'Grok 4.5' }
 ];
 

--- a/src/shared/grokCommands.ts
+++ b/src/shared/grokCommands.ts
@@ -20,7 +20,7 @@ export const GROK_COMMAND_GROUPS: CmdGroup[] = [
     title: 'MODELS & PERMISSIONS',
     items: [
       { cmd: '/model', kind: 'slash', desc: 'Switch the model used by the current session.' },
-      { cmd: 'grok --model grok-4.5', kind: 'cli', desc: 'Launch Grok with the Grok 4.5 coding model.' },
+      { cmd: 'grok --model grok-4.6', kind: 'cli', desc: 'Launch Grok with the Grok 4.6 coding model (the CLI default).' },
       { cmd: '/always-approve', kind: 'slash', desc: 'Toggle automatic approval of tool executions.' },
       { cmd: 'grok --permission-mode bypassPermissions', kind: 'cli', desc: 'Launch in always-approve mode. Munder uses this when Auto Mode is on.' }
     ]

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -73,7 +73,7 @@ test('model picker options stay provider-specific', () => {
   );
   assert.deepEqual(
     modelsForProvider('grok').map((model) => model.id),
-    [undefined, 'grok-4.5']
+    [undefined, 'grok-4.6', 'grok-4.5']
   );
   assert.deepEqual(
     modelsForProvider('kimi').map((model) => model.id),


### PR DESCRIPTION
`grok models` on the current CLI reports:

```
Default model: grok-4.6

Available models:
  * grok-4.6 (default)
  - grok-4.5
```

The picker only listed 4.5, so the CLI's own default model could not be selected explicitly — an agent could reach it only by choosing "CLI default", which the UI cannot label with a model name.

- adds `grok-4.6` above `grok-4.5` in `GROK_MODELS`
- points the Grok command reference at 4.6 and notes it is the CLI default
- updates the model-picker assertion in `test/provider-config.test.cjs`

Tests: 150/150 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUpadJJuEQz1zpQ6Vk83j3