### PR TITLE
feat: add official Gemini CLI provider

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -711,6 +711,11 @@ export class HiveManager {
               // idle inbox-wake nudge is the guaranteed drain fallback.
               env.OPENCODE_CONFIG_DIR = this.installOpenCodePlugin(dir);
             }
+            else if (desc.shim === 'gemini') {
+              // Point only this worker at a per-agent system settings file so
+              // the bridge is trusted and ~/.gemini/settings.json stays untouched.
+              env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = this.installGeminiHooks(dir);
+            }
             else if (desc.shim === 'grok') this.installGrokHooks();
           } else if (desc.kind === 'proxy') {
             // Stable per-spawn session id, stamped on every synthesized payload so
@@ -1569,6 +1574,45 @@ export class HiveManager {
         writeFileSync(p, JSON.stringify(existing, null, 2), 'utf8');
       } catch { /* best-effort per file */ }
     }
+  }
+
+  /** Official Google Gemini CLI lifecycle bridge. Gemini's hook payload is
+   *  already snake_case; the shim maps event names into HookServer's common
+   *  vocabulary and translates deny/steering replies back to Gemini.
+   *
+   *  The system settings path is per agent. Gemini merges object and array
+   *  settings across layers, so auth and user settings remain in their normal
+   *  GEMINI_CLI_HOME while this trusted bridge stays isolated. */
+  private installGeminiHooks(dir: string): string {
+    const home = join(dir, '.gemini-hive');
+    const settingsPath = join(home, 'system-settings.json');
+    try {
+      mkdirSync(home, { recursive: true });
+      const shim = join(home, 'gemini-hook.cjs');
+      writeFileSync(shim, GEMINI_HOOK_SHIM, 'utf8');
+      const hook = (name: string, matcher?: string) => ({
+        ...(matcher ? { matcher } : {}),
+        sequential: true,
+        hooks: [{
+          name: `munder-hive-${name}`,
+          type: 'command',
+          command: this.nodeRunUnquoted(shim),
+          timeout: 30000
+        }]
+      });
+      const settings = {
+        hooksConfig: { enabled: true, notifications: false },
+        hooks: {
+          SessionStart: [hook('session-start')],
+          BeforeAgent: [hook('before-agent')],
+          BeforeTool: [hook('before-tool', '.*')],
+          AfterTool: [hook('after-tool', '.*')],
+          AfterAgent: [hook('after-agent')]
+        }
+      };
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
+    } catch (e) { console.error('[hive] installGeminiHooks failed:', e); }
+    return settingsPath;
   }
 
   /** Codex lifecycle-hook bridge → full hive parity for a `codex` worker (live
@@ -2531,6 +2575,60 @@ server.listen(0, '127.0.0.1', function () {
   const addr = server.address();
   const port = (addr && typeof addr === 'object') ? addr.port : 0;
   try { process.stdout.write(JSON.stringify({ port: port }) + '\\n'); } catch (e) {}
+});
+`;
+
+// Official Gemini CLI bridge. Gemini already sends snake_case payload fields;
+// normalize its event names, then translate HookServer decisions back into
+// Gemini's documented hook output contract.
+const GEMINI_HOOK_SHIM = `#!/usr/bin/env node
+'use strict';
+const net = require('net');
+const agentId = process.env.AGENT_ID || null;
+let data = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (d) => { data += d; });
+process.stdin.on('end', () => {
+  const sock = process.env.HIVE_SOCK;
+  if (!agentId || !sock) { process.exit(0); }
+  let gemini = {};
+  try { gemini = JSON.parse(data || '{}'); } catch (_) {}
+  const names = {
+    SessionStart: 'SessionStart',
+    BeforeAgent: 'UserPromptSubmit',
+    BeforeTool: 'PreToolUse',
+    AfterTool: 'PostToolUse',
+    AfterAgent: 'Stop'
+  };
+  const payload = {
+    ...gemini,
+    hook_event_name: names[gemini.hook_event_name] || gemini.hook_event_name || 'Unknown',
+    agent_id: agentId
+  };
+  let resp = '';
+  const done = () => {
+    let out = null;
+    try {
+      const r = JSON.parse(resp || '{}');
+      if (r.continue === false) out = { continue: false, stopReason: r.stopReason };
+      else if (r.decision === 'block') out = { decision: 'deny', reason: r.reason };
+      else if (r.hookSpecificOutput && r.hookSpecificOutput.permissionDecision === 'deny') {
+        out = { decision: 'deny', reason: r.hookSpecificOutput.permissionDecisionReason };
+      } else if (r.hookSpecificOutput && r.hookSpecificOutput.additionalContext) {
+        out = { hookSpecificOutput: { additionalContext: r.hookSpecificOutput.additionalContext } };
+      }
+    } catch (_) {}
+    if (out) { try { process.stdout.write(JSON.stringify(out)); } catch (_) {} }
+    process.exit(0);
+  };
+  try {
+    const c = net.createConnection(sock, () => c.write(JSON.stringify(payload) + '\\n'));
+    c.setEncoding('utf8');
+    c.on('data', (d) => { resp += d; });
+    c.on('end', done);
+    c.on('error', () => process.exit(0));
+    setTimeout(() => process.exit(0), 5000).unref();
+  } catch (_) { process.exit(0); }
 });
 `;
 

--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -73,6 +73,7 @@ const FEATURES: Feature[] = [
 // One-liner of what each engine is, shown under its row on the orchestrator step
 // so a non-technical user knows what they're picking (item 3).
 const PROVIDER_BLURB: Partial<Record<AgentProvider, string>> = {
+  gemini: 'Gemini CLI - Google Gemini',
   claude: 'Claude Code — Anthropic',
   codex: 'Codex — OpenAI',
   antigravity: 'Antigravity — Google Gemini',

--- a/src/renderer/src/components/ProviderLogo.tsx
+++ b/src/renderer/src/components/ProviderLogo.tsx
@@ -13,6 +13,9 @@ import type { AgentProvider } from '@/store/config';
 
 // Single-path fills (24×24 viewBox), official brand marks.
 const BRAND_PATHS: Partial<Record<AgentProvider, string>> = {
+  // Google Gemini CLI.
+  gemini:
+    'M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81',
   // Anthropic — powers Claude Code.
   claude:
     'M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z',

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -208,6 +208,16 @@ export const ANTIGRAVITY_MODELS: ModelOption[] = [
   { id: 'GPT-OSS 120B (Medium)', label: 'GPT-OSS 120B' }
 ];
 
+/** Stable model aliases accepted by the official Google Gemini CLI. The aliases
+ *  intentionally follow the CLI instead of pinning preview model ids that drift. */
+export const GEMINI_MODELS: ModelOption[] = [
+  { id: undefined, label: 'CLI default' },
+  { id: 'auto', label: 'Auto' },
+  { id: 'pro', label: 'Pro' },
+  { id: 'flash', label: 'Flash' },
+  { id: 'flash-lite', label: 'Flash Lite' }
+];
+
 /** Models offered when an agent runs on qwen-code (`qwen`), the proxy-bridge CLI
  *  driving an OpenAI-compatible endpoint. Starting suggestions only (editable
  *  command field). // TODO-verify the live list (`qwen` model ids). */
@@ -319,6 +329,7 @@ export function modelsForProvider(provider: AgentProvider): ModelOption[] {
   if (provider === 'codex') return CODEX_MODELS;
   if (provider === 'grok') return GROK_MODELS;
   if (provider === 'kimi') return KIMI_MODELS;
+  if (provider === 'gemini') return GEMINI_MODELS;
   if (provider === 'antigravity') return ANTIGRAVITY_MODELS;
   if (provider === 'qwen') return QWEN_MODELS;
   if (provider === 'opencode') return OPENCODE_MODELS;

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -26,6 +26,7 @@ export type AgentProvider =
   | 'codex'
   | 'grok'
   | 'kimi'
+  | 'gemini'
   | 'antigravity'
   | 'qwen'
   | 'opencode'
@@ -49,7 +50,7 @@ export type AgentProvider =
  *               and `inboxDelivery` is how mail reaches it ('terminal' work-order
  *               handoff today; 'serve' reserved for a future HTTP push path). */
 export type BridgeDescriptor =
-  | { kind: 'hooks'; shim: 'agy' | 'codex' | 'pi' | 'opencode' | 'grok' }
+  | { kind: 'hooks'; shim: 'agy' | 'codex' | 'pi' | 'opencode' | 'grok' | 'gemini' }
   | {
       kind: 'proxy';
       api: 'openai' | 'anthropic';
@@ -273,6 +274,29 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     // lifecycle hooks, but Munder Difflin does not yet install a Kimi hook bridge,
     // so mail must bounce rather than being delivered with no drain path.
     canReceiveInbox: false
+  },
+  {
+    // Google's official Gemini CLI. Unlike Antigravity (`agy`), this is the
+    // open-source `@google/gemini-cli` binary and uses Gemini's native settings
+    // hooks (BeforeTool/AfterTool/BeforeAgent/AfterAgent/SessionStart).
+    id: 'gemini',
+    label: 'Gemini CLI',
+    defaultCommand: 'gemini',
+    commandGroups: [],
+    // `--yolo` is deprecated upstream; approval-mode is the current spelling.
+    autoModeFlag: '--approval-mode=yolo',
+    autoFlag: '--approval-mode=yolo',
+    supportsModel: true,
+    modelFlag: '--model',
+    hiveAware: false,
+    bridge: { kind: 'hooks', shim: 'gemini' },
+    canReceiveInbox: true,
+    // Keep the TUI alive after processing the hive protocol seed.
+    initialPromptFlag: '-i',
+    recommendedOrchestratorModel: 'pro',
+    resumeFlag: '--resume',
+    installCommand: 'npm install -g @google/gemini-cli',
+    docsUrl: 'https://github.com/google-gemini/gemini-cli'
   },
   {
     id: 'antigravity',
@@ -513,6 +537,7 @@ export function isAgentProvider(value: unknown): value is AgentProvider {
     value === 'codex' ||
     value === 'grok' ||
     value === 'kimi' ||
+    value === 'gemini' ||
     value === 'antigravity' ||
     value === 'qwen' ||
     value === 'opencode' ||
@@ -563,6 +588,7 @@ export function inferAgentProvider(command: string | undefined, explicit?: unkno
   if (bin === 'codex') return 'codex';
   if (bin === 'grok') return 'grok';
   if (bin === 'kimi') return 'kimi';
+  if (bin === 'gemini') return 'gemini';
   if (bin === 'agy' || bin === 'antigravity') return 'antigravity';
   if (bin === 'qwen') return 'qwen';
   if (bin === 'opencode') return 'opencode';

--- a/src/shared/providerAutomation.ts
+++ b/src/shared/providerAutomation.ts
@@ -89,6 +89,11 @@ const CONTEXT_COMMANDS: Record<AgentProvider, ProviderContextCommands> = {
   // a compaction"). Nothing to type, so: null.
   antigravity: { compact: null, clear: '/clear', compactTakesFocus: false },
 
+  // Google Gemini CLI's command reference documents `/compress` as replacing
+  // the chat context with a summary and `/clear` as starting a clean context.
+  // `/compress` has no focus-argument contract, so never append user prose.
+  gemini: { compact: '/compress', clear: '/clear', compactTakesFocus: false },
+
   // qwen-code's bundled cli.js, verbatim:
   //   compressCommand = { name:"compress", altNames:["summarize"],
   //     description "Compresses the context by replacing it with a summary." }
@@ -219,6 +224,7 @@ export function terminalReadySettleMs(provider: AgentProvider): number {
   switch (provider) {
     case 'kimi': return 650;
     case 'grok': return 500;
+    case 'gemini': return 500;
     case 'codex': return 500;
     default: return 400;
   }

--- a/test/cli-install-ladder.test.cjs
+++ b/test/cli-install-ladder.test.cjs
@@ -18,7 +18,7 @@ const script = (provider, npmAvailable, platform) =>
   buildMissingCliScript(provider, provider, npmAvailable, platform);
 
 test('with npm present the ladder is unchanged — npm install, for every provider', () => {
-  for (const provider of ['claude', 'codex', 'opencode', 'crush', 'copilot']) {
+  for (const provider of ['claude', 'codex', 'gemini', 'opencode', 'crush', 'copilot']) {
     const info = installInfoForProvider(provider);
     const rung = chooseInstallRung(info, true);
     assert.equal(rung.kind, 'npm', provider);

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -48,7 +48,7 @@ function walk(dir, out = []) {
 /** Sweep every config an installer wrote for commands that invoke one of our
  *  shims. Path-agnostic on purpose, so a new installer cannot be missed. */
 function hookCommandsUnder(home) {
-  const shim = /(cth-hook\.cjs|agy-hook\.cjs|grok-hook\.cjs)/;
+  const shim = /(cth-hook\.cjs|agy-hook\.cjs|grok-hook\.cjs|gemini-hook\.cjs)/;
   const found = [];
   for (const file of walk(home)) {
     let text;
@@ -124,6 +124,7 @@ test('every hook installer routes through the launcher — none left on bare nod
 
   hive.installAgyHooks();
   hive.installGrokHooks();
+  hive.installGeminiHooks(path.join(home, 'hive/agents/a1'));
   hive.installCodexHooks(path.join(home, 'hive/agents/a1'));
 
   const launcher = launcherIn(home);
@@ -133,9 +134,35 @@ test('every hook installer routes through the launcher — none left on bare nod
   const bare = commands.filter((c) => !usesLauncher(c, launcher));
   assert.deepEqual(bare, [], 'these hook commands would exit 127 wherever node is not on the bare PATH');
 
-  for (const shim of ['agy-hook.cjs', 'grok-hook.cjs']) {
+  for (const shim of ['agy-hook.cjs', 'grok-hook.cjs', 'gemini-hook.cjs']) {
     assert.ok(commands.some((c) => c.includes(shim)), `${shim} installer produced no command`);
   }
+});
+
+test('Gemini gets isolated lifecycle settings and an interactive protocol seed', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  const injection = await hive.ensureAgent({
+    id: 'gemini-1',
+    name: 'Gemini',
+    provider: 'gemini',
+    cwd: home
+  });
+
+  const settingsPath = injection.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
+  assert.equal(typeof settingsPath, 'string');
+  assert.ok(settingsPath.startsWith(path.join(home, 'hive', 'agents', 'gemini-1')));
+  const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.deepEqual(
+    Object.keys(settings.hooks),
+    ['SessionStart', 'BeforeAgent', 'BeforeTool', 'AfterTool', 'AfterAgent']
+  );
+  assert.equal(settings.hooksConfig.enabled, true);
+  assert.equal(settings.hooks.BeforeTool[0].matcher, '.*');
+  assert.ok(settings.hooks.AfterAgent[0].hooks[0].command.includes('gemini-hook.cjs'));
+  assert.equal(injection.args[0], '-i');
+  assert.match(injection.args[1], /HIVE PROTOCOL/);
 });
 
 test('a hook fires with NO node on PATH, and its payload reaches HIVE_SOCK', { skip: !POSIX }, async (t) => {

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -30,6 +30,20 @@ test('Kimi is a first-class inferred provider with autonomous defaults', () => {
   assert.equal(preset.positionalInitialPrompt, undefined);
 });
 
+test('Gemini CLI has hooks, interactive seeding, resume, and current yolo mode', () => {
+  assert.equal(isAgentProvider('gemini'), true);
+  assert.equal(inferAgentProvider('/usr/local/bin/gemini --model pro'), 'gemini');
+  const preset = providerPreset('gemini');
+  assert.equal(preset.defaultCommand, 'gemini');
+  assert.equal(preset.autoFlag, '--approval-mode=yolo');
+  assert.equal(preset.supportsModel, true);
+  assert.equal(preset.canReceiveInbox, true);
+  assert.deepEqual(preset.bridge, { kind: 'hooks', shim: 'gemini' });
+  assert.equal(preset.initialPromptFlag, '-i');
+  assert.equal(preset.resumeFlag, '--resume');
+  assert.equal(preset.installCommand, 'npm install -g @google/gemini-cli');
+});
+
 test('Grok is a first-class inferred provider with hooks, resume, and always-approve', () => {
   assert.equal(isAgentProvider('grok'), true);
   assert.equal(inferAgentProvider('/Users/test/.local/bin/grok --model grok-4.5'), 'grok');
@@ -60,6 +74,10 @@ test('provider commands use matching models and equivalent bypass modes', () => 
     buildSpawnCommand(autoConfig, 'kimi-code/k3', 'kimi'),
     'kimi --model kimi-code/k3 --auto'
   );
+  assert.equal(
+    buildSpawnCommand(autoConfig, 'pro', 'gemini'),
+    'gemini --model pro --approval-mode=yolo'
+  );
 });
 
 test('model picker options stay provider-specific', () => {
@@ -84,6 +102,10 @@ test('model picker options stay provider-specific', () => {
       'kimi-code/kimi-for-coding-highspeed'
     ]
   );
+  assert.deepEqual(
+    modelsForProvider('gemini').map((model) => model.id),
+    [undefined, 'auto', 'pro', 'flash', 'flash-lite']
+  );
   assert.deepEqual(modelsForProvider('custom'), []);
 });
 
@@ -105,10 +127,10 @@ test('God only sees providers that can drain hive inbox messages', () => {
   // excluded (no inbox drain path), custom is excluded (no model picker).
   assert.deepEqual(
     modelProvidersForAgent(true).map((preset) => preset.id),
-    ['claude', 'codex', 'grok', 'antigravity', 'qwen', 'opencode', 'crush', 'pi']
+    ['claude', 'codex', 'grok', 'gemini', 'antigravity', 'qwen', 'opencode', 'crush', 'pi']
   );
   assert.deepEqual(
     modelProvidersForAgent(false).map((preset) => preset.id),
-    ['claude', 'codex', 'grok', 'kimi', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'copilot']
+    ['claude', 'codex', 'grok', 'kimi', 'gemini', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'copilot']
   );
 });


### PR DESCRIPTION
## Summary

- register the official Google Gemini CLI as a first-class provider
- support model selection, current autonomous mode, interactive protocol seeding, session resume, and installer metadata
- install a per-agent Gemini system settings file instead of mutating the user's global settings
- bridge SessionStart, Before/After Agent, and Before/After Tool hooks into the shared hive lifecycle
- add Gemini model/UI entries and regression coverage for provider config, context automation, installer metadata, and hook setup

## Why

Gemini CLI exposes the lifecycle hooks needed for safe idle detection, operator control, and hive message delivery, so it can participate as an orchestrator or worker rather than acting as a terminal-only preset.

This contributes to #104 without overlapping the Kimi bridge work discussed there.

Implementation follows Gemini CLI's official [CLI reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/cli-reference.md), [hooks reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md), and [configuration layers](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md).

## Validation

- npm run typecheck
- npm run build
- node --test test/agent-provider.test.cjs test/provider-automation.test.cjs test/provider-config.test.cjs (20 passed)
- hook configuration assertions pass locally; the existing Windows-only temp cleanup in hive-hook-node.test.cjs reports EPERM after assertions, while Linux CI exercises the full cleanup path