### PR TITLE
chore(wall): sync hourly instead of every 30 minutes

### DIFF
--- a/.github/workflows/wall-sync.yml
+++ b/.github/workflows/wall-sync.yml
@@ -5,7 +5,19 @@ name: wall-sync
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    # HOURLY (was every 30 min). ONE CADENCE across the whole metrics stack —
+    # the local dashboard runner is hourly too, and the two must not drift apart.
+    #
+    # :50 is chosen so this lands just BEFORE the dashboard's hourly pass at :07,
+    # not after it. The dashboard reports wall_published / wall_pending by
+    # comparing Razorpay truth against the published wall, so it should read a
+    # wall that was reconciled minutes ago rather than most of an hour ago.
+    # Off :00 on purpose: GitHub's scheduled-workflow queue is busiest there and
+    # starts get delayed most.
+    #
+    # Additions still wait on a review PR, so wall_pending legitimately stays
+    # non-zero until the founder merges — that is the gate working, not drift.
+    - cron: "50 * * * *"
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
The Founders' Wall sync was on a 30-minute cron while the dashboard that reports on it runs hourly. Two cadences for one pipeline meant `wall_pending` could disagree between the wall and the dashboard at any given moment.

**One cadence now: both hourly.**

Scheduled at `:50` rather than `:00` or `:30`, for two reasons:

- It lands just **before** the dashboard's hourly pass at `:07`, not most of an hour after it. The dashboard derives `wall_published` / `wall_pending` by comparing Razorpay truth against the published wall, so it should read a wall that was reconciled minutes ago.
- Off `:00`, where GitHub's scheduled-workflow queue is busiest and starts are delayed most.

No behaviour change beyond the schedule: `workflow_dispatch`, the `wall-sync` concurrency group, permissions and the sync script are all untouched, so a manual run still works exactly as before.

Worth stating so it is not read as a regression: additions still open a review PR, so `wall_pending` legitimately stays non-zero until you merge one. That is the approval gate working, not the sync falling behind. Refund/dispute removals still commit directly, and halving the frequency does not change that path's safety — a refunded supporter now comes off the wall within an hour rather than within 30 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)