### PR TITLE
fix(hive): keep the cost ledger out of the hive's git history

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -477,7 +477,7 @@ export class HiveManager {
 
     // Keep the churny/ephemeral live files out of the hive git repo.
     const gitignore = join(root, '.gitignore');
-    const want = ['fleet.json', 'hooks.sock', '.DS_Store'];
+    const want = ['fleet.json', 'hooks.sock', 'cost-ledger.jsonl', '.DS_Store'];
     let lines: string[] = [];
     if (existsSync(gitignore)) { try { lines = readFileSync(gitignore, 'utf8').split('\n'); } catch { lines = []; } }
     const missing = want.filter((w) => !lines.includes(w));
@@ -1859,10 +1859,39 @@ export class HiveManager {
     return { ok: res.status === 0, out: res.stdout ?? '', err: res.stderr ?? '' };
   }
 
+  /** Has the one-time cost-ledger untrack pass run in this process yet? */
+  private untrackedCostLedger = false;
+
+  /**
+   * Stop versioning the cost ledger.
+   *
+   * `cost-ledger.jsonl` is append-only and gains a row per usage sample, so a
+   * repo that tracks it stores a fresh copy of the WHOLE file on every hive
+   * commit — and the hive commits constantly. A quarter-gigabyte ledger with a
+   * few thousand commits behind it is several hundred gigabytes of blob that
+   * git has to walk, which is what turns a routine `gc` into a multi-gigabyte
+   * `pack-objects` run. The ignore line in ensureHive keeps new copies out;
+   * this drops the one already in the index, because git keeps recording a
+   * file it is already tracking no matter what .gitignore says — so the ignore
+   * line alone reads as a fix while the repo goes on growing. The ledger stays
+   * on disk, so the cost history the app reads is untouched.
+   */
+  private untrackCostLedger(root: string): void {
+    if (this.untrackedCostLedger) return;
+    this.untrackedCostLedger = true;
+    // Probe before mutating: `rm --cached` on a repo that never tracked it
+    // would still rewrite the index on every launch, inside the retry path.
+    const tracked = this.git(['ls-files', '--', 'cost-ledger.jsonl'], root);
+    if (!tracked.ok || !tracked.out.trim()) return;
+    this.git(['rm', '--cached', '-q', '--ignore-unmatch', '--', 'cost-ledger.jsonl'], root);
+    console.warn('[hive] untracked the cost ledger from the hive repo');
+  }
+
   /** Commit all hive changes. No-op if there is nothing staged. */
   commit(message: string): void {
     const root = this.root();
     if (!root || !existsSync(join(root, '.git'))) return;
+    this.untrackCostLedger(root);
     for (let attempt = 0; attempt < 5; attempt++) {
       this.clearStaleLock(root);
       const add = this.git(['add', '-A'], root);


### PR DESCRIPTION
`cost-ledger.jsonl` is append-only and gains a row per usage sample, so a repo that tracks it stores a fresh copy of the **whole file** on every hive commit — and the hive commits constantly.

On my machine that is a 251 MB ledger with ~3,700 copies behind it, which leaves git walking hundreds of gigabytes of blob. A routine `git gc --auto` turned into a `pack-objects` run that climbed to **16 GB resident** and pushed the machine 29 GB into swap. Nothing else in the hive grows that way; every other churny live file (`fleet.json`, `hooks.sock`) is already ignored.

**What this does**

- adds `cost-ledger.jsonl` to the hive root `.gitignore` written by `ensureHive`
- drops the copy already in the index, once per process, from `commit()`

The second half is the part that matters for an existing hive: git keeps recording a file it already tracks no matter what `.gitignore` says, so the ignore line alone would have read as applied while the repo went on growing — the same trap `untrackCodexHomes` exists to close (#128).

The ledger stays on disk, so the cost history the app reads is untouched; only its version history stops.

Note: this stops the growth. A hive that already carries the old copies still needs a history rewrite to reclaim the space — that is a local operation, not something the app should do on its own.

Tests: 150/150 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUpadJJuEQz1zpQ6Vk83j3