### PR TITLE
fix(hive): atomically write registry.json and drain cursor.json

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -610,7 +610,7 @@ export class HiveManager {
       lastSeen: Date.now()
     };
     if (meta.isGod) reg.godId = meta.id;
-    this.writeJson(join(root, 'registry.json'), reg);
+    this.atomicWriteJson(join(root, 'registry.json'), reg);
 
     this.appendLog({ kind: 'spawn', agentId: meta.id, name: meta.name, isGod: !!meta.isGod });
     // Only logs on an invalid cwd (rare) — not a per-spawn line, so no log spam.
@@ -808,7 +808,7 @@ export class HiveManager {
       if (!agent || agent.archived === archived) return;
       agent.archived = archived;
       agent.lastSeen = Date.now();
-      this.writeJson(join(root, 'registry.json'), reg);
+      this.atomicWriteJson(join(root, 'registry.json'), reg);
       this.appendLog({ kind: 'archive', agentId: id, archived });
       this.commit(`hive: ${archived ? 'archive' : 'unarchive'} ${id}`);
     } catch { /* best-effort — never crash a lifecycle handler */ }
@@ -830,7 +830,7 @@ export class HiveManager {
       if (!agent || agent.sessionId === sessionId) return; // unknown agent or unchanged → no write
       agent.sessionId = sessionId;
       agent.lastSeen = Date.now();
-      this.writeJson(join(root, 'registry.json'), reg);
+      this.atomicWriteJson(join(root, 'registry.json'), reg);
       this.appendLog({ kind: 'session', agentId, sessionId });
       this.commit(`hive: session ${agentId}`);
     } catch { /* best-effort — never crash a hook handler */ }
@@ -1037,7 +1037,7 @@ export class HiveManager {
     if (fresh.length === 0) return { block: false };
 
     cursor.lastProcessed = fresh[fresh.length - 1].id;
-    this.writeJson(cursorPath, cursor);
+    this.atomicWriteJson(cursorPath, cursor);
     this.appendLog({ kind: 'drain', agentId, count: fresh.length });
 
     const lines = fresh.map((m) => `- [from ${m.from}, ${m.act}] ${m.subject}: ${m.body}`).join('\n');


### PR DESCRIPTION
## Problem

Four hive JSON writes used bare `writeFileSync` (`this.writeJson`), which **truncates the target then writes** — so a torn / interrupted write (process killed mid-write, disk error) can leave the file truncated or corrupt:

- `registry.json` on agent **spawn** (`register`), **archive** (`setArchived`), and **session** capture (`recordSession`) — a corrupt registry loses every agent's registration/session state.
- `cursor.json` in `drainForStop` (per-drain processed-message cursor) — a corrupt cursor could re-deliver already-processed messages on restart.

The project already owns the safe primitive — `this.atomicWriteJson` (write temp + rename), used for inbox message writes — but these four call sites bypass it.

## Change

Route all four writes through `atomicWriteJson` (temp-file + atomic rename). Behavior-preserving; same payload, same commit, same best-effort error handling.

## Test

- `node --test test/hive-task-mutation.test.cjs test/webhook-endpoints.test.cjs test/voice-messages.test.cjs` → 18/18 pass
- `npm run typecheck` → clean
- No behavior change to the written data — only the write mechanism (atomic rename instead of in-place truncate).