### PR TITLE
docs(readme): add the Kimi Open Source Friends badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,4 +357,12 @@ Dunder Mifflin.
 - [`shahar061/the-office`](https://github.com/shahar061/the-office) for the office tileset/map vendoring.
 - [Pixi.js](https://pixijs.com/) · [xterm.js](https://xtermjs.org/) · [node-pty](https://github.com/microsoft/node-pty) · [electron-vite](https://electron-vite.org/) · [CodeMirror](https://codemirror.net/) for the libraries this is built on.
 - [Remotion](https://www.remotion.dev/) for the landing page's animated "how it works" clips (`landing-remotion/`).
+- [Moonshot AI](https://www.moonshot.ai/) for Kimi Code and the Open Source Friends badge.
 - *The Office* (US) for Munder Difflin, Inc.
+
+<a href="https://www.kimi.com/code?aff=munderdifflin">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69mt3v89kkekg24gg">
+    <img alt="Kimi Open Source Friends" src="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69fudcmosb3pipls0" height="40">
+  </picture>
+</a>


### PR DESCRIPTION
Moonshot AI sent this badge in the collaboration thread on 21 Aug, after Tony Yu accepted the trade we proposed. This puts it in the README.

**Read this before merging: the badge href is an affiliate link.**

The href is `https://www.kimi.com/code?aff=munderdifflin`. The `aff=` tag is Moonshot's own, it arrived inside the badge HTML they pasted, and it means every reader who clicks the badge is attributed to us. Merging this publishes an affiliate link in the README of an MIT project with 3k stars. I left it exactly as they sent it rather than quietly stripping it, because editing a partner's badge markup without telling them is its own kind of problem. The call is yours:

1. Keep the tag as sent.
2. Strip it back to `https://www.kimi.com/code` and tell Tony we did.

**Where it sits.** Acknowledgements, at the bottom, not the badge row at the top. We run 11 CLIs and provider neutrality is the positioning, so a Moonshot badge above the fold would read as a preferred provider. At the bottom it reads as recognition, which is what it actually is.

**One more thing worth knowing.** Both image URLs point at `kimi-file.moonshot.cn`, so the README now pulls two assets from a host we do not control, and the badge breaks if they move them. `height="40"` is the only change I made to their markup. The rest of the picture element is theirs verbatim, dark mode source included.

Nothing else on this branch. One file, eight lines.

Context: hive card `kimi-moonshot-collab`, partner brief at `hive/research/moonshot-partner-2026-08-22/PARTNER-BRIEF.md`.
