### PR TITLE
costLifetime's comment keeps the reasoning and drops our floor's figures

### DIFF
--- a/src/main/costLifetime.ts
+++ b/src/main/costLifetime.ts
@@ -10,8 +10,9 @@
  * our accumulator forgot). Every consumer that reads the LAST value therefore
  * understates spend for any agent that has been through a restart.
  *
- * Measured on the live ledger 2026-08-21: 38 such resets, last-value total
- * $987.04 against a true $2,406.64, i.e. 59% of spend invisible.
+ * Measured on a live ledger with dozens of such resets, the last value hid
+ * 59% of real spend. The shortfall scales with how often the app is restarted,
+ * so a long-running floor is affected worse than a fresh one.
  *
  * THE RECOVERY
  * ────────────
@@ -22,18 +23,18 @@
  *     sum(peak of each closed segment) + peak of the open segment
  *
  * Any decrease counts, with only a float-noise epsilon. A dollar threshold was
- * considered and rejected: two genuine restarts in the live ledger drop from
- * $0.92 and $0.73 straight to $0.00, and a $1 threshold silently misses both.
- * A cumulative counter has no legitimate reason to go down, so the magic number
- * bought nothing and cost coverage.
+ * considered and rejected: real restarts routinely drop from well under a
+ * dollar straight to zero, so any threshold big enough to be worth having
+ * silently misses them. A cumulative counter has no legitimate reason to go
+ * down, so the magic number bought nothing and cost coverage.
  *
  * COST / SHAPE
  * ────────────
- * The ledger is append-only and already 32MB (162k lines, 126 distinct
- * agent+session keys). A full fold is ~800ms, which must NOT land on the
- * Electron main thread, so folding is async and INCREMENTAL: each pass reads
- * only the bytes appended since the last one and keeps the running segment
- * state. Steady-state cost per pass is a few hundred bytes.
+ * The ledger is append-only and grows without bound, so on an established
+ * floor a full fold takes long enough that it must NOT land on the Electron
+ * main thread. Folding is therefore async and INCREMENTAL: each pass reads only
+ * the bytes appended since the last one and keeps the running segment state.
+ * Steady-state cost per pass is a few hundred bytes regardless of ledger size.
  *
  * Read-only: this module never writes to the ledger.
  */


### PR DESCRIPTION
Found while verifying a count of where the 59% figure had reached. It reached further than either of us said, and into a file nobody had looked at: **`src/main/costLifetime.ts` documents the bug using our own floor's live numbers.**

Three clusters, all in the header comment:

| Line | What was there |
|---|---|
| 13-14 | the reset count and both dollar totals behind the 59% shortfall |
| 24-25 | two per-agent peaks, used to justify rejecting a threshold |
| 31-32 | the ledger's size in MB, its line count, and distinct agent+session keys |

Source on a public repo is more public than the release notes we scrubbed for exactly this reason before shipping 0.4.5 — a reader lands on this file the moment they want to know how lifetime cost is computed.

**Every argument survives, because none of them rested on the magnitudes.** The shortfall is stated as a proportion, which is what makes the point. The threshold is still rejected, now on the ground that real restarts drop from well under a dollar to zero so any useful threshold misses them. The fold is still async and incremental because the ledger grows without bound, which is a better reason than one day's file size.

**How it was missed, which is the more useful half.** The internal-figures sweep that has run twice on this release reads commit *messages*, never the *tree*. A figure sitting in source was never in scope. And the pattern would not have caught `162k lines` or `32MB` regardless, because it looks for thousands separators and currency, not magnitudes written in prose. Same mistake in both directions: searching for the shape of the leak you remember instead of the class the rule names.

The `59%` proportion is left in deliberately — whether that specific ratio stays is an open call with the founder, and it should be decided once across all the surfaces that carry it rather than piecemeal here.

Comment-only diff, verified. 552/552 tests, typecheck clean.

## Before / After

Applying `no-visual-change`, and being explicit about it since I wrote the rule this morning: a comment-only change has nothing observable, which is exactly and only what that label is for. Holding my own PR to the same standard as anyone else's means saying which exemption I am using and why, not quietly skipping the check.