### PR TITLE
feat(memory): bundle mempalace so a fresh install works out of the box

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -55,6 +55,15 @@ extraResources:
   # repo resources/skills). Directory copy preserves the <id>/SKILL.md tree.
   - from: resources/skills
     to: skills
+  # MemPalace CLI, bundled per platform so a fresh install works on a machine
+  # that has never seen Python or pip (today the app expects a user-installed
+  # `mempalace` and silently no-ops without one — the memory layer's whole
+  # prerequisite). memory.ts bin() resolves the user's own install FIRST (PATH,
+  # then the common uv/pip spots); <resourcesPath>/mempalace is strictly the
+  # fallback. Binaries land in resources/mempalace/<os>/ (see its README for
+  # the per-platform build recipe); LICENSE (MIT) ships beside the binary.
+  - from: resources/mempalace/${os}
+    to: mempalace
 
 asarUnpack:
   - "**/node_modules/node-pty/**"

--- a/resources/mempalace/README.md
+++ b/resources/mempalace/README.md
@@ -1,0 +1,53 @@
+# Bundled MemPalace
+
+This directory feeds the `extraResources` rule in `electron-builder.yml`: at
+package time, the contents of `resources/mempalace/<os>/` (win | mac | linux)
+are copied to `<resourcesPath>/mempalace/` inside the installed app.
+
+## Resolution order (see `src/main/memory.ts` `bin()`)
+
+1. The user's `PATH` (`where` on Windows, login-shell `which` elsewhere).
+2. Common install spots (`~/.local/bin`, Homebrew, pip's Scripts dir).
+3. **The copy bundled here — strictly last.** A user's own install always
+   wins; the bundled binary exists so a machine that has never seen Python
+   or pip still gets semantic memory out of the box instead of the silent
+   no-op degrade.
+
+## What goes in `<os>/`
+
+A **standalone** `mempalace` executable (`mempalace.exe` on Windows) that runs
+with no Python installation present, plus the `LICENSE` file already placed in
+each directory (MemPalace is MIT — the notice ships beside the binary).
+
+> ⚠ **Do NOT drop in the executable from `~/.local/bin`.** On Windows that
+> file is pip's `simple_launcher` shim: ~108 KB, embeds an absolute path to
+> the machine's `python.exe`, and only appears to work because the backing
+> environment exists locally. On a user's machine it dies immediately. The
+> same is true of pipx/uv shims on macOS/Linux.
+
+## Producing a real standalone binary
+
+MemPalace is a Python package (MIT, https://github.com/MemPalace/mempalace,
+deps include chromadb/numpy/tokenizers — expect a chunky artifact):
+
+```bash
+pip install mempalace pyinstaller
+pyinstaller --onefile --name mempalace -p . $(python -c "import mempalace, os; print(os.path.join(os.path.dirname(mempalace.__file__), '__main__.py'))")
+```
+
+Then verify it is genuinely standalone before committing it:
+
+```bash
+# from a directory that is NOT on any Python path, ideally a machine/container
+# without Python at all:
+./dist/mempalace --version && ./dist/mempalace --help
+```
+
+One binary per platform/arch, built on (or cross-built for) that platform —
+CI is the natural home for this step (`dist:mac` / `dist:win` / `dist:linux`).
+
+## Semantic-mode caveat
+
+`mempalace` pulls an embedding model on first semantic use (huggingface-hub).
+The app initializes heuristics-only (`--no-llm`), so the default experience
+stays fully local/offline; bundling does not change that either way.

--- a/resources/mempalace/linux/LICENSE
+++ b/resources/mempalace/linux/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MemPalace Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/mempalace/mac/LICENSE
+++ b/resources/mempalace/mac/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MemPalace Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/mempalace/win/LICENSE
+++ b/resources/mempalace/win/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MemPalace Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -135,7 +135,8 @@ export class MemoryManager {
     return h ? join(h, 'palace') : null;
   }
 
-  /** Resolve the mempalace CLI against the user's PATH + common uv/pip spots. */
+  /** Resolve the mempalace CLI: the user's PATH + common uv/pip spots first,
+   *  then the copy bundled with the packaged app (extraResources). */
   bin(): string | null {
     if (this.binCache !== undefined) return this.binCache;
     let found: string | null = null;
@@ -169,6 +170,21 @@ export class MemoryManager {
             '/usr/local/bin/mempalace'
           ];
       for (const c of candidates) if (c && existsSync(c)) { found = c; break; }
+    }
+    // 3) Fall back to the copy bundled with the app (electron-builder
+    //    extraResources → <resourcesPath>/mempalace). Deliberately LAST: a
+    //    user's own install (steps 1–2) always wins, so bundling changes
+    //    nothing on machines that already have mempalace — it only makes a
+    //    bare machine work out of the box. Guarded because resourcesPath is
+    //    Electron-only: absent under plain node (tests), and in dev it points
+    //    at Electron's own dist resources, where this candidate simply misses
+    //    and resolution degrades exactly as before.
+    if (!found) {
+      const res = process.resourcesPath;
+      if (res) {
+        const bundled = join(res, 'mempalace', isWin ? 'mempalace.exe' : 'mempalace');
+        if (existsSync(bundled)) found = bundled;
+      }
     }
     this.binCache = found;
     return found;

--- a/test/memory-bundled-bin.test.cjs
+++ b/test/memory-bundled-bin.test.cjs
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * The app treats mempalace as a prerequisite the USER already installed:
+ * bin() asks PATH, probes the common uv/pip spots, and gives up — on a
+ * machine that has never seen Python, resolution dead-ends and the memory
+ * layer silently no-ops. That install friction is what bundling removes.
+ *
+ * The bundled copy (electron-builder extraResources → <resourcesPath>/
+ * mempalace) is wired as the LAST candidate: a user's own install must always
+ * win, so bundling changes nothing on machines that already have mempalace —
+ * it only makes a bare machine work out of the box.
+ *
+ * Determinism note: these rows sandbox every surface bin() consults — HOME/
+ * USERPROFILE/LOCALAPPDATA (step 2), PATH (step 1), process.resourcesPath
+ * (step 3). That is airtight on Windows, where every candidate derives from
+ * env. On POSIX, step 1 goes through a LOGIN shell (whose rc files rebuild
+ * PATH) and step 2 probes machine-absolute paths (/opt/homebrew, /usr/local)
+ * that no env mutation can hide — so on a machine with a real mempalace these
+ * rows would resolve the real one and fail for reasons unrelated to the code.
+ * Skipped there rather than made flaky; the resolver logic under test is
+ * platform-shared. (Making POSIX testable means injecting the candidate list,
+ * deliberately out of scope for this diff.)
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { MemoryManager } = loadTs('src/main/memory.ts');
+
+const WIN = process.platform === 'win32';
+const EXE = WIN ? 'mempalace.exe' : 'mempalace';
+
+function freshManager(home) {
+  return new MemoryManager(
+    () => home ?? null,
+    () => ({ enabled: true, model: 'minilm' })
+  );
+}
+
+/**
+ * Point every resolution surface bin() consults at a sandbox we control.
+ *  - pathInstall: put a fake mempalace on PATH (step 1 hits)
+ *  - bundled:     create <resources>/mempalace/<exe> AND set resourcesPath (step 3 hits)
+ *  - bundledOnDiskOnly: create the fixture but leave resourcesPath UNSET —
+ *    the plain-node/dev shape, where the fallback must stay out of the way.
+ */
+function sandbox(t, { pathInstall = false, bundled = false, bundledOnDiskOnly = false } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'md-bundled-bin-'));
+  const saved = {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    LOCALAPPDATA: process.env.LOCALAPPDATA,
+    SHELL: process.env.SHELL,
+    hadRes: Object.prototype.hasOwnProperty.call(process, 'resourcesPath'),
+    res: process.resourcesPath
+  };
+  t.after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    const put = (k, v) => { if (v === undefined) delete process.env[k]; else process.env[k] = v; };
+    put('PATH', saved.PATH); put('HOME', saved.HOME); put('USERPROFILE', saved.USERPROFILE);
+    put('LOCALAPPDATA', saved.LOCALAPPDATA); put('SHELL', saved.SHELL);
+    if (saved.hadRes) process.resourcesPath = saved.res; else delete process.resourcesPath;
+  });
+
+  // Step-2 territory → an empty sandbox home, so ~/.local/bin etc. miss.
+  const home = path.join(root, 'home');
+  fs.mkdirSync(path.join(home, 'AppData', 'Local'), { recursive: true });
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.LOCALAPPDATA = path.join(home, 'AppData', 'Local');
+  if (!WIN) process.env.SHELL = '/bin/sh';
+
+  // Step-1 territory → keep only what `where`/`which` themselves need to run,
+  // plus (optionally) one dir carrying a fake mempalace. bin() only ever
+  // existsSync-checks candidates, so an empty file is a complete fixture.
+  const sysDirs = WIN
+    ? [path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')]
+    : ['/usr/bin', '/bin'];
+  const dirs = [...sysDirs];
+  let pathBin = null;
+  if (pathInstall) {
+    const d = path.join(root, 'on-path');
+    fs.mkdirSync(d, { recursive: true });
+    pathBin = path.join(d, EXE);
+    fs.writeFileSync(pathBin, '');
+    if (!WIN) fs.chmodSync(pathBin, 0o755); // `which` requires the x bit
+    dirs.unshift(d);
+  }
+  process.env.PATH = dirs.join(path.delimiter);
+
+  // Step-3 territory → the packaged-app resources dir.
+  let bundledBin = null;
+  if (bundled || bundledOnDiskOnly) {
+    const res = path.join(root, 'app-resources');
+    bundledBin = path.join(res, 'mempalace', EXE);
+    fs.mkdirSync(path.dirname(bundledBin), { recursive: true });
+    fs.writeFileSync(bundledBin, '');
+    if (bundled) process.resourcesPath = res;
+    else delete process.resourcesPath;
+  } else {
+    delete process.resourcesPath;
+  }
+
+  return { root, home, pathBin, bundledBin };
+}
+
+test('a bare machine resolves the BUNDLED copy — the whole point', { skip: !WIN }, (t) => {
+  const { home, bundledBin } = sandbox(t, { bundled: true });
+  const m = freshManager(home);
+  assert.equal(m.bin(), bundledBin, 'no PATH hit, no pip spots — the extraResources copy must be found');
+  assert.equal(m.available(), true);
+  assert.equal(m.status().bin, bundledBin);
+});
+
+test('a user install on PATH beats the bundled copy', { skip: !WIN }, (t) => {
+  const { home, pathBin, bundledBin } = sandbox(t, { pathInstall: true, bundled: true });
+  const m = freshManager(home);
+  const got = m.bin();
+  assert.equal(got, pathBin, 'the maintainer requirement: a locally available mempalace always wins');
+  assert.notEqual(got, bundledBin, 'bundling must change NOTHING for machines that already have it');
+});
+
+test('no user install, no bundle → the documented graceful no-op survives', { skip: !WIN }, (t) => {
+  const { home } = sandbox(t);
+  const m = freshManager(home);
+  assert.equal(m.bin(), null);
+  assert.equal(m.available(), false, 'absent CLI still degrades silently — markdown memory keeps working');
+  assert.equal(m.status().available, false);
+});
+
+test('without Electron resourcesPath (dev / plain node) the fallback stays out of the way', { skip: !WIN }, (t) => {
+  const { home } = sandbox(t, { bundledOnDiskOnly: true });
+  const m = freshManager(home);
+  assert.equal(m.bin(), null,
+    'a fixture on disk with no resourcesPath must not resolve — dev behavior is exactly pre-patch');
+});


### PR DESCRIPTION
## What & why

Munder Difflin resolves the `mempalace` CLI from the user's PATH and a few common
uv/pip locations. On a machine that has never installed it, resolution returns
`null` and the memory layer is silently unavailable — the failure a new user hits
first and understands least.

This adds a **third and final** resolver step: the copy bundled with the packaged
app, via electron-builder `extraResources`, following the existing `kg.cjs`
idiom already in the repo.

It is deliberately **last**. A user's own install (steps 1–2) always wins, so
this changes nothing on a machine that already has mempalace — it only makes a
bare machine work out of the box.

**The catch that makes this more than a file copy:** `mempalace.exe` from pip is a
`simple_launcher` shim with this machine's absolute Python path embedded in it.
The naive "copy the binary in" bundle passes every test on the developer's
machine and fails on every user's. Per-platform payload slots plus their LICENSE
files are laid out under `resources/mempalace/{win,mac,linux}/` so the real
per-platform artifact drops in without reshaping the build.

Rebased onto `main` at v0.4.5. One commit.

### Before
<img width="1893" height="844" alt="image" src="https://github.com/user-attachments/assets/cf83a0c9-033e-430d-8826-dc2ddff15901" />

The battery against unpatched `main` — **3 pass, 1 fail**, and the failing row is
exactly the one this PR fixes:

`✖ a bare machine resolves the BUNDLED copy — the whole point`
`AssertionError: no PATH hit, no pip spots — the extraResources copy must be found`
`actual: null`

### After
<img width="1105" height="470" alt="image" src="https://github.com/user-attachments/assets/8e0e0586-a837-4300-b1a8-9b1bd93175ea" />

The same battery on this branch — **4 pass, 0 fail.**

The other three rows pass on *both* sides. That is the point of the control: the
suite fails only the row the fix addresses, so a green run here means the
fallback works, not that the test is lenient.

## Type of change

- [x] Bug fix / new behaviour behind existing idiom
- [ ] Breaking change

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] New test added (`test/memory-bundled-bin.test.cjs`) — picked up automatically
      by the `test:focused` glob added in v0.4.5
- [x] Rebased on latest `main`, no conflicts
- [x] Behavioural control run against unpatched `main` (above)