### PR TITLE
Arabic/RTL text support: terminal rendering recipe + markdown/composer bidi

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -10,7 +10,7 @@
          (small caps labels only); body/UI moves to Inter and code/terminal to
          JetBrains Mono — the pixel body fonts (Pixelify/VT323) read as toy-like
          and strained at data-dense sizes. -->
-    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=IBM+Plex+Sans+Arabic:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <style>
       #cth-splash {
         position: fixed; inset: 0; display: flex; flex-direction: column;

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -941,6 +941,7 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
 
                     <Row label="Goal (optional)">
                       <textarea
+                        dir="auto"
                         value={goal}
                         onChange={(e) => setGoal(e.target.value)}
                         placeholder="long-running directive injected on every prompt"

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -199,6 +199,7 @@ export function AgentStrip({ config }: AgentStripProps) {
                       line per bullet) and the fullscreen roster renders every
                       line — an <input> would silently eat the newlines. */}
                   <textarea
+                    dir="auto"
                     autoFocus
                     rows={3}
                     value={a.note ?? ''}

--- a/src/renderer/src/components/AskMeTab.tsx
+++ b/src/renderer/src/components/AskMeTab.tsx
@@ -195,12 +195,13 @@ export function AskMeTab() {
 
             <div style={{ padding: 9, display: 'flex', flexDirection: 'column', gap: 8 }}>
               {/* the question */}
-              <div style={{ fontSize: 15, lineHeight: '19px', color: 'var(--cth-ink-900)', whiteSpace: 'pre-wrap' }}>
+              <div dir="auto" style={{ fontSize: 15, lineHeight: '19px', color: 'var(--cth-ink-900)', whiteSpace: 'pre-wrap' }}>
                 {open.q}
               </div>
 
               {/* answer box */}
               <textarea
+                dir="auto"
                 value={drafts[t.id] ?? ''}
                 onChange={(e) => setAnswerDraft(t.id, e.target.value)}
                 onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void sendAnswer(t); }}

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -618,6 +618,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
           </Select>
         </div>
         <textarea
+          dir="auto"
           value={dispatchText}
           onChange={(e) => setDispatchText(e.target.value)}
           rows={2}
@@ -1274,7 +1275,7 @@ function Pre({ children }: { children: React.ReactNode }) {
       background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
       fontFamily: 'var(--cth-font-mono)', fontSize: 12, lineHeight: '16px',
       color: 'var(--cth-ink-900)', whiteSpace: 'pre-wrap', wordBreak: 'break-word'
-    }}>{children}</pre>
+    }} dir="auto">{children}</pre>
   );
 }
 

--- a/src/renderer/src/components/FullscreenTerminal.tsx
+++ b/src/renderer/src/components/FullscreenTerminal.tsx
@@ -834,6 +834,7 @@ function SidebarRow({
               to make a new line rather than doing nothing. autoFocus is safe
               now that opening is an explicit click, not a pointer fly-by. */}
           <textarea
+            dir="auto"
             autoFocus
             value={agent.note ?? ''}
             onChange={(e) => onNoteChange(e.target.value)}

--- a/src/renderer/src/components/MemoryPanel.tsx
+++ b/src/renderer/src/components/MemoryPanel.tsx
@@ -219,7 +219,7 @@ export function MemoryPanel() {
                     boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
                     padding: 8, fontFamily: 'var(--cth-font-mono)', fontSize: 12,
                     whiteSpace: 'pre-wrap', color: 'var(--cth-ink-900)'
-                  }}>{result}</pre>
+                  }} dir="auto">{result}</pre>
                 )}
               </div>
             )}

--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -331,6 +331,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
           with file/image attachment chips + paste-to-attach (rich-composer). */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
         <textarea
+          dir="auto"
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={onKey}
@@ -464,6 +465,7 @@ function QueuedMessageRow(
       <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
         <div
           ref={bodyRef}
+          dir="auto"
           title={expanded ? undefined : message.text}
           style={{
             fontSize: 12, lineHeight: '18px',

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -23,6 +23,7 @@ import { AiEnginesSettings } from './AiEnginesSettings';
 import { REALTIME_MODEL } from '@shared/realtimePricing';
 import { RealtimeDevicePicker } from '@/realtime/DevicePicker';
 import { CostHud } from '@/realtime/CostHud';
+import { isArabicTerminalEnabled, setArabicTerminalEnabled } from '@/terminal/arabicSetting';
 
 export interface SettingsModalProps {
   config: HarnessConfig;
@@ -163,6 +164,9 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
   const [confirming, setConfirming] = useState(false);
   const [busy, setBusy] = useState(false);
   const [activeSection, setActiveSection] = useState<Section>(initialSection ?? 'General');
+  // Renderer-local, not part of HarnessConfig — it only changes how this window
+  // paints pty output. Read once; the setter keeps localStorage in step.
+  const [arabicTerminal, setArabicTerminal] = useState(isArabicTerminalEnabled);
 
   // Change-home flow: null until the user picks a new folder, then the sub-modal
   // confirms move-vs-fresh. Pre-selects 'move' (recommended - keeps the data).
@@ -933,6 +937,21 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                             </div>
                             <PixelButton variant={simpleMode ? 'primary' : 'secondary'} size="sm" onClick={toggleSimpleMode}>
                               {simpleMode ? 'on' : 'off'}
+                            </PixelButton>
+                          </div>
+                          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                              <span style={{ fontSize: 13, lineHeight: '20px', color: 'var(--cth-ink-900)' }}>Arabic / RTL text in terminals</span>
+                              <span style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-500)' }}>
+                                Renders terminals with the browser's text engine so Arabic joins and reads right-to-left (xterm has no bidi of its own). Off = GPU renderer, faster but RTL-blind. Defaults on for RTL system locales; applies to newly opened terminals.
+                              </span>
+                            </div>
+                            <PixelButton
+                              variant={arabicTerminal ? 'primary' : 'secondary'}
+                              size="sm"
+                              onClick={() => { const next = !arabicTerminal; setArabicTerminalEnabled(next); setArabicTerminal(next); }}
+                            >
+                              {arabicTerminal ? 'on' : 'off'}
                             </PixelButton>
                           </div>
                         </div>

--- a/src/renderer/src/components/TasksKanban.tsx
+++ b/src/renderer/src/components/TasksKanban.tsx
@@ -345,7 +345,7 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
               boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
               fontFamily: 'var(--cth-font-mono)', fontSize: 12, lineHeight: '18px',
               color: 'var(--cth-ink-900)', whiteSpace: 'pre-wrap', wordBreak: 'break-word'
-            }}>
+            }} dir="auto">
               {task.description?.trim() || <span style={{ color: 'var(--cth-ink-300)' }}>(no description on this card)</span>}
             </div>
 
@@ -361,7 +361,7 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
                       padding: '5px 7px', background: 'var(--cth-lilac-light, #ece2f5)',
                       boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
                       fontSize: 12, lineHeight: '17px', color: 'var(--cth-ink-900)', whiteSpace: 'pre-wrap'
-                    }}>
+                    }} dir="auto">
                       <span style={{ fontFamily: 'var(--cth-font-display)', fontSize: 8, marginRight: 6 }}>Q</span>
                       {e.q}
                     </div>
@@ -370,7 +370,7 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
                         padding: '5px 7px', background: 'var(--cth-mint-light, #d9eed9)',
                         boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
                         fontSize: 12, lineHeight: '17px', color: 'var(--cth-ink-900)', whiteSpace: 'pre-wrap'
-                      }}>
+                      }} dir="auto">
                         <span style={{ fontFamily: 'var(--cth-font-display)', fontSize: 8, marginRight: 6 }}>A</span>
                         {e.a}
                       </div>

--- a/src/renderer/src/components/ThreadsPanel.tsx
+++ b/src/renderer/src/components/ThreadsPanel.tsx
@@ -128,7 +128,7 @@ export function ThreadsPanel({ agentId }: ThreadsPanelProps) {
                           {new Date(m.created_at).toLocaleString()}
                         </span>
                       </div>
-                      <div style={{ fontFamily: 'var(--cth-font-ui)', fontSize: 13, lineHeight: '18px', color: 'var(--cth-ink-700)', marginTop: 2, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                      <div dir="auto" style={{ fontFamily: 'var(--cth-font-ui)', fontSize: 13, lineHeight: '18px', color: 'var(--cth-ink-700)', marginTop: 2, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
                         {shown}
                         {long && (
                           <button
@@ -143,6 +143,7 @@ export function ThreadsPanel({ agentId }: ThreadsPanelProps) {
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 4 }}>
                   <textarea
+                    dir="auto"
                     value={drafts[thread.conversation] ?? ''}
                     onChange={e => setDrafts(d => ({ ...d, [thread.conversation]: e.target.value }))}
                     placeholder={`Reply to ${last.from}…`}

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -18,6 +18,9 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { arabicJoinRanges } from '@/terminal/arabicJoiner';
+import { attachArabicSpacingFix } from '@/terminal/arabicSpacingFix';
+import { isArabicTerminalEnabled } from '@/terminal/arabicSetting';
 import {
   createTerminalRecoveryState,
   normalizePtyChunk,
@@ -91,7 +94,7 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     theme,
     // v0.3.4: JetBrains Mono replaces VT323 — the narrow CRT face strained at
     // data density. lineHeight stays 1.0 so TUI box-drawing rows stay joined.
-    fontFamily: '"JetBrains Mono", "SF Mono", Menlo, monospace',
+    fontFamily: '"JetBrains Mono", "IBM Plex Sans Arabic", "SF Mono", Menlo, monospace',
     fontSize,
     lineHeight: 1.0,
     cursorBlink: true,
@@ -469,6 +472,11 @@ export function dismissTerminalPicker(ptyId: string): void {
  *  rather than leave a black terminal. */
 function leaseWebglRenderer(entry: TerminalEntry): void {
   if (entry.webgl) return;
+  // Arabic mode wants the DOM renderer ON PURPOSE: rows become real text nodes,
+  // so the browser's own engine does shaping and (with the CSS in
+  // design/global.css) bidi — what Terminal.app does natively and the WebGL
+  // cell painter cannot. Skipping the lease IS the feature, not a fallback.
+  if (isArabicTerminalEnabled()) return;
   try {
     const webgl = new WebglAddon();
     webgl.onContextLoss(() => {
@@ -520,6 +528,25 @@ export function attachTerminal(entry: TerminalEntry, container: HTMLElement): vo
     // terminal, and xterm needs its host in the document to measure the cell.
     entry.term.open(entry.host);
     entry.opened = true;
+    // Arabic/RTL terminal support, parts 2 and 4 of 4 (the full recipe is
+    // documented in terminal/arabicJoiner.ts): join every Arabic phrase into
+    // one render range, and strip xterm's per-span letter-spacing from Arabic
+    // spans. MUST come after open(): registering a joiner on an unopened
+    // terminal throws. Parts 1 and 3 are the skipped WebGL lease below and the
+    // bidi CSS in design/global.css.
+    if (isArabicTerminalEnabled()) {
+      entry.term.registerCharacterJoiner(arabicJoinRanges);
+      entry.unsub.push(attachArabicSpacingFix(entry.host));
+      // Terminals open at boot, often BEFORE webfonts finish loading, so xterm
+      // measures Arabic glyphs against fallback metrics and keeps them. When
+      // the real fonts land, poke fontFamily (a self-assign) to force a
+      // re-measure and full repaint.
+      void document.fonts?.ready.then(() => {
+        if (entry.exited) return;
+        const fam = entry.term.options.fontFamily;
+        entry.term.options.fontFamily = fam;
+      });
+    }
   }
   leaseWebglRenderer(entry);
   // PTY startup output can arrive before this pooled terminal subscribes.

--- a/src/renderer/src/components/triggers/ContextSection.tsx
+++ b/src/renderer/src/components/triggers/ContextSection.tsx
@@ -141,6 +141,7 @@ function RuleCard({ title, blurb, rule, messageLabel, messageHint, messagePlaceh
           </Field>
           <Field label={messageLabel}>
             <textarea
+              dir="auto"
               value={rule.message}
               onChange={(e) => onPatch({ message: e.target.value })}
               rows={3}

--- a/src/renderer/src/components/triggers/SchedulesSection.tsx
+++ b/src/renderer/src/components/triggers/SchedulesSection.tsx
@@ -133,6 +133,7 @@ export function SchedulesSection({ onSummary }: { onSummary?: (s: string) => voi
           </Field>
           <Field label="PROMPT">
             <textarea
+              dir="auto"
               value={mBody}
               onChange={(e) => setMBody(e.target.value)}
               rows={3}
@@ -252,6 +253,7 @@ function MissionRow({ mission, targetName, agents, onPatch, onDelete }: {
           </Field>
           <Field label="PROMPT">
             <textarea
+              dir="auto"
               value={body}
               onChange={(e) => setBody(e.target.value)}
               rows={4}

--- a/src/renderer/src/components/triggers/TriggerHistoryTab.tsx
+++ b/src/renderer/src/components/triggers/TriggerHistoryTab.tsx
@@ -213,7 +213,7 @@ function MessageBlock({
         <span style={tinyCaps}>{label}</span>
         <span style={{ ...tinyCaps, flexShrink: 0 }}>{relTime(Date.now() - msg.at)}</span>
       </div>
-      <div style={bodyBox}>{body.trim() ? (expanded ? body : text) : '(empty message)'}</div>
+      <div style={bodyBox} dir="auto">{body.trim() ? (expanded ? body : text) : '(empty message)'}</div>
       {clipped && (
         <button type="button" onClick={onToggle} style={linkButton}>
           {expanded ? 'show less' : `show all ${body.length} characters`}

--- a/src/renderer/src/design/global.css
+++ b/src/renderer/src/design/global.css
@@ -138,6 +138,19 @@ canvas, img, svg { image-rendering: pixelated; image-rendering: crisp-edges; }
   font-feature-settings: "liga" 0, "clig" 0, "calt" 0 !important;
 }
 
+/* Arabic/RTL in terminals, part 3 of 4 (see terminal/arabicJoiner.ts for the
+   whole recipe). `plaintext` gives each ROW its own base direction from its
+   first strong character — an Arabic row lays out right-to-left and
+   right-aligned, a Latin row is untouched. The span override matters just as
+   much: xterm's DOM renderer emits inline-block spans, which are ATOMIC to the
+   bidi algorithm — the browser can never reorder them; plain inline text it
+   can. !important is load-bearing: the DOM renderer INJECTS a runtime
+   stylesheet whose rules land after this file and would otherwise win the
+   cascade, silently disabling the whole recipe. Only the DOM renderer reads
+   these rules; the WebGL canvas ignores CSS entirely. */
+.xterm .xterm-rows > div { unicode-bidi: plaintext !important; }
+.xterm .xterm-rows > div > span { display: inline !important; unicode-bidi: normal !important; }
+
 /* ─── Markdown preview (v0.3.4) ──────────────────────────────────────────────
    Shared by the IDE split/preview view and the fullscreen file overlay. All
    colors ride the tokens, so light + dark themes come for free. */
@@ -170,19 +183,26 @@ canvas, img, svg { image-rendering: pixelated; image-rendering: crisp-edges; }
   padding: 10px 12px; overflow-x: auto; border-radius: 2px;
 }
 .cth-md-preview pre code { background: transparent; padding: 0; }
-.cth-md-preview blockquote {
-  margin: 0.8em 0; padding: 2px 0 2px 14px;
-  border-left: 3px solid var(--cth-ink-300); color: var(--cth-ink-700);
+/* Code is LTR no matter what language the prose around it is in. The rehype
+   auto-dir pass skips pre/code, but an inline `code` still INHERITS dir from an
+   RTL paragraph holding it — which would flip a shell command or a path.
+   Pin it back; `unicode-bidi: isolate` keeps it from disturbing the run either. */
+.cth-md-preview code, .cth-md-preview pre {
+  direction: ltr; unicode-bidi: isolate; text-align: left;
 }
-.cth-md-preview ul, .cth-md-preview ol { padding-left: 22px; margin: 0.5em 0; }
+.cth-md-preview blockquote {
+  margin: 0.8em 0; padding-block: 2px; padding-inline-start: 14px;
+  border-inline-start: 3px solid var(--cth-ink-300); color: var(--cth-ink-700);
+}
+.cth-md-preview ul, .cth-md-preview ol { padding-inline-start: 22px; margin: 0.5em 0; }
 .cth-md-preview li { margin: 3px 0; }
 .cth-md-preview li::marker { color: var(--cth-ink-500); }
-.cth-md-preview input[type="checkbox"] { accent-color: var(--cth-mint); margin-right: 6px; }
+.cth-md-preview input[type="checkbox"] { accent-color: var(--cth-mint); margin-inline-end: 6px; }
 .cth-md-preview table {
   border-collapse: collapse; margin: 0.8em 0; display: block; overflow-x: auto;
 }
 .cth-md-preview th, .cth-md-preview td {
-  border: 1px solid var(--cth-ink-100); padding: 5px 10px; text-align: left;
+  border: 1px solid var(--cth-ink-100); padding: 5px 10px; text-align: start;
   font-size: 13px;
 }
 .cth-md-preview th { background: var(--cth-cream-200); font-weight: 600; }

--- a/src/renderer/src/design/tokens.css
+++ b/src/renderer/src/design/tokens.css
@@ -52,9 +52,14 @@
   /* Type — v0.3.4: Press Start 2P stays as the BRAND face for small caps
      labels; everything the user actually reads is Inter (UI) and JetBrains
      Mono (code/terminal). Pixelify/VT323 were the main readability drag. */
-  --cth-font-display: "Press Start 2P", monospace;
-  --cth-font-ui:      "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-  --cth-font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  /* Arabic rides in every stack as a fallback. Font fallback is per-glyph, so
+     Latin still renders in the primary faces and only Arabic runs reach IBM
+     Plex Sans Arabic. Order matters: it sits BEFORE system-ui / -apple-system,
+     which resolve to SF Pro — that DOES carry Arabic and would otherwise win
+     the fallback and make this choice a no-op on macOS. */
+  --cth-font-display: "Press Start 2P", "IBM Plex Sans Arabic", monospace;
+  --cth-font-ui:      "Inter", "IBM Plex Sans Arabic", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --cth-font-mono:    "JetBrains Mono", "IBM Plex Sans Arabic", ui-monospace, "SF Mono", Menlo, monospace;
 
   /* Type scale — v0.3.4: one step tighter (Inter reads larger than Pixelify
      at equal px, and the controls were oversized) */

--- a/src/renderer/src/markdown/MarkdownPreview.tsx
+++ b/src/renderer/src/markdown/MarkdownPreview.tsx
@@ -17,6 +17,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useWorkspaceImage } from '@/hooks/useWorkspaceImage';
 import { isExternal, isRelativeMd, resolveLocalImageRel, resolveRel } from './mdLinks';
+import { rehypeAutoDir } from './rehypeAutoDir';
 
 export interface MarkdownPreviewProps {
   source: string;
@@ -37,6 +38,10 @@ export const MarkdownPreview = memo(function MarkdownPreview({
     <div className="cth-md-preview">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        // Per-block dir="auto" so RTL (e.g. Arabic) agent output reads
+        // right-to-left while Latin blocks in the same file are untouched.
+        // Sets attributes only — NOT rehype-raw; no HTML sink (see header).
+        rehypePlugins={[rehypeAutoDir]}
         components={{
           a: ({ href, children }) => {
             const h = href ?? '';

--- a/src/renderer/src/markdown/rehypeAutoDir.ts
+++ b/src/renderer/src/markdown/rehypeAutoDir.ts
@@ -1,0 +1,54 @@
+/**
+ * rehype plugin: stamp `dir="auto"` on every block-level element of rendered
+ * markdown, so each block picks its own reading direction from its first strong
+ * character.
+ *
+ * WHY a plugin and not CSS: `unicode-bidi: plaintext` resolves the *bidi* order
+ * of a block but leaves the `direction` property alone — so an Arabic list item
+ * would read right-to-left while its bullet stayed pinned on the left, and
+ * `text-align: start` would still resolve against the container's LTR. `dir`
+ * sets the real base direction, which markers, alignment and trailing
+ * punctuation all follow. Doing it here rather than in `components` covers every
+ * block element in one pass, including ones nobody has overridden yet.
+ *
+ * Applied per BLOCK, never to the root: a document with English headings and
+ * Arabic prose (the common case for agent output) gets each block right, where a
+ * single `dir` on the wrapper would have to be wrong for one of them.
+ *
+ * `pre`/`code` are skipped deliberately — code is LTR regardless of the language
+ * of the comments inside it, and reordering a shell command would be a bug.
+ */
+import type { Root, Element } from 'hast';
+
+/** Block elements whose text is prose, so direction should follow content. */
+const AUTO_DIR = new Set([
+  'p', 'li', 'blockquote', 'td', 'th', 'dd', 'dt', 'figcaption', 'summary',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  // The list CONTAINER too, not just its items: `dir` on a `ul` resolves from
+  // the first strong character in its subtree, which is the first item's text.
+  // Without it the container stays LTR and an Arabic item reads right-to-left
+  // with its bullet stranded on the left, over the container's left padding.
+  // `table` is left out on purpose — there `dir` would reverse COLUMN order,
+  // which is a bigger claim than "this text is Arabic"; the per-cell `td`/`th`
+  // entries above already give each cell the right alignment.
+  'ul', 'ol'
+]);
+
+/** Subtrees to leave strictly LTR (code keeps its own order). */
+const SKIP = new Set(['pre', 'code']);
+
+export function rehypeAutoDir() {
+  return (tree: Root): void => {
+    const walk = (node: Root | Element): void => {
+      for (const child of node.children) {
+        if (child.type !== 'element') continue;
+        if (SKIP.has(child.tagName)) continue;
+        if (AUTO_DIR.has(child.tagName)) {
+          child.properties = { ...child.properties, dir: 'auto' };
+        }
+        walk(child);
+      }
+    };
+    walk(tree);
+  };
+}

--- a/src/renderer/src/terminal/arabicJoiner.ts
+++ b/src/renderer/src/terminal/arabicJoiner.ts
@@ -1,0 +1,60 @@
+/**
+ * Arabic rendering for the terminal — the working recipe, three parts:
+ *
+ * 1. DOM renderer (terminalPool skips the WebGL lease in Arabic mode). Rows
+ *    become real DOM text, so the browser's text engine is in play at all.
+ *
+ * 2. A character joiner (this file). On its own the DOM renderer emits a span
+ *    PER CELL with letter-spacing — atomic boxes the browser can neither shape
+ *    across nor reorder. Joining every Arabic phrase into one range makes it a
+ *    single span: real contextual shaping, lam-alef ligatures, marks on their
+ *    letters — by the font itself, no presentation-form tricks.
+ *
+ * 3. CSS in design/global.css: rows get `unicode-bidi: plaintext` (each row
+ *    takes its base direction from its first strong character, like dir=auto)
+ *    and spans drop to `display: inline` (inline-block boxes are atomic to the
+ *    bidi algorithm — inline text isn't, so phrase order follows the UBA).
+ *
+ * Result measured in a real browser: Arabic rows right-aligned and correctly
+ * ordered, mixed Arabic/Latin rows interleave properly, Latin rows unchanged.
+ *
+ * KNOWN TRADE: the block cursor is drawn at the logical cell offset, counted
+ * from the left — on an RTL row it does not sit where the next glyph will
+ * appear. Reading correctness is worth a misplaced cursor.
+ */
+
+/** Arabic script, its supplements, and the presentation-form blocks. */
+export function isArabicCp(cp: number): boolean {
+  return (cp >= 0x0600 && cp <= 0x06ff) || (cp >= 0x0750 && cp <= 0x077f) ||
+         (cp >= 0xfb50 && cp <= 0xfdff) || (cp >= 0xfe70 && cp <= 0xfeff);
+}
+
+/** Characters a phrase may flow across without ending the join: the space and
+ *  punctuation that sit BETWEEN Arabic words. The range still only extends as
+ *  far as the last Arabic character, so trailing punctuation stays outside. */
+const PHRASE_GLUE = ' ,.:;()«»،؛؟!ـ-—';
+
+/**
+ * Ranges of `text` (one terminal row) to render as single units: every maximal
+ * stretch that containsArabic, glued across the punctuation between words.
+ * Shape matches xterm's registerCharacterJoiner contract: [start, end).
+ */
+export function arabicJoinRanges(text: string): [number, number][] {
+  const ranges: [number, number][] = [];
+  let i = 0;
+  while (i < text.length) {
+    if (!isArabicCp(text.charCodeAt(i))) { i++; continue; }
+    const start = i;
+    let end = i + 1;
+    let lastArabic = i + 1;
+    while (end < text.length) {
+      const cp = text.charCodeAt(end);
+      if (isArabicCp(cp)) { end++; lastArabic = end; continue; }
+      if (PHRASE_GLUE.includes(text[end])) { end++; continue; }
+      break;
+    }
+    if (lastArabic - start > 1) ranges.push([start, lastArabic]);
+    i = Math.max(end, lastArabic);
+  }
+  return ranges;
+}

--- a/src/renderer/src/terminal/arabicSetting.ts
+++ b/src/renderer/src/terminal/arabicSetting.ts
@@ -1,0 +1,44 @@
+/**
+ * The renderer switch for RTL-script terminal support: ON keeps xterm on its
+ * DOM renderer, registers the Arabic character joiner, and lets the bidi CSS
+ * in design/global.css do its work — together these render Arabic (and other
+ * RTL scripts' neutral runs) shaped and correctly ordered, which the WebGL
+ * cell painter structurally cannot (xterm.js has no bidi: xtermjs/xterm.js#701).
+ * OFF leases the WebGL renderer: faster, and exactly the previous behavior.
+ *
+ * DEFAULT: follows the system locale — users whose UI language is an RTL
+ * script (Arabic, Farsi, Hebrew, Urdu) get readable terminals out of the box;
+ * everyone else keeps the GPU renderer untouched. The Settings toggle
+ * overrides either way and persists.
+ */
+const KEY = 'cth.arabicTerminal';
+
+function defaultEnabled(): boolean {
+  try {
+    const langs = navigator.languages?.length ? navigator.languages : [navigator.language];
+    return langs.some((l) => /^(ar|fa|he|ur)\b/i.test(l ?? ''));
+  } catch { return false; }
+}
+
+let enabled = read();
+
+function read(): boolean {
+  try {
+    const stored = window.localStorage.getItem(KEY);
+    if (stored === '1') return true;
+    if (stored === '0') return false;
+  } catch { /* private mode — fall through to the locale default */ }
+  return defaultEnabled();
+}
+
+/** Hot path — called on terminal attach; reads the cached value. */
+export function isArabicTerminalEnabled(): boolean {
+  return enabled;
+}
+
+/** Flip the switch. Renderer choice is made when a terminal leases WebGL (on
+ *  attach), so this applies to newly created terminal views. */
+export function setArabicTerminalEnabled(next: boolean): void {
+  enabled = next;
+  try { window.localStorage.setItem(KEY, next ? '1' : '0'); } catch { /* private mode */ }
+}

--- a/src/renderer/src/terminal/arabicSpacingFix.ts
+++ b/src/renderer/src/terminal/arabicSpacingFix.ts
@@ -1,0 +1,55 @@
+/**
+ * Part 4 of the Arabic terminal recipe (see arabicJoiner.ts for parts 1–3):
+ * neutralize xterm's letter-spacing on Arabic spans.
+ *
+ * The DOM renderer pads every text run with `letter-spacing` so its width comes
+ * out at an exact number of cells. For Latin monospace that is a sub-pixel
+ * correction; for a joined Arabic phrase — whose natural width is far narrower
+ * than one-cell-per-character — it stretches the phrase across its whole cell
+ * span. Two failures at once: huge gaps between letters, and the browser
+ * DISABLES cursive joining on any text with letter-spacing, so the letters
+ * disconnect exactly like the bug this whole effort exists to fix.
+ *
+ * CSS cannot express "spans whose text is Arabic", so this is a
+ * MutationObserver: whenever rows change, any span containing Arabic gets its
+ * letter-spacing forced to normal. Latin spans keep their correction, so TUI
+ * box-drawing stays cell-aligned. The pass is cheap — it touches only added
+ * nodes and changed text, a handful of spans per repaint.
+ */
+import { isArabicCp } from './arabicJoiner';
+
+function hasArabic(s: string): boolean {
+  for (let i = 0; i < s.length; i++) if (isArabicCp(s.charCodeAt(i))) return true;
+  return false;
+}
+
+function fixSpan(el: Element): void {
+  if (el.tagName === 'SPAN' && hasArabic(el.textContent ?? '')) {
+    (el as HTMLElement).style.letterSpacing = 'normal';
+  }
+}
+
+function sweep(root: ParentNode): void {
+  for (const el of root.querySelectorAll('span')) fixSpan(el);
+}
+
+/** Observe a terminal's host element; returns a disposer. */
+export function attachArabicSpacingFix(host: HTMLElement): () => void {
+  sweep(host);
+  const mo = new MutationObserver((records) => {
+    for (const r of records) {
+      if (r.type === 'characterData') {
+        const el = r.target.parentElement;
+        if (el) fixSpan(el);
+        continue;
+      }
+      for (const n of r.addedNodes) {
+        if (n.nodeType !== Node.ELEMENT_NODE) continue;
+        fixSpan(n as Element);
+        sweep(n as Element);
+      }
+    }
+  });
+  mo.observe(host, { subtree: true, childList: true, characterData: true });
+  return () => mo.disconnect();
+}


### PR DESCRIPTION
## Problem

xterm.js implements no part of the Unicode bidi algorithm and no Arabic shaping (xtermjs/xterm.js#701, open since 2017 — VS Code's integrated terminal has the same complaint). For anyone running agents in Arabic, every reply renders as **disconnected letters in left-to-right order** — unreadable. The markdown preview and composers also laid Arabic out LTR.

macOS Terminal.app renders the same output perfectly because its text engine does shaping + bidi natively. This PR gets the app's terminals to the same place by letting the **browser's** text engine do that work.

## The terminal recipe (4 parts, opt-in)

1. **DOM renderer** — when the mode is on, the WebGL lease is skipped so rows are real DOM text nodes the browser can shape (`leaseWebglRenderer` returns early; everything else about the pool is untouched).
2. **Character joiner** (`terminal/arabicJoiner.ts`) — `registerCharacterJoiner` merges each Arabic phrase into one render range → one span, so the font applies real contextual joining (including lam-alef, marks on their letters).
3. **Bidi CSS** (`design/global.css`) — rows get `unicode-bidi: plaintext` (per-row base direction, like `dir=auto`: Arabic rows lay out right-to-left and right-aligned, Latin rows are untouched) and spans drop to `display: inline` — inline-block boxes are atomic to the bidi algorithm and can never be reordered. `!important` is load-bearing: the DOM renderer injects a runtime stylesheet that otherwise wins the cascade.
4. **Letter-spacing fix** (`terminal/arabicSpacingFix.ts`) — a MutationObserver strips xterm's cell-fitting letter-spacing from Arabic spans only. Any letter-spacing makes the browser disable cursive joining *and* stretches phrases across their full cell span. Latin spans keep theirs, so TUI box-drawing stays cell-aligned.

Plus one timing fix: terminals open at boot, often before webfonts finish loading, so xterm caches glyph widths measured against fallback metrics — a *different* broken layout every launch. On `document.fonts.ready` the pool pokes `options.fontFamily` (self-assign) to force a re-measure and repaint.

**Defaults:** on when the system locale is an RTL script (ar/fa/he/ur), off otherwise — so non-RTL users keep the GPU renderer exactly as before. A toggle in Settings → General overrides either way.

## HTML surfaces (always on, inert for LTR content)

- `markdown/rehypeAutoDir.ts` — a rehype plugin stamping `dir="auto"` per block in `MarkdownPreview` (headings, paragraphs, lists, cells; `pre`/`code` deliberately stay LTR, and inline `code` is pinned `direction: ltr` in CSS so a shell command never flips inside an Arabic paragraph). No `rehype-raw`; attributes only.
- Markdown preview CSS moves to logical properties (`padding-inline-start`, `border-inline-start`, `text-align: start`) so quotes/lists/tables mirror correctly.
- `dir="auto"` on the user-prose textareas (queue composer, ask-me answers, notes, schedules) and on agent-output display blocks (memory, kanban cards, Q&A, trigger history).
- **IBM Plex Sans Arabic** added to the font stacks as a per-glyph fallback — placed *before* `system-ui`/`-apple-system`, which resolve to SF Pro (it carries Arabic and would otherwise win the fallback, making the choice a no-op on macOS).

## Verification

- Captured real `claude` pty output bytes (an Arabic reply, colors and cursor addressing included) and replayed them through the exact terminal config in a browser — joined, correctly ordered, right-aligned; Latin rows byte-identical behavior.
- Reproduced the late-font failure mode (stylesheet injected 1.5 s after `open()`) and confirmed the `fonts.ready` re-measure repairs it.
- `npm run typecheck`, `npm run build`, and the focused test suite (239 tests) all pass.

Happy to split this into smaller PRs (terminal vs. markdown/composer) if you prefer.


