### PR TITLE
fix(wall-sync): the scope-filter comment keeps the reasoning, drops the count

### DIFF
--- a/scripts/wall-sync.mjs
+++ b/scripts/wall-sync.mjs
@@ -30,7 +30,8 @@ const DRY = process.env.DRY_RUN === "1";
 const PR_BRANCH = "wall/additions";
 
 // Same scope filter as the dashboard collector: the engraving-notes key is the
-// discriminator for wall payments; the date guards against ~9,800 legacy records.
+// discriminator for wall payments; the date guards against the much larger body
+// of legacy records that predates the wall.
 // Epoch is Aug 13 UTC because the first wall payment is 2026-08-13T19:xx UTC
 // (= Aug 14 IST, the wall's listed date).
 const MD_EPOCH = Math.floor(Date.parse("2026-08-13T00:00:00Z") / 1000);


### PR DESCRIPTION
`scripts/wall-sync.mjs:33` carried an absolute count of records in our Razorpay account, in a public repo. The count is not load-bearing — the comment only has to explain why the epoch filter exists, and it does that just as well without a magnitude attached.

Same shape as #233 on `costLifetime.ts`: keep the reasoning, drop the figure. Comment-only, no behaviour change.

### The rule this applies

Absolute internal figures never go public. A base-free ratio that characterises a bug or a behaviour is not an internal figure and may stay. The test is one question: **can a reader recover a business quantity from it?** If yes it goes, if no it stays.

`~9,800 legacy records` is an absolute count of our payment history, so it goes. The `59%` in `costLifetime.ts:14` has no base attached and recovers nothing, so it stays — which is the same line #233 was already drawing in practice when it stripped the dollar pair and left the ratio.

**What this does and does not do:** it reduces the surface going forward. It retracts nothing. The git history still carries the figure.

### Before

`scripts/wall-sync.mjs:32-33`

```js
// Same scope filter as the dashboard collector: the engraving-notes key is the
// discriminator for wall payments; the date guards against ~9,800 legacy records.
```

### After

`scripts/wall-sync.mjs:32-34`

```js
// Same scope filter as the dashboard collector: the engraving-notes key is the
// discriminator for wall payments; the date guards against the much larger body
// of legacy records that predates the wall.
```

The reason the guard exists survives the edit; only the magnitude is gone.

### Sweep

I ran the rule across the tree rather than the log, spelling out every form a figure can take (currency, thousands separators, `k`/`MB`/`GB`, counts of tokens/records/installs/users/payments, `~`-prefixed approximations) rather than searching for the shape of the last leak:

```
git grep -inE '\$[0-9][0-9,]*|[0-9]{1,3},[0-9]{3}|[0-9,]+ ?(tokens|records|installs|users|customers|payments|rows)|install base|~[0-9,]+'
```

Everything else it surfaced fails the recover-a-business-quantity test and stays: technical timings and byte sizes, base-free performance ratios (`~216× real-time`, Opus undercosted `~5×`), and Apple's public `$99/yr` Developer Program fee. The previously-scrubbed absolutes are confirmed gone from every published surface — `CHANGELOG.md`, `docs/`, `blog/`, `RELEASE.md` return no hits for the spend pair, the token total, or the install-base pair.

This branch is cut from `main` at 31ac125, so it includes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111uSG4Ge2U6nUxnea7ZfeY