### PR TITLE
Add native Linux arm64 build to the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,11 @@ jobs:
           - os: windows-2022
             args: --win
           - os: ubuntu-latest
-            args: --linux
+            args: --linux --x64
+          # GitHub-hosted arm64 runner (free for public repos) — builds native so
+          # node-pty/better-sqlite3 rebuild for the right arch without cross-compiling.
+          - os: ubuntu-24.04-arm
+            args: --linux --arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Linux arm64 build.** The release pipeline now also builds a native `arm64` AppImage
+  (`Munder-Difflin-<version>-linux-arm64.AppImage`) on a `ubuntu-24.04-arm` runner, alongside the
+  existing x64 build. `node-pty` and `better-sqlite3` are native modules, so this builds on a real
+  arm64 runner rather than cross-compiling. The existing x64 AppImage is renamed from
+  `-linux-x86_64.AppImage` to `-linux-x64.AppImage` to match the `win-x64`/`arm64` naming already
+  used for the other platforms.
+
 ## [0.4.4] — 2026-08-18
 
 **Windows agents can finally talk to each other** — and the first run stops silently failing.

--- a/blog/src/posts/how-to-install-and-use-munder-difflin.md
+++ b/blog/src/posts/how-to-install-and-use-munder-difflin.md
@@ -85,7 +85,8 @@ release):
 |---|---|
 | macOS | `Munder-Difflin-<version>-mac-universal.dmg` (Apple Silicon + Intel) |
 | Windows | `Munder-Difflin-<version>-win-x64-setup.exe` (64-bit installer) |
-| Linux | `Munder-Difflin-<version>-linux-x86_64.AppImage` |
+| Linux (x64) | `Munder-Difflin-<version>-linux-x64.AppImage` |
+| Linux (arm64) | `Munder-Difflin-<version>-linux-arm64.AppImage` |
 
 Open the installer, launch the app, and skip to [first launch](#step-3-first-launch-the-onboarding-wizard).
 From here the app maintains itself: updates download in the background from GitHub releases, the

--- a/docs/index.html
+++ b/docs/index.html
@@ -2783,12 +2783,15 @@
     var PLATFORMS = [
       { key: 'mac',   icon: '\ud83c\udf4e', os: 'macOS',   sub: 'Universal \u00b7 Apple Silicon + Intel', match: 'mac-universal.dmg',     file: 'Munder-Difflin-' + REL + '-mac-universal.dmg' },
       { key: 'win',   icon: '\ud83e\ude9f', os: 'Windows', sub: '64-bit installer (.exe)',           match: 'win-x64-setup.exe',     file: 'Munder-Difflin-' + REL + '-win-x64-setup.exe' },
-      { key: 'linux', icon: '\ud83d\udc27', os: 'Linux',   sub: 'AppImage \u00b7 x86_64',                 match: 'linux-x86_64.AppImage', file: 'Munder-Difflin-' + REL + '-linux-x86_64.AppImage' }
+      { key: 'linux-x64',   icon: '\ud83d\udc27', os: 'Linux',   sub: 'AppImage \u00b7 x64',   match: 'linux-x64.AppImage',   file: 'Munder-Difflin-' + REL + '-linux-x64.AppImage' },
+      { key: 'linux-arm64', icon: '\ud83d\udc27', os: 'Linux',   sub: 'AppImage \u00b7 arm64', match: 'linux-arm64.AppImage', file: 'Munder-Difflin-' + REL + '-linux-arm64.AppImage' }
     ];
     var ua = navigator.userAgent;
+    // Linux arch isn't in the UA string on most distros, so this is best-effort \u2014
+    // it only catches browsers that do report it (e.g. some ChromeOS/aarch64 builds).
     var cur = /Windows/.test(ua) ? 'win'
             : (/Mac|iPhone|iPad/.test(ua) ? 'mac'
-            : (/Linux|Android|X11/.test(ua) ? 'linux' : null));
+            : (/Linux|Android|X11/.test(ua) ? (/aarch64|arm64/i.test(ua) ? 'linux-arm64' : 'linux-x64') : null));
 
     var backdrop = document.getElementById('smBackdrop');
     if (!backdrop) return;

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -135,10 +135,13 @@ portable:
   artifactName: Munder-Difflin-${version}-win-x64-portable.exe
 
 # ---- Linux ----
+# arm64 builds native on a GitHub-hosted ubuntu-24.04-arm runner (see release.yml) —
+# node-pty/better-sqlite3 are native modules and cross-compiling their arm64 .node
+# binaries from an x64 runner isn't worth the QEMU/toolchain overhead.
 linux:
   category: Development
   icon: build/icon.png
   target:
     - target: AppImage
-      arch: [x64]
-  artifactName: Munder-Difflin-${version}-linux-x86_64.AppImage
+      arch: [x64, arm64]
+  artifactName: Munder-Difflin-${version}-linux-${arch}.${ext}


### PR DESCRIPTION
## Summary
- The release workflow only ever built Linux `x64`. `node-pty` and `better-sqlite3` are native modules, so an `arm64` AppImage needs a real arm64 machine — cross-compiling from an x64 runner fails (`node-gyp`/`g++` can't target `-m64`... err, the reverse: confirmed locally that cross-compiling `x64` node-pty *from* an aarch64 host fails with `g++: error: unrecognized command-line option '-m64'`, which is exactly why this PR keeps each arch on its own native runner instead of trying to cross-compile either direction).
- `electron-builder.yml`: `linux.target` now builds `[x64, arm64]`; `artifactName` uses electron-builder's `${arch}` macro so Linux naming matches the `win-x64` / `mac-universal` convention already used for the other platforms. **This renames the x64 asset** from `Munder-Difflin-<version>-linux-x86_64.AppImage` to `Munder-Difflin-<version>-linux-x64.AppImage`.
- `.github/workflows/release.yml`: split the single `ubuntu-latest` Linux job into two — `ubuntu-latest` with `--linux --x64`, and `ubuntu-24.04-arm` (GitHub's hosted arm64 runner, free for public repos) with `--linux --arm64` — so each builds natively for its own arch rather than cross-compiling.
- `docs/index.html`: the download modal's platform list and its live GitHub-release asset matcher now list Linux x64 and arm64 as separate entries, with a best-effort `User-Agent` sniff (`aarch64|arm64`) to bold whichever matches the visitor — Linux arch isn't reliably in the UA string, so this is best-effort like the rest of that detection.
- Updated the blog install doc and added a `CHANGELOG.md` entry to match the renamed/added assets.

## Why native runners instead of cross-compiling
Tried cross-compiling first since it avoids a second CI job. `better-sqlite3` has prebuilt arm64 binaries so it's fine either direction, but `node-pty` has no arm64 prebuild for Linux and its `node-gyp` build needs a matching `g++` target — which isn't available out of the box on GitHub's stock runners in either direction. Building natively on `ubuntu-24.04-arm` sidesteps that entirely and matches how `node-pty`'s own prebuild story already works (per-arch, no cross-compile).

## Test plan
Verified end-to-end on an aarch64 Ubuntu 24.04 machine (own hardware, not a GH runner):
- [x] `npm ci` — native module rebuild succeeds on arm64
- [x] `npm run build` — electron-vite build succeeds
- [x] `npm run typecheck` — no new type errors from the doc/config changes
- [x] `npx electron-builder --linux --arm64 --publish never` — produces `Munder-Difflin-0.4.4-linux-arm64.AppImage` (confirmed `ELF 64-bit LSB executable, ARM aarch64` via `file`)
- [x] Launched the resulting AppImage (`--no-sandbox`, headless VM) — boots and logs `[updater] native updater ready (current v0.4.4)`; only errors are GPU/EGL failures from the VM having no real GPU, unrelated to the arch build
- [ ] Have not run the actual `ubuntu-24.04-arm` GitHub-hosted runner (that only happens once this PR runs in CI / on a tag push) — flagging in case that runner image needs anything the standard `ubuntu-latest` steps (setup-node, setup-python + distutils shim, `npm ci`) don't already cover

Happy to adjust the naming/rename approach if you'd rather keep the `x86_64` filename and give arm64 a different suffix instead — the rename touches `docs/index.html`'s live asset matcher and the blog doc, both updated here, but any external links to the old `-linux-x86_64.AppImage` filename from past releases are obviously unaffected (this only changes what's produced going forward).