### PR TITLE
fix: prevent antigravity queue from getting stuck for 30s

### DIFF
--- a/src/shared/providerAutomation.ts
+++ b/src/shared/providerAutomation.ts
@@ -238,5 +238,8 @@ export function terminalReadyToReceive(
   elapsedMs: number,
   provider: AgentProvider
 ): boolean {
+  if (provider === 'antigravity') {
+    return elapsedMs >= terminalReadySettleMs(provider);
+  }
   return hasOutput !== false && elapsedMs >= terminalReadySettleMs(provider);
 }


### PR DESCRIPTION
This fixes an issue where Munder Difflin gets stuck waiting for `hasOutput` for `antigravity` agents, which causes messages to sit in the queue until the 30-second timeout.

Since `agy` buffers its output, `hasOutput` stays false, so we simply bypass the output check and wait for the settle time.