### PR TITLE
fix(hive): let a broadcast reach agents on hookless providers

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -36,6 +36,7 @@ import {
   type AgentProvider
 } from '../shared/agentProvider';
 import { MCP_CATALOG } from '../shared/mcpCatalog';
+import { selectBroadcastTargets } from '../shared/broadcast';
 import { expandTilde } from './fs';
 
 /** The subset of HarnessConfig the hive consumes for the default-MCP merge.
@@ -1142,15 +1143,11 @@ export class HiveManager {
     const resolveTo = (to: string): string => (to === 'human' || to === 'god' ? godId : to);
     const targets = msg.to === 'broadcast'
       // The roster for fan-out is the ACTIVE registry: skip the send-only prep
-      // assistant, any archived agent (closed tab), and providers that can't
-      // expose safe-idle lifecycle state (hookless custom commands), so mail never
-      // piles into a dead inbox. Claude, Codex and Antigravity are included; their
-      // hooks let the renderer wake them only after a safe idle boundary.
-      ? Object.keys(reg.agents).filter((a) =>
-          a !== msg.from
-          && !reg.agents[a]?.isAssistant
-          && !reg.agents[a]?.archived
-          && canReceiveInbox(reg.agents[a]?.provider))
+      // assistant and any archived agent (closed tab). Hookless providers are
+      // NOT skipped — the per-target path below already serves them a terminal
+      // work order, so excluding them here only made a broadcast invisible to an
+      // agent that direct mail reaches fine. See selectBroadcastTargets.
+      ? selectBroadcastTargets(reg.agents, msg.from)
       // Never deliver to self — guards a god → "human" message looping back to god.
       : [resolveTo(msg.to)].filter((t) => t !== msg.from);
     for (const t of targets) {

--- a/src/shared/broadcast.ts
+++ b/src/shared/broadcast.ts
@@ -1,0 +1,48 @@
+/**
+ * Broadcast fan-out target selection.
+ *
+ * Kept as a pure function (and out of `hive.ts`) so the rule is testable on its
+ * own, the way `queueDelivery` / `codexRemote` are.
+ */
+
+/** The subset of a registry agent that fan-out actually looks at. */
+export interface BroadcastCandidate {
+  /** Michael's prep assistant — send-only, drains no inbox. */
+  isAssistant?: boolean;
+  /** PTY tab closed; the record is retained but the agent is not live. */
+  archived?: boolean;
+}
+
+/**
+ * The agents a `to: 'broadcast'` message fans out to.
+ *
+ * Excluded: the sender itself, the send-only prep assistant (direct mail to it
+ * would rot unread), and archived agents (no live PTY).
+ *
+ * NOT excluded: providers without a hook/proxy bridge. Fan-out used to gate on
+ * `canReceiveInbox`, which meant an agent on a hookless provider — `custom`,
+ * i.e. any CLI the presets don't know — silently never heard a broadcast, even
+ * though a DIRECT message to that same agent was delivered fine. That asymmetry
+ * was the bug: `deliver` already routes a hookless target through
+ * `emitTerminalHandoff` (a terminal work order) and only bounces to the god when
+ * the renderer is unavailable. Fan-out now selects the same agents direct mail
+ * can reach, and that existing per-target path decides HOW each one is served.
+ *
+ * The trade-off this accepts: with the renderer down, a broadcast to N hookless
+ * agents produces N bounces to the god instead of silence. That is the same
+ * behaviour N direct messages already produce, and it is the loud failure —
+ * nothing is dropped without the god being told.
+ */
+export function selectBroadcastTargets(
+  agents: Record<string, BroadcastCandidate | undefined>,
+  fromId: string
+): string[] {
+  return Object.keys(agents).filter((id) => {
+    const agent = agents[id];
+    if (!agent) return false;
+    if (id === fromId) return false;
+    if (agent.isAssistant) return false;
+    if (agent.archived) return false;
+    return true;
+  });
+}

--- a/test/broadcast-targets.test.cjs
+++ b/test/broadcast-targets.test.cjs
@@ -1,0 +1,45 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { selectBroadcastTargets } = loadTs('src/shared/broadcast.ts');
+
+const roster = {
+  michael: {},
+  dev1: {},
+  // A worker on a hookless provider (`custom`): no hook bridge, no proxy.
+  toby: {},
+  prep: { isAssistant: true },
+  creed: { archived: true }
+};
+
+test('a broadcast reaches every live agent except the sender', () => {
+  const targets = selectBroadcastTargets(roster, 'michael');
+  assert.deepEqual(targets.sort(), ['dev1', 'toby']);
+});
+
+test('the send-only prep assistant is never a broadcast target', () => {
+  assert.ok(!selectBroadcastTargets(roster, 'michael').includes('prep'));
+});
+
+test('an archived agent (closed PTY tab) is skipped', () => {
+  assert.ok(!selectBroadcastTargets(roster, 'michael').includes('creed'));
+});
+
+test('a hookless agent is included — direct mail already reaches it', () => {
+  // Regression: fan-out used to gate on canReceiveInbox, so an agent on the
+  // `custom` provider silently never heard a broadcast while a DIRECT message
+  // to the same agent was delivered as a terminal work order.
+  assert.ok(selectBroadcastTargets(roster, 'michael').includes('toby'));
+});
+
+test('the sender is excluded even when it is the only other agent', () => {
+  assert.deepEqual(selectBroadcastTargets({ solo: {} }, 'solo'), []);
+});
+
+test('a missing registry entry is not a target', () => {
+  const holes = { dev1: {}, ghost: undefined };
+  assert.deepEqual(selectBroadcastTargets(holes, 'michael'), ['dev1']);
+});


### PR DESCRIPTION
## The bug

Broadcast fan-out gated its target list on `canReceiveInbox`, so an agent running
the `custom` provider **never heard a `to: 'broadcast'` message** — while a
**direct** message to that very same agent was delivered fine, as a terminal work
order.

That asymmetry is the surprising part. From the office floor it looks like the
agent is present and reachable (you can mail it, it answers), but every broadcast
quietly skips it.

## Why the gate isn't needed

`deliver()` already knows how to serve a hookless target. For any target where
`canReceiveInbox` is false it calls `emitTerminalHandoff(msg, t)` and only bounces
to the god when the renderer is unavailable:

```ts
if (t !== godId && !canReceiveInbox(reg.agents[t]?.provider)) {
  if (!this.emitTerminalHandoff(msg, t)) {
    this.deliver({ ...msg, to: godId, subject: `[undeliverable — …]` }, godId);
  }
  continue;
}
```

So the extra gate on the fan-out list was redundant for the providers it let
through, and lossy for the ones it excluded.

Fan-out now selects the agents direct mail can reach — skipping the sender, the
send-only prep assistant, and archived agents, exactly as before — and the
existing per-target path decides *how* each one is served.

## Trade-off

With the renderer down, a broadcast to N hookless agents produces N bounces to the
god instead of silence. That is the same thing N direct messages already produce
today, and it is the loud failure rather than the quiet one — nothing is dropped
without the god being told.

## Shape of the change

The rule moved into `src/shared/broadcast.ts` as a pure function, so it is
testable on its own the way `queueDelivery` and `codexRemote` are. `hive.ts` calls
it and keeps everything else unchanged. The old comment in `hive.ts` explained the
hookless exclusion, so it is rewritten rather than left to describe behaviour that
no longer exists.

## Testing

- `npm run typecheck` — exit 0.
- 6 new tests in `test/broadcast-targets.test.cjs`, all passing.
- `npm run test:focused` — the set of failing tests is **identical before and
  after** this change (8 failures, all pre-existing).

### On those 8 pre-existing failures

I developed this on **Windows**, which `CONTRIBUTING.md` notes is untested. On a
clean checkout of `main`, `npm run test:focused` already fails 8 tests here, all
of them platform issues rather than logic ones:

- `codex-remote` — asserts a `unix://` socket path
- `cli-install-ladder` / `node-install` — asserts the npm/native installer rungs
- `transcript-project-dir` (4) — asserts POSIX path normalization, e.g. expects
  `-Users-me-MDv0-3-0` and gets a Windows path

I stashed this change and re-ran to confirm the same 8 fail without it. Happy to
be told if any of those are already known.

## What this PR does not do

No UI change, so no screenshot. It does not give `custom` a bridge — a hookless
agent still has no safe-idle lifecycle state, and still receives via the terminal
work-order path rather than the guarded inbox. This only stops broadcasts from
skipping it.
