### PR TITLE
docs: sync CONTRIBUTING.md with current cross-platform support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,15 @@ npm run dev        # live-reloading Electron build
 ## Before you open a PR
 
 1. **Keep the type-checker green:** `npm run typecheck` (runs both the node and
-   web TS projects). This is the de-facto CI gate — there is no test suite yet.
-2. **Confirm a production build works:** `npm run build`.
-3. **Match the aesthetic.** Any new UI **must** derive from the design tokens in
+   web TS projects). This is the de-facto CI gate.
+2. **Run the tests:** `npm run test:focused` (the core suite), or
+   `node --test test/*.test.cjs` to run everything in `test/`.
+3. **Confirm a production build works:** `npm run build`.
+4. **Match the aesthetic.** Any new UI **must** derive from the design tokens in
    [`DESIGN.md`](./DESIGN.md) / `src/renderer/src/design/tokens.ts` — no ad-hoc
    colors, spacing, or fonts. `tokens.ts` and `tokens.css` are mirrored; if you
    change one, change both.
-4. **For anything visual, include a screenshot or short clip** in the PR.
+5. **For anything visual, include a screenshot or short clip** in the PR.
 
 ## Project layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,16 @@ participating, you agree to uphold it.
 
 ### Prerequisites
 
-- **macOS** — the app is macOS-first. Windows/Linux are untested but PRs that
-  improve cross-platform support are welcome.
+- **macOS, Windows, or Linux** — signed/notarized macOS builds, plus Windows and
+  Linux builds, ship from the [releases page](https://github.com/chaitanyagiri/munder-difflin/releases/latest).
+  Cross-platform smoke-testing and fixes are still very welcome (see
+  [Good first areas](#good-first-areas)).
 - **Node.js 18+** and npm.
 - A **C/C++ toolchain** to build `node-pty`'s native addon. On macOS:
   ```bash
   xcode-select --install
   ```
+  On Windows/Linux, follow [`node-pty`'s own prerequisites](https://github.com/microsoft/node-pty#dependencies).
 - **[Claude Code](https://claude.com/claude-code)** on your `PATH` if you want
   agents to actually run `claude` (the default command). Any other command works.
 
@@ -68,7 +71,8 @@ data-flow overview.
   by a mock event loop (`src/renderer/src/store/mockEvents.ts`). Replacing it
   with real tool events is the headline next milestone.
 - The add-agent flow and config drawer.
-- Cross-platform smoke-testing (Linux/Windows).
+- Cross-platform smoke-testing — Windows and Linux builds ship, but real-world
+  coverage (WSL2, various distros, uncommon shells) is thin.
 
 ## Commit & PR conventions
 

--- a/README.md
+++ b/README.md
@@ -288,11 +288,12 @@ chrome. The 15 avatars are the cast of *The Office*, differentiated by hair/skin
 
 ## Roadmap
 
-Shipped through **v0.4.3** — ten agent engines with BYOK keys and local LLMs, voice orchestration,
+Shipped through **v0.4.4** — ten agent engines with BYOK keys and local LLMs, voice orchestration,
 the hive (memory · mailboxes · blackboard · event log), Command Center with kanban and schedules,
 a built-in Monaco IDE with git rails, integrations registry + secret broker, Slack-spawned workers,
 shareable hires and the Agent Gallery, observability and the circuit breaker, durable persistence,
-session resume, multi-window floors, and working auto-update.
+session resume, multi-window floors, working auto-update, a Skills browser, and a live Prerequisites
+check.
 Full history in [`CHANGELOG.md`](./CHANGELOG.md).
 
 Next up:


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` still described the app as macOS-first with Windows/Linux "untested," but `README.md` and the v0.4.4 release (which specifically fixed agent-to-agent messaging on Windows) show signed builds shipping for macOS, Windows, and Linux from the releases page. Updated the prerequisites to match, and pointed to `node-pty`'s own build dependencies for the Windows/Linux native toolchain step (the doc previously only covered macOS via `xcode-select`).
- Softened the "Cross-platform smoke-testing" good-first-area bullet to reflect that Windows/Linux builds now ship, while noting real-world coverage (WSL2, distros, uncommon shells) is still thin.
- `README.md`'s Roadmap section was still pinned to "Shipped through v0.4.3," even though the badge/version and the note above it already reflect v0.4.4. Bumped it and added the two v0.4.4 additions (Skills browser, Prerequisites check) that weren't mentioned there yet.

No code changes — docs only.

## Test plan

- [x] Read-through of `CHANGELOG.md` v0.4.4 entry and `git blame`/`git log` on both files to confirm the claims (CONTRIBUTING.md prerequisites last touched 2026-05-31, predating the v0.4.4 Windows fixes and README's current platform badge).
- [x] Verified the `node-pty` dependencies link resolves to a real `## Dependencies` section in that repo's README.
- N/A — no code/build changes to verify with `npm run typecheck` / `npm run build`.