### PR TITLE
fix(build): ad-hoc sign the mac app when there is no Developer ID identity

### DIFF
--- a/build/notarize.cjs
+++ b/build/notarize.cjs
@@ -12,6 +12,41 @@
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');
 
+/**
+ * Ad-hoc sign the bundle when there is no Developer ID identity to sign with.
+ *
+ * Without this the app ships with NO valid signature at all — `codesign
+ * --verify` reports "code object is not signed at all", and macOS will not
+ * persist a TCC grant for a bundle whose identity it cannot validate. The
+ * practical effect is the one this config exists to prevent: the folder-access
+ * prompt returns on EVERY agent file touch instead of being answered once. An
+ * ad-hoc signature is not distributable and Gatekeeper still blocks it for
+ * other users, but it is self-consistent, which is all TCC needs to remember
+ * the grant on the machine that built it.
+ *
+ * Deliberately best-effort: a contributor without Xcode's command line tools
+ * should still end up with a working (if re-prompting) build rather than a
+ * failed release.
+ */
+function adhocSign(context) {
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(context.appOutDir, `${appName}.app`);
+  const entitlements = path.join(__dirname, 'entitlements.mac.plist');
+  try {
+    execFileSync('codesign', [
+      '--force', '--deep', '--sign', '-',
+      '--options', 'runtime',
+      '--entitlements', entitlements,
+      appPath
+    ], { stdio: 'pipe' });
+    execFileSync('codesign', ['--verify', '--deep', '--strict', appPath], { stdio: 'pipe' });
+    console.log('[notarize] ad-hoc signed the app so macOS can remember folder-access grants.');
+  } catch (err) {
+    console.warn('[notarize] ⚠️  ad-hoc signing failed — macOS will re-prompt for folder access on every agent action.');
+    console.warn(`[notarize] codesign said: ${err && err.message ? err.message : err}`);
+  }
+}
+
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== 'darwin') return; // mac only
@@ -24,7 +59,8 @@ exports.default = async function notarizing(context) {
   const hasPassword = !!(APPLE_ID && APPLE_APP_SPECIFIC_PASSWORD && APPLE_TEAM_ID);
   const hasApiKey = !!(APPLE_API_KEY && APPLE_API_KEY_ID && APPLE_API_ISSUER);
   if (!hasPassword && !hasApiKey) {
-    console.log('[notarize] no APPLE_* credentials in env — skipping notarization (build stays unsigned).');
+    console.log('[notarize] no APPLE_* credentials in env — skipping notarization.');
+    adhocSign(context);
     return;
   }
 


### PR DESCRIPTION
Without a Developer ID cert in the keychain, the `afterSign` hook returns early and the build ships with **no valid signature at all**:

```
$ codesign --verify --deep --strict "Munder Difflin.app"
Munder Difflin.app: code object is not signed at all
```

macOS will not persist a TCC grant for a bundle whose identity it cannot validate, so the folder-access prompt comes back on **every agent file touch** — handing one Desktop screenshot to an agent produced ten consecutive Allow / Don't Allow dialogs. That is precisely what the usage strings and entitlements already in `electron-builder.yml` exist to prevent; the comment there says so out loud:

> for a signed app, remembers the grant — so the user is asked ONCE instead of on every agent action

**Fix:** ad-hoc sign as a fallback when no Apple credentials are present.

An ad-hoc signature is not distributable and Gatekeeper still blocks it for other users — this changes nothing for released builds, which continue to be Developer ID signed and notarized. But it is self-consistent and carries the real bundle identifier (`in.munderdiffl.app`) instead of Electron's linker-signed `Electron`, which is what TCC needs to remember the grant on the machine that built it. Anyone running a local `npm run dist:mac` gets the one-time prompt the app was designed around.

Best-effort by design: if `codesign` is unavailable the hook warns and the build still completes, so a contributor without the command line tools is no worse off than today.

Verified locally — before / after on the same bundle:

```
before:  code object is not signed at all   Identifier=Electron
after:   (verifies clean)                   Identifier=in.munderdiffl.app  Signature=adhoc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUpadJJuEQz1zpQ6Vk83j3