### PR TITLE
Open a Discord, and hand contributors a role when their PR lands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,13 @@
 
 <!-- REQUIRED for any visual change: a screenshot or short clip (before/after). -->
 
+## Discord (optional)
+
+<!-- If you'd like the `employee of the month` role in our Discord when this merges,
+     put your handle below. Join first so we can find you: https://discord.gg/SEDzP5ZPk5 -->
+
+Discord: 
+
 ## Checklist
 
 - [ ] `npm run typecheck` passes (the de-facto CI gate).

--- a/.github/workflows/contributor-role.yml
+++ b/.github/workflows/contributor-role.yml
@@ -1,0 +1,65 @@
+# Grants the Discord "employee of the month" role when a PR is merged.
+#
+# pull_request_target is required so the job can see repo secrets for PRs opened
+# from forks. It deliberately does NOT check out the PR's code — the only thing
+# read from the pull request is its body text, and that arrives via an env var so
+# it is never interpolated into the shell.
+name: contributor role
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  grant:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: grant "employee of the month"
+        env:
+          BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          GUILD_ID: "1539397814352613496"
+          ROLE_ID: "1539474540298764308"
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          API=https://discord.com/api/v10
+
+          if [ -z "${BOT_TOKEN:-}" ]; then
+            echo "DISCORD_BOT_TOKEN is not set — nothing to do."; exit 0
+          fi
+
+          # "Discord: someone" anywhere in the PR body. Optional by design.
+          HANDLE=$(printf '%s' "${PR_BODY:-}" \
+            | grep -iEo 'Discord:[[:space:]]*[A-Za-z0-9._]+' \
+            | head -1 | sed -E 's/.*:[[:space:]]*//' || true)
+
+          if [ -z "$HANDLE" ]; then
+            echo "No Discord handle in the PR body from @$PR_AUTHOR — skipping (this is fine)."; exit 0
+          fi
+          echo "Looking up Discord handle: $HANDLE"
+
+          Q=$(jq -rn --arg q "$HANDLE" '$q|@uri')
+          USER_ID=$(curl -sS -H "Authorization: Bot $BOT_TOKEN" \
+              "$API/guilds/$GUILD_ID/members/search?query=$Q&limit=10" \
+            | jq -r --arg h "$HANDLE" \
+              '[.[] | select((.user.username // "" | ascii_downcase) == ($h | ascii_downcase))][0].user.id // empty')
+
+          if [ -z "$USER_ID" ]; then
+            echo "'$HANDLE' is not a member of the server yet — skipping."
+            echo "They can join at https://discord.gg/SEDzP5ZPk5 and we'll grant it on their next PR."
+            exit 0
+          fi
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' -X PUT \
+            -H "Authorization: Bot $BOT_TOKEN" -H 'Content-Length: 0' \
+            "$API/guilds/$GUILD_ID/members/$USER_ID/roles/$ROLE_ID")
+
+          case "$code" in
+            204) echo "Granted 'employee of the month' to $HANDLE ($USER_ID)." ;;
+            *)   echo "Discord returned HTTP $code — role not granted."; exit 1 ;;
+          esac

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ visualized as avatars at work on a shared office floor.
   <img alt="Status: prototype" src="https://img.shields.io/badge/status-working%20prototype-F4F1EA.svg?style=flat-square&labelColor=6E1423">
   <img alt="Platform: macOS | Windows | Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-F4F1EA.svg?style=flat-square&labelColor=6E1423">
   <a href="./CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
+  <a href="https://discord.gg/SEDzP5ZPk5"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20the%20office-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
 </p>
 
 <br>
@@ -310,6 +311,8 @@ Contributions are welcome — this is an early prototype with a lot of surface a
 [`CONTRIBUTING.md`](./CONTRIBUTING.md). The short version: fork, `npm install && npm run dev`, keep
 `npm run typecheck` green, and **derive any new UI from [`DESIGN.md`](./DESIGN.md) tokens**. Good
 first areas: wiring real hook events, the add-agent flow, the config drawer, and cross-platform work.
+
+Questions, bugs, or want to show off your office? Join the Discord: **<https://discord.gg/SEDzP5ZPk5>**. Add your Discord handle to a PR and you'll get the `employee of the month` role when it merges.
 
 ## Telemetry
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1010,6 +1010,7 @@
       <a class="txt" href="#security">Security</a>
       <a class="txt" href="#pricing">Pricing</a>
       <a class="txt" href="/blog/">Blog</a>
+      <a class="txt" href="https://discord.gg/SEDzP5ZPk5" target="_blank" rel="noopener">Discord</a>
       <a class="btn ghost sm" data-gh-stars href="https://github.com/chaitanyagiri/munder-difflin" target="_blank" rel="noopener">
         <span class="ic">★</span><span class="nav-gh-label">Star</span><span class="star-count"></span>
       </a>
@@ -1750,6 +1751,7 @@
     <div class="foot-links">
       <a href="https://github.com/chaitanyagiri/munder-difflin" target="_blank" rel="noopener">GitHub</a>
       <a href="/blog/">Blog</a>
+      <a href="https://discord.gg/SEDzP5ZPk5" target="_blank" rel="noopener">Discord</a>
       <a href="#pricing">Pricing</a>
       <a href="/wall.html">Founders' Wall</a>
       <a href="mailto:girichaitanya11@gmail.com">Contact</a>


### PR DESCRIPTION
Adds the community server to the site and automates the one part of it that shouldn't be manual. **No dependency on the app build** — this is site + CI only, safe to ship ahead of any release.

## What's here

| File | Change |
|---|---|
| `docs/index.html` | Discord link in the top nav and the footer |
| `README.md` | badge in the existing shields palette + a line in Contributing |
| `.github/PULL_REQUEST_TEMPLATE.md` | optional `Discord:` handle field |
| `.github/workflows/contributor-role.yml` | on merge → grant `employee of the month` |

Invite: https://discord.gg/SEDzP5ZPk5

## How the role automation works

On a merged PR the job reads an optional `Discord:` line from the PR body, resolves that handle against the server via `members/search`, and PUTs the role. No mapping file to maintain.

**Every miss exits 0** — no handle, handle not a member yet, or no token configured. This can never fail someone's merge.

## Security notes

- `pull_request_target` is required so fork PRs can see repo secrets. The job **does not check out PR code**.
- The only untrusted input is the PR body, passed via an env var so it's never interpolated into the shell.
- `permissions: contents: read` only.

## Before this does anything

Add a `DISCORD_BOT_TOKEN` repo secret. Guild and role IDs are inlined in the workflow (they're not secrets).

## Not included

`docs/media/hero-demo-9x16.mp4` is still untracked — unrelated to this change, so it's left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)