### PR TITLE
Automate the Founders' Wall from Razorpay (PR-gated additions)

### DIFF
--- a/.github/workflows/wall-sync.yml
+++ b/.github/workflows/wall-sync.yml
@@ -1,0 +1,34 @@
+# Founders' Wall sync — rebuilds docs/wall-data.json from Razorpay truth.
+# Additions open a PR for founder review; refund/dispute removals commit directly.
+# Requires repo Actions secrets: RAZORPAY_KEY_ID, RAZORPAY_KEY_SECRET.
+name: wall-sync
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: wall-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Sync wall from Razorpay
+        env:
+          RAZORPAY_KEY_ID: ${{ secrets.RAZORPAY_KEY_ID }}
+          RAZORPAY_KEY_SECRET: ${{ secrets.RAZORPAY_KEY_SECRET }}
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/wall-sync.mjs

--- a/scripts/wall-sync.mjs
+++ b/scripts/wall-sync.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// scripts/wall-sync.mjs — keep docs/wall-data.json in sync with Razorpay truth.
+//
+// Runs from .github/workflows/wall-sync.yml on a schedule. Read-only against
+// Razorpay. The wall list is REBUILT from the API every run (never append-only):
+// a refunded or disputed payment drops off automatically on the next run.
+//
+//   - membership comes from the API (captured, not refunded, not disputed)
+//   - names/dates of entries ALREADY on the wall are preserved verbatim —
+//     manual curation always wins; this script never rewrites a published name
+//   - new supporters are added with the name they asked to have engraved,
+//     unless the name fails the gates below, in which case the entry is held
+//     out and listed in the PR body for a human decision. We never substitute
+//     a name we invented.
+//   - REMOVALS are committed directly (leaving a refunded payer up is the bug)
+//   - ADDITIONS open/refresh a PR on the stable branch wall/additions
+//   - any Razorpay error aborts the run with no changes (fail-closed)
+//
+// Env: RAZORPAY_KEY_ID, RAZORPAY_KEY_SECRET (Actions secrets), GH_TOKEN (for gh),
+//      DRY_RUN=1 to print the plan and touch nothing.
+
+import { readFileSync, writeFileSync, mkdtempSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const WALL_FILE = "docs/wall-data.json";
+const API = "https://api.razorpay.com";
+const DRY = process.env.DRY_RUN === "1";
+const PR_BRANCH = "wall/additions";
+
+// Same scope filter as the dashboard collector: the engraving-notes key is the
+// discriminator for wall payments; the date guards against ~9,800 legacy records.
+// Epoch is Aug 13 UTC because the first wall payment is 2026-08-13T19:xx UTC
+// (= Aug 14 IST, the wall's listed date).
+const MD_EPOCH = Math.floor(Date.parse("2026-08-13T00:00:00Z") / 1000);
+const ENGRAVE_KEY = "name_(as_you_want_it_engraved)";
+const FOUNDER_EMAIL = "girichaitanya11@gmail.com"; // self-test payments held for confirmation
+const MAX_NAME_LEN = 40;
+
+function auth() {
+  const id = process.env.RAZORPAY_KEY_ID, secret = process.env.RAZORPAY_KEY_SECRET;
+  if (!id || !secret) throw new Error("RAZORPAY_KEY_ID / RAZORPAY_KEY_SECRET missing from env");
+  return "Basic " + Buffer.from(`${id}:${secret}`).toString("base64");
+}
+
+async function get(pathname, params = {}) {
+  const url = new URL(pathname, API);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, String(v));
+  const res = await fetch(url, { headers: { Authorization: auth() } });
+  if (!res.ok) {
+    const body = (await res.text()).slice(0, 200);
+    const err = new Error(`GET ${pathname} -> HTTP ${res.status}: ${body}`);
+    err.status = res.status;
+    throw err;
+  }
+  return res.json();
+}
+
+async function paginate(pathname, params = {}) {
+  const items = [];
+  for (let skip = 0; ; skip += 100) {
+    const page = await get(pathname, { ...params, count: 100, skip });
+    const batch = page.items ?? [];
+    items.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return items;
+}
+
+// Reasons a name can't be auto-published. Structural checks only — the PR
+// review is the real gate for anything a regex can't judge.
+function nameGate(payment) {
+  const raw = String(payment.notes?.[ENGRAVE_KEY] ?? "");
+  const name = raw.trim().replace(/\s+/g, " ");
+  if (!name) return { held: "empty name" };
+  if (name.length > MAX_NAME_LEN) return { held: `name longer than ${MAX_NAME_LEN} chars` };
+  if (/https?:\/\/|www\.|[a-z0-9-]+\.[a-z]{2,}(\/|$)/i.test(name)) return { held: "looks like a URL/domain" };
+  if (!/\p{L}/u.test(name)) return { held: "no letters in name" };
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(name)) return { held: "control characters in name" };
+  if ((payment.email ?? "").toLowerCase() === FOUNDER_EMAIL)
+    return { held: "paid from the founder's own email — confirm it's meant for the wall" };
+  return { name };
+}
+
+function sh(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"], ...opts }).trim();
+}
+
+async function main() {
+  // 1. Truth from Razorpay (fail-closed: any throw aborts before any write).
+  const payments = (await paginate("/v1/payments", { from: MD_EPOCH }))
+    .filter((p) => p.created_at >= MD_EPOCH && p.notes && Object.hasOwn(p.notes, ENGRAVE_KEY));
+
+  let disputedIds = new Set();
+  try {
+    const disputes = await paginate("/v1/disputes");
+    disputedIds = new Set(disputes.filter((d) => d.status !== "won").map((d) => d.payment_id));
+  } catch (err) {
+    // Disputes endpoint may not be enabled on this account; that must not
+    // brick the pipeline. Auth/server errors still abort.
+    if (err.status !== 400 && err.status !== 404) throw err;
+    console.error(`note: disputes endpoint unavailable (HTTP ${err.status}); proceeding without dispute checks`);
+  }
+
+  const eligible = payments.filter(
+    (p) => p.status === "captured" && (p.amount_refunded ?? 0) === 0 && !p.refund_status && !disputedIds.has(p.id),
+  );
+  const eligibleById = new Map(eligible.map((p) => [p.id, p]));
+
+  // 2. Current wall.
+  const wall = JSON.parse(readFileSync(WALL_FILE, "utf8"));
+  const wallIds = new Set(wall.map((e) => e.payment_id));
+
+  // 3. Membership diff. Existing entries keep their curated name/date.
+  const kept = wall.filter((e) => eligibleById.has(e.payment_id));
+  const removals = wall.filter((e) => !eligibleById.has(e.payment_id));
+  const additions = [];
+  const heldOut = [];
+  for (const p of eligible) {
+    if (wallIds.has(p.id)) continue;
+    const gate = nameGate(p);
+    if (gate.held) heldOut.push({ payment_id: p.id, reason: gate.held });
+    else additions.push({ name: gate.name, date: new Date(p.created_at * 1000).toISOString().slice(0, 10), payment_id: p.id });
+  }
+
+  const at = (id) => eligibleById.get(id)?.created_at ?? 0;
+  const sortByPayment = (list) => list.sort((a, b) => at(a.payment_id) - at(b.payment_id));
+
+  console.log(JSON.stringify({
+    eligible: eligible.length, on_wall: wall.length, kept: kept.length,
+    removals: removals.map((e) => e.payment_id), additions: additions.length, held_out: heldOut,
+  }));
+
+  if (DRY) {
+    console.log("DRY_RUN=1 — plan only, nothing written.");
+    if (additions.length) console.log("would add:", additions.map((a) => `${a.name} (${a.payment_id})`).join("; "));
+    return;
+  }
+  if (!removals.length && !additions.length && !heldOut.length) {
+    console.log("wall is in sync; nothing to do");
+    return;
+  }
+
+  sh("git", ["config", "user.name", "wall-sync"]);
+  sh("git", ["config", "user.email", "wall-sync@users.noreply.github.com"]);
+  const baseBranch = sh("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+
+  // 4. Removals: straight to the default branch. Speed is safety here.
+  if (removals.length) {
+    const afterRemoval = sortByPayment([...kept]);
+    writeFileSync(WALL_FILE, JSON.stringify(afterRemoval, null, 2) + "\n");
+    sh("git", ["add", WALL_FILE]);
+    sh("git", ["commit", "-m", `wall: remove ${removals.length} refunded/disputed plaque(s)\n\n${removals.map((e) => e.payment_id).join("\n")}`]);
+    sh("git", ["push", "origin", `HEAD:${baseBranch}`]);
+    console.log(`removed ${removals.length} entr(ies) and pushed to ${baseBranch}`);
+  }
+
+  // 5. Additions (and/or held-outs needing a decision): a rolling PR.
+  if (additions.length || heldOut.length) {
+    const prList = sortByPayment([...kept, ...additions]);
+    sh("git", ["checkout", "-B", PR_BRANCH]);
+    writeFileSync(WALL_FILE, JSON.stringify(prList, null, 2) + "\n");
+    sh("git", ["add", WALL_FILE]);
+    const title = `wall: ${additions.length} new Founding Supporter(s)`;
+    sh("git", ["commit", "--allow-empty", "-m", title]);
+    sh("git", ["push", "-f", "origin", PR_BRANCH]);
+
+    const bodyFile = path.join(mkdtempSync(path.join(tmpdir(), "wall-")), "pr-body.md");
+    const body = [
+      "Automated wall sync — review the names, then merge to publish.",
+      "",
+      ...(additions.length ? ["## Additions", "", "| engraved name | date | payment |", "|---|---|---|",
+        ...additions.map((a) => `| ${a.name} | ${a.date} | ${a.payment_id} |`), ""] : []),
+      ...(heldOut.length ? ["## Held out — needs your decision (not in the JSON)", "",
+        ...heldOut.map((h) => `- \`${h.payment_id}\` — ${h.reason}`), "",
+        "To publish a held-out supporter, add them to `docs/wall-data.json` in this PR by hand; the sync preserves manual entries.", ""] : []),
+      "Removals (refunds/disputes) are committed directly by the sync, not via this PR.",
+    ].join("\n");
+    writeFileSync(bodyFile, body);
+
+    const existing = sh("gh", ["pr", "list", "--head", PR_BRANCH, "--state", "open", "--json", "number", "--jq", ".[0].number // empty"]);
+    if (existing) {
+      sh("gh", ["pr", "edit", existing, "--title", title, "--body-file", bodyFile]);
+      console.log(`updated PR #${existing}`);
+    } else {
+      sh("gh", ["pr", "create", "--base", baseBranch, "--head", PR_BRANCH, "--title", title, "--body-file", bodyFile]);
+      console.log("opened wall additions PR");
+    }
+    sh("git", ["checkout", baseBranch]);
+  }
+}
+
+main().catch((err) => {
+  console.error(`wall-sync failed (no changes made): ${err.message ?? err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What this is

The wall automation from the metrics-dashboard workstream, ready to enable. **Merging this PR is what turns it on** — the cron only runs from the default branch.

- Every 30 minutes, `scripts/wall-sync.mjs` rebuilds `docs/wall-data.json` from Razorpay truth (captured + unrefunded + undisputed payments with the engraving field, from the wall's launch date).
- **Additions open a rolling PR** (`wall/additions`) so a human reviews every user-supplied name before it hits the public page. Held-out names (empty / URL-like / over-length / founder self-test) are listed in the PR body, never auto-published.
- **Removals commit directly** — a refunded or disputed supporter comes off the wall on the next run without waiting for review.
- **Rebuild-from-truth applies to MEMBERSHIP, not display names.** The API decides only who is on the wall (captured, unrefunded, undisputed). Entries already in `docs/wall-data.json` keep their name and date **verbatim** — manual curation always wins (entry № 1 was manually corrected from its as-typed engraving, and the sync will never revert that). The sync never rewrites a published name.
- Fails closed: any Razorpay error aborts with no changes. Read-only against Razorpay.

## Before merging — required setup

Add two repository Actions secrets (Settings → Secrets and variables → Actions):
- `RAZORPAY_KEY_ID`
- `RAZORPAY_KEY_SECRET`

(the same two values from the credentials file, without the quotes)

## Verified

Dry-run against the live account: 19 eligible, 14 kept, **5 pending additions**, 0 removals, 0 held out. The first scheduled run after merge will open the additions PR with those 5 supporters — reviewing it is the proof of the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
