### PR TITLE
Allow agent names to be edited after spin-up

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -815,6 +815,55 @@ export class HiveManager {
   }
 
   /**
+   * Change an agent's display name without changing its durable identity.
+   * The registry key, agent directory, session id, and every mailbox path remain
+   * keyed by `id`; only the human-facing name is updated.
+   *
+   * `fleet.json` is patched in the same operation so god's next prompt receives
+   * the new name immediately rather than waiting for the periodic fleet refresh.
+   */
+  renameAgent(id: string, name: string): { ok: boolean; name?: string; error?: string } {
+    const root = this.root();
+    if (!root) return { ok: false, error: 'hive disabled (no harnessHome)' };
+
+    const nextName = name.trim();
+    if (!nextName) return { ok: false, error: 'Name is required' };
+
+    try {
+      const reg = this.registry();
+      const agent = reg.agents[id];
+      if (!agent) return { ok: false, error: 'Agent not found' };
+      if (agent.name === nextName) return { ok: true, name: nextName };
+
+      const previousName = agent.name;
+      agent.name = nextName;
+      this.writeJson(join(root, 'registry.json'), reg);
+
+      // fleet.json is ephemeral and may not exist yet. When it does, keep its
+      // display name in lockstep with the registry so rosterContext() is fresh.
+      const fleetPath = join(root, 'fleet.json');
+      if (existsSync(fleetPath)) {
+        try {
+          const fleet = this.readJson<{ agents?: Array<{ id?: string; name?: string }> }>(fleetPath, {});
+          if (Array.isArray(fleet.agents)) {
+            const row = fleet.agents.find((candidate) => candidate.id === id);
+            if (row) {
+              row.name = nextName;
+              this.writeJson(fleetPath, fleet);
+            }
+          }
+        } catch { /* periodic snapshot will repair a malformed/stale fleet file */ }
+      }
+
+      this.appendLog({ kind: 'rename', agentId: id, previousName, name: nextName });
+      this.commit(`hive: rename ${id}`);
+      return { ok: true, name: nextName };
+    } catch {
+      return { ok: false, error: 'Could not rename agent' };
+    }
+  }
+
+  /**
    * Persist the agent's Claude Code session_id (Lane A #6.6a). Captured from hook
    * payloads; written only when it actually changes (a new session), so this is a
    * no-op on the vast majority of hook events. The id is the `--resume` key for

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3146,6 +3146,12 @@ ipcMain.handle('roster:write', (_evt, snap: unknown) => roster.write(snap));
 
 // ─── IPC: hive (multi-agent coordination) ───────────────────────────────────
 ipcMain.handle('hive:registry', () => hive.registry());
+ipcMain.handle('hive:renameAgent', (_evt, id: unknown, name: unknown) => {
+  if (typeof id !== 'string' || typeof name !== 'string') {
+    return { ok: false, error: 'Invalid rename request' };
+  }
+  return hive.renameAgent(id, name);
+});
 ipcMain.handle('hive:board', () => hive.board());
 ipcMain.handle('hive:tasks', () => hive.tasks());
 ipcMain.handle('hive:log', (_evt, n: unknown) => hive.logTail(typeof n === 'number' ? n : 200));

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -727,6 +727,9 @@ const api = {
 
   // ─── Hive (multi-agent coordination) ─────────────────────────────────────
   hiveRegistry: (): Promise<HiveRegistry> => ipcRenderer.invoke('hive:registry'),
+  /** Rename an agent's display name. Its id, hive directory, and PTY are unchanged. */
+  hiveRenameAgent: (id: string, name: string): Promise<{ ok: boolean; name?: string; error?: string }> =>
+    ipcRenderer.invoke('hive:renameAgent', id, name),
   hiveBoard: (): Promise<string> => ipcRenderer.invoke('hive:board'),
   hiveTasks: (): Promise<unknown> => ipcRenderer.invoke('hive:tasks'),
   hiveLog: (n?: number): Promise<unknown[]> => ipcRenderer.invoke('hive:log', n ?? 200),

--- a/src/renderer/src/components/AgentCard.tsx
+++ b/src/renderer/src/components/AgentCard.tsx
@@ -7,6 +7,7 @@ import { RealtimeMichaelToggle } from './RealtimeMichaelToggle';
 import { CostHud } from '@/realtime/CostHud';
 import { AccentColorName } from '@/design/tokens';
 import { OfficeCharacterName } from '@/scene/office/cast';
+import { AgentNameEditor } from './AgentNameEditor';
 
 export interface AgentCardProps {
   name: string;
@@ -30,6 +31,8 @@ export interface AgentCardProps {
    *  (`isGod` / the `god` agent id stay as-is internally; this is display only.) */
   isGod?: boolean;
   onClick?: () => void;
+  /** Persists an inline display-name edit; identity and hive paths stay unchanged. */
+  onRename?: (name: string) => Promise<{ ok: boolean; error?: string }>;
   /** Number of ledger tasks this agent is actively DOING — rendered as a blue
    *  sticky note stuck to the card. Clicking it opens the first task's detail. */
   doingCount?: number;
@@ -52,7 +55,7 @@ const fmtK = (n: number): string => `${Math.round(n / 1000)}k`;
  */
 export function AgentCard({
   name, character, accent, status, ptyId, project, action, progress = 0,
-  contextTokens, contextLimit, selected, isGod, onClick,
+  contextTokens, contextLimit, selected, isGod, onClick, onRename,
   doingCount = 0, onTaskNoteClick, draggable, note, onEditNote
 }: AgentCardProps) {
   const [hover, setHover] = useState(false);
@@ -124,8 +127,17 @@ export function AgentCard({
   const noteFirstLine = (note ?? '').split('\n').find((l) => l.trim()) ?? '';
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick?.();
+        }
+      }}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       draggable={draggable}
@@ -187,15 +199,19 @@ export function AgentCard({
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
             {/* Identity row: name (+ BOSS tag) + status. */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'space-between', minWidth: 0 }}>
-              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
-                <span style={{
-                  fontFamily: 'var(--cth-font-display)',
-                  fontSize: 'var(--cth-text-display-sm)',
-                  lineHeight: 'var(--cth-lh-display-sm)',
-                  color: 'var(--cth-ink-900)',
-                  flex: 1, minWidth: 0,
-                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
-                }}>{name.toUpperCase()}</span>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, minWidth: 0, flex: 1 }}>
+                {onRename ? (
+                  <AgentNameEditor name={name} onCommit={onRename} uppercase />
+                ) : (
+                  <span style={{
+                    fontFamily: 'var(--cth-font-display)',
+                    fontSize: 'var(--cth-text-display-sm)',
+                    lineHeight: 'var(--cth-lh-display-sm)',
+                    color: 'var(--cth-ink-900)',
+                    flex: 1, minWidth: 0,
+                    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+                  }}>{name.toUpperCase()}</span>
+                )}
                 {isGod && (
                   <span style={{
                     fontFamily: 'var(--cth-font-display)', fontSize: 7, lineHeight: '11px',
@@ -290,6 +306,6 @@ export function AgentCard({
           </div>
         </div>
       </PixelPanel>
-    </button>
+    </div>
   );
 }

--- a/src/renderer/src/components/AgentDetailPanel.tsx
+++ b/src/renderer/src/components/AgentDetailPanel.tsx
@@ -14,6 +14,7 @@ import { ToolWaterfall } from './ToolWaterfall';
 import { AgentControlStrip } from './AgentControlStrip';
 import { GitTab } from './GitTab';
 import { Icon } from './Icon';
+import { AgentNameEditor } from './AgentNameEditor';
 import { useStore, type Agent } from '@/store/store';
 import { usePtyParser } from '@/hooks/usePtyParser';
 
@@ -26,6 +27,7 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
   const [openTerminalError, setOpenTerminalError] = useState<string | undefined>();
   const archiveAgent = useStore(s => s.archiveAgent);
   const updateAgent = useStore(s => s.updateAgent);
+  const renameAgent = useStore(s => s.renameAgent);
   const setFullscreen = useStore(s => s.setFullscreen);
   const fullscreenAgentId = useStore(s => s.fullscreenAgentId);
   const sidebarTab = useStore(s => s.sidebarTab);
@@ -101,12 +103,14 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
           <SpritePortrait character={agent.character} scale={1} />
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{
-            fontFamily: 'var(--cth-font-display)',
-            fontSize: 10, lineHeight: '14px',
-            color: 'var(--cth-ink-900)',
-            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
-          }}>{agent.name.toUpperCase()}</div>
+          <div style={{ display: 'flex', minWidth: 0, lineHeight: '14px' }}>
+            <AgentNameEditor
+              name={agent.name}
+              onCommit={(name) => renameAgent(agent.id, name)}
+              uppercase
+              fontSize={10}
+            />
+          </div>
           <div style={{
             display: 'flex', gap: 6, alignItems: 'center', marginTop: 1
           }}>

--- a/src/renderer/src/components/AgentNameEditor.tsx
+++ b/src/renderer/src/components/AgentNameEditor.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface AgentNameEditorProps {
+  name: string;
+  onCommit: (name: string) => Promise<{ ok: boolean; error?: string }>;
+  /** Cards render names in their established all-caps display style. */
+  uppercase?: boolean;
+  fontSize?: number | string;
+}
+
+/** Inline display-name editor shared by the floor card and agent detail header. */
+export function AgentNameEditor({
+  name,
+  onCommit,
+  uppercase = false,
+  fontSize = 'var(--cth-text-display-sm)'
+}: AgentNameEditorProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const [error, setError] = useState<string>();
+  const committing = useRef(false);
+  const cancelling = useRef(false);
+
+  useEffect(() => {
+    if (!editing) setDraft(name);
+  }, [editing, name]);
+
+  const beginEditing = () => {
+    setDraft(name);
+    setError(undefined);
+    setEditing(true);
+  };
+
+  const commit = async () => {
+    if (committing.current || cancelling.current) return;
+    const nextName = draft.trim();
+    if (!nextName) {
+      setError('Name is required');
+      return;
+    }
+    if (nextName === name) {
+      setEditing(false);
+      return;
+    }
+
+    committing.current = true;
+    setError(undefined);
+    try {
+      const result = await onCommit(nextName);
+      if (result.ok) setEditing(false);
+      else setError(result.error ?? 'Could not rename agent');
+    } catch (commitError) {
+      setError(commitError instanceof Error ? commitError.message : 'Could not rename agent');
+    } finally {
+      committing.current = false;
+    }
+  };
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        draggable={false}
+        value={draft}
+        aria-label={`Rename ${name}`}
+        title={error}
+        onFocus={(event) => event.currentTarget.select()}
+        onChange={(event) => setDraft(event.target.value)}
+        onClick={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+        onBlur={() => { void commit(); }}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            void commit();
+          } else if (event.key === 'Escape') {
+            cancelling.current = true;
+            setEditing(false);
+            queueMicrotask(() => { cancelling.current = false; });
+          }
+        }}
+        style={{
+          width: '100%', minWidth: 0, height: 20, padding: '1px 4px', boxSizing: 'border-box',
+          border: 'none', outline: 'none',
+          background: 'var(--cth-paper-100)',
+          boxShadow: `inset 0 0 0 1px var(--cth-${error ? 'coral' : 'ink-300'})`,
+          fontFamily: 'var(--cth-font-display)', fontSize,
+          color: 'var(--cth-ink-900)', textTransform: uppercase ? 'uppercase' : undefined
+        }}
+      />
+    );
+  }
+
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, minWidth: 0, flex: 1 }}>
+      <span
+        onDoubleClick={(event) => { event.stopPropagation(); beginEditing(); }}
+        title={`${name} — double-click to rename`}
+        style={{
+          fontFamily: 'var(--cth-font-display)', fontSize,
+          color: 'var(--cth-ink-900)',
+          minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'
+        }}
+      >{uppercase ? name.toUpperCase() : name}</span>
+      <button
+        type="button"
+        draggable={false}
+        aria-label={`Rename ${name}`}
+        title={`Rename ${name}`}
+        onClick={(event) => { event.stopPropagation(); beginEditing(); }}
+        onMouseDown={(event) => event.stopPropagation()}
+        style={{
+          flexShrink: 0, width: 14, height: 14, padding: 0,
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          border: 'none', background: 'transparent', cursor: 'text',
+          color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-ui)', fontSize: 9, lineHeight: 1
+        }}
+      >✎</button>
+    </span>
+  );
+}

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -20,6 +20,7 @@ export function AgentStrip({ config }: AgentStripProps) {
   const setAddAgentOpen = useStore(s => s.setAddAgentOpen);
   const openTaskDetail = useStore(s => s.openTaskDetail);
   const reorderAgents = useStore(s => s.reorderAgents);
+  const renameAgent = useStore(s => s.renameAgent);
   const setAgentNote = useStore(s => s.setAgentNote);
   // Shared with the fullscreen roster so both show one restore in progress.
   const { restoring, autoRestoring, restoreTeam } = useRestoreTeam(config);
@@ -141,6 +142,7 @@ export function AgentStrip({ config }: AgentStripProps) {
             selected={a.id === selectedId}
             isGod={a.isGod}
             onClick={() => select(a.id)}
+            onRename={(name) => renameAgent(a.id, name)}
             doingCount={doingByAgent[a.id]?.length ?? 0}
             onTaskNoteClick={() => {
               const first = doingByAgent[a.id]?.[0];

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -184,6 +184,9 @@ interface State {
   setGodStatus: (status: GodStatus) => void;
   select: (id: string) => void;
   updateAgent: (id: string, patch: Partial<Agent>) => void;
+  /** Persist a display-name change to both the hive registry and renderer roster.
+   *  The agent id and all id-derived paths remain unchanged. */
+  renameAgent: (id: string, name: string) => Promise<{ ok: boolean; error?: string }>;
   setAgentNote: (id: string, note: string) => void;
   pushFeed: (id: string, line: string) => void;
   addAgent: (agent: Agent) => void;
@@ -612,6 +615,28 @@ export const useStore = create<State>((set) => ({
       if (touchesDurableAgentField(patch)) persistAgents(agents, s.selectedId);
       return { agents };
     }),
+  renameAgent: async (id, name) => {
+    try {
+      const result = await window.cth.hiveRenameAgent(id, name);
+      if (!result.ok || !result.name) return { ok: false, error: result.error ?? 'Could not rename agent' };
+      const nextName = result.name;
+
+      set((s) => {
+        const rename = (agents: Agent[]): Agent[] =>
+          agents.map((agent) => agent.id === id ? { ...agent, name: nextName } : agent);
+        const agents = rename(s.agents);
+        const archivedAgents = rename(s.archivedAgents);
+        const restorableAgents = rename(s.restorableAgents);
+        persistAgents(agents, s.selectedId);
+        persistArchived(archivedAgents);
+        persistRestorable(restorableAgents);
+        return { agents, archivedAgents, restorableAgents };
+      });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : 'Could not rename agent' };
+    }
+  },
   setAgentNote: (id, note) =>
     set((s) => {
       const agents = s.agents.map((a) => a.id === id ? { ...a, note } : a);

--- a/test/hive-roster-injection.test.cjs
+++ b/test/hive-roster-injection.test.cjs
@@ -83,6 +83,30 @@ test('the roster line carries the whole floor and its state', async (t) => {
   assert.ok(line.length < 1200, `too long for a 3-agent floor: ${line.length} chars`);
 });
 
+test('renaming changes only the display name and reaches god immediately', async (t) => {
+  const { home, hive } = await floor(t);
+  snapshot(hive);
+  const agentDir = path.join(home, 'hive', 'agents', 'jim-1');
+  const before = hive.registry().agents['jim-1'];
+
+  const result = hive.renameAgent('jim-1', '  Kevin  ');
+
+  assert.deepEqual(result, { ok: true, name: 'Kevin' });
+  assert.deepEqual(hive.registry().agents['jim-1'], { ...before, name: 'Kevin' },
+    'registry metadata must be unchanged apart from the display name');
+  assert.equal(fs.existsSync(agentDir), true, 'the id-derived agent directory must not move');
+  assert.match(hive.rosterContext(), /jim-1 "Kevin"/);
+  assert.doesNotMatch(hive.rosterContext(), /jim-1 "Jim"/);
+});
+
+test('rename rejects empty and unknown agents without changing the registry', async (t) => {
+  const { hive } = await floor(t);
+
+  assert.equal(hive.renameAgent('jim-1', '   ').ok, false);
+  assert.equal(hive.renameAgent('missing', 'Kevin').ok, false);
+  assert.equal(hive.registry().agents['jim-1'].name, 'Jim');
+});
+
 test('god gets the roster on SessionStart and on every prompt — nobody else does', async (t) => {
   const { hive, fire } = await floor(t);
   snapshot(hive);


### PR DESCRIPTION
## Summary

Adds a safe post-spawn rename path for agents from both places users naturally reach for it:

- the agent card on the office floor
- the agent detail header

Names are edited inline and committed on Enter or blur. Escape cancels an edit.

## Motivation

Agent names were previously written only during spawn. Correcting a typo or replacing a temporary worker name required firing and rehiring the agent, which discarded its memory, mailbox history, live terminal, and floor position.

The agent ID is derived from the original name and is also the durable key for its hive directory, memory, inbox/outbox, roster records, and PTY session. Renaming that ID would therefore have a much larger and riskier blast radius.

## Implementation

- Adds a single main-process rename operation that validates and updates only the registry display name.
- Exposes the operation through the preload IPC bridge.
- Adds one renderer store action that writes through to the hive registry first and then persists the same canonical name to the roster mirror.
- Reuses a shared inline editor in the floor card and detail header.
- Patches the current `fleet.json` snapshot immediately so the live roster injected into God's next prompt uses the new name without an app or agent restart.
- Updates active, archived, and restorable renderer records with the same ID to prevent stale display names.

## Identity and persistence guarantees

A rename does **not** change or move any identity-derived resource:

- agent ID / registry key
- hive agent directory
- `memory.md`
- inbox or outbox
- PTY/session identity
- working directory or worktree
- task assignee references

For example, an agent renamed from `worker-1` to `Kevin` can continue to live under the original `worker-1-…` ID and hive path.

## Validation

- `npm run typecheck`
- `npm run build`
- `node --test test/hive-roster-injection.test.cjs test/roster.test.cjs` — 17/17 passed
- `npm run test:focused` — 228 passed, including all rename coverage; 11 unrelated existing Windows path/CLI expectation failures remain outside this change

The new regression coverage verifies that:

- names are trimmed and persisted to the registry
- empty and unknown-agent renames are rejected
- registry metadata is unchanged apart from the display name
- the ID-derived agent directory remains untouched
- God's live roster context receives the renamed display name immediately

Closes #188.