### PR TITLE
fix(control): cap the per-agent steer queue to bound memory on stalled agents

### DIFF
--- a/src/main/control.ts
+++ b/src/main/control.ts
@@ -17,6 +17,13 @@
  * Runs in the Electron main process; no electron import (unit-testable).
  */
 
+/** Max steer notes queued per agent before the OLDEST is dropped. Each note
+ *  rides the next hook's additionalContext; a stalled/halted agent never drains
+ *  the queue, so without a cap a burst of steers (closing-time loop, a stuck
+ *  caller) would grow memory forever. The latest instruction wins: when full we
+ *  drop from the front (FIFO) so a busy agent still hears the most recent note. */
+const MAX_PENDING_STEERS = 20;
+
 export interface AgentControlSnapshot {
   paused: boolean;
   halted: boolean;
@@ -70,7 +77,10 @@ export class ControlRegistry {
   }
   steer(id: string, text: string): void {
     const t = text.trim();
-    if (t) this.ensure(id).steerQueue.push(t.slice(0, 10000)); // hook additionalContext cap
+    if (!t) return;
+    const q = this.ensure(id).steerQueue;
+    if (q.length >= MAX_PENDING_STEERS) q.shift(); // keep the newest note, drop the oldest
+    q.push(t.slice(0, 10000)); // hook additionalContext cap
   }
   /** Request a graceful stop at the next hook boundary. */
   halt(id: string): void { this.ensure(id).halted = true; }

--- a/src/main/control.ts
+++ b/src/main/control.ts
@@ -79,7 +79,13 @@ export class ControlRegistry {
     const t = text.trim();
     if (!t) return;
     const q = this.ensure(id).steerQueue;
-    if (q.length >= MAX_PENDING_STEERS) q.shift(); // keep the newest note, drop the oldest
+    if (q.length >= MAX_PENDING_STEERS) {
+      // Drop the oldest so the newest instruction still reaches the next hook
+      // boundary. Log a breadcrumb so a note silently falling off the front is
+      // diagnosable — a full queue means the agent has been unreachable for a long time.
+      console.warn(`[control] ${id}: steer queue full (${MAX_PENDING_STEERS}) — dropping oldest note`);
+      q.shift(); // keep the newest note, drop the oldest
+    }
     q.push(t.slice(0, 10000)); // hook additionalContext cap
   }
   /** Request a graceful stop at the next hook boundary. */

--- a/test/control.test.cjs
+++ b/test/control.test.cjs
@@ -30,3 +30,28 @@ test('persisted delivery pauses replace stale in-memory state', () => {
   assert.equal(control.isAutoDeliveryPaused('dev2'), true);
   assert.equal(control.isAutoDeliveryPaused('dev3'), true);
 });
+
+test('steer queue is capped so a stalled agent cannot accumulate unbounded notes', () => {
+  const control = new ControlRegistry();
+  for (let i = 1; i <= 25; i++) control.steer('dev9', `note ${i}`);
+
+  // Only the cap is retained, never all 25.
+  assert.equal(control.snapshot('dev9').pendingSteers, 20);
+
+  // FIFO + drop-oldest: the oldest notes are shed, so the survivors start at
+  // note 6 and the newest (note 25) is the last one delivered.
+  assert.equal(control.takeSteer('dev9'), 'note 6');
+  let last = '';
+  for (let i = 0; i < 19; i++) last = control.takeSteer('dev9'); // notes 7..25
+  assert.equal(last, 'note 25');
+  assert.equal(control.takeSteer('dev9'), undefined, 'queue fully drained');
+});
+
+test('whitespace-only steers are ignored and never fill the queue', () => {
+  const control = new ControlRegistry();
+  control.steer('dev9', '   ');
+  control.steer('dev9', '');
+  control.steer('dev9', 'real guidance');
+  assert.equal(control.snapshot('dev9').pendingSteers, 1);
+  assert.equal(control.takeSteer('dev9'), 'real guidance');
+});


### PR DESCRIPTION
## Summary

`ControlRegistry.steer()` pushes a note onto a per-agent queue (`steerQueue`) that is drained one-at-a-time by `takeSteer()` on each hook boundary. A halted/stalled agent never drains, so a burst of steers (a closing-time loop, a stuck caller, or repeated operator input) grows the queue in memory **without bound**.

This caps the queue at `MAX_PENDING_STEERS` (20) and drops the **oldest** note when full, so the most recent instruction still reaches the next hook boundary. Behavior is unchanged for the normal case (≤20 pending steers).

## Changes

- `src/main/control.ts` — add `MAX_PENDING_STEERS = 20`; in `steer()`, drop the oldest queue entry when at capacity before pushing the new note.
- `test/control.test.cjs` — regression tests: the queue caps at 20 with FIFO drop-oldest (survivors start at `note 6`, newest `note 25` delivered last), and whitespace-only steers are ignored.

## Verification

- `npm run typecheck` (node + web): pass
- `node --test test/control.test.cjs`: 4/4 pass