### PR TITLE
fix(fs): use expandTilde in statAbs for cross-platform path resolution

### DIFF
--- a/src/main/fs.ts
+++ b/src/main/fs.ts
@@ -218,9 +218,8 @@ export function normalizeHiveHome(
  *  the home dir). Read-only metadata: returns whether a regular file exists and
  *  the normalized absolute path; never file contents. */
 export async function statAbs(p: string): Promise<{ exists: boolean; isFile: boolean; path: string }> {
-  let abs = p.startsWith('~/') ? join(homedir(), p.slice(2)) : p;
+  const abs = expandTilde(p);
   if (!isAbsolute(abs)) return { exists: false, isFile: false, path: p };
-  abs = normalize(abs);
   try {
     const s = await stat(abs);
     return { exists: true, isFile: s.isFile(), path: abs };

--- a/test/expand-tilde.test.cjs
+++ b/test/expand-tilde.test.cjs
@@ -13,7 +13,7 @@ const os = require('node:os');
 const path = require('node:path');
 const loadTs = require('./load-ts.cjs');
 
-const { expandTilde } = loadTs('src/main/fs.ts');
+const { expandTilde, statAbs } = loadTs('src/main/fs.ts');
 
 const HOME = os.homedir();
 
@@ -120,4 +120,25 @@ test('#140: both entry points agree on the same directory', () => {
   // different one — the failure this pair of fixes exists to prevent.
   const typed = '~/HarnessAgents';
   assert.equal(expandTilde(typed), normalizeHiveHome(typed).home);
+});
+
+test('statAbs expands bare ~, Windows-style ~\\, and whitespace paths', async () => {
+  const fileBasename = `.md-statabs-${process.pid}`;
+  const inHome = path.join(HOME, fileBasename);
+  fs.writeFileSync(inHome, 'x');
+  try {
+    const resSlash = await statAbs(`~/${fileBasename}`);
+    assert.equal(resSlash.exists, true);
+    assert.equal(resSlash.isFile, true);
+
+    const resWin = await statAbs(`~\\${fileBasename}`);
+    assert.equal(resWin.exists, true);
+    assert.equal(resWin.isFile, true);
+
+    const resPadded = await statAbs(` ~/${fileBasename} `);
+    assert.equal(resPadded.exists, true);
+    assert.equal(resPadded.isFile, true);
+  } finally {
+    fs.rmSync(inHome, { force: true });
+  }
 });


### PR DESCRIPTION
statAbs previously checked p.startsWith('~/') directly, missing bare '~', Windows backslash paths ('~\\...'), and leading/trailing whitespace. Updated statAbs to use the central expandTilde function so tilde expansion works consistently across all OS platforms and path formats.

<!-- Thanks for contributing to Munder Difflin! -->

## What & why

<!-- What does this change do, and why? Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Screenshots / clips

<!-- REQUIRED for any visual change: a screenshot or short clip (before/after). -->

## Discord (optional)

<!-- If you'd like the `employee of the month` role in our Discord when this merges,
     put your handle below. Join first so we can find you: https://discord.gg/SEDzP5ZPk5 -->

Discord: 

## Checklist

- [ ] `npm run typecheck` passes (the de-facto CI gate).
- [ ] `npm run build` succeeds.
- [ ] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts.
- [ ] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`.
- [ ] PR is focused on a single change.
