### PR TITLE
feat(hive): flag each agent's live context-window occupancy in god's roster

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1825,10 +1825,20 @@ export class HiveManager {
    * told to read fleet.json, but "told to" is not "always knows" — so we push the
    * truth in on every turn instead. One line, so the cost is negligible.
    *
+   * `ctxOf` (optional, supplied by HookServer) lets the caller layer the LIVE
+   * context-window occupancy on top of the disk snapshot — each agent gets a
+   * `ctx NN%` so god can see at a glance whose context is nearly full when it
+   * routes work. fleet.json only carries cumulative `tokens`, which is a spend
+   * figure, not how full the CURRENT window is; the real occupancy lives in
+   * HookServer.contextById (from the statusLine shim). Omitted when the callback
+   * is absent or an agent has no Status tick yet.
+   *
    * Returns null when there is nothing to say (no hive, no snapshot, no agents),
    * so the hook stays a no-op rather than injecting noise.
    */
-  rosterContext(): string | null {
+  rosterContext(
+    ctxOf?: (agentId: string) => { tokens: number; limit: number } | undefined
+  ): string | null {
     const root = this.root();
     if (!root) return null;
     try {
@@ -1862,6 +1872,15 @@ export class HiveManager {
         if (a.inboxBacklog) bits.push(`inbox ${a.inboxBacklog}`);
         if (a.breaker && a.breaker !== 'ok' && a.breaker !== 'none') bits.push(`breaker ${a.breaker}`);
         if (a.isGod) bits.push('you');
+        // Live context-window occupancy from the statusLine shim — lets god see
+        // which agents are near-full when routing, instead of guessing from the
+        // cumulative token count. Clamp to 0-100; a fresh meter can briefly
+        // report more than 100% before a window rotation.
+        const cw = ctxOf?.(a.id);
+        if (cw && cw.limit > 0) {
+          const pct = Math.max(0, Math.min(100, Math.round((cw.tokens / cw.limit) * 100)));
+          bits.push(`ctx ${pct}%`);
+        }
         return `${a.id}${a.name ? ` "${a.name}"` : ''} (${bits.join(', ')})`;
       });
       const more = agents.length > shown.length ? ` +${agents.length - shown.length} more` : '';

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1100,6 +1100,8 @@ export class HiveManager {
     // Native-separator path helpers — see the 🪟 note above.
     const inDir = (...parts: string[]): string => join(dir, ...parts);
     const inRoot = (...parts: string[]): string => join(root, ...parts);
+    const ctxLine = 'LIVE CONTEXT: each agent row in the LIVE ROSTER carries a `ctx NN%` tag — its live context-window occupancy. Treat it as the real headroom signal when routing: prefer an agent with a LOW `ctx` for a big task; treat a HIGH `ctx` (near 100%) as busy rather than idle, even if the cumulative token count looks modest.';
+
     const memoryLine = semanticMemory
       // The palace location is named, not spelled as `$MEMPALACE_PALACE_PATH`:
       // `mempalace` reads that env var itself, and the POSIX `$` form was noise
@@ -1139,6 +1141,7 @@ export class HiveManager {
       knowledgeLine,
       godLine,
       slackLine,
+      ctxLine,
       `Env vars available to you: AGENT_ID, AGENT_NAME, HIVE_ROOT, AGENT_DIR.`
     ].filter(Boolean).join('\n');
   }
@@ -1864,6 +1867,7 @@ export class HiveManager {
       // remainder is still counted, and fleet.json is one Read away.
       const MAX = 24;
       const shown = agents.slice(0, MAX);
+      let anyCtx = false;
       const rows = shown.map((a) => {
         const bits = [a.role ?? 'agent',
           typeof a.lastActiveSecAgo === 'number' ? `active ${ago(a.lastActiveSecAgo)}` : 'no activity yet'];
@@ -1880,6 +1884,7 @@ export class HiveManager {
         if (cw && cw.limit > 0) {
           const pct = Math.max(0, Math.min(100, Math.round((cw.tokens / cw.limit) * 100)));
           bits.push(`ctx ${pct}%`);
+          anyCtx = true;
         }
         return `${a.id}${a.name ? ` "${a.name}"` : ''} (${bits.join(', ')})`;
       });
@@ -1890,6 +1895,9 @@ export class HiveManager {
         + `${agents.length} ACTIVE agent(s): ${rows.join('; ')}.${more} `
         + 'This is the CURRENT floor and it SUPERSEDES any roster earlier in this conversation — '
         + 'agents you remember that are absent here have been archived or killed, so do not message them. '
+        + (anyCtx
+          ? ' `ctx NN%` = live window occupancy; absent = not yet reported (unknown, not empty).'
+          : '')
         + 'Route work to someone on this list before spawning anyone new.';
     } catch { return null; }
   }

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -256,7 +256,12 @@ export class HookServer {
     // God-only and one line — every other agent is unaffected.
     const wantsRoster = (event === 'SessionStart' || event === 'UserPromptSubmit')
       && !!agentId && this.hive.isGod(agentId);
-    const roster = wantsRoster ? this.hive.rosterContext() : null;
+    // Hand the roster the LIVE context-window occupancy (contextById) so each
+    // agent line can carry a `ctx NN%` — god then sees whose context is nearly
+    // full when it routes work, instead of guessing from cumulative token spend.
+    const roster = wantsRoster
+      ? this.hive.rosterContext((id) => this.contextFor(id))
+      : null;
 
     if (steer || roster) {
       this.emit(agentId, event, p);

--- a/test/hive-roster-injection.test.cjs
+++ b/test/hive-roster-injection.test.cjs
@@ -47,7 +47,7 @@ async function floor(t, { steer } = {}) {
     ? { takeSteer: (id) => (id === 'god-1' ? steer : null), shouldHalt: () => false, toolDecision: () => ({ deny: false }) }
     : undefined;
   const server = new HookServer(hive, () => null, () => CONFIG, control, undefined);
-  const fire = (agent_id, hook_event_name) => server.handle({ agent_id, hook_event_name, session_id: 's1' });
+  const fire = (agent_id, hook_event_name, extra = {}) => server.handle({ agent_id, hook_event_name, session_id: 's1', ...extra });
   return { home, hive, server, fire };
 }
 
@@ -81,6 +81,29 @@ test('the roster line carries the whole floor and its state', async (t) => {
   assert.match(line, /no activity yet/, 'an agent that never ran must not read as "active never"');
   assert.match(line, /SUPERSEDES/, 'the point is to override what god remembers');
   assert.ok(line.length < 1200, `too long for a 3-agent floor: ${line.length} chars`);
+});
+
+test('each agent line carries its live context-window occupancy (ctx NN%)', async (t) => {
+  const { hive, fire } = await floor(t);
+  snapshot(hive);
+
+  // No Status tick yet — a bare direct call (no callback) must not add ctx.
+  assert.ok(!hive.rosterContext().includes('ctx '), 'no occupancy when no statusLine tick has fired');
+
+  // Seed live context-window accounting through the statusLine shim path.
+  // god-1: 62% of a 200k window; jim-1: 99% (near-full, the routing signal).
+  await fire('god-1', 'Status', { context_window: { total_input_tokens: 124000, context_window_size: 200000 } });
+  await fire('jim-1', 'Status', { context_window: { total_input_tokens: 99000, context_window_size: 100000 } });
+
+  // Read the roster the way god actually receives it: injected on a prompt,
+  // which is where HookServer layers the LIVE occupancy onto the disk snapshot.
+  const line = context(await fire('god-1', 'UserPromptSubmit'));
+  assert.ok(line.includes('LIVE ROSTER'), 'roster injected on prompt');
+  assert.match(line, /god-1[^;]*ctx 62%/, 'god line shows its own occupancy');
+  assert.match(line, /jim-1[^;]*ctx 99%/, 'a near-full agent is flagged to god');
+  // pam-1 never fired a Status tick — its line must NOT get ctx.
+  assert.match(line, /pam-1[^;]*\(agent, no activity yet\)/, 'no ctx for an agent with no Status data');
+  assert.ok(!line.includes('\n'), 'still a single compact line');
 });
 
 test('god gets the roster on SessionStart and on every prompt — nobody else does', async (t) => {


### PR DESCRIPTION
## Summary

God's injected roster line now carries a **`ctx NN%`** occupancy figure per agent, so Michael can see at a glance whose context window is nearly full when routing work — instead of guessing from fleet.json's cumulative token spend.

- **`src/main/hive.ts`** — `rosterContext()` gains an optional `ctxOf` callback; each agent's status bits get `ctx NN%` (clamped to 0–100) when the callback returns live data with `limit > 0`. Omitted when no Status tick has fired.
- **`src/main/hooks.ts`** — the roster call feeds the LIVE occupancy via `rosterContext((id) => this.contextFor(id))` (dependency stays HookServer → HiveManager via callback).
- **`test/hive-roster-injection.test.cjs`** — new test asserts occupancy wiring end-to-end (62% / 99% shown, no Status data → no ctx field).

## Why

`contextById` (from the statusLine shim) is already tracked per agent and exposed via `contextFor()`. This change surfaces "whose context is ${X}% full" directly on the roster God receives on SessionStart and every prompt.

## Verification

- `npm run typecheck` (node + web): clean
- `node --test` hive/roster suites: 22 pass, 0 fail
- New test exercises the full hook path (statusLine → `contextFor` → roster string)

## Notes

- `ctx NN%` uses LIVE window occupancy, not fleet.json's cumulative `tokens` (a spend figure).
- To fully benefit, God's system prompt could later route work to the lowest-occupancy agent — this PR only adds the field.