### PR TITLE
fix: enable Electron renderer sandbox

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2120,7 +2120,9 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
     show: false,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false,
+      // Keep Chromium's OS renderer sandbox active; privileged work stays behind
+      // the narrow contextBridge/IPC surface owned by the main process.
+      sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
       // The renderer runs the hive's heartbeat loops (inbox nudge, message

--- a/test/renderer-sandbox.test.cjs
+++ b/test/renderer-sandbox.test.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Pins the Electron renderer boundary on every application-created window.
+ *
+ * The desktop can run inside a hardened container while its web renderer is
+ * still unsandboxed: Electron turns `webPreferences.sandbox: false` into an
+ * effective renderer `--no-sandbox` switch. Parse the TypeScript AST so comments,
+ * unrelated objects, or string markers cannot satisfy this security contract.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+
+const sourcePath = path.join(__dirname, '..', 'src', 'main', 'index.ts');
+
+function property(object, name) {
+  return object.properties.find((entry) => (
+    ts.isPropertyAssignment(entry)
+    && ((ts.isIdentifier(entry.name) && entry.name.text === name)
+      || (ts.isStringLiteral(entry.name) && entry.name.text === name))
+  ));
+}
+
+function browserWindowOptions() {
+  const text = fs.readFileSync(sourcePath, 'utf8');
+  const source = ts.createSourceFile(sourcePath, text, ts.ScriptTarget.Latest, true);
+  const windows = [];
+
+  function visit(node) {
+    if (
+      ts.isNewExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === 'BrowserWindow'
+    ) {
+      windows.push(node.arguments?.[0]);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+  return windows;
+}
+
+test('every BrowserWindow explicitly enables the Chromium renderer sandbox', () => {
+  const windows = browserWindowOptions();
+  assert.ok(windows.length > 0, 'no BrowserWindow construction found');
+
+  for (const options of windows) {
+    assert.ok(options && ts.isObjectLiteralExpression(options), 'BrowserWindow options must be literal');
+    const webPreferences = property(options, 'webPreferences');
+    assert.ok(
+      webPreferences && ts.isObjectLiteralExpression(webPreferences.initializer),
+      'BrowserWindow webPreferences must be literal'
+    );
+    const sandbox = property(webPreferences.initializer, 'sandbox');
+    assert.ok(sandbox, 'BrowserWindow must declare sandbox explicitly');
+    assert.equal(sandbox.initializer.kind, ts.SyntaxKind.TrueKeyword);
+  }
+});


### PR DESCRIPTION
## What & why

Enable Electron's Chromium renderer sandbox for every application-created `BrowserWindow`.

The window already uses context isolation with Node integration disabled, but `sandbox: false` still disables Chromium's OS renderer sandbox. Privileged operations remain behind the existing narrow preload/contextBridge and main-process IPC boundary.

An AST-based regression test inspects every `new BrowserWindow(...)` call and requires an explicit `webPreferences.sandbox: true`, so comments or unrelated string markers cannot satisfy the contract.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Screenshots / clips

Not applicable; there is no visual change.

## Validation

- `node --test test/*.test.cjs` — 259/259 passing.
- `npm run typecheck` — both Node and web projects passing.
- `npm run build` — production build passing.
- Clean two-file diff against current upstream `main` (`57a6ce6`).
- No dependency changes.

Supporting runtime validation was completed on two fresh hardened-container starts for the identical production change before rebasing onto current `main`: the renderer ran non-root with zero capabilities, `NoNewPrivs: 1`, seccomp filtering, `--enable-sandbox`, and none of the prohibited sandbox-disabling switches. Since upstream `main` advanced afterward, the current PR SHA was separately reverified with the complete local suite, typechecks, and production build; hosted CI remains the exact-commit convergence check.

## Discord (optional)

Discord:

## Checklist

- [x] `npm run typecheck` passes (the de-facto CI gate).
- [x] `npm run build` succeeds.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no UI change.
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md` — no art added.
- [x] PR is focused on a single change.
