### PR TITLE
security: keep the OS sandbox on in auto mode

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -613,6 +613,10 @@ export class HiveManager {
        *  copied into the agent's `.claude/skills/` per spawn; undefined or missing
        *  is a no-op (tolerated until Kevin populates the resource dir). */
       skillsDir?: string;
+      /** Extra directories the agent's sandbox may write (e.g. the shared
+       *  MemPalace dir, which `mempalace` mutates). Absolute paths; ignored
+       *  for providers without a sandbox. */
+      extraWritableDirs?: string[];
     } = {}
   ): Promise<SpawnInjection> {
     const root = this.root();
@@ -759,6 +763,12 @@ export class HiveManager {
               // that already vets hook sources"). Without it the hooks silently
               // never fire. Must precede the positional prompt.
               preArgs.push('--dangerously-bypass-hook-trust');
+              // Auto mode keeps codex's OS sandbox (`-a never -s workspace-write`,
+              // agentProvider.ts). workspace-write only covers cwd, so the agent
+              // folder (inbox/.done, memory.md, outbox) and the shared hive root
+              // (research deliverables, the board for god) are added as extra
+              // writable roots. Harmless outside auto mode.
+              for (const d of this.sandboxWritableDirs(meta, dir, root, opts.extraWritableDirs)) preArgs.push('--add-dir', d);
             }
             else if (desc.shim === 'pi') {
               // Pi (earendil-works) has a rich pi.on(event) lifecycle. We drop a
@@ -862,7 +872,7 @@ export class HiveManager {
     if (sock && shim) {
       env.HIVE_SOCK = sock;
       const settingsPath = join(dir, 'settings.json');
-      this.writeJson(settingsPath, this.hookSettings(shim, meta.cwd, opts.mcpDefaults, opts.theme));
+      this.writeJson(settingsPath, this.hookSettings(shim, meta.cwd, opts.mcpDefaults, opts.theme, this.sandboxWritableDirs(meta, dir, root, opts.extraWritableDirs)));
       args.push('--settings', settingsPath);
     }
     return { args, env };
@@ -1031,7 +1041,19 @@ export class HiveManager {
    *  (W3) the default MCP bundle merged into this PER-SESSION settings file. cwd
    *  scopes the filesystem/git servers; cfg (the consent map) gates which servers
    *  are written. Claude-only — this is invoked solely on the Claude spawn path. */
-  private hookSettings(shim: string, cwd: string, cfg: McpDefaultsMap, theme?: 'light' | 'dark'): unknown {
+  /**
+   * Directories a sandboxed agent may write BESIDES its cwd: its own agent
+   * folder (hive housekeeping) and the hive root (research deliverables; the
+   * board and tasks.json for god; outbox delivery is done by main, not the agent).
+   * This is what lets auto mode keep the OS sandbox on — the old full-bypass
+   * posture existed only because these paths sit outside the project cwd.
+   */
+  private sandboxWritableDirs(meta: AgentMeta, dir: string, root: string, extra?: string[]): string[] {
+    const out = [dir, root, ...(extra ?? [])].filter((d) => typeof d === 'string' && d.length > 0);
+    return Array.from(new Set(out));
+  }
+
+  private hookSettings(shim: string, cwd: string, cfg: McpDefaultsMap, theme?: 'light' | 'dark', writableDirs: string[] = []): unknown {
     // Bundled node, NOT bare `node` — see nodeLauncherPath(). Claude runs each of
     // these through `sh -c` with a stripped PATH, where `node` is often absent.
     const cmd = this.nodeRun(shim);
@@ -1064,6 +1086,22 @@ export class HiveManager {
       // window. The shim prints a compact in-terminal gauge and forwards the
       // payload to the harness (agent-card context gauge, exact limit).
       statusLine: { type: 'command', command: `${cmd} --status`, padding: 0 },
+      // Native OS sandbox for Bash subprocesses (macOS Seatbelt / Linux bubblewrap).
+      // Auto mode spawns with `--permission-mode bypassPermissions`, which only
+      // silences PROMPTS; the sandbox is a separate, opt-in layer that was never
+      // switched on. Verified live (claude 2.1.239): with this block, bypass mode
+      // still writes cwd and the listed dirs but `touch $HOME/x` fails with
+      // "Operation not permitted". Two layers are needed: `sandbox.filesystem`
+      // governs Bash children, `permissions.additionalDirectories` governs the
+      // Edit/Write tools; with only one the agent deadlocks on its own inbox.
+      // failIfUnavailable stays false: a platform without a sandbox (Windows)
+      // runs as before rather than refusing to spawn.
+      ...(writableDirs.length
+        ? {
+            sandbox: { enabled: true, filesystem: { allowWrite: writableDirs } },
+            permissions: { additionalDirectories: writableDirs }
+          }
+        : {}),
       hooks: {
         Stop: [entry()],
         SubagentStop: [entry()],

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2663,7 +2663,10 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
           theme: readConfig().terminalTheme ?? 'light',
           // W3 — default-MCP consent state + the bundled skills source dir.
           mcpDefaults: readConfig().mcpDefaults,
-          skillsDir: skillsResourceDir()
+          skillsDir: skillsResourceDir(),
+          // The shared palace is mutated by the agent's own `mempalace` calls, so
+          // the OS sandbox must let it through (empty when memory is off).
+          extraWritableDirs: [memory.env().MEMPALACE_PALACE_PATH].filter((p): p is string => !!p)
         }
       );
       opts.args = [...(opts.args ?? []), ...inj.args];

--- a/src/main/workerLaunch.ts
+++ b/src/main/workerLaunch.ts
@@ -3,7 +3,7 @@
  * pure function: this exact translation silently killed real workers for days
  * while reporting success, which is what earned it a unit test.
  */
-import { autoModeFlagForProvider, inferAgentProvider } from '../shared/agentProvider';
+import { autoModeFlagForProvider, hasAutoModeStance, inferAgentProvider } from '../shared/agentProvider';
 import { tokenizeCommand } from '../shared/commandLine';
 
 export interface WorkerLaunch {
@@ -33,14 +33,14 @@ export function buildWorkerLaunch(opts: {
   // stance of its own: a headless worker has no human to click through tool
   // prompts, so without the flag it stalls at the first ask until the idle
   // reaper kills it. The flag is the PROVIDER'S — a codex worker needs
-  // --dangerously-bypass-approvals-and-sandbox, and claude's --permission-mode
+  // `-a never -s workspace-write`, and claude's --permission-mode
   // would mean nothing to it (an earlier hardcoded-claude version left every
   // non-claude worker stalling; review caught it). An explicit stance in the
   // request still wins: the flag's leading token already present as a TOKEN
   // (not substring — copilot's flag starts with `-s`) means the request chose.
   const provider = inferAgentProvider(command, opts.requestProvider);
   const autoFlag = opts.autoMode ? autoModeFlagForProvider(provider) : '';
-  if (autoFlag && !tokenizeCommand(command).includes(tokenizeCommand(autoFlag)[0])) {
+  if (autoFlag && !hasAutoModeStance(tokenizeCommand(command), provider)) {
     command += ` ${autoFlag}`;
   }
   // god authors `command` as a full command LINE ("claude --model … --permission-mode …"),

--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -599,7 +599,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
               <>
                 {/* AUTONOMY — merged from the old "auto mode" step (item 5). One choice
                     that maps to each engine's flag (item 6): autoMode → claude
-                    bypassPermissions / codex --dangerously-bypass-approvals-and-sandbox,
+                    bypassPermissions / codex -a never -s workspace-write (sandbox kept),
                     etc.; off → each engine's ask-first default. */}
                 <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 10, color: 'var(--cth-ink-700)' }}>
                   HOW MUCH CAN AGENTS DO ON THEIR OWN?

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -161,6 +161,9 @@ export interface AgentProviderPreset {
   nativeInstallCommand?: { posix: string; win32: string };
   /** Optional docs URL surfaced as a manual-setup hint in the missing-CLI banner. */
   docsUrl?: string;
+  /** Extra argv tokens that count as an explicit permission stance (so the auto
+   *  flag is not appended). Defaults to the auto flag's own leading token. */
+  autoStanceTokens?: string[];
   resumeSubcommand?: string; // CLIs that resume via a subcommand instead of a flag (Codex: `codex resume [OPTIONS] [SESSION_ID]`)
 }
 
@@ -195,17 +198,20 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     label: 'Codex · GPT',
     defaultCommand: 'codex',
     commandGroups: CODEX_COMMAND_GROUPS,
-    // Full claude-parity auto mode: skip ALL approval prompts AND drop the sandbox,
-    // exactly like Claude's `bypassPermissions` / agy's `--dangerously-skip-permissions`.
-    // The earlier `-a never -s workspace-write` confined writes to the PTY cwd
-    // (the user's project), but a hive worker must also write to its agent folder
-    // at <harnessHome>/hive/agents/<id>/ (inbox→.done, memory.md, outbox JSON,
-    // deliverables) — a DIFFERENT path tree from cwd, which workspace-write blocked,
-    // so codex workers couldn't do HIVE PROTOCOL housekeeping. The single bypass flag
-    // is codex's documented equivalent of `--dangerously-skip-permissions` (no -a/-s
-    // alongside it). The app already runs claude/agy in this same full-access posture.
-    autoModeFlag: '--dangerously-bypass-approvals-and-sandbox',
-    autoFlag: '--dangerously-bypass-approvals-and-sandbox',
+    // Auto mode: never prompt (-a never) but KEEP codex's OS sandbox, scoped to the
+    // workspace (-s workspace-write). The app used to spawn with
+    // `--dangerously-bypass-approvals-and-sandbox` for one reason only: a hive
+    // worker must write to its agent folder at <harnessHome>/hive/agents/<id>/,
+    // a different path tree from cwd, which workspace-write blocked. That is a
+    // path-layout problem, not a reason to drop the sandbox: codex's documented
+    // `--add-dir <DIR>` makes extra directories writable alongside the workspace,
+    // and the hive spawn path (hive.ts, which knows the agent dir) appends it.
+    // So: approvals off, sandbox on, hive housekeeping still works.
+    autoModeFlag: '-a never -s workspace-write',
+    autoFlag: '-a never -s workspace-write',
+    // Any of these on a command line means the user already chose a posture
+    // (including the old full bypass) — do not stack ours on top.
+    autoStanceTokens: ['-a', '--ask-for-approval', '-s', '--sandbox', '--full-auto', '--dangerously-bypass-approvals-and-sandbox'],
     // Suppresses first-run interactive prompts (directory-trust gate, installer).
     nonInteractiveEnv: { CODEX_NON_INTERACTIVE: '1' },
     supportsModel: true,
@@ -678,9 +684,19 @@ export function argsWithAutoModeFlag(args: string[], autoMode: boolean, provider
   if (!autoMode) return args;
   const flag = autoModeFlagForProvider(provider);
   if (!flag) return args;
-  const tokens = flag.trim().split(/\s+/);
-  if (args.includes(tokens[0])) return args;
-  return [...args, ...tokens];
+  if (hasAutoModeStance(args, provider)) return args;
+  return [...args, ...flag.trim().split(/\s+/)];
+}
+
+/** True when argv already states a permission posture for this provider: the
+ *  auto flag's leading token, or any of the preset's `autoStanceTokens`. Token
+ *  match, not substring — copilot's flag starts with `-s`. */
+export function hasAutoModeStance(args: string[], provider: AgentProvider): boolean {
+  const preset = providerPreset(provider);
+  const flag = preset.autoModeFlag ?? '';
+  const lead = flag.trim().split(/\s+/)[0];
+  const stance = new Set([...(lead ? [lead] : []), ...(preset.autoStanceTokens ?? [])]);
+  return args.some((a) => stance.has(a));
 }
 
 /** Returns any env vars the provider needs for non-interactive / first-run suppression. */

--- a/src/shared/codexCommands.ts
+++ b/src/shared/codexCommands.ts
@@ -45,8 +45,8 @@ export const CODEX_COMMAND_GROUPS: CmdGroup[] = [
   {
     title: 'APPROVALS & PERMISSIONS',
     items: [
-      { cmd: 'codex --dangerously-bypass-approvals-and-sandbox', kind: 'cli', desc: 'Auto mode: skip ALL approval prompts AND drop the OS sandbox (full filesystem access). Used by Munder Difflin when auto mode is on — full parity with Claude bypassPermissions, and required so a hive worker can write to its agent folder outside the project cwd.' },
-      { cmd: 'codex -a never -s workspace-write', kind: 'cli', desc: 'Never prompt for approval (-a never) but scope the sandbox to the project workspace (-s workspace-write). Safer, but blocks writes outside cwd (e.g. a hive agent folder in another path tree).' },
+      { cmd: 'codex --dangerously-bypass-approvals-and-sandbox', kind: 'cli', desc: 'Skip ALL approval prompts AND drop the OS sandbox (full filesystem access). Munder Difflin no longer uses this for auto mode; it keeps the sandbox and adds the hive agent folder via --add-dir.' },
+      { cmd: 'codex -a never -s workspace-write', kind: 'cli', desc: 'Never prompt for approval (-a never) but keep the sandbox scoped to the project workspace (-s workspace-write). What Munder Difflin uses for auto mode; the hive agent folder is added with --add-dir <dir>.' },
       { cmd: 'codex -a untrusted', kind: 'cli', desc: 'Only run trusted commands without asking; escalate to the user for anything else.' },
       { cmd: 'codex -s danger-full-access', kind: 'cli', desc: 'Remove all sandbox restrictions (fine-grained flag — pair with -a for full control).' }
     ]

--- a/test/auto-mode-sandbox.test.cjs
+++ b/test/auto-mode-sandbox.test.cjs
@@ -1,0 +1,56 @@
+/**
+ * Auto mode keeps the OS sandbox ON.
+ *
+ * The app used to spawn every auto-mode agent with no sandbox at all (codex
+ * `--dangerously-bypass-approvals-and-sandbox`; Claude with its opt-in sandbox
+ * never enabled) for one reason: a hive worker writes to its agent folder under
+ * <harnessHome>/hive/agents/<id>/, which sits OUTSIDE the project cwd. That is a
+ * path-layout problem. Fix: keep the sandbox and declare those paths writable —
+ * codex via `--add-dir`, Claude via `sandbox.filesystem.allowWrite` plus
+ * `permissions.additionalDirectories` in the per-session settings file.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const electron = require.resolve('electron');
+require.cache[electron] = {
+  id: electron, filename: electron, loaded: true,
+  exports: { Notification: class { show() {} static isSupported() { return false; } } }
+};
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+const { autoModeFlagForProvider } = loadTs('src/shared/agentProvider.ts');
+
+function tmpHome() { return fs.mkdtempSync(path.join(os.tmpdir(), 'md-sandbox-')); }
+
+test('codex auto mode is workspace-write with approvals off, never the full bypass', () => {
+  const flag = autoModeFlagForProvider('codex');
+  assert.equal(flag, '-a never -s workspace-write');
+  assert.ok(!flag.includes('dangerously'));
+});
+
+test('a Claude agent gets a native sandbox that still allows its agent dir and the hive root', async () => {
+  const home = tmpHome();
+  const hive = new HiveManager(() => home);
+  const palace = path.join(home, 'palace');
+  const inj = await hive.ensureAgent(
+    { id: 'jim-1', name: 'Jim', provider: 'claude', cwd: home },
+    { extraWritableDirs: [palace] }
+  );
+  const i = inj.args.indexOf('--settings');
+  assert.ok(i >= 0, 'claude spawn carries --settings');
+  const settings = JSON.parse(fs.readFileSync(inj.args[i + 1], 'utf8'));
+  const agentDir = path.join(home, 'hive', 'agents', 'jim-1');
+  const hiveRoot = path.join(home, 'hive');
+  assert.equal(settings.sandbox.enabled, true);
+  assert.notEqual(settings.sandbox.failIfUnavailable, true, 'Windows must still spawn');
+  assert.deepEqual(settings.sandbox.filesystem.allowWrite, [agentDir, hiveRoot, palace]);
+  // Both layers, or the agent deadlocks: Edit/Write allowed but `mv … .done/` denied.
+  assert.deepEqual(settings.permissions.additionalDirectories, settings.sandbox.filesystem.allowWrite);
+  // No bypass of the sandbox anywhere in the injected args.
+  assert.ok(!inj.args.some((a) => /dangerously/.test(a)));
+});

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -64,7 +64,7 @@ test('provider commands use matching models and equivalent bypass modes', () => 
   );
   assert.equal(
     buildSpawnCommand(autoConfig, 'gpt-5.6-sol', 'codex'),
-    'codex --model gpt-5.6-sol --dangerously-bypass-approvals-and-sandbox'
+    'codex --model gpt-5.6-sol -a never -s workspace-write'
   );
   assert.equal(
     buildSpawnCommand(autoConfig, 'grok-4.5', 'grok'),

--- a/test/worker-launch.test.cjs
+++ b/test/worker-launch.test.cjs
@@ -62,7 +62,7 @@ test("auto-mode appends the PROVIDER'S flag, not claude's", () => {
   // A codex worker given --permission-mode would still stall at its first ask;
   // each provider's preset knows its own flag, same as the renderer's spawn path.
   const codex = launch({ requestCommand: 'codex', autoMode: true });
-  assert.deepEqual(codex.args, ['--dangerously-bypass-approvals-and-sandbox']);
+  assert.deepEqual(codex.args, ['-a', 'never', '-s', 'workspace-write']);
   const agy = launch({ requestCommand: 'agy', autoMode: true });
   assert.deepEqual(agy.args, ['--dangerously-skip-permissions']);
   const kimi = launch({ requestCommand: 'kimi', autoMode: true });
@@ -91,7 +91,7 @@ test('a multi-token auto flag appends whole, and the stance check is by token', 
 
 test("an explicit request provider picks that provider's flag for a custom binary", () => {
   const l = launch({ requestCommand: 'my-codex-wrapper', requestProvider: 'codex', autoMode: true });
-  assert.deepEqual(l.args, ['--dangerously-bypass-approvals-and-sandbox']);
+  assert.deepEqual(l.args, ['-a', 'never', '-s', 'workspace-write']);
 });
 
 test('a missing command falls back to the default, then to claude', () => {

--- a/test/worker-permission-parity.test.cjs
+++ b/test/worker-permission-parity.test.cjs
@@ -60,9 +60,9 @@ test('a provider with no auto-mode flag (custom) is left alone', () => {
   assert.deepEqual(argsWithAutoModeFlag(['--foo'], true, 'custom'), ['--foo']);
 });
 
-test('a single-token auto flag (codex) is applied the same way as Claude\'s two-token flag', () => {
+test('codex\'s multi-token auto flag is applied the same way as Claude\'s two-token flag', () => {
   assert.deepEqual(
     argsWithAutoModeFlag(['--model', 'gpt-5.6-sol'], true, 'codex'),
-    ['--model', 'gpt-5.6-sol', '--dangerously-bypass-approvals-and-sandbox']
+    ['--model', 'gpt-5.6-sol', '-a', 'never', '-s', 'workspace-write']
   );
 });


### PR DESCRIPTION
> **Do not merge until the founder signs off on the permission posture.** This changes what an agent in auto mode is allowed to write. See "Behaviour change" below.

## The mechanism, verified before anything was changed

Auto mode ran every agent with no OS sandbox at all. The reason was a path layout: a hive worker writes to its agent folder at `<harnessHome>/hive/agents/<id>/`, which sits outside the project cwd.

- **Codex**: the preset's auto flag was `--dangerously-bypass-approvals-and-sandbox`, and the code comment gave exactly that reason: `-s workspace-write` blocked the agent folder. Codex 0.137 has `--add-dir <DIR>` (extra writable roots alongside the workspace), so the folder never needed to move.
- **Claude**: `--permission-mode bypassPermissions` only silences prompts. Claude's sandbox is a separate, opt-in setting the app never enabled, so nothing was "dropped"; it was never on. The fix there is the per-session `settings.json` the hive already writes.
- gemini `--yolo`, grok, agy and the rest have no OS sandbox to restore; untouched.

## The fix, zero new dependencies, no layout change

- Codex auto flag is now `-a never -s workspace-write`; `hive.ts` appends `--add-dir` for the agent dir, the hive root (research deliverables; the board for god) and the MemPalace dir. An explicit posture already on the command line, including the old bypass flag, still wins (`autoStanceTokens` / `hasAutoModeStance`).
- Claude's per-session `settings.json` gets `sandbox.enabled: true` with `sandbox.filesystem.allowWrite` **and** `permissions.additionalDirectories` for the same dirs. Both layers are needed: one governs Bash children, the other the Edit/Write tools; with only one the agent deadlocks on its own inbox.
- `sandbox.failIfUnavailable` stays off, so a platform without a sandbox (Windows) spawns exactly as before.

## Proof the sandbox is back

Real run, claude 2.1.239, `--permission-mode bypassPermissions --settings <new block>`:

```
touch $HOME/md-sandbox-probe   → touch: Operation not permitted   (file does not exist afterwards)
touch <agent dir>/probe        → ok
touch ./probe (cwd)            → ok
```

`test/auto-mode-sandbox.test.cjs` pins the settings shape and the codex flag. 554/554 tests, typecheck clean.

## Behaviour change, read this

**Agents writing anywhere outside cwd + their agent dir + the hive root (+ palace) are now DENIED by the OS.** Concrete case from this floor this week: I cherry-picked a commit onto another agent's worktree (Kevin's) from my own session. Under this PR that write fails with "Operation not permitted". That is the single-writer rule enforced by the OS, which is the point, but it is a change in what auto mode can do and deserves a line in the release notes.

## What was NOT tested

The codex behavioural write test could not run: there are no OpenAI credits on this machine. The `-a never -s workspace-write --add-dir` semantics come from `codex --help` (0.137) and a prior banner check (`sandbox: workspace-write [workdir, /tmp, $TMPDIR, <agent dir>]`), not from a live codex run that attempted a write. The Claude side is the part proven live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5X7vQmQDwrTCn2qBzuBiJ