### PR TITLE
feat: replace mockEvents.ts direct store writes with MockHookServer IPC

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,8 @@ import {
 } from './git';
 import { HiveManager, type AgentMeta, type HiveMessage, type HiveTask } from './hive';
 import { HookServer } from './hooks';
+import { MockHookServer } from './mockHookServer';
+import { registerMockLoopIpc } from './mockLoopIpc';
 import { CircuitBreaker, type BreakerInput } from './breaker';
 import type { UsageProvider } from './usage';
 import { MemoryManager } from './memory';
@@ -301,6 +303,9 @@ const hookServer = new HookServer(
   standingGoalFromRoster,
   (agentId, event, message) => workerWake.noteHook(agentId, event, message)
 );
+// MockHookServer — synthetic events for avatar demo mode when no live agents exist.
+const mockServer = new MockHookServer(() => liveWebContents());
+registerMockLoopIpc(mockServer, () => liveWebContents());
 const memory = new MemoryManager(
   () => readConfig().harnessHome,
   () => { const c = readConfig(); return { enabled: c.semanticMemory !== false, model: c.embeddingModel ?? 'minilm' }; }

--- a/src/main/mockHookServer.ts
+++ b/src/main/mockHookServer.ts
@@ -1,0 +1,182 @@
+/**
+ * MockHookServer — generates synthetic Claude Code hook events so avatar
+ * animation works without a live agent. Emits the same hive:hookEvent payloads
+ * as the real HookServer, so the renderer's useHive handler treats mock and
+ * real events identically.
+ *
+ * Replaces the old renderer-side mockEvents.ts (which wrote the zustand store
+ * directly). This server runs in the main process and pushes events through
+ * IPC, keeping all avatar state centralized in useHive.ts.
+ */
+
+import { WebContents } from 'electron';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface MockHookPayload {
+  hook_event_name: string;
+  agent_id: string;
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  notification_type?: string;
+  message?: string;
+  model?: string;
+  input?: number;
+  output?: number;
+  cache_read?: number;
+  cache_creation?: number;
+}
+
+interface ToolSample {
+  event: string;
+  tool: string;
+  what: string;
+  station: string;
+  lines: string[];
+  thought: string;
+}
+
+// ─── Tool samples (ported from the old renderer-side mockEvents.ts) ───────────
+
+const TOOL_SAMPLES: ToolSample[] = [
+  { event: 'PreToolUse', tool: 'Read', what: 'reading SPEC.md', station: 'shelf',
+    lines: ['\x1b[36m● Read\x1b[0m SPEC.md', '   read 412 lines.'],
+    thought: 'Pulling up the spec so I can confirm the state machine before touching the implementation.' },
+  { event: 'PostToolUse', tool: 'Read', what: 'reading SPEC.md', station: 'shelf',
+    lines: ['\x1b[36m● Read\x1b[0m SPEC.md', '   read 412 lines.'], thought: '' },
+  { event: 'PreToolUse', tool: 'Edit', what: 'editing PixelPanel.tsx', station: 'shelf',
+    lines: ['\x1b[36m● Edit\x1b[0m src/renderer/src/components/PixelPanel.tsx', '   +14 / -3'],
+    thought: 'Tightening up the panel border math — the inner stroke was a pixel off in inset mode.' },
+  { event: 'PostToolUse', tool: 'Edit', what: 'editing PixelPanel.tsx', station: 'shelf',
+    lines: ['\x1b[36m● Edit\x1b[0m src/renderer/src/components/PixelPanel.tsx', '   +14 / -3'], thought: '' },
+  { event: 'PreToolUse', tool: 'Bash', what: 'running tests', station: 'terminal',
+    lines: ['\x1b[36m● Bash\x1b[0m npm test', '   ✓ 24 passed'],
+    thought: 'Running the renderer suite to make sure nothing regressed before I move on.' },
+  { event: 'PostToolUse', tool: 'Bash', what: 'running tests', station: 'terminal',
+    lines: ['\x1b[36m● Bash\x1b[0m npm test', '   ✓ 24 passed'], thought: '' },
+  { event: 'PreToolUse', tool: 'WebFetch', what: 'fetching docs', station: 'web',
+    lines: ['\x1b[36m● WebFetch\x1b[0m https://docs.example.com/hooks', '   ok 200 (1.2kb)'],
+    thought: 'Grabbing the hooks doc to double-check the PreToolUse payload shape.' },
+  { event: 'PostToolUse', tool: 'WebFetch', what: 'fetching docs', station: 'web',
+    lines: ['\x1b[36m● WebFetch\x1b[0m https://docs.example.com/hooks', '   ok 200 (1.2kb)'], thought: '' },
+  { event: 'PreToolUse', tool: 'Glob', what: 'searching for skill files', station: 'shelf',
+    lines: ['\x1b[36m● Glob\x1b[0m **/*.skill.md', '   23 matches'],
+    thought: 'Enumerating all the skill files so I can walk each one and look for stale script paths.' },
+  { event: 'PostToolUse', tool: 'Glob', what: 'searching for skill files', station: 'shelf',
+    lines: ['\x1b[36m● Glob\x1b[0m **/*.skill.md', '   23 matches'], thought: '' },
+  { event: 'PreToolUse', tool: 'TodoWrite', what: 'updating the todo board', station: 'board',
+    lines: ['\x1b[36m● TodoWrite\x1b[0m 4 items'],
+    thought: 'Splitting the remaining work into four discrete tasks so I can track them as I go.' },
+  { event: 'PostToolUse', tool: 'TodoWrite', what: 'updating the todo board', station: 'board',
+    lines: ['\x1b[36m● TodoWrite\x1b[0m 4 items'], thought: '' },
+];
+
+const PRE_SAMPLES = TOOL_SAMPLES.filter(s => s.event === 'PreToolUse');
+const POST_SAMPLES = TOOL_SAMPLES.filter(s => s.event === 'PostToolUse');
+const MOCK_ACTS = ['request', 'inform', 'propose', 'query', 'agree'] as const;
+const TICK_MS = 1800;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export class MockHookServer {
+  private webContents: WebContents | null = null;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private agentStates = new Map<string, { status: 'idle' | 'thinking'; lastTool: string }>();
+
+  constructor(getWebContents: () => WebContents | null) {
+    this.webContents = getWebContents();
+  }
+
+  /** Start the synthetic event loop. Idempotent. */
+  start(agentIds: string[]): void {
+    if (this.interval !== null) return;
+    for (const id of agentIds) {
+      this.agentStates.set(id, { status: 'idle', lastTool: '' });
+    }
+    this.interval = setInterval(() => this.tick(agentIds), TICK_MS);
+  }
+
+  /** Stop the loop and clear agent state. */
+  stop(): void {
+    if (this.interval !== null) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.agentStates.clear();
+  }
+
+  /** Sync the agent roster (add new, remove stale). */
+  syncAgents(agentIds: string[]): void {
+    for (const id of agentIds) {
+      if (!this.agentStates.has(id)) {
+        this.agentStates.set(id, { status: 'idle', lastTool: '' });
+      }
+    }
+    for (const [id] of this.agentStates) {
+      if (!agentIds.includes(id)) this.agentStates.delete(id);
+    }
+  }
+
+  // ─── Private ───────────────────────────────────────────────────────────────
+
+  private tick(agentIds: string[]): void {
+    if (!this.webContents) return;
+
+    for (const agentId of agentIds) {
+      const state = this.agentStates.get(agentId);
+      if (!state) continue;
+
+      if (state.status === 'idle' && Math.random() < 0.4) {
+        const preSample = PRE_SAMPLES[Math.floor(Math.random() * PRE_SAMPLES.length)];
+        state.status = 'thinking';
+        state.lastTool = preSample.tool;
+        this.emitHook(agentId, {
+          hook_event_name: 'PreToolUse', agent_id: agentId,
+          tool_name: preSample.tool,
+        });
+        this.webContents.send('hive:mockFeed', { agentId, lines: preSample.lines });
+      } else if (state.status === 'thinking') {
+        const postSample = POST_SAMPLES.find(s => s.tool === state.lastTool) ?? POST_SAMPLES[0];
+        state.status = 'idle';
+        state.lastTool = '';
+        this.emitHook(agentId, {
+          hook_event_name: 'PostToolUse', agent_id: agentId,
+          tool_name: postSample.tool,
+        });
+        this.webContents.send('hive:mockFeed', { agentId, lines: postSample.lines });
+        this.emitHook(agentId, {
+          hook_event_name: 'Stop', agent_id: agentId,
+          tool_name: undefined,
+        });
+      }
+    }
+
+    this.maybeFlyMessage(agentIds);
+  }
+
+  private emitHook(agentId: string, payload: MockHookPayload): void {
+    if (!this.webContents) return;
+    this.webContents.send('hive:hookEvent', {
+      agentId: payload.agent_id,
+      event: payload.hook_event_name,
+      tool: payload.tool_name,
+      notificationType: undefined,
+      source: undefined,
+      message: payload.message,
+      blocked: false,
+    });
+  }
+
+  private maybeFlyMessage(agentIds: string[]): void {
+    if (agentIds.length < 2 || Math.random() >= 0.45) return;
+    const from = agentIds[Math.floor(Math.random() * agentIds.length)];
+    let to = from;
+    for (let i = 0; i < 6 && to === from; i++) {
+      to = agentIds[Math.floor(Math.random() * agentIds.length)];
+    }
+    if (to === from) return;
+    const act = MOCK_ACTS[Math.floor(Math.random() * MOCK_ACTS.length)];
+    this.webContents?.send('cth:demo-handoff', { from, to, act });
+  }
+}

--- a/src/main/mockLoopIpc.ts
+++ b/src/main/mockLoopIpc.ts
@@ -1,0 +1,26 @@
+/**
+ * mockLoopIpc — registers IPC handlers that wire the renderer's mock loop
+ * requests to the main-process MockHookServer.
+ *
+ * Add this import to src/main/index.ts:
+ *   import { registerMockLoopIpc } from './mockLoopIpc';
+ *
+ * And call it after constructing the HookServer:
+ *   registerMockLoopIpc(hookServer, mockServer, mainWindow);
+ */
+
+import { ipcMain } from 'electron';
+import { MockHookServer } from './mockHookServer';
+
+export function registerMockLoopIpc(
+  mockServer: MockHookServer,
+  getWindow: () => Electron.WebContents | null
+): void {
+  ipcMain.on('mock:start', (_event, agentIds: string[]) => {
+    mockServer.start(agentIds);
+  });
+
+  ipcMain.on('mock:stop', () => {
+    mockServer.stop();
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -851,6 +851,23 @@ const api = {
     ipcRenderer.on('hive:hookEvent', listener);
     return () => ipcRenderer.removeListener('hive:hookEvent', listener);
   },
+  /** Start/stop the main-process MockHookServer synthetic event loop
+   *  (demo-mode avatars). Mirrors the real HookServer lifecycle. */
+  startMockLoop: (agentIds: string[]): Promise<void> =>
+    ipcRenderer.invoke('mock:start', agentIds),
+  stopMockLoop: (): Promise<void> =>
+    ipcRenderer.invoke('mock:stop'),
+
+  /** Push-based mock terminal output from the main-process MockHookServer.
+   *  Feeds lines into the agent's terminal pane so mock agents produce visible output. */
+  onHiveMockFeed: (
+    cb: (e: { agentId: string; lines: string[] }) => void
+  ): (() => void) => {
+    const listener = (_e: IpcRendererEvent, payload: { agentId: string; lines: string[] }) => cb(payload);
+    ipcRenderer.on('hive:mockFeed', listener);
+    return () => ipcRenderer.removeListener('hive:mockFeed', listener);
+  },
+
   /** Push-based context accounting from the status line: live tokens + the
    *  session's EXACT context-window size. Same pattern as onHiveHookEvent. */
   onHiveContextUpdate: (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -195,8 +195,10 @@ export function App() {
     const DEMO = import.meta.env.DEV && import.meta.env.VITE_CTH_DEMO === '1';
     const evaluate = () => {
       const hasLive = useStore.getState().agents.some((a) => a.ptyId);
-      if (DEMO || !hasLive) startMockLoop();
-      else stopMockLoop();
+      if (DEMO || !hasLive) {
+        const mockAgentIds = useStore.getState().agents.filter((a) => !a.ptyId).map((a) => a.id);
+        if (mockAgentIds.length > 0) startMockLoop(mockAgentIds);
+      } else stopMockLoop();
     };
     evaluate();
     const unsub = useStore.subscribe(evaluate);

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -531,6 +531,19 @@ export function useHive(config: HarnessConfig | null): void {
     });
   }, []);
 
+  // 2a-1) Mock terminal output from the main-process MockHookServer — feeds
+  //       lines into the agent's terminal pane so demo agents produce visible
+  //       output through the same pushFeed path as real PTY output.
+  useEffect(() => {
+    return window.cth.onHiveMockFeed?.(({ agentId, lines }: { agentId: string; lines: string[] }) => {
+      const { agents } = useStore.getState();
+      if (!agents.some(a => a.id === agentId)) return;
+      for (const line of lines) {
+        useStore.getState().pushFeed(agentId, line);
+      }
+    });
+  }, []);
+
   // 2b) Consume circuit-breaker state (#7C.4/#5C). Lane A's breaker policy (#6)
   //     pushes BreakerState on `control:breakerState`; this gives it PRECEDENCE
   //     over hook-derived status: a constrained/stopped agent is pinned to

--- a/src/renderer/src/store/mockEvents.ts
+++ b/src/renderer/src/store/mockEvents.ts
@@ -1,180 +1,22 @@
-// Synthetic event stream so the avatars actually move while we wait on real tmux/hook wiring.
+// Synthetic event loop — driven by the main-process MockHookServer via IPC.
+//
+// Previously this module wrote the zustand store directly (bypassing the
+// HookServer → IPC → useHive pipeline). It now delegates to preload-exposed
+// IPC methods, so all avatar state flows through the same path as real events.
 
-import { useStore, type Agent, type StationKind, type ToolKind } from './store';
+import type { ToolKind, StationKind } from './store';
 
-const STATION_BY_TOOL: Record<ToolKind, StationKind> = {
-  Read: 'shelf', Edit: 'shelf', Write: 'shelf',
-  Bash: 'terminal',
-  WebFetch: 'web', WebSearch: 'web',
-  Grep: 'shelf', Glob: 'shelf',
-  TodoWrite: 'board',
-  MCP: 'mcp'
-};
-
-interface ToolSample {
-  tool: ToolKind;
-  what: string;            // short — used as the action text
-  lines: string[];         // terminal stream output
-  thought: string;         // first-person assistant text, streamed in the sidebar
+/**
+ * Start the mock loop. The main process MockHookServer will emit
+ * hive:hookEvent + hive:mockFeed messages that useHive.ts consumes.
+ */
+export function startMockLoop(agentIds: string[]): void {
+  window.cth?.startMockLoop?.(agentIds);
 }
 
-const TOOL_SAMPLES: ToolSample[] = [
-  {
-    tool: 'Read', what: 'reading SPEC.md',
-    lines: ['\x1b[36m● Read\x1b[0m SPEC.md', '   read 412 lines.'],
-    thought: "Pulling up the spec so I can confirm the state machine before touching the implementation."
-  },
-  {
-    tool: 'Edit', what: 'editing PixelPanel.tsx',
-    lines: ['\x1b[36m● Edit\x1b[0m src/renderer/src/components/PixelPanel.tsx', '   +14 / -3'],
-    thought: "Tightening up the panel border math — the inner stroke was a pixel off in inset mode."
-  },
-  {
-    tool: 'Bash', what: 'running tests',
-    lines: ['\x1b[36m● Bash\x1b[0m npm test', '   ✓ 24 passed'],
-    thought: "Running the renderer suite to make sure nothing regressed before I move on."
-  },
-  {
-    tool: 'WebFetch', what: 'fetching docs',
-    lines: ['\x1b[36m● WebFetch\x1b[0m https://docs.example.com/hooks', '   ok 200 (1.2kb)'],
-    thought: "Grabbing the hooks doc to double-check the PreToolUse payload shape — my memory of the field names is hazy."
-  },
-  {
-    tool: 'Glob', what: 'searching for skill files',
-    lines: ['\x1b[36m● Glob\x1b[0m **/*.skill.md', '   23 matches'],
-    thought: "Enumerating all the skill files so I can walk each one and look for stale script paths."
-  },
-  {
-    tool: 'TodoWrite', what: 'updating the todo board',
-    lines: ['\x1b[36m● TodoWrite\x1b[0m 4 items'],
-    thought: "Splitting the remaining work into four discrete tasks so I can track them as I go."
-  }
-];
-
-function pickSample() {
-  return TOOL_SAMPLES[Math.floor(Math.random() * TOOL_SAMPLES.length)];
-}
-
-const TICK_MS = 1800;
-
-function stepAgent(agent: Agent) {
-  const { updateAgent, pushFeed } = useStore.getState();
-
-  if (agent.status === 'blocked') {
-    // Wait for user action; don't move automatically.
-    return;
-  }
-
-  // Decision based on current status
-  if (agent.status === 'idle') {
-    // Maybe start a new task
-    if (Math.random() < 0.4) {
-      const sample = pickSample();
-      const station = STATION_BY_TOOL[sample.tool];
-      updateAgent(agent.id, {
-        status: 'thinking',
-        action: `heading to ${station}`,
-        currentStation: station,
-        progress: 1
-      });
-    }
-    return;
-  }
-
-  if (agent.status === 'thinking') {
-    // Arrived at the station — kick off the tool
-    // (in real life this fires on PreToolUse arrival)
-
-    const station = agent.currentStation ?? 'desk';
-    const tool: ToolKind = station === 'shelf' ? (Math.random() < 0.5 ? 'Read' : 'Edit')
-      : station === 'terminal' ? 'Bash'
-      : station === 'web' ? 'WebFetch'
-      : station === 'board' ? 'TodoWrite' : 'Read';
-    const sample = pickSample();
-    updateAgent(agent.id, {
-      status: 'working',
-      action: sample.what,
-      carrying: tool,
-      progress: Math.min(agent.progress + 1, 8),
-      recentAssistantText: sample.thought,
-      recentTextTs: Date.now()
-    });
-    sample.lines.forEach(l => pushFeed(agent.id, l));
-    return;
-  }
-
-  if (agent.status === 'working') {
-    // Finish the tool and either keep going or settle
-    if (Math.random() < 0.5) {
-      updateAgent(agent.id, {
-        status: 'thinking',
-        action: 'heading back to desk',
-        currentStation: 'desk',
-        progress: Math.min(agent.progress + 1, 8)
-      });
-    } else {
-      // Move to a new station
-      const sample = pickSample();
-      const station = STATION_BY_TOOL[sample.tool];
-      updateAgent(agent.id, {
-        status: 'thinking',
-        action: `heading to ${station}`,
-        currentStation: station,
-        progress: Math.min(agent.progress + 1, 8)
-      });
-    }
-    return;
-  }
-}
-
-const MOCK_ACTS = ['request', 'inform', 'propose', 'query', 'agree'] as const;
-
-/** Occasionally fire a synthetic agent-to-agent message so the office floor's
- *  envelope-handoff animation is visible in demo mode (no live hive routing
- *  happens without real `claude` agents). The scene listens for this event and
- *  flies an envelope between the two avatars; see OfficeFloor's demo path. */
-function maybeFlyMessage(mockIds: string[]): void {
-  if (mockIds.length < 2 || Math.random() >= 0.45) return;
-  const from = mockIds[Math.floor(Math.random() * mockIds.length)];
-  let to = from;
-  for (let i = 0; i < 6 && to === from; i++) {
-    to = mockIds[Math.floor(Math.random() * mockIds.length)];
-  }
-  if (to === from) return;
-  const act = MOCK_ACTS[Math.floor(Math.random() * MOCK_ACTS.length)];
-  window.dispatchEvent(new CustomEvent('cth:demo-handoff', { detail: { from, to, act } }));
-}
-
-let interval: number | null = null;
-
-export function startMockLoop() {
-  if (interval !== null) return;
-  interval = window.setInterval(() => {
-    const { agents } = useStore.getState();
-    // Only step mock agents (no ptyId). Real agents are driven by the pty parser.
-    for (const a of agents) if (!a.ptyId) stepAgent(a);
-
-    const { agents: a2, updateAgent } = useStore.getState();
-    for (const a of a2) {
-      if (a.ptyId) continue;
-      if (a.status === 'thinking' && a.currentStation === 'desk' && Math.random() < 0.4) {
-        updateAgent(a.id, {
-          status: 'idle',
-          action: 'awaiting',
-          carrying: undefined,
-          recentAssistantText: 'Done with that one. What next?',
-          recentTextTs: Date.now()
-        });
-      }
-    }
-
-    maybeFlyMessage(a2.filter((a) => !a.ptyId).map((a) => a.id));
-  }, TICK_MS) as unknown as number;
-}
-
-export function stopMockLoop() {
-  if (interval !== null) {
-    window.clearInterval(interval);
-    interval = null;
-  }
+/**
+ * Stop the mock loop.
+ */
+export function stopMockLoop(): void {
+  window.cth?.stopMockLoop?.();
 }


### PR DESCRIPTION

## Before
![before - renderer-side mock loop writing the store directly](https://github.com/Lion-1209/munder-difflin/releases/download/pr198-evidence/before.png)

Old renderer-side mock loop (`mockEvents.ts` writing the zustand store directly, bypassing IPC): demo avatars driven by an in-renderer `setInterval`; action text like "heading to shelf" / "reading SPEC.md" comes from that module's own private state machine.

## After
![after - main-process MockHookServer over IPC](https://github.com/Lion-1209/munder-difflin/releases/download/pr198-evidence/after.png)

Same demo floor, now driven by the main-process `MockHookServer`: synthetic PreToolUse/PostToolUse/Stop events flow over the same `hive:hookEvent` IPC channel as real hook events, and terminal lines arrive via `hive:mockFeed` -> `pushFeed`. Action text ("using Bash", "using Edit") now comes from the shared `stationForTool` path in `useHive.ts` - identical to how live agents are rendered.

## Summary

Replace the synthetic event loop in \`src/renderer/src/store/mockEvents.ts\` (which wrote the zustand store directly, bypassing the IPC pipeline) with a main-process \`MockHookServer\` that emits the same \`hive:hookEvent\` payloads as the real \`HookServer\`.

## What demo mode is for

From the code, demo mode serves two purposes:

1. **Dev-time visual feedback** (`VITE_CTH_DEMO=1` in dev): the office floor animates while the
   real tmux/hook wiring is still being worked on, and the envelope-handoff animation is visible
   without live `claude` agents (the original module comment: *"Synthetic event stream so the avatars
   actually move while we wait on real tmux/hook wiring"*).
2. **Empty-floor fallback**: `App.tsx` starts the mock loop whenever no agent has a live PTY
   (`DEMO || !hasLive`) and stops it the instant the first real PTY agent appears — so a first-run
   floor is not frozen while agents are still being spawned.

It is not a user-facing product surface; it is developer/first-run scaffolding. I agree that puts this
PR in the "hygiene, not urgent" bucket — happy for it to be parked until the higher-priority
user-facing fixes land.

## Motivation

Currently avatar animation has two separate code paths:

| Path | Source | Store writes |
|------|--------|-------------|
| Real agents | \`HookServer\` → IPC → \`useHive.ts\` | Centralized in \`useHive.ts\` |
| Mock agents | \`mockEvents.ts\` → direct store | **Bypasses IPC entirely** |

This causes mock events and real events to have different state-machine paths, and \`pushFeed\` (terminal output) only works for mock agents.

## Changes

- **\`src/main/mockHookServer.ts\`** (new) — Main-process server that generates synthetic PreToolUse/PostToolUse/Stop events and emits them on the same \`hive:hookEvent\` IPC channel.
- **\`src/main/mockLoopIpc.ts\`** (new) — Registers \`mock:start\` / \`mock:stop\` IPC handlers.
- **\`src/renderer/src/store/mockEvents.ts\`** — Rewritten from 183 lines to 22: the old direct-store loop (\`setInterval\`, \`stepAgent\`, \`updateAgent\`/\`pushFeed\` writes, its own STATION_BY_TOOL state machine) is **fully deleted, not dormant**. The module now exports only two IPC delegates (\`startMockLoop(agentIds)\` / \`stopMockLoop()\`), and \`App.tsx\` is its sole importer. There is exactly one mock system: the main-process \`MockHookServer\`.
- **\`src/preload/index.ts\`** — Added \`startMockLoop\` and \`stopMockLoop\` IPC bridge methods.
- **\`src/renderer/src/hooks/useHive.ts\`** — Added \`onHiveMockFeed\` listener for terminal output and \`stationForTool\` helper.

## Architecture after merge

\`\`\`
MockHookServer (main)
    │
    ├─► webContents.send('hive:hookEvent') ──► useHive.ts ──► store
    ├─► webContents.send('hive:mockFeed')  ──► useHive.ts ──► pushFeed
    └─► webContents.send('cth:demo-handoff') ──► OfficeFloor

Real HookServer (main)
    │
    └─► webContents.send('hive:hookEvent') ──► useHive.ts ──► store
\`\`\`

All avatar state updates now flow through \`useHive.ts\`. No store writes from \`mockEvents.ts\`.

## Testing

Run \`npm run typecheck\` and \`npm run test:focused\` to verify.

Closes #197

