### PR TITLE
fix(hive): point Crush config env at agent dir

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -740,7 +740,7 @@ export class HiveManager {
                 // proxy's real target. Per-agent CRUSH_GLOBAL_DATA isolates session
                 // state from the user's global ~/.config/crush.
                 const crush = this.installCrushConfig(dir, loopback, desc.api);
-                env.CRUSH_GLOBAL_CONFIG = crush.config;
+                env.CRUSH_GLOBAL_CONFIG = dir;
                 env.CRUSH_GLOBAL_DATA = crush.data;
               } else {
                 env[desc.baseUrlEnv] = loopback;

--- a/test/crush-provider-config.test.cjs
+++ b/test/crush-provider-config.test.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-crush-config-'));
+}
+
+test('crush provider points CRUSH_GLOBAL_CONFIG at the agent directory', async (t) => {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  const hive = new HiveManager(() => home);
+  const injection = await hive.ensureAgent({
+    id: 'crush-1',
+    name: 'Crush Worker',
+    provider: 'crush',
+    cwd: home
+  });
+
+  const agentDir = path.join(home, 'hive', 'agents', 'crush-1');
+  assert.equal(injection.env.CRUSH_GLOBAL_CONFIG, agentDir);
+  assert.equal(injection.env.CRUSH_GLOBAL_DATA, path.join(agentDir, '.crush-data'));
+
+  const configPath = path.join(agentDir, 'crush.json');
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  assert.equal(config.providers.openai.base_url.startsWith('http://127.0.0.1:'), true);
+});


### PR DESCRIPTION
## What & why

Fixes #194 by pointing `CRUSH_GLOBAL_CONFIG` at the per-agent directory instead of the generated `crush.json` file path. Crush appends `crush.json` to `CRUSH_GLOBAL_CONFIG`, so the old env value produced `<dir>/crush.json/crush.json` and prevented Crush workers from starting.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Screenshots / clips

Not applicable; no UI change.

## Discord (optional)

Discord:

## Checklist

- [x] `npm run typecheck` passes (the de-facto CI gate).
- [x] `npm run build` succeeds.
- [x] PR is focused on a single change.
