### PR TITLE
docs+site: the 0.4.5 content pass, and a badge row that survives dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ visualized as avatars at work on a shared office floor.
 
 <p>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
-  <a href="./CHANGELOG.md"><img alt="Version: 0.4.4" src="https://img.shields.io/badge/version-0.4.4-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
+  <a href="./CHANGELOG.md"><img alt="Version: 0.4.5" src="https://img.shields.io/badge/version-0.4.5-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
   <img alt="Status: prototype" src="https://img.shields.io/badge/status-working%20prototype-F4F1EA.svg?style=flat-square&labelColor=6E1423">
   <img alt="Platform: macOS | Windows | Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-F4F1EA.svg?style=flat-square&labelColor=6E1423">
   <a href="./CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-F4D35E.svg?style=flat-square&labelColor=6E1423"></a>
@@ -144,17 +144,21 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
 - **Slack & webhooks** — message a channel or POST a webhook; Michael can spawn an ephemeral worker, reply in-thread, and tear it down.
 - **Shareable hires + Agent Gallery** — import a role from a `munderdifflin://hire` link; import only pre-fills the form, a human still spawns it. Browse roles at the [Agent Gallery](https://munderdiffl.in/hires/).
 - **BYOK keys + local LLMs** — per-provider keys in a write-only secret broker, plus Ollama / LM Studio / vLLM base URLs. Guides: [open models](https://munderdiffl.in/blog/run-munder-difflin-on-open-models/) · [Mac Mini](https://munderdiffl.in/blog/run-munder-difflin-on-a-mac-mini/).
-- **Auto-update** — new releases download in the background; you click restart, and the notes arrive as a designed page rather than a version number.
+- **Updates in one click** — the title-bar badge fetches the build for your machine and tells you how to install it, and it reads `latest` once a check confirms you are current. The first run afterwards opens that release's notes as a designed page rather than a version number. Background auto-update stays in Settings.
 - **Prerequisites** — one Settings page showing which supporting tools (uv, git, Node, MemPalace, each agent CLI) you have, what each is for, and a button that asks Michael to install what is missing.
 
 > [!NOTE]
-> **Status: v0.4.4 — Windows agents can finally talk to each other.** On Windows, agents were
-> never told they could message one another: the protocol reaches them as a multi-line command
-> line, and `cmd.exe` cut it at the first newline. They started, looked healthy, and ignored each
-> other forever. If you tried Munder Difflin on Windows and your team just sat there, that was
-> this bug. Also fixed: a fresh install now starts its own message router instead of waiting for a
-> restart, the setup wizard can be finished, and dark mode is rebuilt for readability. New in this
-> release: **Skills**, **Prerequisites**, and release notes that carry their own page.
+> **Status: v0.4.5, the release that fixes three things you trusted and were quietly wrong.**
+> Cost reporting reset its counter on every app restart while the session id stayed the same, so
+> the floor under reported what you had actually spent. It is now folded from the ledger, with a
+> separate session figure kept alongside. Semantic memory never worked on Apple Silicon: CoreML
+> overflowed the quantized embedding graph, every vector came back NaN, and every upsert was
+> rejected. Embeddings are pinned to CPU on macOS. And agents did not reliably reach each other,
+> so mail could sit in an inbox nobody woke up for. There is now an inbox wake watchdog, no more
+> stale nudges, and mail to a missing inbox is bounced and logged instead of dropped. Also in this
+> release: triggers that run on weekdays at a time of day, clickable paths in every terminal, one
+> editor instead of two, one click updates, and a renderer inside Chromium's sandbox.
+> 23 community pull requests landed.
 > **If you're on 0.3.8, update:** that build's usage-limit guard never released the agents it held,
 > and it has been removed entirely.
 > macOS (signed & notarized), Windows, and Linux builds are on the
@@ -289,12 +293,13 @@ chrome. The 15 avatars are the cast of *The Office*, differentiated by hair/skin
 
 ## Roadmap
 
-Shipped through **v0.4.4** — ten agent engines with BYOK keys and local LLMs, voice orchestration,
-the hive (memory · mailboxes · blackboard · event log), Command Center with kanban and schedules,
-a built-in Monaco IDE with git rails, integrations registry + secret broker, Slack-spawned workers,
-shareable hires and the Agent Gallery, observability and the circuit breaker, durable persistence,
-session resume, multi-window floors, working auto-update, a Skills browser, and a live Prerequisites
-check.
+Shipped through **v0.4.5** — ten agent engines with BYOK keys and local LLMs, voice orchestration,
+the hive (memory · mailboxes · blackboard · event log), Command Center with kanban and weekday
+schedules, a built-in Monaco IDE with git rails, integrations registry + secret broker,
+Slack-spawned workers, shareable hires and the Agent Gallery, observability and the circuit
+breaker, durable persistence, session resume, multi-window floors, one click updates, a Skills
+browser, a live Prerequisites check, cost reporting folded from the ledger, and semantic memory
+that works on Apple Silicon.
 Full history in [`CHANGELOG.md`](./CHANGELOG.md).
 
 Next up:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ you already run into a clone of you, one that keeps working while you're away an
 coordinates a whole office of agents on your own machine.
 
 Wraps [Claude Code](https://claude.com/claude-code), Antigravity (Gemini), OpenAI Codex,
-**xAI Grok**, **Kimi Code**, **Qwen**, **OpenCode**, **Crush**, **pi.dev**, and
-**GitHub Copilot CLI** — with bring-your-own keys and local LLMs.
+**xAI Grok**, **Kimi Code**, **Gemini CLI**, **Qwen**, **OpenCode**, **Crush**,
+**pi.dev**, **GitHub Copilot CLI**, and **Cursor** — with bring-your-own keys and local LLMs.
 Agents that message, route, and remember, coordinated by **your clone** (Michael) and
 visualized as avatars at work on a shared office floor.
 
@@ -120,7 +120,7 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
 ## Features
 
 **The floor**
-- **Every terminal is a real agent.** Claude Code, Antigravity (Gemini), OpenAI Codex, xAI Grok, Kimi Code, Qwen, OpenCode, Crush, pi.dev, GitHub Copilot CLI, or a custom command — each in its own `node-pty` PTY, rendered with xterm.js.
+- **Every terminal is a real agent.** Claude Code, Antigravity (Gemini), OpenAI Codex, xAI Grok, Kimi Code, Gemini CLI, Qwen, OpenCode, Crush, pi.dev, GitHub Copilot CLI, Cursor, or a custom command — each in its own `node-pty` PTY, rendered with xterm.js.
 - **Every agent is an avatar.** A Pixi.js office floor where agents walk to stations, envelopes fly desk to desk, and avatar state reflects real work.
 - **A GOD orchestrator you talk to.** It routes tasks, adjudicates traffic, and escalates only what needs a human. Or press **Talk** and run the floor by voice.
 - **Per-agent git worktrees.** Optional isolation so parallel agents never collide on branches.
@@ -178,8 +178,9 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
   ```
 - At least one supported agent CLI on your `PATH` — **[Claude Code](https://claude.com/claude-code)**
   (`claude`, the default), **Antigravity** (`agy`), **OpenAI Codex** (`codex`), **xAI Grok** (`grok`),
-  **Kimi Code** (`kimi`), **Qwen** (`qwen`), **OpenCode** (`opencode`), **Crush** (`crush`),
-  **pi.dev** (`pi`), or **GitHub Copilot** (`copilot`). Most missing CLIs self-heal: the harness runs the installer in the
+  **Kimi Code** (`kimi`), **Gemini CLI** (`gemini`), **Qwen** (`qwen`), **OpenCode** (`opencode`),
+  **Crush** (`crush`), **pi.dev** (`pi`), **GitHub Copilot** (`copilot`), or **Cursor** (`cursor-agent`).
+  Most missing CLIs self-heal: the harness runs the installer in the
   terminal and continues into the new binary.
 - *Optional:* **your own API keys and local LLMs** in **Settings → AI Engines** (Ollama / LM Studio / vLLM).
 - *Optional:* the semantic memory index for instant cross-session recall — markdown memory works without it.
@@ -293,7 +294,7 @@ chrome. The 15 avatars are the cast of *The Office*, differentiated by hair/skin
 
 ## Roadmap
 
-Shipped through **v0.4.5** — ten agent engines with BYOK keys and local LLMs, voice orchestration,
+Shipped through **v0.4.5** — twelve agent engines with BYOK keys and local LLMs, voice orchestration,
 the hive (memory · mailboxes · blackboard · event log), Command Center with kanban and weekday
 schedules, a built-in Monaco IDE with git rails, integrations registry + secret broker,
 Slack-spawned workers, shareable hires and the Agent Gallery, observability and the circuit

--- a/blog/src/_data/media.json
+++ b/blog/src/_data/media.json
@@ -2681,6 +2681,31 @@
     },
     "youtube": []
   },
+  "the-spend-counter-that-went-back-to-zero": {
+    "title": "The Spend Counter That Went Back to Zero",
+    "category": "internals",
+    "hero": {
+      "file": "assets/media/the-spend-counter-that-went-back-to-zero/hero.png",
+      "alt": "Illustration: The Spend Counter That Went Back to Zero",
+      "prompt": "Hero image for a blog post titled \"The Spend Counter That Went Back to Zero\". The post is about: Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.",
+      "status": "placeholder"
+    },
+    "inline": {
+      "note-1": {
+        "file": "assets/media/the-spend-counter-that-went-back-to-zero/note-1.png",
+        "alt": "Hand-drawn sketch from “The Spend Counter That Went Back to Zero”",
+        "prompt": "",
+        "status": "placeholder"
+      },
+      "note-2": {
+        "file": "assets/media/the-spend-counter-that-went-back-to-zero/note-2.png",
+        "alt": "Hand-drawn sketch from “The Spend Counter That Went Back to Zero”",
+        "prompt": "",
+        "status": "placeholder"
+      }
+    },
+    "youtube": []
+  },
   "tmux-and-scripts-vs-an-agent-harness": {
     "title": "Running Agents in tmux vs an Agent Harness",
     "category": "comparisons",

--- a/blog/src/posts/the-spend-counter-that-went-back-to-zero.md
+++ b/blog/src/posts/the-spend-counter-that-went-back-to-zero.md
@@ -1,0 +1,254 @@
+---
+title: "The Spend Counter That Went Back to Zero"
+description: "Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log."
+date: 2026-08-22
+category: internals
+categoryLabel: Internals
+type: Technical
+primaryKeyword: "ai agent cost tracking bug"
+secondaryKeywords: ["cumulative counter reset", "append-only ledger recovery", "electron main thread blocking read", "monotonic counter invariant", "agent spend tracking"]
+tags: ["Internals", "Cost", "Telemetry", "Debugging", "Postmortem"]
+author:
+  name: Chaitanya Giri
+  initials: CG
+faq:
+  - q: "What was wrong with cost reporting in Munder Difflin?"
+    a: "The per-agent spend figure counted from the moment the app process started, not from the moment the agent started. Restarting the app rebuilt the in-memory accumulator empty, so the counter began again at zero under the same session id. Anything reading the latest value read one app session's worth of spend and called it the total. On our own floor that hid 59 percent of it."
+  - q: "Why did nobody notice a number that was wrong by more than half?"
+    a: "Because it never looked wrong. Inside any single run the counter only climbed, so it behaved exactly like a lifetime total. Nothing threw, nothing went negative, nothing came back NaN. The reset is only visible if you look at the whole history at once, and the number is the kind you glance at rather than reconcile."
+  - q: "How do you recover a total from a counter that resets?"
+    a: "You use the invariant the counter already gives you. Within one agent and one session the value can only go up, so any decrease is a restart and nothing else. Lifetime is the sum of the high-water mark of each segment that a reset closed, plus the high-water mark of the segment still open. Every sample was already on disk in an append-only ledger, so the past was recoverable without a migration."
+  - q: "Why not ignore small drops as noise?"
+    a: "We looked at that and rejected it. Real restarts in our own ledger fall from peaks under a dollar straight to zero, so a one dollar threshold would have silently missed them. A cumulative counter has no legitimate reason to fall at all, so the threshold bought tidiness and cost coverage. Any decrease counts, with a float epsilon and nothing more."
+---
+
+<div class="callout tldr"><span class="ic">TL;DR</span><p>Munder Difflin tells you what your
+floor of agents costs. That number was wrong by <strong>59 percent</strong>, and it had been
+wrong quietly, because it was a counter that measured from process start while its label said
+lifetime. Restart the app and it began again at zero under the same session id. The fix is not a
+new counter. It is reading the reset back out of the log we already had, using the one property a
+cumulative counter cannot break: it only goes up.</p></div>
+
+You can build an agent harness that does everything right and still hand people a number that
+lies. Ours did. Every agent card on the floor carried a dollar figure, `fleet.json` carried it
+for Michael, and the LIVE ROSTER line every agent reads carried it too. It was the number you
+would look at to decide whether to hire another worker or send everyone home.
+
+It was under reporting by more than half.
+
+This is the postmortem, because the bug is not really about money. It is about what happens when
+a value's name describes something more permanent than the thing that computes it.
+
+## What the number was supposed to mean
+
+Each agent reports usage as it works. The collector folds those samples into a per-agent record
+with tokens in, tokens out, cache reads, cache creation, and a dollar figure. That record is
+written into `fleet.json` on a timer, which is what the orchestrator and every agent read when
+they want to know the shape of the floor.
+
+The contract everyone assumed was simple: `usd` is what this agent has cost you.
+
+## What it actually meant
+
+`AgentUsageSample.usd` is cumulative since **process start**. Not since the agent started. Since
+the app started.
+
+The collector accumulates into in-memory maps. An app restart builds those maps fresh, so every
+running total goes back to zero. The agent itself does not go back to zero, because the agent
+resumes: same worker, same work, same `session_id`. Only our accumulator forgot.
+
+So the sequence on disk looks like this. The counter climbs through a session. The app restarts.
+The counter appears again at almost nothing, under the same session id, and starts climbing
+again. Anything that reads the latest value is reading spend since the most recent restart and
+reporting it as spend, full stop.
+
+The longer an agent lives, the more restarts it survives, and the more wrong its number gets. The
+agents you have invested the most in are the ones whose cost you understate the worst.
+
+## Why this survived in plain sight
+
+Here is the uncomfortable part. Every check you would write against this number passes.
+
+The value is never negative. It is never NaN. Nothing throws, nothing warns, no read fails.
+Within any single run of the app the counter is perfectly monotonic, which is exactly how a
+lifetime total behaves, so a person watching it for an hour sees nothing suspicious. It is
+plausible in magnitude: too small to be absurd, too large to be obviously stubbed.
+
+And the reset itself is invisible from where the number is consumed. Restarting an app is the
+single most normal thing a user does. Nobody restarts and then reconciles a dollar figure against
+what it read before, because the app was closed in between and closing an app is allowed to
+change what is on screen.
+
+The signature only exists in the history. You cannot see it in a value. You can only see it in a
+sequence, and only if you look at the whole sequence at once.
+
+{% img "note-1", "The counter climbs, the app restarts, the counter starts over. Every single value is fine. Only the sequence is wrong." %}
+
+## The data was never lost
+
+The thing that made this fixable rather than merely diagnosable: the ledger is append-only.
+
+Every usage sample ever emitted is a line in `cost-ledger.jsonl`, and lines are never rewritten.
+The pre-reset peaks were all still sitting on disk. The bug was in what we read out of that file,
+not in what we put into it, which means the past could be corrected rather than written off.
+
+That distinction is worth more than the fix. A bug in a derived read is recoverable. The same
+bug in the write path would have meant a number that starts being right today and is wrong
+forever behind you.
+
+## Reading a reset out of a monotonic counter
+
+Within one agent and one session, the counter can only climb. That is not a convention, it is
+what cumulative means. So a decrease is not ambiguous. It is not a rounding artifact, or a
+correction, or a refund. **A decrease is a restart, and it is the only thing a decrease can be.**
+
+That gives the whole algorithm. Walk the ledger. For each agent and session, hold two numbers:
+the high-water mark of the segment currently open, and the sum of the high-water marks of every
+segment a reset has already closed. When the value drops, the open segment just ended at its
+peak, so commit the peak and open a new segment at the new value.
+
+```ts
+if (usd < s.peak - EPS) {
+  // Counter went backwards: the previous segment ended at its peak.
+  s.committed += s.peak;
+  s.peak = usd;
+} else if (usd > s.peak) {
+  s.peak = usd;
+}
+```
+
+Lifetime is then `committed + peak`, summed across every session an agent has had. That is the
+entire recovery. It is a handful of arithmetic, because the invariant did the hard part.
+
+The general shape is worth keeping: **if a value is only allowed to move one way, every move the
+other way is a free detector you already have on disk.** You do not need to have instrumented the
+event. You need to have recorded enough that the event leaves a shadow.
+
+## The threshold we deliberately did not add
+
+The tempting version of this code ignores small drops. Float noise, out-of-order samples, a
+rounding difference somewhere upstream: surely you want a floor before you call something a
+restart. A dollar sounds sensible. Ten cents sounds cautious.
+
+We looked at our own ledger and found real restarts falling from peaks **under a dollar** straight
+to zero. A one dollar threshold misses those completely, and it misses them silently, which is
+the same failure we were already fixing wearing a different hat.
+
+So the threshold is a float epsilon and nothing else. A cumulative counter has no legitimate
+reason to go down by any amount, so there is no band of "probably fine" to carve out. The magic
+number bought tidiness and cost coverage, and coverage was the entire point.
+
+If you find yourself picking a threshold to suppress a signal, check whether the signal has any
+legitimate instances at all. If it does not, the right threshold is zero and the number you were
+about to type is just a hole.
+
+## Doing it without freezing the app
+
+Munder Difflin is an Electron app, and the ledger is append-only, which is a polite way of saying
+it grows forever. A full pass over it is not something you want on the main thread. Block that
+thread and the whole UI stops: the floor, the terminals, the window itself.
+
+So the fold is async and incremental. It keeps a byte offset and reads only what has been
+appended since the last pass, which in steady state is a few hundred bytes. Three details in
+there are load bearing.
+
+**The trailing partial line is held as bytes, not text.** A read boundary can land in the middle
+of a multi-byte character, and decoding half of one produces a replacement character that no
+longer parses as JSON. Buffering the tail as a `Buffer` and only decoding up to the last newline
+means the split is invisible.
+
+**Each pass is capped.** A cold start on a large ledger would otherwise be one enormous read. It
+reads a bounded chunk, keeps its segment state, and resumes on the next tick.
+
+**Truncation is detected, not assumed away.** If the file is smaller than the offset we hold, the
+file was rotated or replaced under us, and every segment we are carrying is suspect. That case
+resets the reader instead of reading garbage from a stale position.
+
+The reader never writes to the ledger, and a ledger it cannot read leaves the last good totals in
+place rather than throwing into a timer.
+
+## A cold zero is worse than an admitted unknown
+
+Until the first full pass completes, the fold genuinely does not know what an agent has cost.
+There are two things you can publish at that moment: zero, or nothing.
+
+Zero is a lie with a confident face. Somebody reads it, believes an agent is free, and the
+mistake propagates. So `usdFor` returns `null` until a pass has actually reached the end of the
+file, and there is an explicit `warm` flag behind it so a caller can tell "no spend" apart from
+"not read yet".
+
+`fleet.json` uses that to fall back to the old session figure while the fold is cold, and swaps
+to lifetime the moment it is warm. The old number is still there permanently as `sessionUsd`,
+because "what has this agent cost me since I opened the app" is a real question, it just is not
+the one the field named `usd` was being asked.
+
+Nullable is not a nuisance here. It is the type telling the truth about what is known.
+
+## Checking a number you recovered by inference
+
+This is a computed answer with no ground truth to compare it against. There is no invoice that
+says what an agent cost. The number is only as good as the reasoning that produced it, which
+means a passing test proves the code matches the assumptions, not that the assumptions are right.
+
+So the ledger was folded a second time by a separately written implementation and the two were
+compared. They agree to the cent, with no per-agent disagreement anywhere in the set. That is not
+proof, but two independent implementations agreeing on every agent is a very different level of
+confidence than one implementation agreeing with itself.
+
+For any number you recover by inference rather than measurement, write it twice. It is cheap and
+it is the only check that tests the reasoning instead of the typing.
+
+## What we did not fix, and why we said so
+
+The circuit breaker has a floor-wide cost cap, and it reads the same resetting counter.
+
+That means the cap re-arms to zero on every restart and is, in effect, measuring one app session
+rather than lifetime. That is not a bug in the same sense. It is an unanswered question about what
+a spending cap should mean. Is it "stop the floor when it has spent this much today", or "ever"?
+Those are different products, and one of them is a policy the founder gets to choose, not a
+default an agent should quietly change while fixing something else.
+
+So it is written up rather than patched. **A fix that silently rewrites a policy is not a fix, it
+is a decision taken by whoever happened to be in the file.**
+
+{% img "note-2", "Same counter, second consumer. Fixing the display without fixing the cap would have been half a fix that looked whole." %}
+
+## What we wrote down
+
+- **A counter named for a lifetime should not be scoped to a process.** If the value resets when
+  something restarts, the name has to say so. Ours now ships as `usd` and `sessionUsd` side by
+  side, and the ambiguity is gone because both answers exist.
+- **A monotonic invariant is a detector you already own.** If a value can only move one way, every
+  move the other way is an event you can recover after the fact, with no new instrumentation.
+- **Append-only logs let you fix the past.** The write path being correct is what made this a
+  read-side fix instead of a line in the changelog apologising for old data.
+- **Check whether your threshold has any legitimate instances.** If nothing real lives below the
+  cutoff, the cutoff is only hiding things you wanted to see.
+- **Never publish a confident zero for a value you have not read yet.** Return null, keep a warm
+  flag, and let callers decide.
+- **Write the second implementation.** For inferred numbers it is the only verification that
+  tests the reasoning rather than the code.
+
+The failure class here is the same one behind
+[the newline that silenced every Windows agent](/blog/the-newline-that-silenced-windows-agents/)
+and [the auto-update that never ran](/blog/why-our-auto-update-never-ran/): nothing errored,
+every health check passed, and the product was quietly not doing the thing it said it did.
+Loud failures get fixed in an afternoon. These are the ones that need somebody to go and
+[verify the claim](/blog/how-ai-agents-verify-their-own-work/) rather than the absence of an
+exception.
+
+## The rest of v0.4.5
+
+This shipped in **v0.4.5**, alongside two other things that were quietly wrong: semantic memory
+never worked on Apple Silicon, where CoreML overflowed the quantized embedding graph and returned
+NaN for every vector, and agents did not reliably reach each other, which now has an inbox wake
+watchdog behind it and bounces mail to a missing inbox instead of dropping it. Plus weekday
+scheduling for triggers, clickable paths everywhere in terminal output, one editor instead of
+two, one click updates, and 23 community pull requests.
+
+The full notes are on the
+[releases page](https://github.com/chaitanyagiri/munder-difflin/releases/latest), and if you want
+the wider version of this argument, the
+[multi-agent cost playbook](/blog/the-multi-agent-cost-playbook/) is about spending less rather
+than counting it correctly. Both matter. Counting it correctly comes first, because you cannot
+manage a number you are not actually reading.

--- a/docs/blog/agents-ran-our-launch-week-analytics/index.html
+++ b/docs/blog/agents-ran-our-launch-week-analytics/index.html
@@ -276,7 +276,7 @@ half of this ran while we slept off the launch.</p>
 
   <footer class="post-foot wrap"><div class="prevnext">
       <a class="pn prev" href="/blog/an-agent-redesigned-this-blog/"><span class="k">← Older</span><span class="t">An Agent Redesigned the Blog You&#39;re Reading</span></a>
-      <span></span>
+      <a class="pn next" href="/blog/the-spend-counter-that-went-back-to-zero/"><span class="k">Newer →</span><span class="t">The Spend Counter That Went Back to Zero</span></a>
     </div>
     <section class="related">
       <h2>Related in Use Cases</h2>

--- a/docs/blog/append-only-event-log-agents/index.html
+++ b/docs/blog/append-only-event-log-agents/index.html
@@ -312,6 +312,22 @@ it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -340,22 +356,6 @@ it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/architecture-two-planes-one-renderer/index.html
+++ b/docs/blog/architecture-two-planes-one-renderer/index.html
@@ -315,6 +315,22 @@ free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -343,22 +359,6 @@ free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/atomic-file-mailboxes-for-agents/index.html
+++ b/docs/blog/atomic-file-mailboxes-for-agents/index.html
@@ -327,6 +327,22 @@ the office floor; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -355,22 +371,6 @@ the office floor; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/building-a-terminal-ui-xterm-node-pty/index.html
+++ b/docs/blog/building-a-terminal-ui-xterm-node-pty/index.html
@@ -370,6 +370,22 @@ to watch many real terminals at once; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -398,22 +414,6 @@ to watch many real terminals at once; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/building-an-ai-office-floor/index.html
+++ b/docs/blog/building-an-ai-office-floor/index.html
@@ -315,6 +315,22 @@ techniques — the hard part is wiring them to <em>real</em> agent events, not t
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -343,22 +359,6 @@ techniques — the hard part is wiring them to <em>real</em> agent events, not t
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/claude-code-hooks-explained/index.html
+++ b/docs/blog/claude-code-hooks-explained/index.html
@@ -329,6 +329,22 @@ free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -357,22 +373,6 @@ free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/compressing-agent-memory/index.html
+++ b/docs/blog/compressing-agent-memory/index.html
@@ -297,6 +297,22 @@ without forgetting; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -325,22 +341,6 @@ without forgetting; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/feed.xml
+++ b/docs/blog/feed.xml
@@ -4,9 +4,17 @@
   <subtitle>Guides, deep dives, and comparisons on running multi-agent Claude Code: orchestration, agent memory, automation, and the tooling landscape.</subtitle>
   <link href="https://munderdiffl.in/blog/feed.xml" rel="self" />
   <link href="https://munderdiffl.in/blog/" />
-  <updated>2026-08-19T00:00:00.000Z</updated>
+  <updated>2026-08-22T00:00:00.000Z</updated>
   <id>https://munderdiffl.in/blog/</id>
   <author><name>Chaitanya Giri</name><uri>https://munderdiffl.in</uri></author>
+  <entry>
+    <title>The Spend Counter That Went Back to Zero</title>
+    <link href="https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/" />
+    <id>https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/</id>
+    <published>2026-08-22T00:00:00.000Z</published>
+    <updated>2026-08-22T00:00:00.000Z</updated><category term="Internals" />
+    <summary>Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</summary>
+  </entry>
   <entry>
     <title>Our Agents Ran Our Launch-Week Analytics</title>
     <link href="https://munderdiffl.in/blog/agents-ran-our-launch-week-analytics/" />
@@ -478,13 +486,5 @@
     <published>2026-06-04T00:00:00.000Z</published>
     <updated>2026-06-04T00:00:00.000Z</updated><category term="Concepts" />
     <summary>Meta&#39;s Agents Rule of Two for coding agents: don&#39;t let one session combine untrusted input, private data, and external reach at once — or supervise.</summary>
-  </entry>
-  <entry>
-    <title>Munder Difflin&#39;s Architecture: Two Data Planes, One Renderer</title>
-    <link href="https://munderdiffl.in/blog/architecture-two-planes-one-renderer/" />
-    <id>https://munderdiffl.in/blog/architecture-two-planes-one-renderer/</id>
-    <published>2026-06-04T00:00:00.000Z</published>
-    <updated>2026-06-04T00:00:00.000Z</updated><category term="Internals" />
-    <summary>A walkthrough of the multi-agent harness architecture: a node-pty terminal plane and a hooks/hive event plane feeding one React + Pixi.js renderer.</summary>
   </entry>
 </feed>

--- a/docs/blog/file-based-coordination-vs-message-queues/index.html
+++ b/docs/blog/file-based-coordination-vs-message-queues/index.html
@@ -288,6 +288,22 @@ durable, git-versioned, and debuggable by just looking.
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -316,22 +332,6 @@ durable, git-versioned, and debuggable by just looking.
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/hire-manifest-untrusted-input/index.html
+++ b/docs/blog/hire-manifest-untrusted-input/index.html
@@ -313,6 +313,22 @@ for hop in 0..5:                // cap at 5 hops
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -341,22 +357,6 @@ for hop in 0..5:                // cap at 5 hops
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/compressing-agent-memory/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/compressing-agent-memory/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-05">Jun 5, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/compressing-agent-memory/">Compressing Agent Memory Without Losing the Original</a></h3>
-    <p class="dek">How and why to compress an agent&#39;s long-term memory: the toolbox, the lossy trap, and keeping a lossless original beside a compact copy.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -107,13 +107,13 @@
   building a self-coordinating hive of agents with a GOD orchestrator you talk to.</p>
 
   <div class="filters" role="navigation" aria-label="Topics">
-    <a class="chip" aria-current="page">All<span class="ct">129</span></a>
+    <a class="chip" aria-current="page">All<span class="ct">130</span></a>
     
     <a class="chip" href="/blog/topics/guides/">guides<span class="ct">34</span></a>
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
@@ -129,7 +129,29 @@
 </header>
 
 
-<div class="wrap featured"><article class="card t-use-cases">
+<div class="wrap featured"><article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+
+</div>
+
+
+<section class="wrap">
+  <div class="post-grid">
+    <article class="card t-use-cases">
   <a class="thumb t-use-cases" href="/blog/agents-ran-our-launch-week-analytics/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/agents-ran-our-launch-week-analytics/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -145,13 +167,7 @@
     </div>
   </div>
 </article>
-
-</div>
-
-
-<section class="wrap">
-  <div class="post-grid">
-    <article class="card t-use-cases">
+<article class="card t-use-cases">
   <a class="thumb t-use-cases" href="/blog/an-agent-redesigned-this-blog/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/an-agent-redesigned-this-blog/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">

--- a/docs/blog/node-pty-electron-real-terminals/index.html
+++ b/docs/blog/node-pty-electron-real-terminals/index.html
@@ -350,6 +350,22 @@ real terminals driving real agents; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -378,22 +394,6 @@ real terminals driving real agents; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/observability-for-agent-fleets/index.html
+++ b/docs/blog/observability-for-agent-fleets/index.html
@@ -287,6 +287,22 @@ open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -315,22 +331,6 @@ open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/recovering-from-agent-failures/index.html
+++ b/docs/blog/recovering-from-agent-failures/index.html
@@ -307,6 +307,22 @@ there to read.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -335,22 +351,6 @@ there to read.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/rendering-many-live-terminals-performance/index.html
+++ b/docs/blog/rendering-many-live-terminals-performance/index.html
@@ -310,6 +310,22 @@ to run many real terminals without melting your CPU; it’s free and open source
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -338,22 +354,6 @@ to run many real terminals without melting your CPU; it’s free and open source
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/single-committer-git-pattern/index.html
+++ b/docs/blog/single-committer-git-pattern/index.html
@@ -317,6 +317,22 @@ never corrupt their own state; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -345,22 +361,6 @@ never corrupt their own state; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/tags/cost/index.html
+++ b/docs/blog/tags/cost/index.html
@@ -80,11 +80,27 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Cost</h1>
-  <p class="lead">7 posts tagged <strong>Cost</strong>.</p>
+  <p class="lead">8 posts tagged <strong>Cost</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
-    <article class="card t-guides">
+    <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-guides">
   <a class="thumb t-guides" href="/blog/command-center-guide/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/command-center-guide/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">

--- a/docs/blog/tags/internals/index.html
+++ b/docs/blog/tags/internals/index.html
@@ -80,11 +80,27 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Internals</h1>
-  <p class="lead">25 posts tagged <strong>Internals</strong>.</p>
+  <p class="lead">26 posts tagged <strong>Internals</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">

--- a/docs/blog/tags/postmortem/index.html
+++ b/docs/blog/tags/postmortem/index.html
@@ -80,11 +80,27 @@
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
   <h1>#Postmortem</h1>
-  <p class="lead">1 post tagged <strong>Postmortem</strong>.</p>
+  <p class="lead">2 posts tagged <strong>Postmortem</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
     <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">

--- a/docs/blog/tags/telemetry/index.html
+++ b/docs/blog/tags/telemetry/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Debugging — Munder Difflin Blog</title>
-<meta name="description" content="Munder Difflin blog posts tagged Debugging." />
-<link rel="canonical" href="https://munderdiffl.in/blog/tags/debugging/" />
+<title>Telemetry — Munder Difflin Blog</title>
+<meta name="description" content="Munder Difflin blog posts tagged Telemetry." />
+<link rel="canonical" href="https://munderdiffl.in/blog/tags/telemetry/" />
 
 <link rel="icon" type="image/png" href="https://munderdiffl.in/logo.png" />
 <link rel="apple-touch-icon" href="https://munderdiffl.in/logo.png" />
@@ -14,17 +14,17 @@
 <!-- Open Graph -->
 <meta property="og:site_name" content="Munder Difflin Blog" />
 <meta property="og:type" content="website" />
-<meta property="og:title" content="Debugging — Munder Difflin Blog" />
-<meta property="og:description" content="Munder Difflin blog posts tagged Debugging." />
-<meta property="og:url" content="https://munderdiffl.in/blog/tags/debugging/" />
+<meta property="og:title" content="Telemetry — Munder Difflin Blog" />
+<meta property="og:description" content="Munder Difflin blog posts tagged Telemetry." />
+<meta property="og:url" content="https://munderdiffl.in/blog/tags/telemetry/" />
 <meta property="og:image" content="https://munderdiffl.in/media/og.png" />
 <meta property="og:locale" content="en_US" />
 
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="Debugging — Munder Difflin Blog" />
-<meta name="twitter:description" content="Munder Difflin blog posts tagged Debugging." />
+<meta name="twitter:title" content="Telemetry — Munder Difflin Blog" />
+<meta name="twitter:description" content="Munder Difflin blog posts tagged Telemetry." />
 <meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
 
 <link rel="alternate" type="application/atom+xml" title="Munder Difflin Blog" href="https://munderdiffl.in/blog/feed.xml" />
@@ -79,8 +79,8 @@
 <main id="main">
 <header class="page-head wrap">
   <p class="eyebrow">Tag</p>
-  <h1>#Debugging</h1>
-  <p class="lead">4 posts tagged <strong>Debugging</strong>.</p>
+  <h1>#Telemetry</h1>
+  <p class="lead">1 post tagged <strong>Telemetry</strong>.</p>
 </header>
 <section class="wrap">
   <div class="post-grid">
@@ -97,54 +97,6 @@
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-08-19">Aug 19, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>4 min</span>
-    </div>
-    <h3><a href="/blog/the-newline-that-silenced-windows-agents/">The Newline That Silenced Every Windows Agent</a></h3>
-    <p class="dek">A cmd.exe parsing rule from the 1980s meant Windows agents received exactly one line of their multi-line startup protocol — and nothing errored. The anatomy of our worst silent failure, and the fix.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/the-newline-that-silenced-windows-agents/" aria-label="Read: The Newline That Silenced Every Windows Agent">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/why-our-auto-update-never-ran/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-08-08">Aug 8, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
-    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-guides">
-  <a class="thumb t-guides" href="/blog/debugging-multi-agent-systems/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/debugging-multi-agent-systems/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-04">Jun 4, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/debugging-multi-agent-systems/">How to Debug a Multi-Agent System</a></h3>
-    <p class="dek">How to debug a multi-agent system: use the event log, per-agent terminals, message trails, and git history to find why a hive of AI agents went sideways.</p>
-    <div class="foot">
-      <span class="tag kind">Guides</span>
-      <a class="more" href="/blog/debugging-multi-agent-systems/" aria-label="Read: How to Debug a Multi-Agent System">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/the-hook-shim-pattern/index.html
+++ b/docs/blog/the-hook-shim-pattern/index.html
@@ -306,6 +306,22 @@ at the mercy of the bridge.
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -334,22 +350,6 @@ at the mercy of the bridge.
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/the-newline-that-silenced-windows-agents/index.html
+++ b/docs/blog/the-newline-that-silenced-windows-agents/index.html
@@ -276,6 +276,22 @@ the target is a <code>.cmd</code>. We’ll wait. It’s probably ten minutes and
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/why-our-auto-update-never-ran/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -304,22 +320,6 @@ the target is a <code>.cmd</code>. We’ll wait. It’s probably ten minutes and
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/compressing-agent-memory/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/compressing-agent-memory/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-05">Jun 5, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/compressing-agent-memory/">Compressing Agent Memory Without Losing the Original</a></h3>
-    <p class="dek">How and why to compress an agent&#39;s long-term memory: the toolbox, the lossy trap, and keeping a lossless original beside a compact copy.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/the-spend-counter-that-went-back-to-zero/index.html
+++ b/docs/blog/the-spend-counter-that-went-back-to-zero/index.html
@@ -1,0 +1,493 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>The Spend Counter That Went Back to Zero — Munder Difflin Blog</title>
+<meta name="description" content="Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log." />
+<link rel="canonical" href="https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/" />
+
+<link rel="icon" type="image/png" href="https://munderdiffl.in/logo.png" />
+<link rel="apple-touch-icon" href="https://munderdiffl.in/logo.png" />
+<meta name="theme-color" content="#F5F2E8" />
+
+<!-- Open Graph -->
+<meta property="og:site_name" content="Munder Difflin Blog" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="The Spend Counter That Went Back to Zero — Munder Difflin Blog" />
+<meta property="og:description" content="Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log." />
+<meta property="og:url" content="https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/" />
+<meta property="og:image" content="https://munderdiffl.in/media/og.png" />
+<meta property="og:locale" content="en_US" />
+<meta property="article:published_time" content="2026-08-22T00:00:00.000Z" />
+<meta property="article:author" content="Chaitanya Giri" />
+<meta property="article:tag" content="Internals" />
+<meta property="article:tag" content="Cost" />
+<meta property="article:tag" content="Telemetry" />
+<meta property="article:tag" content="Debugging" />
+<meta property="article:tag" content="Postmortem" />
+
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="The Spend Counter That Went Back to Zero — Munder Difflin Blog" />
+<meta name="twitter:description" content="Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log." />
+<meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
+
+<link rel="alternate" type="application/atom+xml" title="Munder Difflin Blog" href="https://munderdiffl.in/blog/feed.xml" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700;9..144,900&amp;family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&amp;family=Space+Grotesk:wght@500;600;700&amp;family=JetBrains+Mono:wght@400;600&amp;display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/blog/assets/blog-press.css" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "The Spend Counter That Went Back to Zero",
+  "description": "Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.",
+  "image": ["https://munderdiffl.in/media/og.png"],
+  "datePublished": "2026-08-22T00:00:00.000Z",
+  "dateModified": "2026-08-22T00:00:00.000Z",
+  "author": { "@type": "Person", "name": "Chaitanya Giri" },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Munder Difflin",
+    "logo": { "@type": "ImageObject", "url": "https://munderdiffl.in/logo.png" }
+  },
+  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/" },
+  "keywords": "ai agent cost tracking bug, cumulative counter reset, append-only ledger recovery, electron main thread blocking read, monotonic counter invariant, agent spend tracking",
+  "articleSection": "Internals",
+  "inLanguage": "en-US",
+  "url": "https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://munderdiffl.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://munderdiffl.in/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "The Spend Counter That Went Back to Zero", "item": "https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What was wrong with cost reporting in Munder Difflin?", "acceptedAnswer": { "@type": "Answer", "text": "The per-agent spend figure counted from the moment the app process started, not from the moment the agent started. Restarting the app rebuilt the in-memory accumulator empty, so the counter began again at zero under the same session id. Anything reading the latest value read one app session's worth of spend and called it the total. On our own floor that hid 59 percent of it." } },
+    { "@type": "Question", "name": "Why did nobody notice a number that was wrong by more than half?", "acceptedAnswer": { "@type": "Answer", "text": "Because it never looked wrong. Inside any single run the counter only climbed, so it behaved exactly like a lifetime total. Nothing threw, nothing went negative, nothing came back NaN. The reset is only visible if you look at the whole history at once, and the number is the kind you glance at rather than reconcile." } },
+    { "@type": "Question", "name": "How do you recover a total from a counter that resets?", "acceptedAnswer": { "@type": "Answer", "text": "You use the invariant the counter already gives you. Within one agent and one session the value can only go up, so any decrease is a restart and nothing else. Lifetime is the sum of the high-water mark of each segment that a reset closed, plus the high-water mark of the segment still open. Every sample was already on disk in an append-only ledger, so the past was recoverable without a migration." } },
+    { "@type": "Question", "name": "Why not ignore small drops as noise?", "acceptedAnswer": { "@type": "Answer", "text": "We looked at that and rejected it. Real restarts in our own ledger fall from peaks under a dollar straight to zero, so a one dollar threshold would have silently missed them. A cumulative counter has no legitimate reason to fall at all, so the threshold bought tidiness and cost coverage. Any decrease counts, with a float epsilon and nothing more." } }
+    
+  ]
+}
+</script>
+
+
+<script>
+  // Anonymous blog analytics (PostHog) — same posture as the main site and the
+  // app's TELEMETRY.md: public write-only token ('' = inert), anonymous-only
+  // (person_profiles 'never'), no autocapture/recording, DNT respected.
+  (function () {
+    var PH_KEY = 'phc_qJzsokwcbtTGHemnvywR3nSqivNNgMjHeNVEWkZNydFB';
+    if (!PH_KEY || navigator.doNotTrack === '1') return;
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://us-assets.i.posthog.com/static/array.js';
+    s.onload = function () {
+      if (!window.posthog) return;
+      window.posthog.init(PH_KEY, {
+        api_host: 'https://us.i.posthog.com',
+        person_profiles: 'never',
+        autocapture: false,
+        disable_session_recording: true,
+        respect_dnt: true
+      });
+    };
+    document.head.appendChild(s);
+  })();
+</script>
+</head>
+<body class="theme-press">
+<a class="skip-link" href="#main">Skip to content</a>
+<nav id="nav">
+  <a class="brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+    <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+  </a>
+  <span class="spacer"></span>
+  <div class="links">
+    <a href="/blog/">Latest</a>
+    <a href="/blog/topics/">Topics</a>
+    <a href="/blog/about/">About</a>
+    <a href="https://munderdiffl.in">↗ Product</a>
+  </div>
+  <div class="nav-actions">
+    <a class="btn sm" href="https://munderdiffl.in/blog/feed.xml" aria-label="RSS feed">⤵ RSS</a>
+    <a class="btn sm primary" href="https://munderdiffl.in/#install">⤓ Download</a>
+  </div>
+</nav>
+
+<main id="main">
+
+<article class="t-internals">
+  <header class="post-head wrap">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/blog/">Blog</a>
+      <span>/</span>
+      <a href="/blog/topics/internals/">Internals</a>
+    </nav>
+    <h1>The Spend Counter That Went Back to Zero</h1>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="byline">
+      <span class="av" aria-hidden="true">CG</span>
+      <strong>Chaitanya Giri</strong>
+      <span class="dot" aria-hidden="true">·</span>
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true">·</span>
+      <span>10 min read</span>
+      <span class="tag kind">Internals</span>
+    </div>
+  </header>
+
+  <div class="hero-wrap wrap"><figure class="fig fig-placeholder t-internals fig-hero" role="img" aria-label="Illustration: The Spend Counter That Went Back to Zero"><div class="ph-art" aria-hidden="true"><span class="ph-glyph">✶</span><span class="ph-note">illustration on its way</span></div></figure></div>
+
+  <div class="post-wrap wrap">
+    <div class="prose">
+      <div class="callout tldr"><span class="ic">TL;DR</span><p>Munder Difflin tells you what your
+floor of agents costs. That number was wrong by <strong>59 percent</strong>, and it had been
+wrong quietly, because it was a counter that measured from process start while its label said
+lifetime. Restart the app and it began again at zero under the same session id. The fix is not a
+new counter. It is reading the reset back out of the log we already had, using the one property a
+cumulative counter cannot break: it only goes up.</p></div>
+<p>You can build an agent harness that does everything right and still hand people a number that
+lies. Ours did. Every agent card on the floor carried a dollar figure, <code>fleet.json</code> carried it
+for Michael, and the LIVE ROSTER line every agent reads carried it too. It was the number you
+would look at to decide whether to hire another worker or send everyone home.</p>
+<p>It was under reporting by more than half.</p>
+<p>This is the postmortem, because the bug is not really about money. It is about what happens when
+a value’s name describes something more permanent than the thing that computes it.</p>
+<h2 id="what-the-number-was-supposed-to-mean" tabindex="-1">What the number was supposed to mean <a class="anchor" href="#what-the-number-was-supposed-to-mean" aria-hidden="true">#</a></h2>
+<p>Each agent reports usage as it works. The collector folds those samples into a per-agent record
+with tokens in, tokens out, cache reads, cache creation, and a dollar figure. That record is
+written into <code>fleet.json</code> on a timer, which is what the orchestrator and every agent read when
+they want to know the shape of the floor.</p>
+<p>The contract everyone assumed was simple: <code>usd</code> is what this agent has cost you.</p>
+<h2 id="what-it-actually-meant" tabindex="-1">What it actually meant <a class="anchor" href="#what-it-actually-meant" aria-hidden="true">#</a></h2>
+<p><code>AgentUsageSample.usd</code> is cumulative since <strong>process start</strong>. Not since the agent started. Since
+the app started.</p>
+<p>The collector accumulates into in-memory maps. An app restart builds those maps fresh, so every
+running total goes back to zero. The agent itself does not go back to zero, because the agent
+resumes: same worker, same work, same <code>session_id</code>. Only our accumulator forgot.</p>
+<p>So the sequence on disk looks like this. The counter climbs through a session. The app restarts.
+The counter appears again at almost nothing, under the same session id, and starts climbing
+again. Anything that reads the latest value is reading spend since the most recent restart and
+reporting it as spend, full stop.</p>
+<p>The longer an agent lives, the more restarts it survives, and the more wrong its number gets. The
+agents you have invested the most in are the ones whose cost you understate the worst.</p>
+<h2 id="why-this-survived-in-plain-sight" tabindex="-1">Why this survived in plain sight <a class="anchor" href="#why-this-survived-in-plain-sight" aria-hidden="true">#</a></h2>
+<p>Here is the uncomfortable part. Every check you would write against this number passes.</p>
+<p>The value is never negative. It is never NaN. Nothing throws, nothing warns, no read fails.
+Within any single run of the app the counter is perfectly monotonic, which is exactly how a
+lifetime total behaves, so a person watching it for an hour sees nothing suspicious. It is
+plausible in magnitude: too small to be absurd, too large to be obviously stubbed.</p>
+<p>And the reset itself is invisible from where the number is consumed. Restarting an app is the
+single most normal thing a user does. Nobody restarts and then reconciles a dollar figure against
+what it read before, because the app was closed in between and closing an app is allowed to
+change what is on screen.</p>
+<p>The signature only exists in the history. You cannot see it in a value. You can only see it in a
+sequence, and only if you look at the whole sequence at once.</p>
+<figure class="fig fig-placeholder t-internals fig-inline" role="img" aria-label="Hand-drawn sketch from “The Spend Counter That Went Back to Zero”"><div class="ph-art" aria-hidden="true"><span class="ph-glyph">✶</span><span class="ph-note">illustration on its way</span></div><figcaption>The counter climbs, the app restarts, the counter starts over. Every single value is fine. Only the sequence is wrong.</figcaption></figure>
+<h2 id="the-data-was-never-lost" tabindex="-1">The data was never lost <a class="anchor" href="#the-data-was-never-lost" aria-hidden="true">#</a></h2>
+<p>The thing that made this fixable rather than merely diagnosable: the ledger is append-only.</p>
+<p>Every usage sample ever emitted is a line in <code>cost-ledger.jsonl</code>, and lines are never rewritten.
+The pre-reset peaks were all still sitting on disk. The bug was in what we read out of that file,
+not in what we put into it, which means the past could be corrected rather than written off.</p>
+<p>That distinction is worth more than the fix. A bug in a derived read is recoverable. The same
+bug in the write path would have meant a number that starts being right today and is wrong
+forever behind you.</p>
+<h2 id="reading-a-reset-out-of-a-monotonic-counter" tabindex="-1">Reading a reset out of a monotonic counter <a class="anchor" href="#reading-a-reset-out-of-a-monotonic-counter" aria-hidden="true">#</a></h2>
+<p>Within one agent and one session, the counter can only climb. That is not a convention, it is
+what cumulative means. So a decrease is not ambiguous. It is not a rounding artifact, or a
+correction, or a refund. <strong>A decrease is a restart, and it is the only thing a decrease can be.</strong></p>
+<p>That gives the whole algorithm. Walk the ledger. For each agent and session, hold two numbers:
+the high-water mark of the segment currently open, and the sum of the high-water marks of every
+segment a reset has already closed. When the value drops, the open segment just ended at its
+peak, so commit the peak and open a new segment at the new value.</p>
+<pre class="language-ts"><code class="language-ts"><span class="token keyword">if</span> <span class="token punctuation">(</span>usd <span class="token operator">&lt;</span> s<span class="token punctuation">.</span>peak <span class="token operator">-</span> <span class="token constant">EPS</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+  <span class="token comment">// Counter went backwards: the previous segment ended at its peak.</span>
+  s<span class="token punctuation">.</span>committed <span class="token operator">+=</span> s<span class="token punctuation">.</span>peak<span class="token punctuation">;</span>
+  s<span class="token punctuation">.</span>peak <span class="token operator">=</span> usd<span class="token punctuation">;</span>
+<span class="token punctuation">}</span> <span class="token keyword">else</span> <span class="token keyword">if</span> <span class="token punctuation">(</span>usd <span class="token operator">></span> s<span class="token punctuation">.</span>peak<span class="token punctuation">)</span> <span class="token punctuation">{</span>
+  s<span class="token punctuation">.</span>peak <span class="token operator">=</span> usd<span class="token punctuation">;</span>
+<span class="token punctuation">}</span></code></pre>
+<p>Lifetime is then <code>committed + peak</code>, summed across every session an agent has had. That is the
+entire recovery. It is a handful of arithmetic, because the invariant did the hard part.</p>
+<p>The general shape is worth keeping: <strong>if a value is only allowed to move one way, every move the
+other way is a free detector you already have on disk.</strong> You do not need to have instrumented the
+event. You need to have recorded enough that the event leaves a shadow.</p>
+<h2 id="the-threshold-we-deliberately-did-not-add" tabindex="-1">The threshold we deliberately did not add <a class="anchor" href="#the-threshold-we-deliberately-did-not-add" aria-hidden="true">#</a></h2>
+<p>The tempting version of this code ignores small drops. Float noise, out-of-order samples, a
+rounding difference somewhere upstream: surely you want a floor before you call something a
+restart. A dollar sounds sensible. Ten cents sounds cautious.</p>
+<p>We looked at our own ledger and found real restarts falling from peaks <strong>under a dollar</strong> straight
+to zero. A one dollar threshold misses those completely, and it misses them silently, which is
+the same failure we were already fixing wearing a different hat.</p>
+<p>So the threshold is a float epsilon and nothing else. A cumulative counter has no legitimate
+reason to go down by any amount, so there is no band of “probably fine” to carve out. The magic
+number bought tidiness and cost coverage, and coverage was the entire point.</p>
+<p>If you find yourself picking a threshold to suppress a signal, check whether the signal has any
+legitimate instances at all. If it does not, the right threshold is zero and the number you were
+about to type is just a hole.</p>
+<h2 id="doing-it-without-freezing-the-app" tabindex="-1">Doing it without freezing the app <a class="anchor" href="#doing-it-without-freezing-the-app" aria-hidden="true">#</a></h2>
+<p>Munder Difflin is an Electron app, and the ledger is append-only, which is a polite way of saying
+it grows forever. A full pass over it is not something you want on the main thread. Block that
+thread and the whole UI stops: the floor, the terminals, the window itself.</p>
+<p>So the fold is async and incremental. It keeps a byte offset and reads only what has been
+appended since the last pass, which in steady state is a few hundred bytes. Three details in
+there are load bearing.</p>
+<p><strong>The trailing partial line is held as bytes, not text.</strong> A read boundary can land in the middle
+of a multi-byte character, and decoding half of one produces a replacement character that no
+longer parses as JSON. Buffering the tail as a <code>Buffer</code> and only decoding up to the last newline
+means the split is invisible.</p>
+<p><strong>Each pass is capped.</strong> A cold start on a large ledger would otherwise be one enormous read. It
+reads a bounded chunk, keeps its segment state, and resumes on the next tick.</p>
+<p><strong>Truncation is detected, not assumed away.</strong> If the file is smaller than the offset we hold, the
+file was rotated or replaced under us, and every segment we are carrying is suspect. That case
+resets the reader instead of reading garbage from a stale position.</p>
+<p>The reader never writes to the ledger, and a ledger it cannot read leaves the last good totals in
+place rather than throwing into a timer.</p>
+<h2 id="a-cold-zero-is-worse-than-an-admitted-unknown" tabindex="-1">A cold zero is worse than an admitted unknown <a class="anchor" href="#a-cold-zero-is-worse-than-an-admitted-unknown" aria-hidden="true">#</a></h2>
+<p>Until the first full pass completes, the fold genuinely does not know what an agent has cost.
+There are two things you can publish at that moment: zero, or nothing.</p>
+<p>Zero is a lie with a confident face. Somebody reads it, believes an agent is free, and the
+mistake propagates. So <code>usdFor</code> returns <code>null</code> until a pass has actually reached the end of the
+file, and there is an explicit <code>warm</code> flag behind it so a caller can tell “no spend” apart from
+“not read yet”.</p>
+<p><code>fleet.json</code> uses that to fall back to the old session figure while the fold is cold, and swaps
+to lifetime the moment it is warm. The old number is still there permanently as <code>sessionUsd</code>,
+because “what has this agent cost me since I opened the app” is a real question, it just is not
+the one the field named <code>usd</code> was being asked.</p>
+<p>Nullable is not a nuisance here. It is the type telling the truth about what is known.</p>
+<h2 id="checking-a-number-you-recovered-by-inference" tabindex="-1">Checking a number you recovered by inference <a class="anchor" href="#checking-a-number-you-recovered-by-inference" aria-hidden="true">#</a></h2>
+<p>This is a computed answer with no ground truth to compare it against. There is no invoice that
+says what an agent cost. The number is only as good as the reasoning that produced it, which
+means a passing test proves the code matches the assumptions, not that the assumptions are right.</p>
+<p>So the ledger was folded a second time by a separately written implementation and the two were
+compared. They agree to the cent, with no per-agent disagreement anywhere in the set. That is not
+proof, but two independent implementations agreeing on every agent is a very different level of
+confidence than one implementation agreeing with itself.</p>
+<p>For any number you recover by inference rather than measurement, write it twice. It is cheap and
+it is the only check that tests the reasoning instead of the typing.</p>
+<h2 id="what-we-did-not-fix-and-why-we-said-so" tabindex="-1">What we did not fix, and why we said so <a class="anchor" href="#what-we-did-not-fix-and-why-we-said-so" aria-hidden="true">#</a></h2>
+<p>The circuit breaker has a floor-wide cost cap, and it reads the same resetting counter.</p>
+<p>That means the cap re-arms to zero on every restart and is, in effect, measuring one app session
+rather than lifetime. That is not a bug in the same sense. It is an unanswered question about what
+a spending cap should mean. Is it “stop the floor when it has spent this much today”, or “ever”?
+Those are different products, and one of them is a policy the founder gets to choose, not a
+default an agent should quietly change while fixing something else.</p>
+<p>So it is written up rather than patched. <strong>A fix that silently rewrites a policy is not a fix, it
+is a decision taken by whoever happened to be in the file.</strong></p>
+<figure class="fig fig-placeholder t-internals fig-inline" role="img" aria-label="Hand-drawn sketch from “The Spend Counter That Went Back to Zero”"><div class="ph-art" aria-hidden="true"><span class="ph-glyph">✶</span><span class="ph-note">illustration on its way</span></div><figcaption>Same counter, second consumer. Fixing the display without fixing the cap would have been half a fix that looked whole.</figcaption></figure>
+<h2 id="what-we-wrote-down" tabindex="-1">What we wrote down <a class="anchor" href="#what-we-wrote-down" aria-hidden="true">#</a></h2>
+<ul>
+<li><strong>A counter named for a lifetime should not be scoped to a process.</strong> If the value resets when
+something restarts, the name has to say so. Ours now ships as <code>usd</code> and <code>sessionUsd</code> side by
+side, and the ambiguity is gone because both answers exist.</li>
+<li><strong>A monotonic invariant is a detector you already own.</strong> If a value can only move one way, every
+move the other way is an event you can recover after the fact, with no new instrumentation.</li>
+<li><strong>Append-only logs let you fix the past.</strong> The write path being correct is what made this a
+read-side fix instead of a line in the changelog apologising for old data.</li>
+<li><strong>Check whether your threshold has any legitimate instances.</strong> If nothing real lives below the
+cutoff, the cutoff is only hiding things you wanted to see.</li>
+<li><strong>Never publish a confident zero for a value you have not read yet.</strong> Return null, keep a warm
+flag, and let callers decide.</li>
+<li><strong>Write the second implementation.</strong> For inferred numbers it is the only verification that
+tests the reasoning rather than the code.</li>
+</ul>
+<p>The failure class here is the same one behind
+<a href="/blog/the-newline-that-silenced-windows-agents/">the newline that silenced every Windows agent</a>
+and <a href="/blog/why-our-auto-update-never-ran/">the auto-update that never ran</a>: nothing errored,
+every health check passed, and the product was quietly not doing the thing it said it did.
+Loud failures get fixed in an afternoon. These are the ones that need somebody to go and
+<a href="/blog/how-ai-agents-verify-their-own-work/">verify the claim</a> rather than the absence of an
+exception.</p>
+<h2 id="the-rest-of-v045" tabindex="-1">The rest of v0.4.5 <a class="anchor" href="#the-rest-of-v045" aria-hidden="true">#</a></h2>
+<p>This shipped in <strong>v0.4.5</strong>, alongside two other things that were quietly wrong: semantic memory
+never worked on Apple Silicon, where CoreML overflowed the quantized embedding graph and returned
+NaN for every vector, and agents did not reliably reach each other, which now has an inbox wake
+watchdog behind it and bounces mail to a missing inbox instead of dropping it. Plus weekday
+scheduling for triggers, clickable paths everywhere in terminal output, one editor instead of
+two, one click updates, and 23 community pull requests.</p>
+<p>The full notes are on the
+<a href="https://github.com/chaitanyagiri/munder-difflin/releases/latest">releases page</a>, and if you want
+the wider version of this argument, the
+<a href="/blog/the-multi-agent-cost-playbook/">multi-agent cost playbook</a> is about spending less rather
+than counting it correctly. Both matter. Counting it correctly comes first, because you cannot
+manage a number you are not actually reading.</p>
+
+
+      
+      <section class="faq" aria-label="Frequently asked questions">
+        <h2 id="faq">FAQ</h2>
+        
+        <div class="qa">
+          <p class="q">What was wrong with cost reporting in Munder Difflin?</p>
+          <p class="a">The per-agent spend figure counted from the moment the app process started, not from the moment the agent started. Restarting the app rebuilt the in-memory accumulator empty, so the counter began again at zero under the same session id. Anything reading the latest value read one app session&#39;s worth of spend and called it the total. On our own floor that hid 59 percent of it.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Why did nobody notice a number that was wrong by more than half?</p>
+          <p class="a">Because it never looked wrong. Inside any single run the counter only climbed, so it behaved exactly like a lifetime total. Nothing threw, nothing went negative, nothing came back NaN. The reset is only visible if you look at the whole history at once, and the number is the kind you glance at rather than reconcile.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">How do you recover a total from a counter that resets?</p>
+          <p class="a">You use the invariant the counter already gives you. Within one agent and one session the value can only go up, so any decrease is a restart and nothing else. Lifetime is the sum of the high-water mark of each segment that a reset closed, plus the high-water mark of the segment still open. Every sample was already on disk in an append-only ledger, so the past was recoverable without a migration.</p>
+        </div>
+        
+        <div class="qa">
+          <p class="q">Why not ignore small drops as noise?</p>
+          <p class="a">We looked at that and rejected it. Real restarts in our own ledger fall from peaks under a dollar straight to zero, so a one dollar threshold would have silently missed them. A cumulative counter has no legitimate reason to fall at all, so the threshold bought tidiness and cost coverage. Any decrease counts, with a float epsilon and nothing more.</p>
+        </div>
+        
+      </section>
+      
+
+      
+      <hr />
+      <div class="share">
+        <span class="lbl">Tags</span>
+        <a class="tag" href="/blog/tags/internals/">Internals</a><a class="tag" href="/blog/tags/cost/">Cost</a><a class="tag" href="/blog/tags/telemetry/">Telemetry</a><a class="tag" href="/blog/tags/debugging/">Debugging</a><a class="tag" href="/blog/tags/postmortem/">Postmortem</a>
+      </div>
+      
+    </div>
+
+    
+    <aside class="toc-rail" aria-label="Table of contents">
+      <div class="tt">On this page</div>
+      <ol>
+        <li class="lvl-2"><a href="#what-the-number-was-supposed-to-mean">What the number was supposed to mean</a></li><li class="lvl-2"><a href="#what-it-actually-meant">What it actually meant</a></li><li class="lvl-2"><a href="#why-this-survived-in-plain-sight">Why this survived in plain sight</a></li><li class="lvl-2"><a href="#the-data-was-never-lost">The data was never lost</a></li><li class="lvl-2"><a href="#reading-a-reset-out-of-a-monotonic-counter">Reading a reset out of a monotonic counter</a></li><li class="lvl-2"><a href="#the-threshold-we-deliberately-did-not-add">The threshold we deliberately did not add</a></li><li class="lvl-2"><a href="#doing-it-without-freezing-the-app">Doing it without freezing the app</a></li><li class="lvl-2"><a href="#a-cold-zero-is-worse-than-an-admitted-unknown">A cold zero is worse than an admitted unknown</a></li><li class="lvl-2"><a href="#checking-a-number-you-recovered-by-inference">Checking a number you recovered by inference</a></li><li class="lvl-2"><a href="#what-we-did-not-fix-and-why-we-said-so">What we did not fix, and why we said so</a></li><li class="lvl-2"><a href="#what-we-wrote-down">What we wrote down</a></li><li class="lvl-2"><a href="#the-rest-of-v045">The rest of v0.4.5</a></li>
+      </ol>
+    </aside>
+    
+  </div>
+
+  <footer class="post-foot wrap"><div class="prevnext">
+      <a class="pn prev" href="/blog/agents-ran-our-launch-week-analytics/"><span class="k">← Older</span><span class="t">Our Agents Ran Our Launch-Week Analytics</span></a>
+      <span></span>
+    </div>
+    <section class="related">
+      <h2>Related in Internals</h2>
+      <div class="post-grid">
+        <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-19">Aug 19, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>4 min</span>
+    </div>
+    <h3><a href="/blog/the-newline-that-silenced-windows-agents/">The Newline That Silenced Every Windows Agent</a></h3>
+    <p class="dek">A cmd.exe parsing rule from the 1980s meant Windows agents received exactly one line of their multi-line startup protocol — and nothing errored. The anatomy of our worst silent failure, and the fix.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-newline-that-silenced-windows-agents/" aria-label="Read: The Newline That Silenced Every Windows Agent">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/why-our-auto-update-never-ran/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/why-our-auto-update-never-ran/hero.png" alt="" loading="lazy" decoding="async" /></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-08">Aug 8, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>5 min</span>
+    </div>
+    <h3><a href="/blog/why-our-auto-update-never-ran/">Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace</a></h3>
+    <p class="dek">Munder Difflin shipped auto-update in v0.3.4 and it silently never worked in a single packaged build. The cause was one destructuring assignment across the CommonJS/ESM boundary — and a catch block that threw the evidence away. Here&#39;s how we found it, and what v0.3.7 changes.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-06-15">Jun 15, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>12 min</span>
+    </div>
+    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
+    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
+    </div>
+  </div>
+</article>
+
+      </div>
+    </section>
+    
+  </footer>
+</article>
+
+</main>
+<footer class="site-foot">
+  <div class="wrap">
+    <div class="foot-top">
+      <a class="foot-brand brand" href="https://munderdiffl.in" aria-label="Munder Difflin home">
+        <img class="brand-logo" src="https://munderdiffl.in/logo.png" width="1318" height="840" alt="Munder Difflin, Inc. — Multi-Agent Harness" />
+      </a>
+      <div class="foot-links">
+        <a href="/blog/">Latest</a>
+        <a href="/blog/topics/">Topics</a>
+        <a href="/blog/about/">About</a>
+        <a href="https://munderdiffl.in/blog/feed.xml">RSS</a>
+        <a href="https://github.com/chaitanyagiri/munder-difflin">GitHub</a>
+        <a href="https://munderdiffl.in">munderdiffl.in ↗</a>
+      </div>
+    </div>
+    <div class="foot-meta">
+      © 2026 Munder Difflin · Local-first · MIT-licensed ·
+      Built on <a href="https://munderdiffl.in">Electron, React, Pixi.js, xterm.js &amp; node-pty</a>.
+      Run an office of agents while you sleep.
+    </div>
+  </div>
+</footer>
+
+<script>
+  // sticky-nav border on scroll
+  (function () {
+    var nav = document.getElementById('nav');
+    if (!nav) return;
+    var onScroll = function () { nav.classList.toggle('scrolled', window.scrollY > 8); };
+    onScroll(); window.addEventListener('scroll', onScroll, { passive: true });
+  })();
+  // YouTube click-to-load: thumbnail button → youtube-nocookie iframe
+  (function () {
+    document.addEventListener('click', function (e) {
+      var btn = e.target.closest('.yt-load');
+      if (!btn) return;
+      var box = btn.closest('.yt');
+      var id = box && box.getAttribute('data-yt');
+      if (!id) return;
+      var frame = document.createElement('iframe');
+      frame.src = 'https://www.youtube-nocookie.com/embed/' + id + '?autoplay=1';
+      frame.title = box.getAttribute('data-title') || 'YouTube video';
+      frame.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+      frame.setAttribute('allowfullscreen', '');
+      box.replaceChildren(frame);
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/blog/topics/comparisons/index.html
+++ b/docs/blog/topics/comparisons/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/" aria-current="page">comparisons<span class="ct">17</span></a>
     

--- a/docs/blog/topics/concepts/index.html
+++ b/docs/blog/topics/concepts/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/" aria-current="page">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     

--- a/docs/blog/topics/guides/index.html
+++ b/docs/blog/topics/guides/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     

--- a/docs/blog/topics/index.html
+++ b/docs/blog/topics/index.html
@@ -110,7 +110,7 @@
       <span class="thumb t-internals" aria-hidden="true">INTERNALS</span>
       <div class="body">
         <h3 style="color:var(--ink)">internals</h3>
-        <p class="dek">18 posts.</p>
+        <p class="dek">19 posts.</p>
         <div class="foot"><span class="more">View topic →</span></div>
       </div>
     </a>
@@ -170,7 +170,7 @@
     
     <a class="chip" href="/blog/tags/claude-code/">Claude Code<span class="ct">45</span></a>
     
-    <a class="chip" href="/blog/tags/internals/">Internals<span class="ct">25</span></a>
+    <a class="chip" href="/blog/tags/internals/">Internals<span class="ct">26</span></a>
     
     <a class="chip" href="/blog/tags/guides/">Guides<span class="ct">23</span></a>
     
@@ -198,13 +198,13 @@
     
     <a class="chip" href="/blog/tags/memory/">Memory<span class="ct">8</span></a>
     
+    <a class="chip" href="/blog/tags/cost/">Cost<span class="ct">8</span></a>
+    
     <a class="chip" href="/blog/tags/workflow/">Workflow<span class="ct">7</span></a>
     
     <a class="chip" href="/blog/tags/human-in-the-loop/">Human-in-the-Loop<span class="ct">7</span></a>
     
     <a class="chip" href="/blog/tags/security/">Security<span class="ct">7</span></a>
-    
-    <a class="chip" href="/blog/tags/cost/">Cost<span class="ct">7</span></a>
     
     <a class="chip" href="/blog/tags/mempalace/">MemPalace<span class="ct">6</span></a>
     
@@ -226,6 +226,8 @@
     
     <a class="chip" href="/blog/tags/reliability/">Reliability<span class="ct">4</span></a>
     
+    <a class="chip" href="/blog/tags/debugging/">Debugging<span class="ct">4</span></a>
+    
     <a class="chip" href="/blog/tags/cli-agents/">CLI Agents<span class="ct">4</span></a>
     
     <a class="chip" href="/blog/tags/voice/">Voice<span class="ct">4</span></a>
@@ -233,8 +235,6 @@
     <a class="chip" href="/blog/tags/ide/">IDE<span class="ct">4</span></a>
     
     <a class="chip" href="/blog/tags/terminals/">Terminals<span class="ct">3</span></a>
-    
-    <a class="chip" href="/blog/tags/debugging/">Debugging<span class="ct">3</span></a>
     
     <a class="chip" href="/blog/tags/model-routing/">Model Routing<span class="ct">3</span></a>
     
@@ -285,6 +285,8 @@
     <a class="chip" href="/blog/tags/agent-design/">Agent Design<span class="ct">2</span></a>
     
     <a class="chip" href="/blog/tags/windows/">Windows<span class="ct">2</span></a>
+    
+    <a class="chip" href="/blog/tags/postmortem/">Postmortem<span class="ct">2</span></a>
     
     <a class="chip" href="/blog/tags/community/">Community<span class="ct">2</span></a>
     
@@ -414,8 +416,6 @@
     
     <a class="chip" href="/blog/tags/changelog/">Changelog<span class="ct">1</span></a>
     
-    <a class="chip" href="/blog/tags/postmortem/">Postmortem<span class="ct">1</span></a>
-    
     <a class="chip" href="/blog/tags/feedback/">Feedback<span class="ct">1</span></a>
     
     <a class="chip" href="/blog/tags/product/">Product<span class="ct">1</span></a>
@@ -423,6 +423,8 @@
     <a class="chip" href="/blog/tags/discord/">Discord<span class="ct">1</span></a>
     
     <a class="chip" href="/blog/tags/reddit/">Reddit<span class="ct">1</span></a>
+    
+    <a class="chip" href="/blog/tags/telemetry/">Telemetry<span class="ct">1</span></a>
     
   </div>
   

--- a/docs/blog/topics/internals/index.html
+++ b/docs/blog/topics/internals/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/" aria-current="page">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/" aria-current="page">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     
@@ -111,6 +111,22 @@
 <section class="wrap">
   <div class="post-grid">
     <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">

--- a/docs/blog/topics/memory/index.html
+++ b/docs/blog/topics/memory/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     

--- a/docs/blog/topics/orchestration/index.html
+++ b/docs/blog/topics/orchestration/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     

--- a/docs/blog/topics/story/index.html
+++ b/docs/blog/topics/story/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     

--- a/docs/blog/topics/use-cases/index.html
+++ b/docs/blog/topics/use-cases/index.html
@@ -93,7 +93,7 @@
     
     <a class="chip" href="/blog/topics/concepts/">concepts<span class="ct">21</span></a>
     
-    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">18</span></a>
+    <a class="chip" href="/blog/topics/internals/">internals<span class="ct">19</span></a>
     
     <a class="chip" href="/blog/topics/comparisons/">comparisons<span class="ct">17</span></a>
     

--- a/docs/blog/visualizing-ai-agents-pixijs/index.html
+++ b/docs/blog/visualizing-ai-agents-pixijs/index.html
@@ -307,6 +307,22 @@ to see your agents at work; it’s free and open source.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -335,22 +351,6 @@ to see your agents at work; it’s free and open source.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/why-our-auto-update-never-ran/" aria-label="Read: Our Auto-Update Never Ran Once: A CommonJS Export That Vanished Into an ESM Namespace">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/hire-manifest-untrusted-input/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/hire-manifest-untrusted-input/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-15">Jun 15, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>12 min</span>
-    </div>
-    <h3><a href="/blog/hire-manifest-untrusted-input/">Treating a Hire Manifest as Untrusted Input</a></h3>
-    <p class="dek">A shareable agent-config manifest is attacker input. How Munder Difflin&#39;s import pipeline stays inert: no auto-spawn, default-deny flags, and an SSRF-safe bounded fetch.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/blog/why-our-auto-update-never-ran/index.html
+++ b/docs/blog/why-our-auto-update-never-ran/index.html
@@ -317,6 +317,22 @@ why.</p>
       <h2>Related in Internals</h2>
       <div class="post-grid">
         <article class="card t-internals">
+  <a class="thumb t-internals" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-hidden="true" tabindex="-1"><span class="thumb-ph"><em class="ph-glyph" aria-hidden="true">✶</em><span>INTERNALS</span></span></a>
+  <div class="body">
+    <div class="meta">
+      <time datetime="2026-08-22">Aug 22, 2026</time>
+      <span class="dot" aria-hidden="true"></span>
+      <span>10 min</span>
+    </div>
+    <h3><a href="/blog/the-spend-counter-that-went-back-to-zero/">The Spend Counter That Went Back to Zero</a></h3>
+    <p class="dek">Our own floor was under reporting what it cost by 59 percent. The counter was cumulative since process start, the app restarts, and the session id stayed the same. Here is how a monotonic invariant let us recover the real number from an append-only log.</p>
+    <div class="foot">
+      <span class="tag kind">Internals</span>
+      <a class="more" href="/blog/the-spend-counter-that-went-back-to-zero/" aria-label="Read: The Spend Counter That Went Back to Zero">Read →</a>
+    </div>
+  </div>
+</article>
+<article class="card t-internals">
   <a class="thumb t-internals" href="/blog/the-newline-that-silenced-windows-agents/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/the-newline-that-silenced-windows-agents/hero.png" alt="" loading="lazy" decoding="async" /></a>
   <div class="body">
     <div class="meta">
@@ -345,22 +361,6 @@ why.</p>
     <div class="foot">
       <span class="tag kind">Internals</span>
       <a class="more" href="/blog/hire-manifest-untrusted-input/" aria-label="Read: Treating a Hire Manifest as Untrusted Input">Read →</a>
-    </div>
-  </div>
-</article>
-<article class="card t-internals">
-  <a class="thumb t-internals" href="/blog/compressing-agent-memory/" aria-hidden="true" tabindex="-1"><img src="/blog/assets/media/compressing-agent-memory/hero.png" alt="" loading="lazy" decoding="async" /></a>
-  <div class="body">
-    <div class="meta">
-      <time datetime="2026-06-05">Jun 5, 2026</time>
-      <span class="dot" aria-hidden="true"></span>
-      <span>5 min</span>
-    </div>
-    <h3><a href="/blog/compressing-agent-memory/">Compressing Agent Memory Without Losing the Original</a></h3>
-    <p class="dek">How and why to compress an agent&#39;s long-term memory: the toolbox, the lossy trap, and keeping a lossless original beside a compact copy.</p>
-    <div class="foot">
-      <span class="tag kind">Internals</span>
-      <a class="more" href="/blog/compressing-agent-memory/" aria-label="Read: Compressing Agent Memory Without Losing the Original">Read →</a>
     </div>
   </div>
 </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,14 +4,14 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Munder Difflin — Agent harness to run an office of your clones</title>
-<meta name="description" content="Free, open source and performant multi-agent harness, works with your existing subscriptions (uses hourly limits). It wraps the CLI agents you already use — Claude Code, Codex, Copilot and 7 more — and runs an office of your clones on your own machine." />
+<meta name="description" content="Free, open source and performant multi-agent harness, works with your existing subscriptions (uses hourly limits). It wraps the CLI agents you already use — Claude Code, Codex, Copilot and 9 more — and runs an office of your clones on your own machine." />
 <link rel="canonical" href="https://munderdiffl.in/" />
 <link rel="icon" type="image/svg+xml" href="./logo.svg" />
 <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32.png" />
 <link rel="icon" type="image/png" sizes="512x512" href="./logo.png" />
 <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
 <meta property="og:title" content="Munder Difflin — Agent harness to run an office of your clones" />
-<meta property="og:description" content="Free, open source and performant multi-agent harness, works with your existing subscriptions (uses hourly limits). It wraps the CLI agents you already use — Claude Code, Codex, Copilot and 7 more — and runs an office of your clones on your own machine." />
+<meta property="og:description" content="Free, open source and performant multi-agent harness, works with your existing subscriptions (uses hourly limits). It wraps the CLI agents you already use — Claude Code, Codex, Copilot and 9 more — and runs an office of your clones on your own machine." />
 <meta property="og:image" content="https://munderdiffl.in/media/og.png" />
 <meta property="og:image:type" content="image/png" />
 <meta property="og:image:width" content="2400" />
@@ -21,7 +21,7 @@
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Munder Difflin — Agent harness to run an office of your clones" />
-<meta name="twitter:description" content="Free, open source and performant multi-agent harness, works with your existing subscriptions (uses hourly limits). It wraps the CLI agents you already use — Claude Code, Codex, Copilot and 7 more — and runs an office of your clones on your own machine." />
+<meta name="twitter:description" content="Free, open source and performant multi-agent harness, works with your existing subscriptions (uses hourly limits). It wraps the CLI agents you already use — Claude Code, Codex, Copilot and 9 more — and runs an office of your clones on your own machine." />
 <meta name="twitter:image" content="https://munderdiffl.in/media/og.png" />
 <meta name="twitter:image:alt" content="Munder Difflin — clones for you and your team, working 24/7. Free, open-source multi-agent harness." />
 <meta name="theme-color" content="#FFF8E7" />
@@ -31,7 +31,7 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "Munder Difflin",
-  "description": "Munder Difflin turns each person on a team into an always-on AI clone of themselves. It wraps the CLI agent they already use (Claude Code, Codex, Grok, Qwen, GitHub Copilot CLI, and more), captures their workflow, tooling, and knowledge, and works 24/7 — on their laptop or a dedicated sandbox VM. Clones share one org knowledge base, coordinate over an end-to-end encrypted org network, hand off work, and unblock each other; new clones inherit the org's collective knowledge on day one. Free and open source for individuals; Secure Org Network licenses for teams (Teams Lite and Teams PRO, from 10 to 100+ seats) and a Cloud + Network license that adds dedicated sandbox VMs and a hosted knowledge base in the customer's own controlled environment.",
+  "description": "Munder Difflin turns each person on a team into an always-on AI clone of themselves. It wraps the CLI agent they already use (Claude Code, Codex, Grok, Qwen, Gemini CLI, Cursor, GitHub Copilot CLI, and more), captures their workflow, tooling, and knowledge, and works 24/7 — on their laptop or a dedicated sandbox VM. Clones share one org knowledge base, coordinate over an end-to-end encrypted org network, hand off work, and unblock each other; new clones inherit the org's collective knowledge on day one. Free and open source for individuals; Secure Org Network licenses for teams (Teams Lite and Teams PRO, from 10 to 100+ seats) and a Cloud + Network license that adds dedicated sandbox VMs and a hosted knowledge base in the customer's own controlled environment.",
   "url": "https://munderdiffl.in/",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "macOS, Windows, Linux",
@@ -221,32 +221,54 @@
   .featured-badges { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; margin-bottom: 26px; }
   .featured-badges img { height: 34px; width: auto; display: block; border-radius: 6px; }
 
-  /* TAAFT ships exactly one badge asset and it is greyscale, which went dead
-     next to the Product Hunt badge. Rebuilt here in our own tokens, laid out
-     like the PH badge (mark + label over name) so the row reads as a pair.
-     Theme-aware for free: every colour is a var, so it follows the toggle. */
-  .taaft-badge {
+  /* One badge component, two badges. Third-party badge assets ship as fixed
+     rasters in someone else's palette (TAAFT's is greyscale, Trendshift's is
+     purple on white), which go dead next to ours and cannot follow the theme
+     toggle. Both are rebuilt here in our own tokens, laid out like the PH badge
+     (mark + label over name) so the row reads as a set. Theme-aware for free:
+     every colour is a var.
+     TRADE-OFF, on purpose: a rebuilt badge freezes the claim the live endpoint
+     was making when we copied it. Both claims are dated awards rather than a
+     live rank, and the PH badge alongside is frozen the same way. Re-check the
+     source badge if you are ever unsure it still says this. */
+  .site-badge {
     display: inline-flex; align-items: center; gap: 8px;
     height: 34px; padding: 0 11px; box-sizing: border-box;
     background: var(--surface); border: 1px solid var(--accent-line);
     border-radius: 6px; text-decoration: none; white-space: nowrap;
     transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
   }
-  .taaft-badge:hover { background: var(--accent-soft); border-color: var(--accent); transform: translateY(-1px); }
-  .taaft-badge .tb-mark { color: var(--accent); flex: none; }
-  .taaft-badge .tb-txt { display: flex; flex-direction: column; gap: 1px; line-height: 1; }
-  .taaft-badge .tb-l {
+  .site-badge:hover { background: var(--accent-soft); border-color: var(--accent); transform: translateY(-1px); }
+  .site-badge .tb-mark { color: var(--accent); flex: none; }
+  .site-badge .tb-txt { display: flex; flex-direction: column; gap: 1px; line-height: 1; }
+  .site-badge .tb-l {
     font-family: var(--font-mono); font-weight: 600; font-size: 0.46rem;
     letter-spacing: 0.16em; text-transform: uppercase; color: var(--faint);
   }
-  .taaft-badge .tb-n {
+  .site-badge .tb-n {
     font-family: var(--font-display); font-weight: 700; font-size: 0.72rem;
     letter-spacing: -0.015em; color: var(--ink);
     display: inline-flex; align-items: center; gap: 3px;
   }
-  .taaft-badge .tb-ai {
+  .site-badge .tb-ai {
     background: var(--accent-fill); color: var(--accent-ink);
     border-radius: 3px; padding: 0 3px; font-size: 0.64rem; font-weight: 800;
+  }
+
+  /* Product Hunt ships a raster with the theme baked into the URL, so it cannot
+     follow a token. Both variants are in the markup and CSS picks one. Light is
+     the no-attribute fallback because the theme script calls light canonical,
+     which is also what a JS-off visitor gets. */
+  .ph-badge { display: inline-block; line-height: 0; }
+  .ph-badge .ph-d { display: none; }
+  html[data-theme="dark"] .ph-badge .ph-l { display: none; }
+  html[data-theme="dark"] .ph-badge .ph-d { display: block; }
+
+  /* The TAAFT badge moved off the hero and into the footer. Same component,
+     same tokens; only the container metrics change. */
+  .foot-badges {
+    max-width: var(--maxw); margin: 0 auto 26px; padding: 0 var(--pad-x);
+    display: flex; flex-wrap: wrap; gap: 12px; align-items: center;
   }
 
   /* download modal — the support ask lives between the click and the platform
@@ -584,7 +606,10 @@
   .teams-bar p { color: var(--muted); font-size: 0.94rem; max-width: 620px; margin: 0 auto 18px; }
 
   .cli-chips span.more { background: var(--accent-soft); color: var(--accent); border-color: var(--accent-line); }
-  .cli-logos { display: grid; grid-template-columns: repeat(auto-fit, minmax(80px, 1fr)); gap: 10px; margin-top: 22px; }
+  /* 12 engines. auto-fit landed on 11 + 1 orphan at desktop widths, so the
+     column count is explicit and divides evenly: 6 across (two rows), 4 on a
+     phone (three rows). Revisit both when the roster changes. */
+  .cli-logos { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; margin-top: 22px; }
   .clp {
     display: flex; flex-direction: column; align-items: center; gap: 9px;
     padding: 16px 6px 12px; border: 1px solid var(--border); border-radius: var(--radius-sm);
@@ -976,12 +1001,12 @@
     .dex { padding-left: 6px; padding-right: 6px; }
     .featured-badges { gap: 8px; margin-bottom: 20px; }
     .featured-badges img { height: 30px; border-radius: 5px; }
-    .taaft-badge { height: 30px; padding: 0 9px; gap: 6px; border-radius: 5px; }
-    .taaft-badge .tb-n { font-size: 0.66rem; }
-    .taaft-badge .tb-l { font-size: 0.42rem; }
+    .site-badge { height: 30px; padding: 0 9px; gap: 6px; border-radius: 5px; }
+    .site-badge .tb-n { font-size: 0.66rem; }
+    .site-badge .tb-l { font-size: 0.42rem; }
     /* CLI provider grid: auto-fit lands on 3 uneven columns at phone widths —
-       force 5 across (10 engines = two even rows) and shrink to fit. */
-    .cli-logos { grid-template-columns: repeat(5, 1fr); gap: 6px; }
+       force 4 across (12 engines = three even rows) and shrink to fit. */
+    .cli-logos { grid-template-columns: repeat(4, 1fr); gap: 6px; }
     .clp { padding: 10px 3px 8px; gap: 6px; border-radius: 8px; }
     .clp svg { width: 18px; height: 18px; }
     .clp span { font-size: 0.5rem; letter-spacing: 0.02em; }
@@ -1025,14 +1050,14 @@
   <div class="wrap hero-grid">
     <div>
       <div class="featured-badges">
-        <a class="taaft-badge" href="https://theresanaiforthat.com/ai/munder-difflin/?ref=featured&v=11668376" target="_blank" rel="nofollow" aria-label="Featured on There's An AI For That">
-          <svg class="tb-mark" width="11" height="14" viewBox="0 0 11 14" aria-hidden="true" focusable="false"><path d="M1 1h9v12L5.5 9.7 1 13V1Z" fill="currentColor"/></svg>
+        <a class="site-badge" href="https://trendshift.io/repositories/46562?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-46562" target="_blank" rel="noopener noreferrer" aria-label="GitHub Trending: number 1 repository of the day on Trendshift">
+          <svg class="tb-mark" width="14" height="14" viewBox="0 0 14 14" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="square"><path d="M1 10.6 4.9 6.7 7.3 9.1 12.6 3.4"/><path d="M9.2 3.4H12.9V7"/></svg>
           <span class="tb-txt">
-            <span class="tb-l">Featured on</span>
-            <span class="tb-n">There&rsquo;s an <b class="tb-ai">AI</b> for that</span>
+            <span class="tb-l">GitHub Trending</span>
+            <span class="tb-n"><b class="tb-ai">#1</b> Repository of the Day</span>
           </span>
         </a>
-        <a href="https://www.producthunt.com/products/munder-difflin?embed=true&amp;utm_source=badge-top-post-badge&amp;utm_medium=badge&amp;utm_campaign=badge-munder-difflin" target="_blank" rel="noopener noreferrer"><img alt="Munder Difflin - Make clones with Claude Code and Codex to do your work | Product Hunt — #5 Product of the Day" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1221363&amp;theme=light&amp;period=daily&amp;t=1786777619876"></a>
+        <a class="ph-badge" href="https://www.producthunt.com/products/munder-difflin?embed=true&amp;utm_source=badge-top-post-badge&amp;utm_medium=badge&amp;utm_campaign=badge-munder-difflin" target="_blank" rel="noopener noreferrer" aria-label="Munder Difflin on Product Hunt — #5 Product of the Day"><img class="ph-l" alt="" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1221363&amp;theme=light&amp;period=daily&amp;t=1786777619876"><img class="ph-d" alt="" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1221363&amp;theme=dark&amp;period=daily&amp;t=1786777619876"></a>
       </div>
       <h1><span class="u">Agent harness</span> to run an office of your clones</h1>
       <p class="lead">
@@ -1046,7 +1071,7 @@
     </div>
         <div class="cli-bar rv">
       <h3>Munder Difflin uses CLI agents running on your computer to do anything you can do</h3>
-      <p>Supports 10 CLI agent providers off the shelf, more coming soon</p>
+      <p>Supports 12 CLI agent providers off the shelf, more coming soon</p>
       <div class="cli-logos">
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" fill="currentColor"/></svg><span>Claude Code</span></div>
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" fill="currentColor"/></svg><span>Codex</span></div>
@@ -1054,10 +1079,12 @@
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21.765.351C22.998.351 24 1.353 24 2.586S22.998 4.82 21.765 4.82h-1.974c-.15 0-.26-.12-.26-.26V2.586A2.237 2.237 0 0 1 21.765.35M9.41 13.388l8.447-8.377c.16-.16.07-.471-.14-.471h-4.55s-.1.02-.14.06l-9.099 9.029c-.14.14-.35.02-.35-.21V4.81c0-.15-.1-.27-.221-.27H.22c-.12 0-.22.12-.22.27v18.57c0 .15.1.27.22.27h3.137c.12 0 .22-.12.22-.27v-3.79c0-.08.03-.16.08-.21l2.826-2.796c.07-.07.16-.08.241-.03l7.546 5.551a8.9 8.9 0 0 0 4.018 1.493c.12.01.23-.11.23-.27V19.76c0-.14-.08-.25-.19-.26a5.8 5.8 0 0 1-2.355-.942l-6.533-4.73c-.14-.09-.15-.32-.03-.441" fill="currentColor"/></svg><span>Kimi Code</span></div>
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" fill="currentColor"/></svg><span>Antigravity</span></div>
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z" fill="currentColor"/></svg><span>Qwen</span></div>
+        <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" fill="currentColor"/></svg><span>Gemini CLI</span></div>
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22 24H2V0h20zM17 4.8H7v14.4h10z" fill="currentColor"/></svg><span>OpenCode</span></div>
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21.35C5.4 15.86 2.6 11.9 2.6 8.6a4.9 4.9 0 0 1 9.4-1.9 4.9 4.9 0 0 1 9.4 1.9c0 3.3-2.8 7.26-9.4 12.75z" fill="currentColor"/></svg><span>Crush</span></div>
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="square"><path d="M3.5 6.5 H20.5" /><path d="M8 6.5 V19" /><path d="M16 6.5 V17 a2 2 0 0 0 2 2 h1" /></svg><span>Pi</span></div>
         <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23.922 16.997C23.061 18.492 18.063 22.02 12 22.02 5.937 22.02.939 18.492.078 16.997A.641.641 0 0 1 0 16.741v-2.869a.883.883 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.098 10.098 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952C7.255 2.937 9.248 1.98 11.978 1.98c2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.841.841 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256Zm-11.75-5.992h-.344a4.359 4.359 0 0 1-.355.508c-.77.947-1.918 1.492-3.508 1.492-1.725 0-2.989-.359-3.782-1.259a2.137 2.137 0 0 1-.085-.104L4 11.746v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.359 4.359 0 0 1-.355-.508Zm2.328 3.25c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm-5 0c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm3.313-6.185c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z" fill="currentColor"/></svg><span>Copilot</span></div>
+        <div class="clp"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 2.6 19.1 14.4 12.3 14.4 15.6 21.1 12.9 22.4 9.6 15.7 6 19.4Z" fill="currentColor"/></svg><span>Cursor</span></div>
       </div>
         <figure class="cap-shot rv">
           <video class="hero-video" src="./media/hero-demo.mp4?v=2" width="2300" height="1440"
@@ -1693,9 +1720,9 @@
       <details class="rv">
         <summary>What actually powers my clone?</summary>
         <p>The agent CLI you already use — Claude Code, Codex, Grok, Kimi Code,
-        Antigravity, Qwen, OpenCode, Crush, Pi, or Copilot. Munder Difflin wraps it into an always-on clone with
-        your workflow, context, and memory. Bring your own subscriptions or API
-        keys.</p>
+        Gemini CLI, Antigravity, Qwen, OpenCode, Crush, Pi, Copilot, or Cursor. Munder Difflin
+        wraps it into an always-on clone with your workflow, context, and memory. Bring your own
+        subscriptions or API keys.</p>
       </details>
       <details class="rv">
         <summary>Does my laptop need to stay on?</summary>
@@ -1746,6 +1773,15 @@
 </section>
 
 <footer>
+  <div class="foot-badges">
+    <a class="site-badge" href="https://theresanaiforthat.com/ai/munder-difflin/?ref=featured&v=11668376" target="_blank" rel="nofollow" aria-label="Featured on There's An AI For That">
+      <svg class="tb-mark" width="11" height="14" viewBox="0 0 11 14" aria-hidden="true" focusable="false"><path d="M1 1h9v12L5.5 9.7 1 13V1Z" fill="currentColor"/></svg>
+      <span class="tb-txt">
+        <span class="tb-l">Featured on</span>
+        <span class="tb-n">There&rsquo;s an <b class="tb-ai">AI</b> for that</span>
+      </span>
+    </a>
+  </div>
   <div class="foot-in">
     <span>© 2026 Munder Difflin — free &amp; open source</span>
     <div class="foot-links">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -10,7 +10,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://munderdiffl.in/</loc>
-    <lastmod>2026-08-19</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -20,6 +20,12 @@
   <url><loc>https://munderdiffl.in/blog/</loc><changefreq>daily</changefreq><priority>0.9</priority></url>
   <url><loc>https://munderdiffl.in/blog/topics/</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
   <url><loc>https://munderdiffl.in/blog/about/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url>
+    <loc>https://munderdiffl.in/blog/the-spend-counter-that-went-back-to-zero/</loc>
+    <lastmod>2026-08-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <url>
     <loc>https://munderdiffl.in/blog/agents-ran-our-launch-week-analytics/</loc>
     <lastmod>2026-08-19</lastmod>
@@ -818,10 +824,10 @@
   <url><loc>https://munderdiffl.in/blog/tags/tools/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/getting-started/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/memory/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/cost/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/workflow/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/human-in-the-loop/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/security/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/cost/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/mempalace/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/hive/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/observability/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -832,11 +838,11 @@
   <url><loc>https://munderdiffl.in/blog/tags/mcp/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/architecture/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/reliability/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/debugging/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/cli-agents/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/voice/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/ide/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/terminals/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/debugging/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/model-routing/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/agentic-ai/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/aeo/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -862,6 +868,7 @@
   <url><loc>https://munderdiffl.in/blog/tags/code-review/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/agent-design/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/windows/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/postmortem/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/community/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/subagents/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/markdown/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
@@ -926,9 +933,9 @@
   <url><loc>https://munderdiffl.in/blog/tags/meta/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/product-hunt/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/changelog/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://munderdiffl.in/blog/tags/postmortem/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/feedback/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/product/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/discord/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
   <url><loc>https://munderdiffl.in/blog/tags/reddit/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://munderdiffl.in/blog/tags/telemetry/</loc><changefreq>weekly</changefreq><priority>0.3</priority></url>
 </urlset>


### PR DESCRIPTION
The 0.4.5 content pass: README, a blog post, the website, and the badge row.

### README (`76e6329`, `57d4ebc`)
- Version badge, status note and roadmap all read 0.4.5. The status note leads with the three things 0.4.5 fixes: cost reporting resetting on restart, semantic memory returning NaN on Apple Silicon, and agents not reliably reaching each other.
- The auto-update bullet describes the one click badge that actually ships now, with background auto-update named as the Settings option it became.
- Gemini CLI and Cursor joined the roster in 0.4.5, so the intro list, the terminal bullet, the prerequisites line and the engine count were a release behind. Twelve now, with `cursor-agent` named as the binary the prerequisites check looks for.

### Blog post (`463027d`)
`blog/src/posts/the-spend-counter-that-went-back-to-zero.md`, an Internals postmortem on the cost bug. The per-agent dollar figure counted from process start while its name said lifetime, so an app restart rebuilt the accumulator empty and the counter began again at zero under the same session id. Every value it produced was fine. Only the sequence was wrong, which is why it survived in plain sight.

The post is the recovery rather than the complaint: a cumulative counter can only climb, so a decrease is a restart and nothing else, and the append-only ledger still held every pre reset peak. It also covers the threshold we refused to add, the incremental fold that keeps a long read off the Electron main thread, returning null instead of a confident zero, checking an inferred number with a second implementation, and the breaker cap we wrote up rather than quietly repolicying.

Media manifest gains a placeholder hero and two inline slots. `docs/blog` is the rebuilt output.

### Website (`b7b0658`)
- **Content.** "Supports 10 CLI agent providers" and the ten chips were both short. Twelve now, in the FAQ answer and the three meta descriptions too. Qwen sits between Antigravity and Gemini CLI, because both carry the same Google Gemini mark and side by side that read as a rendering bug. Grid columns are explicit at both widths: auto-fit landed on 11 plus one orphan, so it is 6 across on desktop and 4 on a phone, which divide evenly.
- **Badges.** Trendshift is at the top of the hero row, rebuilt in our tokens the way the TAAFT badge already was: same component, same height, the rank in the accent chip. There's an AI For That moved down to the footer. The shared component is no longer called `taaft-badge`, since two badges use it.
- **The Product Hunt dark mode break.** It was an external raster with `theme=light` in the URL, so it sat as a white slab the moment anyone toggled dark. Both variants are in the markup now and CSS picks one, with light as the no-attribute fallback because the theme script calls light canonical and that is also what a JS-off visitor gets.

Verified in headless Chrome at 1280 and 390, both themes.

### One trade-off worth naming
Rebuilding a third-party badge freezes the claim its live endpoint was making. Both claims here are dated awards rather than a live rank, and the Product Hunt badge alongside was already frozen the same way. There is a comment in the CSS saying so.

### Checks
- `npm run check:links` green at v0.4.5
- Blog builds clean, 274 files written
- No internal figures in the diff or in any commit message. The only scan hits are `59 percent`, which is already published in `CHANGELOG.md` and in the v0.4.5 release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYQTCqgNW2UFuix1WEpztL
