### PR TITLE
feat(provider): Cursor CLI preset + standing goal editor

### DIFF
--- a/docs/hires/scripts/build-data.py
+++ b/docs/hires/scripts/build-data.py
@@ -14,7 +14,7 @@ may use any model string; suggestions never validate).
 """
 import json, os, re, sys, urllib.request
 
-PROVIDERS = ['claude', 'antigravity', 'codex']
+PROVIDERS = ['claude', 'antigravity', 'codex', 'cursor']
 UPSTREAM_CONFIG = ('https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/'
                    'main/src/renderer/src/store/config.ts')
 

--- a/docs/hires/validator.js
+++ b/docs/hires/validator.js
@@ -5,8 +5,8 @@
 
 window.HireSpec = (function () {
   const SPEC = 'munder-difflin/hire@1';
-  const PROVIDERS = ['claude', 'antigravity', 'codex'];
-  const PROVIDER_LABEL = { claude: 'Claude Code', antigravity: 'Antigravity', codex: 'Codex' };
+  const PROVIDERS = ['claude', 'antigravity', 'codex', 'cursor'];
+  const PROVIDER_LABEL = { claude: 'Claude Code', antigravity: 'Antigravity', codex: 'Codex', cursor: 'Cursor' };
   const FLAG_RE = /^[A-Za-z0-9._\/=:,@+-]{1,100}$/;
   // model flows onto the spawn command line — reject shell metacharacters
   // (mirror of MODEL_RE in the app's src/shared/hire.ts).
@@ -43,7 +43,7 @@ window.HireSpec = (function () {
     cap(raw.homepage, 300, 'homepage');
     if (raw.provider !== undefined) {
       const p = normalizeProvider(raw.provider);
-      if (!PROVIDERS.includes(p)) errors.push('"provider" must be claude, antigravity (or agy), or codex');
+      if (!PROVIDERS.includes(p)) errors.push('"provider" must be claude, antigravity (or agy), codex, or cursor');
     }
     if (raw.commandFlags !== undefined) {
       if (!Array.isArray(raw.commandFlags) || raw.commandFlags.length > 16) {

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -67,7 +67,10 @@ export class HookServer {
     private control?: ControlRegistry,
     /** Circuit breaker (Lane A #6.6b) — fed the hook-derived signals (session id,
      *  repeated identical tool calls). Optional so the server still runs without it. */
-    private breaker?: CircuitBreaker
+    private breaker?: CircuitBreaker,
+    /** Standing goal text for an agent (from the durable roster). Optional so
+     *  tests can omit it; when set, injected on SessionStart / UserPromptSubmit. */
+    private getStandingGoal?: (agentId: string) => string | null
   ) {}
 
   start(): void {
@@ -258,12 +261,22 @@ export class HookServer {
       && !!agentId && this.hive.isGod(agentId);
     const roster = wantsRoster ? this.hive.rosterContext() : null;
 
-    if (steer || roster) {
+    // Standing goal (hire Briefing) — durable roster field, re-read every cycle so
+    // an Edit Agent save is picked up on the next SessionStart / UserPromptSubmit
+    // without restarting the worker. Kept out of --append-system-prompt (volatile-
+    // free cache invariant); lives on the live hook channel instead.
+    const wantsGoal = (event === 'SessionStart' || event === 'UserPromptSubmit') && !!agentId;
+    const goalRaw = wantsGoal ? (this.getStandingGoal?.(agentId) ?? null) : null;
+    const goal = goalRaw
+      ? `<goal>\n${goalRaw}\n</goal>`
+      : null;
+
+    if (steer || roster || goal) {
       this.emit(agentId, event, p);
       return {
         hookSpecificOutput: {
           hookEventName: event,
-          additionalContext: [roster, steer].filter(Boolean).join('\n\n')
+          additionalContext: [roster, goal, steer].filter(Boolean).join('\n\n')
         }
       };
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -258,9 +258,30 @@ let breakerBeatTimer: ReturnType<typeof setInterval> | null = null;
 // Feed the breaker's api_error-storm trip from Oscar's OTel api_error spans —
 // Jim's one breaker input with no on-branch source (telemetry.onApiError seam).
 telemetry.onApiError((agentId) => breaker.recordError(agentId));
+// Shared roster on disk — created early so HookServer can re-read standing goals
+// on every UserPromptSubmit (Edit Agent saves land here via persistAgents).
+const roster = new RosterStore(() => readConfig().harnessHome);
+function standingGoalFromRoster(agentId: string): string | null {
+  const snap = roster.read();
+  if (!snap || !Array.isArray(snap.agents)) return null;
+  for (const entry of snap.agents) {
+    if (!entry || typeof entry !== 'object') continue;
+    const a = entry as { id?: unknown; goal?: unknown };
+    if (a.id !== agentId) continue;
+    return typeof a.goal === 'string' && a.goal.trim() ? a.goal.trim() : null;
+  }
+  return null;
+}
 // HookServer needs BOTH: Oscar's control registry (HITL pause/gate/steer/halt via
 // hook returns) AND Jim's breaker (feed recordToolUse on each PostToolUse).
-const hookServer = new HookServer(hive, () => liveWebContents(), () => readConfig(), control, breaker);
+const hookServer = new HookServer(
+  hive,
+  () => liveWebContents(),
+  () => readConfig(),
+  control,
+  breaker,
+  standingGoalFromRoster
+);
 const memory = new MemoryManager(
   () => readConfig().harnessHome,
   () => { const c = readConfig(); return { enabled: c.semanticMemory !== false, model: c.embeddingModel ?? 'minilm' }; }
@@ -3053,7 +3074,7 @@ ipcMain.handle('git:checkout', async (_evt, cwd: unknown, ref: unknown, detach: 
 // IPC could resolve, so the read is `ipcMain.on` + `returnValue` — one blocking
 // round trip at boot, in exchange for the roster being correct on first paint
 // instead of flashing an empty floor and then filling in.
-const roster = new RosterStore(() => readConfig().harnessHome);
+// (`roster` itself is constructed earlier so HookServer can read standing goals.)
 ipcMain.on('roster:readSync', (evt) => { evt.returnValue = roster.read(); });
 ipcMain.handle('roster:read', () => roster.read());
 ipcMain.handle('roster:write', (_evt, snap: unknown) => roster.write(snap));

--- a/src/main/realtimeActions.ts
+++ b/src/main/realtimeActions.ts
@@ -160,7 +160,8 @@ const PENDING_TTL_MS = 120_000;
 
 const PROVIDER_COMMAND: Record<string, string> = {
   claude: 'claude', codex: 'codex', antigravity: 'antigravity', gemini: 'gemini',
-  opencode: 'opencode', crush: 'crush', pi: 'pi', qwen: 'qwen', copilot: 'copilot'
+  opencode: 'opencode', crush: 'crush', pi: 'pi', qwen: 'qwen', copilot: 'copilot',
+  cursor: 'agent'
 };
 
 /** Bare affirmations that must NEVER authorize a destructive op on their own —

--- a/src/main/realtimeActions.ts
+++ b/src/main/realtimeActions.ts
@@ -161,7 +161,7 @@ const PENDING_TTL_MS = 120_000;
 const PROVIDER_COMMAND: Record<string, string> = {
   claude: 'claude', codex: 'codex', antigravity: 'antigravity', gemini: 'gemini',
   opencode: 'opencode', crush: 'crush', pi: 'pi', qwen: 'qwen', copilot: 'copilot',
-  cursor: 'agent'
+  cursor: 'cursor-agent'
 };
 
 /** Bare affirmations that must NEVER authorize a destructive op on their own —

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -77,7 +77,7 @@ const DESCRIPTION_TEMPLATES: { label: string; description: string; goal: string 
 // Copy-paste prompt the user hands to any AI to generate a hire manifest. It pins
 // the exact JSON shape the importer accepts and ends with a fill-in section so the
 // user adds their own details (item 7). Kept in sync with the HireManifest schema
-// (src/shared/hire.ts) — provider allowlist is claude | codex | antigravity.
+// (src/shared/hire.ts) — provider allowlist is claude | codex | antigravity | cursor.
 const HIRE_PROMPT = `You are designing a "hire" — a ready-to-spawn AI agent for Munder Difflin, an app that runs a team of CLI coding agents. Output ONE JSON object (a hire manifest) and nothing else.
 
 Make the agent genuinely useful: give it a sharp role, a concrete standing goal, and a description that makes it behave like an expert operator of its CLI engine (Claude Code, Codex, or Antigravity/Gemini). It should know how to use the terminal, read and edit files, run and inspect commands, lean on available skills and MCP tools, keep notes in memory, and work autonomously toward its goal without hand-holding.
@@ -98,7 +98,7 @@ Return EXACTLY this shape (omit optional fields you don't need; keep the spec st
 }
 
 Rules:
-- "provider" MUST be one of: claude | codex | antigravity. "model" must be a real model id for that provider (e.g. claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
+- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
 - Do NOT include shell commands or any flags beyond these fields.
 - Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
 

--- a/src/renderer/src/components/AgentDetailPanel.tsx
+++ b/src/renderer/src/components/AgentDetailPanel.tsx
@@ -12,6 +12,7 @@ import { SidebarTabs } from './SidebarTabs';
 import { ThreadsPanel } from './ThreadsPanel';
 import { ToolWaterfall } from './ToolWaterfall';
 import { AgentControlStrip } from './AgentControlStrip';
+import { EditAgentModal } from './EditAgentModal';
 import { GitTab } from './GitTab';
 import { Icon } from './Icon';
 import { useStore, type Agent } from '@/store/store';
@@ -24,6 +25,7 @@ export interface AgentDetailPanelProps {
 export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
   const [openTerminalState, setOpenTerminalState] = useState<'idle' | 'opening' | 'ok' | 'error'>('idle');
   const [openTerminalError, setOpenTerminalError] = useState<string | undefined>();
+  const [editOpen, setEditOpen] = useState(false);
   const archiveAgent = useStore(s => s.archiveAgent);
   const updateAgent = useStore(s => s.updateAgent);
   const setFullscreen = useStore(s => s.setFullscreen);
@@ -117,6 +119,14 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
             }}>{agent.project}</span>
           </div>
         </div>
+        <PixelButton
+          variant="secondary"
+          size="sm"
+          onClick={() => setEditOpen(true)}
+          title="Edit identity, engine, and briefing"
+        >
+          edit
+        </PixelButton>
         {/* v0.3.4: the IDE lives at agent level (replaces the old files tab) —
             opens the full-window Monaco editor rooted at this agent's workspace. */}
         <PixelButton variant="secondary" size="sm" onClick={() => useStore.getState().setIdeOpen(true)}>
@@ -201,6 +211,10 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
           <ToolWaterfall agentId={agent.id} />
         )}
       </div>
+
+      {editOpen && (
+        <EditAgentModal agent={agent} onClose={() => setEditOpen(false)} />
+      )}
     </PixelPanel>
   );
 }

--- a/src/renderer/src/components/EditAgentModal.tsx
+++ b/src/renderer/src/components/EditAgentModal.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useState, type CSSProperties } from 'react';
+import { PixelPanel } from './PixelPanel';
+import { PixelButton } from './PixelButton';
+import { SpritePortrait } from './SpritePortrait';
+import { ProviderLogo } from './ProviderLogo';
+import { useStore, type Agent } from '@/store/store';
+import { OFFICE_CAST, type OfficeCharacterName } from '@/scene/office/cast';
+import { type AccentColorName } from '@/design/tokens';
+import {
+  type AgentProvider,
+  type HarnessConfig,
+  AGENT_PROVIDER_PRESETS,
+  buildSpawnCommand,
+  modelsForProvider,
+  inferAgentProvider,
+  providerPreset,
+  isClaudeProvider
+} from '@/store/config';
+
+const ACCENTS: AccentColorName[] = ['coral', 'mint', 'sky', 'lemon', 'lilac', 'peach'];
+
+export interface EditAgentModalProps {
+  agent: Agent;
+  onClose: () => void;
+}
+
+/**
+ * Compact post-hire editor for Identity / Engine / Briefing. Mirrors the Add
+ * Agent fields that matter after spawn; save only patches the durable roster
+ * via updateAgent (engine changes apply on the next restart).
+ */
+export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
+  const updateAgent = useStore((s) => s.updateAgent);
+  const [config, setConfig] = useState<HarnessConfig | null>(null);
+
+  const [name, setName] = useState(agent.name);
+  const [character, setCharacter] = useState<OfficeCharacterName>(agent.character);
+  const [accent, setAccent] = useState<AccentColorName>(agent.accent);
+  const [provider, setProvider] = useState<AgentProvider>(
+    inferAgentProvider(agent.command, agent.provider)
+  );
+  const [model, setModel] = useState<string | undefined>(agent.model);
+  const [description, setDescription] = useState(agent.description);
+  const [goal, setGoal] = useState(agent.goal ?? '');
+
+  useEffect(() => {
+    void window.cth.getConfig().then(setConfig).catch(() => setConfig(null));
+  }, []);
+
+  // Keep form in sync when the selected agent changes while the modal is open.
+  useEffect(() => {
+    setName(agent.name);
+    setCharacter(agent.character);
+    setAccent(agent.accent);
+    setProvider(inferAgentProvider(agent.command, agent.provider));
+    setModel(agent.model);
+    setDescription(agent.description);
+    setGoal(agent.goal ?? '');
+  }, [agent.id]);
+
+  const pickProvider = (id: AgentProvider) => {
+    setProvider(id);
+    if (!config) {
+      setModel(undefined);
+      return;
+    }
+    const nextModel = isClaudeProvider(id) ? config.defaultModel : config.providerDefaultModels?.[id];
+    setModel(nextModel);
+  };
+
+  const preset = providerPreset(provider);
+
+  const save = () => {
+    const trimmedName = name.trim() || agent.name;
+    const trimmedDescription = description.trim() || 'a fresh harness';
+    const trimmedGoal = goal.trim();
+    const command = config
+      ? buildSpawnCommand(config, model, provider)
+      : agent.command;
+
+    updateAgent(agent.id, {
+      name: trimmedName,
+      character,
+      accent,
+      provider,
+      model,
+      command,
+      description: trimmedDescription,
+      goal: trimmedGoal || undefined
+    });
+    onClose();
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0,
+        background: 'rgba(26, 19, 32, 0.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 500
+      }}
+    >
+      <div onClick={(e) => e.stopPropagation()} style={{ width: 520, maxWidth: '94vw' }}>
+        <PixelPanel variant="dialog" title="EDIT AGENT" style={{ padding: 16 }} noPadding>
+          <div style={{
+            display: 'flex', flexDirection: 'column', gap: 14,
+            padding: 16, maxHeight: '82vh', overflowY: 'auto'
+          }}>
+            <Section label="Identity" hint="name · character · color">
+              <Row label="Name">
+                <input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Stanley"
+                  style={inputStyle}
+                  autoFocus
+                />
+              </Row>
+
+              <Row label="Character">
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  {OFFICE_CAST.map((c) => {
+                    const active = character === c.name;
+                    return (
+                      <button
+                        key={c.name}
+                        type="button"
+                        onClick={() => { setCharacter(c.name); setName(c.displayName); }}
+                        title={c.blurb}
+                        style={{
+                          padding: 4,
+                          background: active ? `var(--cth-${accent}-light)` : 'var(--cth-cream-100)',
+                          boxShadow: active
+                            ? 'inset 0 0 0 1.5px var(--cth-ink-500)'
+                            : 'inset 0 0 0 1px var(--cth-ink-100)',
+                          cursor: 'pointer', border: 'none', width: 52,
+                          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2
+                        }}
+                      >
+                        <div style={{
+                          width: 40, height: 48,
+                          display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
+                          overflow: 'hidden'
+                        }}>
+                          <SpritePortrait character={c.name} scale={1.5} />
+                        </div>
+                        <span style={{ fontSize: 10, color: 'var(--cth-ink-700)' }}>{c.displayName}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </Row>
+
+              <Row label="Color">
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {ACCENTS.map((a) => (
+                    <button
+                      key={a}
+                      type="button"
+                      onClick={() => setAccent(a)}
+                      title={a}
+                      style={{
+                        width: 28, height: 28,
+                        background: `var(--cth-${a})`,
+                        boxShadow: accent === a
+                          ? 'inset 0 0 0 1.5px var(--cth-ink-500), 0 0 0 2px var(--cth-ink-900)'
+                          : 'inset 0 0 0 1px var(--cth-ink-300)',
+                        cursor: 'pointer', border: 'none'
+                      }}
+                    />
+                  ))}
+                </div>
+              </Row>
+            </Section>
+
+            <Section label="Engine" hint="provider · model · next restart">
+              <Row label="Provider">
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  {AGENT_PROVIDER_PRESETS.map((p) => {
+                    const active = provider === p.id;
+                    return (
+                      <button
+                        key={p.id}
+                        type="button"
+                        onClick={() => pickProvider(p.id)}
+                        title={p.label}
+                        style={{
+                          padding: '3px 8px 1px',
+                          background: active ? `var(--cth-${accent}-light)` : 'var(--cth-cream-100)',
+                          boxShadow: active
+                            ? 'inset 0 0 0 1.5px var(--cth-ink-500)'
+                            : 'inset 0 0 0 1px var(--cth-ink-100)',
+                          fontFamily: 'var(--cth-font-ui)', fontSize: 12,
+                          color: 'var(--cth-ink-900)', cursor: 'pointer', border: 'none',
+                          display: 'inline-flex', alignItems: 'center', gap: 6
+                        }}
+                      >
+                        <ProviderLogo provider={p.id} size={14} />
+                        {p.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </Row>
+
+              {preset.supportsModel && (
+                <Row label="Model">
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    {(() => {
+                      const known = modelsForProvider(provider);
+                      return model && !known.some((m) => m.id === model)
+                        ? [...known, { id: model, label: `${model} (current)` }]
+                        : known;
+                    })().map((m) => {
+                      const active = (model ?? '') === (m.id ?? '');
+                      return (
+                        <button
+                          key={m.label}
+                          type="button"
+                          onClick={() => setModel(m.id)}
+                          title={m.id ?? 'CLI default model'}
+                          style={{
+                            padding: '3px 8px 1px',
+                            background: active ? `var(--cth-${accent}-light)` : 'var(--cth-cream-100)',
+                            boxShadow: active
+                              ? 'inset 0 0 0 1.5px var(--cth-ink-500)'
+                              : 'inset 0 0 0 1px var(--cth-ink-100)',
+                            fontFamily: 'var(--cth-font-ui)', fontSize: 12,
+                            color: 'var(--cth-ink-900)', cursor: 'pointer', border: 'none'
+                          }}
+                        >
+                          {m.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </Row>
+              )}
+
+              <span style={{ fontSize: 12, color: 'var(--cth-ink-500)', lineHeight: '16px' }}>
+                Engine changes are saved for the next restart. Use Command Center → Floor to restart a live session onto a new provider/model now.
+              </span>
+            </Section>
+
+            <Section label="Briefing" hint="description · goal">
+              <Row label="Description">
+                <input
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="what is this agent for"
+                  style={inputStyle}
+                />
+              </Row>
+
+              <Row label="Goal (optional)">
+                <textarea
+                  value={goal}
+                  onChange={(e) => setGoal(e.target.value)}
+                  placeholder="long-running directive injected on every prompt"
+                  rows={4}
+                  style={{ ...inputStyle, fontFamily: 'var(--cth-font-ui)', resize: 'vertical', minHeight: 72 }}
+                />
+              </Row>
+            </Section>
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4 }}>
+              <PixelButton variant="ghost" size="md" onClick={onClose}>cancel</PixelButton>
+              <div style={{ flex: 1 }} />
+              <PixelButton variant="primary" size="md" onClick={save}>save changes</PixelButton>
+            </div>
+          </div>
+        </PixelPanel>
+      </div>
+    </div>
+  );
+}
+
+const inputStyle: CSSProperties = {
+  width: '100%',
+  padding: '6px 8px 4px',
+  background: 'var(--cth-paper-100)',
+  border: 'none',
+  boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
+  fontFamily: 'var(--cth-font-ui)',
+  fontSize: 16,
+  color: 'var(--cth-ink-900)',
+  outline: 'none',
+  boxSizing: 'border-box'
+};
+
+function Section({
+  label,
+  hint,
+  children
+}: {
+  label: string;
+  hint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <span style={{
+          fontFamily: 'var(--cth-font-display)',
+          fontSize: 9, lineHeight: '12px',
+          color: 'var(--cth-ink-900)',
+          textTransform: 'uppercase'
+        }}>{label}</span>
+        <span style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>{hint}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <span style={{
+        fontFamily: 'var(--cth-font-display)',
+        fontSize: 8, lineHeight: '12px',
+        color: 'var(--cth-ink-700)',
+        textTransform: 'uppercase'
+      }}>{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -28,9 +28,9 @@ interface Feature {
 const FEATURES: Feature[] = [
   {
     icon: 'mcp',
-    label: 'TEN ENGINES, ONE OFFICE',
-    desc: 'Claude Code, Codex, Grok, Kimi, Antigravity, Qwen, OpenCode, Crush, pi & Copilot — live agents on one floor.',
-    descPlain: 'Ten AI assistants — Claude, Codex, Gemini, Grok and more — working side by side in one shared office.',
+    label: 'ELEVEN ENGINES, ONE OFFICE',
+    desc: 'Claude Code, Codex, Grok, Kimi, Antigravity, Qwen, OpenCode, Crush, pi, Copilot & Cursor — live agents on one floor.',
+    descPlain: 'Eleven AI assistants — Claude, Codex, Cursor, Gemini, Grok and more — working side by side in one shared office.',
     tint: 'var(--cth-lilac-light)', edge: 'var(--cth-lilac)'
   },
   {
@@ -76,7 +76,8 @@ const PROVIDER_BLURB: Partial<Record<AgentProvider, string>> = {
   claude: 'Claude Code — Anthropic',
   codex: 'Codex — OpenAI',
   antigravity: 'Antigravity — Google Gemini',
-  qwen: 'Qwen — runs a local Qwen model on your machine'
+  qwen: 'Qwen — runs a local Qwen model on your machine',
+  cursor: 'Cursor Agent CLI — uses your Cursor credits (Luna, Composer, …)'
 };
 
 export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../shared/providerAutomation';
 import { DEFAULT_CONTEXT_TRIGGER, type ContextRule } from '../../../shared/triggers';
 import type { AgentProvider } from '../../../shared/agentProvider';
+import { bridgeOf, providerPreset } from '../../../shared/agentProvider';
 import { acquireTerminal, resetTerminal, isTerminalAutomationSafe } from '@/components/terminalPool';
 import { deliverWithAcknowledgement } from './queueDelivery';
 import { OFFICE_CAST, DEFAULT_CHARACTER } from '@/scene/office/cast';
@@ -45,6 +46,26 @@ const BOOT_GRACE_MS = 35_000;
 // long enough for the TUI to finish painting and surface any permission prompt.
 // submitToPty additionally waits for the terminal's readiness handshake.
 const SEED_BOOT_MS = 12_000;
+
+/** Hive-aware / hooks-bridge engines get standing goals via HookServer
+ *  (SessionStart + UserPromptSubmit). Cursor and other no-hook engines need the
+ *  goal prepended onto queued PTY deliveries so an Edit Agent save still lands
+ *  on the next drain cycle without a restart. */
+function usesHookStandingGoal(agent: Agent): boolean {
+  const provider = inferAgentProvider(agent.command, agent.provider);
+  const preset = providerPreset(provider);
+  if (preset.hiveAware) return true;
+  return bridgeOf(provider)?.kind === 'hooks';
+}
+
+/** Prepend `<goal>…</goal>` for engines that cannot inject via hooks. Reads the
+ *  live store field, so a just-saved goal is picked up on the next queue flush. */
+function withStandingGoal(agent: Agent, text: string): string {
+  const goal = agent.goal?.trim();
+  if (!goal || usesHookStandingGoal(agent)) return text;
+  if (text.includes('<goal>')) return text;
+  return `<goal>\n${goal}\n</goal>\n\n${text}`;
+}
 
 // The first thing Michael (god) is told on a fresh spawn — orient him and put
 // him to work running the floor. Kept terse and action-oriented.
@@ -657,7 +678,11 @@ export function useHive(config: HarnessConfig | null): void {
             useStore.getState().updateAgent(a.id, { seedPrompt: seed });
             return;
           }
-          submitToPty(ptyId, seed, inferAgentProvider(live.command, live.provider))
+          submitToPty(
+            ptyId,
+            withStandingGoal(live, seed),
+            inferAgentProvider(live.command, live.provider)
+          )
             .catch(() => { /* pty may have died */ });
         }, SEED_BOOT_MS);
       }
@@ -717,7 +742,10 @@ export function useHive(config: HarnessConfig | null): void {
           // the PTY; UI/card surfaces continue to show the readable `text`.
           () => submitToPty(
             target.ptyId!,
-            wrap ? wrap(next) : (next.instruction ?? next.text),
+            withStandingGoal(
+              target,
+              wrap ? wrap(next) : (next.instruction ?? next.text)
+            ),
             inferAgentProvider(target.command, target.provider)
           ),
           () => {

--- a/src/renderer/src/hooks/usePtyParser.ts
+++ b/src/renderer/src/hooks/usePtyParser.ts
@@ -63,7 +63,6 @@ export function usePtyParser(agentId: string) {
       updateAgent(agentId, {
         status: 'idle',
         action: 'awaiting',
-        description: 'on standby',
         carrying: undefined,
         currentStation: 'desk'
       });
@@ -124,7 +123,6 @@ export function usePtyParser(agentId: string) {
       updateAgent(agentId, {
         status: 'working',
         action: summary,
-        description: summary,
         currentStation: station,
         carrying
       });
@@ -155,7 +153,6 @@ export function usePtyParser(agentId: string) {
         updateAgent(agentId, {
           status: 'blocked',
           action: 'waiting on you',
-          description: 'waiting on you',
           currentStation: 'mailbox',
           blockReason: {
             summary: 'Waiting for your reply',
@@ -170,7 +167,6 @@ export function usePtyParser(agentId: string) {
         updateAgent(agentId, {
           status: 'waiting',
           action: 'waiting on god',
-          description: 'waiting on god',
           currentStation: 'desk',
           blockReason: undefined
         });

--- a/src/renderer/src/realtime/actions.ts
+++ b/src/renderer/src/realtime/actions.ts
@@ -187,7 +187,7 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
       parameters: {
         type: 'object',
         properties: {
-          provider: { type: 'string', description: 'Engine: claude (default), codex, gemini, opencode, crush, pi, qwen, copilot.' },
+          provider: { type: 'string', description: 'Engine: claude (default), codex, gemini, opencode, crush, pi, qwen, copilot, cursor.' },
           role: { type: 'string', description: 'Optional. The role/job for the new agent.' },
           name: { type: 'string', description: 'Optional. A name for the agent.' },
           cwd: { type: 'string', description: 'Optional. Working directory; defaults to the hive root.' }

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -276,6 +276,23 @@ export const COPILOT_MODELS: ModelOption[] = [
   { id: 'gpt-5', label: 'GPT-5' }
 ];
 
+/** Models offered when an agent runs on Cursor Agent CLI (`agent`). Ids match
+ *  `agent models` / `--model` (Cursor account catalog). Luna is the cheap,
+ *  high-context default for Michael; other entries are curated quick-picks —
+ *  the command field stays editable for any live slug. */
+export const CURSOR_MODELS: ModelOption[] = [
+  { id: undefined, label: 'CLI default (auto)' },
+  { id: 'auto', label: 'Auto' },
+  { id: 'gpt-5.6-luna-high', label: 'GPT-5.6 Luna 1M High (cheap)' },
+  { id: 'gpt-5.6-sol-medium', label: 'GPT-5.6 Sol 1M' },
+  { id: 'gpt-5.6-sol-high', label: 'GPT-5.6 Sol 1M High' },
+  { id: 'composer-2.5', label: 'Composer 2.5' },
+  { id: 'composer-2.5-fast', label: 'Composer 2.5 Fast' },
+  { id: 'gpt-5.2', label: 'GPT-5.2' },
+  { id: 'claude-opus-4-8-high', label: 'Opus 4.8 1M' },
+  { id: 'claude-sonnet-5-thinking-high', label: 'Sonnet 5 1M Thinking' }
+];
+
 /** Models reported by the installed Grok CLI (`grok models`). */
 export const GROK_MODELS: ModelOption[] = [
   // No `--model` flag at all — whatever the CLI itself defaults to. NOT the
@@ -318,6 +335,7 @@ export function modelsForProvider(provider: AgentProvider): ModelOption[] {
   if (provider === 'crush') return CRUSH_MODELS;
   if (provider === 'pi') return PI_MODELS;
   if (provider === 'copilot') return COPILOT_MODELS;
+  if (provider === 'cursor') return CURSOR_MODELS;
   if (provider === 'custom') return [];
   return AGENT_MODELS;
 }

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -276,8 +276,8 @@ export const COPILOT_MODELS: ModelOption[] = [
   { id: 'gpt-5', label: 'GPT-5' }
 ];
 
-/** Models offered when an agent runs on Cursor Agent CLI (`agent`). Ids match
- *  `agent models` / `--model` (Cursor account catalog). Luna is the cheap,
+/** Models offered when an agent runs on Cursor Agent CLI (`cursor-agent`). Ids match
+ *  `cursor-agent models` / `--model` (Cursor account catalog). Luna is the cheap,
  *  high-context default for Michael; other entries are curated quick-picks —
  *  the command field stays editable for any live slug. */
 export const CURSOR_MODELS: ModelOption[] = [

--- a/src/renderer/src/store/mockEvents.ts
+++ b/src/renderer/src/store/mockEvents.ts
@@ -162,7 +162,6 @@ export function startMockLoop() {
         updateAgent(a.id, {
           status: 'idle',
           action: 'awaiting',
-          description: 'on standby',
           carrying: undefined,
           recentAssistantText: 'Done with that one. What next?',
           recentTextTs: Date.now()

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -32,6 +32,7 @@ export type AgentProvider =
   | 'crush'
   | 'pi'
   | 'copilot'
+  | 'cursor'
   | 'custom';
 
 /** Structured descriptor for how a NON-hiveAware provider gets hive lifecycle
@@ -466,6 +467,44 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     docsUrl: 'https://docs.github.com/copilot/concepts/agents/about-copilot-cli'
   },
   {
+    // Cursor Agent CLI (`agent`, https://cursor.com/docs/cli). Interactive TUI by
+    // default (no `-p`), so the session stays alive for hive mail via the renderer
+    // idle / work-order path — same class as Crush. Print mode (`agent -p`) is
+    // available for scripts but exits per turn; this preset intentionally does
+    // NOT use `-p` so Michael and workers remain god-eligible / inbox-capable.
+    // Models (including cheap gpt-5.6-luna-*) bill against Cursor credits via the
+    // logged-in CLI — there is no separate "plain OpenAI API" path for Luna.
+    id: 'cursor',
+    label: 'Cursor',
+    defaultCommand: 'agent',
+    commandGroups: [],
+    // --force/--yolo: allow tool calls without confirmations. --trust: skip the
+    // workspace trust prompt so unattended Mac Mini spawns do not stall. Gated by
+    // the floor config.autoMode toggle like every other engine.
+    autoModeFlag: '--force --trust',
+    autoFlag: '--force --trust',
+    supportsModel: true,
+    modelFlag: '--model', // e.g. gpt-5.6-luna-high, auto, composer-2.5
+    hiveAware: false,
+    // No Cursor hook bridge yet — mail delivery uses the terminal work-order /
+    // idle-nudge fallback (same honesty as Crush before its proxy is verified).
+    canReceiveInbox: true,
+    // `agent` parses early argv as Cobra-style commands (login, models, mcp, …).
+    // A long hive protocol string must NOT ride as a positional — type it into
+    // the TUI after boot instead (Crush pattern).
+    initialPromptFlag: undefined,
+    seedDelivery: 'type-into-tui',
+    recommendedOrchestratorModel: 'gpt-5.6-luna-high',
+    resumeFlag: '--resume',
+    // Official install is a curl|bash script (not npm). Prefer the native rung so
+    // a node-free machine can still self-heal. Trusted hardcoded constants only.
+    nativeInstallCommand: {
+      posix: 'curl https://cursor.com/install -fsS | bash',
+      win32: 'irm https://cursor.com/install?win32=true | iex'
+    },
+    docsUrl: 'https://cursor.com/docs/cli/install'
+  },
+  {
     id: 'custom',
     label: 'Custom',
     defaultCommand: '',
@@ -490,6 +529,7 @@ export function isAgentProvider(value: unknown): value is AgentProvider {
     value === 'crush' ||
     value === 'pi' ||
     value === 'copilot' ||
+    value === 'cursor' ||
     value === 'custom'
   );
 }
@@ -540,6 +580,8 @@ export function inferAgentProvider(command: string | undefined, explicit?: unkno
   if (bin === 'crush') return 'crush';
   if (bin === 'pi') return 'pi';
   if (bin === 'copilot') return 'copilot';
+  // Cursor ships as `agent` (and sometimes `cursor-agent` on older installs).
+  if (bin === 'agent' || bin === 'cursor-agent') return 'cursor';
   if (bin === 'claude' || !bin) return 'claude';
   return 'custom';
 }

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -467,16 +467,17 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     docsUrl: 'https://docs.github.com/copilot/concepts/agents/about-copilot-cli'
   },
   {
-    // Cursor Agent CLI (`agent`, https://cursor.com/docs/cli). Interactive TUI by
-    // default (no `-p`), so the session stays alive for hive mail via the renderer
-    // idle / work-order path — same class as Crush. Print mode (`agent -p`) is
+    // Cursor Agent CLI (`cursor-agent`, https://cursor.com/docs/cli). The official
+    // installer puts `cursor-agent` on PATH; `agent` is a shorter alias. Interactive
+    // TUI by default (no `-p`), so the session stays alive for hive mail via the
+    // renderer idle / work-order path — same class as Crush. Print mode (`-p`) is
     // available for scripts but exits per turn; this preset intentionally does
     // NOT use `-p` so Michael and workers remain god-eligible / inbox-capable.
     // Models (including cheap gpt-5.6-luna-*) bill against Cursor credits via the
     // logged-in CLI — there is no separate "plain OpenAI API" path for Luna.
     id: 'cursor',
     label: 'Cursor',
-    defaultCommand: 'agent',
+    defaultCommand: 'cursor-agent',
     commandGroups: [],
     // --force/--yolo: allow tool calls without confirmations. --trust: skip the
     // workspace trust prompt so unattended Mac Mini spawns do not stall. Gated by
@@ -489,7 +490,7 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     // No Cursor hook bridge yet — mail delivery uses the terminal work-order /
     // idle-nudge fallback (same honesty as Crush before its proxy is verified).
     canReceiveInbox: true,
-    // `agent` parses early argv as Cobra-style commands (login, models, mcp, …).
+    // `cursor-agent` parses early argv as Cobra-style commands (login, models, mcp, …).
     // A long hive protocol string must NOT ride as a positional — type it into
     // the TUI after boot instead (Crush pattern).
     initialPromptFlag: undefined,
@@ -580,8 +581,9 @@ export function inferAgentProvider(command: string | undefined, explicit?: unkno
   if (bin === 'crush') return 'crush';
   if (bin === 'pi') return 'pi';
   if (bin === 'copilot') return 'copilot';
-  // Cursor ships as `agent` (and sometimes `cursor-agent` on older installs).
-  if (bin === 'agent' || bin === 'cursor-agent') return 'cursor';
+  // Cursor ships as `cursor-agent`; `agent` is a shorter alias (generic name — check last).
+  if (bin === 'cursor-agent') return 'cursor';
+  if (bin === 'agent') return 'cursor';
   if (bin === 'claude' || !bin) return 'claude';
   return 'custom';
 }

--- a/src/shared/hire.ts
+++ b/src/shared/hire.ts
@@ -37,7 +37,7 @@ export const BUNDLED_SKILL_IDS: ReadonlySet<string> = new Set([
 /** Providers a manifest may request ('agy' is accepted as an alias for
  *  'antigravity'). 'custom' is deliberately NOT allowed — it would let a
  *  manifest choose an arbitrary local binary. */
-export type HireProvider = 'claude' | 'antigravity' | 'codex';
+export type HireProvider = 'claude' | 'antigravity' | 'codex' | 'cursor';
 
 export interface HireManifest {
   /** Spec tag; exactly `munder-difflin/hire@1` for this version. */
@@ -90,7 +90,7 @@ export interface HireValidation {
   consentRequired?: string[];
 }
 
-const PROVIDERS: readonly string[] = ['claude', 'antigravity', 'codex'];
+const PROVIDERS: readonly string[] = ['claude', 'antigravity', 'codex', 'cursor'];
 const MAX_BYTES = 64 * 1024;
 
 /** A flag ("-x", "--flag", "--flag=value") or a bare value token that may follow

--- a/src/shared/providerAutomation.ts
+++ b/src/shared/providerAutomation.ts
@@ -133,6 +133,12 @@ const CONTEXT_COMMANDS: Record<AgentProvider, ProviderContextCommands> = {
   // into, so both are null by construction rather than by ignorance.
   copilot: NO_CONTEXT_COMMANDS,
 
+  // Cursor Agent CLI (`agent`) is interactive in this preset, but its slash /
+  // command surface is not yet verified against a frozen binary catalog in-repo.
+  // Prefer null over guessing — wrong slashes into a live TUI are worse than no
+  // auto-compact. Revisit when a shipped command table is transcribed.
+  cursor: NO_CONTEXT_COMMANDS,
+
   // An arbitrary user binary. We cannot know its command surface, and guessing
   // means typing slashes into someone's unknown REPL.
   custom: NO_CONTEXT_COMMANDS

--- a/test/agent-provider.test.cjs
+++ b/test/agent-provider.test.cjs
@@ -62,6 +62,32 @@ test('copilot passes model + resume through, non-hiveAware, never auto-receives 
   assert.strictEqual(ap.bridgeOf('copilot'), undefined, 'no hook/proxy bridge');
 });
 
+test('cursor is a recognized, selectable, god-eligible provider', () => {
+  assert.ok(ap.isAgentProvider('cursor'), 'isAgentProvider("cursor")');
+  assert.ok(ap.AGENT_PROVIDER_PRESETS.some((p) => p.id === 'cursor'), 'preset registered');
+  assert.strictEqual(ap.canReceiveInbox('cursor'), true, 'interactive TUI can receive inbox');
+});
+
+test('inferAgentProvider maps the agent / cursor-agent binary to cursor', () => {
+  assert.strictEqual(ap.inferAgentProvider('agent'), 'cursor');
+  assert.strictEqual(ap.inferAgentProvider('/Users/me/.local/bin/agent --model gpt-5.6-luna-high'), 'cursor');
+  assert.strictEqual(ap.inferAgentProvider('cursor-agent'), 'cursor');
+});
+
+test('cursor preset is interactive (no -p), uses force+trust auto flags, types seed into TUI', () => {
+  const p = ap.providerPreset('cursor');
+  assert.strictEqual(p.defaultCommand, 'agent', 'default command binary');
+  assert.strictEqual(p.initialPromptFlag, undefined, 'no -p; stay interactive');
+  assert.strictEqual(p.seedDelivery, 'type-into-tui', 'hive protocol typed after boot');
+  assert.strictEqual(ap.autoModeFlagForProvider('cursor'), '--force --trust');
+  assert.strictEqual(p.autoFlag, '--force --trust', 'autoFlag mirrors autoModeFlag');
+  assert.strictEqual(p.recommendedOrchestratorModel, 'gpt-5.6-luna-high');
+  assert.ok(p.supportsModel && p.modelFlag === '--model', 'model picker + --model');
+  assert.strictEqual(p.resumeFlag, '--resume', 'session resume flag');
+  assert.strictEqual(p.hiveAware, false, 'no Claude-only identity injection');
+  assert.strictEqual(ap.bridgeOf('cursor'), undefined, 'no hook/proxy bridge yet');
+});
+
 test('codex preset still resolves (no regression)', () => {
   assert.strictEqual(ap.inferAgentProvider('codex'), 'codex');
   assert.strictEqual(ap.providerPreset('codex').defaultCommand, 'codex');

--- a/test/agent-provider.test.cjs
+++ b/test/agent-provider.test.cjs
@@ -68,15 +68,15 @@ test('cursor is a recognized, selectable, god-eligible provider', () => {
   assert.strictEqual(ap.canReceiveInbox('cursor'), true, 'interactive TUI can receive inbox');
 });
 
-test('inferAgentProvider maps the agent / cursor-agent binary to cursor', () => {
-  assert.strictEqual(ap.inferAgentProvider('agent'), 'cursor');
-  assert.strictEqual(ap.inferAgentProvider('/Users/me/.local/bin/agent --model gpt-5.6-luna-high'), 'cursor');
+test('inferAgentProvider maps cursor-agent (canonical) and agent (alias) to cursor', () => {
   assert.strictEqual(ap.inferAgentProvider('cursor-agent'), 'cursor');
+  assert.strictEqual(ap.inferAgentProvider('/Users/me/.local/bin/cursor-agent --model gpt-5.6-luna-high'), 'cursor');
+  assert.strictEqual(ap.inferAgentProvider('agent'), 'cursor');
 });
 
 test('cursor preset is interactive (no -p), uses force+trust auto flags, types seed into TUI', () => {
   const p = ap.providerPreset('cursor');
-  assert.strictEqual(p.defaultCommand, 'agent', 'default command binary');
+  assert.strictEqual(p.defaultCommand, 'cursor-agent', 'default command binary');
   assert.strictEqual(p.initialPromptFlag, undefined, 'no -p; stay interactive');
   assert.strictEqual(p.seedDelivery, 'type-into-tui', 'hive protocol typed after boot');
   assert.strictEqual(ap.autoModeFlagForProvider('cursor'), '--force --trust');

--- a/test/cli-install-ladder.test.cjs
+++ b/test/cli-install-ladder.test.cjs
@@ -34,6 +34,17 @@ test('with npm absent, a provider shipping a native installer uses it', () => {
   assert.doesNotMatch(rung.command, /\bnpm\b/, 'the whole point is that npm is not there');
 });
 
+test('cursor prefers its native curl installer (no npm package)', () => {
+  const info = installInfoForProvider('cursor');
+  assert.equal(info.command, undefined, 'cursor is not an npm global package');
+  assert.ok(info.nativeCommand, 'ships curl|bash / irm|iex installer');
+  const withNpm = chooseInstallRung(info, true);
+  assert.equal(withNpm.kind, 'native', 'native rung even when npm exists');
+  const withoutNpm = chooseInstallRung(info, false);
+  assert.equal(withoutNpm.kind, 'native');
+  assert.match(withoutNpm.command, /cursor\.com\/install/);
+});
+
 test('with npm absent and no native installer, NOTHING is run', () => {
   const info = installInfoForProvider('codex');
   assert.equal(info.nativeCommand, undefined, 'fixture assumes codex has no native installer');

--- a/test/provider-automation.test.cjs
+++ b/test/provider-automation.test.cjs
@@ -17,7 +17,7 @@ const {
 // — the queue's one-pending-compact invariant depends entirely on this predicate —
 
 test('isCompactionCommand matches every provider that has a compact verb', () => {
-  for (const p of ['claude', 'codex', 'grok', 'kimi', 'qwen', 'opencode', 'pi', 'copilot']) {
+  for (const p of ['claude', 'codex', 'grok', 'kimi', 'qwen', 'opencode', 'pi', 'copilot', 'cursor']) {
     const cmd = compactionCommandForProvider(p, '');
     if (!cmd) continue; // provider has no typeable compaction — nothing to dedupe
     assert.equal(isCompactionCommand(cmd), true, `${p}: ${cmd}`);
@@ -58,7 +58,7 @@ test('each provider receives only its supported compaction syntax', () => {
   assert.equal(compactionCommandForProvider('pi', ''), '/compact');
 
   // No command we can trust → no keystrokes at all.
-  for (const p of ['antigravity', 'crush', 'copilot', 'custom']) {
+  for (const p of ['antigravity', 'crush', 'copilot', 'cursor', 'custom']) {
     assert.equal(compactionCommandForProvider(p), null, p);
   }
 });
@@ -95,8 +95,8 @@ test('clearing uses each CLI own verb, not a hardcoded /clear', () => {
   assert.equal(clearCommandForProvider('grok'), '/new');
   assert.equal(clearCommandForProvider('opencode'), '/new');
   assert.equal(clearCommandForProvider('pi'), '/new');
-  // Palette-only TUI, print-mode CLI, unknown binary: nothing typed can land.
-  for (const p of ['crush', 'copilot', 'custom']) {
+  // Palette-only TUI, print-mode CLI, Cursor (unverified slash surface), unknown binary.
+  for (const p of ['crush', 'copilot', 'cursor', 'custom']) {
     assert.equal(clearCommandForProvider(p), null, p);
   }
 });

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -103,12 +103,13 @@ test('Command Center model choices round-trip provider and model', () => {
 test('God only sees providers that can drain hive inbox messages', () => {
   // God-eligible = supportsModel && canReceiveInbox: kimi and copilot are
   // excluded (no inbox drain path), custom is excluded (no model picker).
+  // Cursor is interactive (no -p) so it IS god-eligible.
   assert.deepEqual(
     modelProvidersForAgent(true).map((preset) => preset.id),
-    ['claude', 'codex', 'grok', 'antigravity', 'qwen', 'opencode', 'crush', 'pi']
+    ['claude', 'codex', 'grok', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'cursor']
   );
   assert.deepEqual(
     modelProvidersForAgent(false).map((preset) => preset.id),
-    ['claude', 'codex', 'grok', 'kimi', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'copilot']
+    ['claude', 'codex', 'grok', 'kimi', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'copilot', 'cursor']
   );
 });


### PR DESCRIPTION
## What & why

Sorry for the churn on #145 — I closed that PR after your review because I realised it bundled unrelated changes (dependency upgrades, a personal sidebar feature) and I wanted to resubmit something cleaner. That was my mistake; I should have fixed it in place instead of closing it.

This PR replaces #145 with a focused set of changes:

1. **Cursor Agent CLI provider preset** — register `cursor` as a first-class, god-eligible provider so Michael and workers can run on Cursor credits. Interactive spawn (no `-p`) keeps the TUI alive for hive mail via `seedDelivery: 'type-into-tui'`; auto-mode uses `--force --trust`.
2. **Standing goal editor** — agents' standing goals are injected on session start (via hooks where supported, or prepended in `useHive` for engines without hook injection). Adds an Edit Agent modal from the agent detail panel.

**Review feedback addressed from #145:**
- No `package.json` / `package-lock.json` / `electron.vite.config.ts` changes
- No Project Noticeboard / sidebar tab / App layout restructure
- Default binary is now **`cursor-agent`** (canonical installer name); `agent` remains an alias in `inferAgentProvider`

Closes nothing — supersedes the intent of #145.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Screenshots / clips

Standing goal editor (visual change) — screenshot to follow in a comment after manual smoke test. Cursor provider appears in onboarding Step 2 model picker like other providers.

## Checklist

- [x] `npm run typecheck` passes (the de-facto CI gate).
- [ ] `npm run build` succeeds. *(not run in this environment — will verify locally)*
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`.
- [x] PR is focused on a single change. *(two related agent-management features; happy to split standing goals if you prefer)*

## Test plan

- [x] `node test/agent-provider.test.cjs`
- [x] `node --test test/provider-config.test.cjs test/provider-automation.test.cjs test/cli-install-ladder.test.cjs`
- [x] `npm run typecheck`
- [ ] Manual: `npm run dev` → onboarding Step 2 shows **Cursor** → pick `gpt-5.6-luna-high` → Michael spawns `cursor-agent --force --trust --model gpt-5.6-luna-high`
- [ ] Manual: Edit an agent's standing goal from the detail panel; confirm it appears on next session start
- [ ] Manual: missing `cursor-agent` on PATH triggers native install banner


Made with [Cursor](https://cursor.com)