### PR TITLE
fix(update): the update installs itself, and says something true while asking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.4.6] — 2026-08-22
+
+**The update that installs itself, and tells the truth while it asks.** 0.4.5 shipped a restart
+prompt whose "What's new" read `{ box-sizing: border-box; }`, and a first-run release page that
+could not fire on the release that introduced it. Both are fixed, and an update no longer waits
+on a button press that most people never make.
+
+### Fixed
+
+- **A downloaded update installs when you quit.** `autoInstallOnAppQuit` was off, so a staged
+  update sat until someone pressed "restart to update" and was replaced by the next one if they
+  never did. On the existing install base only 41.7% took 0.4.4 within four days, while 56.7%
+  stayed on 0.4.3. The explicit restart is still the fast path and still the only thing that
+  interrupts; quitting now finishes the job for everyone else. Nothing installs under a running
+  app.
+- **The first run after an update shows that release's page, including for anyone coming from a
+  build older than the stamp.** The version stamp shipped in 0.4.5, so every user upgrading from
+  0.4.4 arrived with no stamp and was read as a brand-new install. `telemetry-install-id` has
+  been minted on first run since 0.4.2, so finding one with no stamp beside it proves an older
+  build already ran here. Installs with telemetry off have no id and stay quiet, which is the
+  honest answer: they cannot be told apart from a genuinely new install.
+- **The restart prompt no longer shows CSS.** Its notes came from electron-updater, which builds
+  them from `releases.atom` — GitHub's rendered markdown, where HTML comments do not survive and
+  a `<style>` block leaves its declarations behind as prose. `* { box-sizing: border-box; }` is
+  character-for-character a markdown bullet, and it was the only one in the entire feed, so it
+  beat the whole release note. The notes are now read from the release itself, unrendered. A
+  failed read leaves no notes at all, deliberately: a missing digest beats a digest made of
+  somebody's stylesheet.
+- **A dev run can no longer eat the installed app's update signal.** Dev shares its user-data
+  directory with the packaged app, and a dev build stamping the new version hours before the real
+  upgrade made that upgrade read as no change at all. Only a packaged build writes the stamp.
+
 ## [0.4.5] — 2026-08-22
 
 **The release that fixes the things you trusted and were quietly wrong.** Cost reporting was off

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munder-difflin",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "description": "Clones for you and your team, working 24/7 — a free, local-first multi-agent harness that turns the CLI coding agent you already run into a clone of you, coordinating an office of agents on your machine.",
   "main": "out/main/index.js",

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,7 +1,7 @@
 import { app, ipcMain, shell } from 'electron';
 import type { WebContents } from 'electron';
 import { request as httpsRequest } from 'node:https';
-import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { readConfig } from './config';
 import { DEFAULT_DROP_HTML } from '../shared/releaseDrop';
@@ -404,16 +404,41 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
   // fetch failing just means no page, never a broken boot.
   if (!previewPath) {
     try {
-      const stampFile = join(app.getPath('userData'), 'last-run-version');
+      const userData = app.getPath('userData');
+      const stampFile = join(userData, 'last-run-version');
       let previous: string | null = null;
-      try { previous = readFileSync(stampFile, 'utf8').trim() || null; } catch { /* first run */ }
+      try { previous = readFileSync(stampFile, 'utf8').trim() || null; } catch { /* first run, or a build older than the stamp */ }
       const current = app.getVersion();
-      if (previous !== current) {
-        mkdirSync(app.getPath('userData'), { recursive: true });
+
+      // NO STAMP IS AMBIGUOUS, and reading it as "fresh install" is what made
+      // 0.4.5 silent. The stamp itself shipped IN 0.4.5, so every user upgrading
+      // 0.4.4 -> 0.4.5 arrived with no stamp, took the `previous &&` branch, and
+      // never saw the release page. A detector that only fires on a stamp it
+      // wrote itself can never fire on the release that introduces it.
+      // `telemetry-install-id` settles the ambiguity: it has been minted on
+      // first run since 0.4.2, so finding one with no stamp beside it proves
+      // this profile has already run an older build. Telemetry being off means
+      // no id, and then staying quiet is the right answer anyway — we cannot
+      // tell that install apart from a genuinely new one.
+      const upgradedFromUnstamped =
+        previous === null && existsSync(join(userData, 'telemetry-install-id'));
+
+      // A DEV RUN SHARES userData WITH THE INSTALLED APP (same `name` in
+      // package.json), so writing the stamp here consumes the packaged app's
+      // one-shot signal before the real update ever happens. That is precisely
+      // how 0.4.5 was lost on this machine: a dev build stamped 0.4.5 at 06:02Z,
+      // hours before the 0.4.4 -> 0.4.5 upgrade at 09:57Z, which then read as no
+      // move at all. Dev reads the stamp; only a packaged build writes it.
+      if (app.isPackaged && previous !== current) {
+        mkdirSync(userData, { recursive: true });
         writeFileSync(stampFile, current + '\n', 'utf8');
       }
-      if (previous && previous !== current && isNewer(current, previous)) {
-        logLine(`first run after update ${previous} -> ${current}; fetching its release page`);
+
+      const moved = previous
+        ? previous !== current && isNewer(current, previous)
+        : upgradedFromUnstamped;
+      if (moved) {
+        logLine(`first run after update ${previous ?? 'an unstamped build'} -> ${current}; fetching its release page`);
         fetchReleaseBody(current, (notes) => {
           emit({ state: 'just-updated', version: current, notes });
           logLine(`just-updated ${current} ${notes ? 'with' : 'without'} release notes`);
@@ -447,7 +472,14 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
     try {
       const autoUpdater = await loadAutoUpdater();
       autoUpdater.autoDownload = true;
-      autoUpdater.autoInstallOnAppQuit = false; // install ONLY on explicit restart
+      // Install on the next ordinary quit as well as on an explicit restart.
+      // This was false, meaning an update that had already downloaded sat there
+      // until someone pressed a button, and a user who never presses it never
+      // upgrades — the staged installer just gets replaced by the next one. The
+      // explicit restart is still the fast path and still the only thing that
+      // interrupts; this is what catches everyone who simply closes the app.
+      // Nothing installs UNDER a running app: quitting is the trigger.
+      autoUpdater.autoInstallOnAppQuit = true;
       autoUpdater.on('update-available', (info) => {
         logLine(`update available: ${info.version}`);
         emit({ state: 'available', version: info.version, notes: typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined });
@@ -458,7 +490,26 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
       });
       autoUpdater.on('update-downloaded', (info) => {
         logLine(`update downloaded: ${info.version} — waiting for the user to restart`);
-        emit({ state: 'downloaded', version: info.version, notes: typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined });
+        // The restart affordance appears immediately, with no notes; they are
+        // fetched separately below and fill in a moment later.
+        //
+        // NOT `info.releaseNotes`. electron-updater's GitHubProvider builds that
+        // from releases.atom (providers/GitHubProvider.js, computeReleaseNotes →
+        // getNoteValue), which is GitHub's RENDERED markdown. Two things die in
+        // the rendering: HTML comments, so a `<!-- drop -->` can never survive
+        // this path, and the `<style>` tag, whose CSS is left behind as prose —
+        // where `* { box-sizing: border-box; }` is character-for-character a
+        // markdown bullet and the only one in the whole feed, so it wins the
+        // digest outright. That is the literal text 0.4.5 shipped as its "what's
+        // new". The API body is the same release unrendered, markers intact.
+        //
+        // A failed fetch leaves the state with NO notes, deliberately: "no
+        // notes, no block" is a supported render, and a missing digest beats a
+        // digest made of someone's stylesheet.
+        emit({ state: 'downloaded', version: info.version });
+        fetchReleaseBody(info.version, (notes) => {
+          if (notes) emit({ state: 'downloaded', version: info.version, notes });
+        });
       });
       autoUpdater.on('error', (err) => {
         const message = errText(err);

--- a/src/shared/releaseNotes.ts
+++ b/src/shared/releaseNotes.ts
@@ -62,6 +62,38 @@ const TABLE_ROW_RE = /^\s*\|/;
 /** Setext underline (`====` under a title) — structure, never content. */
 const SETEXT_RE = /^\s{0,3}=+\s*$/;
 const WHATS_NEW_RE = /^\s{0,3}#{1,6}\s+.*what[’']?s\s+new/i;
+/**
+ * CSS that reached the body as prose, which is not a hypothetical.
+ *
+ * One of the three paths that feeds this function is electron-updater's, whose
+ * notes come from `releases.atom` — GitHub's RENDERED markdown. Rendering drops
+ * the `<style>` TAG and leaves its declarations behind as text. In that text
+ * `  * { box-sizing: border-box; }` is character-for-character a markdown
+ * bullet, and in a real release feed it was the ONLY bullet-shaped line, so it
+ * beat every sentence in the release and shipped as 0.4.5's "What's new".
+ *
+ * Filtering here rather than trusting the author is the right layer: this
+ * function is handed remote text by three callers and cannot assume any of them
+ * cleaned it first. Deliberately narrow — a block, an at-rule, or a bare
+ * selector list — so a bullet that merely mentions `display: flex` survives.
+ */
+const CSS_AT_RULE_RE = /^\s*@(?:media|keyframes|import|supports|font-face|charset)\b/i;
+/** A line that opens (and possibly closes) a CSS block: `.hero {`, `* { … }`. */
+const CSS_BLOCK_START_RE = /^\s*[^{}]{0,200}\{/;
+/** A selector list continued across lines: `#pg1:checked ~ .stage .p1,`. */
+const CSS_SELECTOR_RE = /^\s*[.#*@]?[\w\-.#:>~+*\[\]="'(),\s]+,\s*$/;
+/** `:root {` — a selector opening a block whose declarations are on later lines.
+ *  Only selector characters before the brace, so a sentence cannot qualify. */
+const CSS_OPEN_LINE_RE = /^\s*[\w\-.#*:>~+\[\]="'(),\s]+\{\s*$/;
+/** Only lines that are structurally CSS — `isMeaningful` prose never is. */
+function looksLikeCssOpener(line: string): boolean {
+  if (CSS_AT_RULE_RE.test(line)) return true;
+  if (CSS_SELECTOR_RE.test(line)) return true;
+  if (CSS_OPEN_LINE_RE.test(line)) return true;
+  // A brace alone proves nothing (`${var}` appears in real notes); a brace plus
+  // a `prop: value` declaration after it is CSS and nothing else.
+  return CSS_BLOCK_START_RE.test(line) && /\{[^{}]*[-\w]+\s*:[^{}]*(;|\})/.test(line);
+}
 /** GitHub appends this to auto-generated bodies; it is a URL, not news. */
 const FULL_CHANGELOG_RE = /^\s*\**\s*full\s+changelog\s*\**\s*:/i;
 const BARE_URL_RE = /^\s*<?https?:\/\/\S+>?\s*$/i;
@@ -74,6 +106,16 @@ const BARE_URL_RE = /^\s*<?https?:\/\/\S+>?\s*$/i;
  */
 export function stripMarkdown(md: string): string {
   return String(md ?? '')
+    // Entities FIRST. One caller is fed GitHub's RENDERED html, where `&` in a
+    // title arrives as `&amp;` and reached the toast verbatim — and where an
+    // escaped `&lt;style&gt;` has to become a tag again before the tag strip
+    // below can remove it, or it survives as literal `<style>` text.
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&amp;/g, '&')       // last, so `&amp;lt;` cannot become `<`
     .replace(/!\[[^\]]*\]\([^)]*\)/g, '')            // images/badges: gone entirely
     .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')         // inline links → their label
     .replace(/\[([^\]]*)\]\[[^\]]*\]/g, '$1')        // reference links → their label
@@ -91,7 +133,6 @@ export function stripMarkdown(md: string): string {
     .replace(/(?<![\w_])__([^_\n]+)__(?!\w)/g, '$1')
     .replace(/(?<![\w_])_([^_\n]+)_(?!\w)/g, '$1')
     .replace(/^\s{0,3}#{1,6}\s*/, '')                // a heading marker that slipped through
-    .replace(/&nbsp;/g, ' ')
     .replace(/\s+/g, ' ')
     .replace(/^[\s—–:.,;·-]+/, '')         // leading orphan punctuation from a stripped link
     .trim();
@@ -111,9 +152,49 @@ function isMeaningful(text: string): boolean {
 function usableLines(body: string): string[] {
   const out: string[] = [];
   let inFence = false;
-  for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
-    if (FENCE_RE.test(raw)) { inFence = !inFence; continue; }
+  // Depth of the CSS block we are inside, by brace count. Tracked the same way
+  // as the fence above, because leaked stylesheet text keeps its line breaks and
+  // therefore its structure — `@media (…) { .p1 { … } }` nests and a single
+  // "skip until the next }" would stop one rule too early.
+  let cssDepth = 0;
+  const braceDelta = (s: string): number =>
+    (s.match(/\{/g)?.length ?? 0) - (s.match(/\}/g)?.length ?? 0);
+  // A `/* … */` comment is the other half of a leaked stylesheet, it is not
+  // inside any block, and it spans lines. The v0.4.5 feed's comments read as
+  // sentences ("Two pages, no JavaScript…"), so they are the one kind of CSS
+  // that looks exactly like release prose and has to be removed by structure.
+  let inCssComment = false;
+  for (const source of body.replace(/\r\n?/g, '\n').split('\n')) {
+    if (FENCE_RE.test(source)) { inFence = !inFence; continue; }
     if (inFence) continue;
+    let raw = source;
+    if (inCssComment) {
+      const close = raw.indexOf('*/');
+      if (close === -1) continue;
+      raw = raw.slice(close + 2);
+      inCssComment = false;
+    }
+    raw = raw.replace(/\/\*[\s\S]*?\*\//g, '');
+    const open = raw.indexOf('/*');
+    if (open !== -1) { raw = raw.slice(0, open); inCssComment = true; }
+    // A line that was nothing but comment is dropped, not blanked: a blank line
+    // ends a digest item, and a stripped comment must not split one in two.
+    if (raw.trim() === '' && source.trim() !== '') continue;
+    // Test the line's TEXT, not its markup. On the rendered path GitHub turns
+    // `@media`, `@import` and `@keyframes` into user mentions — a real anchor to
+    // a real account, which is also why `@keyframes` came back as `@Keyframes`,
+    // GitHub's canonical casing for the org of that name. So an at-rule never
+    // begins its own line there; it begins with `<a class="user-mention"…`.
+    // Tags are stripped for the test only, and the original line is what ships.
+    const probe = raw.replace(/<[^>]+>/g, '');
+    if (cssDepth > 0) {
+      cssDepth = Math.max(0, cssDepth + braceDelta(probe));
+      continue;
+    }
+    if (looksLikeCssOpener(probe)) {
+      cssDepth = Math.max(0, braceDelta(probe));
+      continue;
+    }
     const line = raw
       .replace(/<!--[\s\S]*?-->/g, '')
       .replace(/^\s{0,3}>\s?/, '')

--- a/test/fixtures/release-atom-v0.4.5.html
+++ b/test/fixtures/release-atom-v0.4.5.html
@@ -1,0 +1,95 @@
+<h1>Munder Difflin v0.4.5</h1>
+<p><strong>A local hive of Claude Code, Antigravity, Codex, Gemini, Cursor, Grok &amp; Copilot agents that run themselves.</strong><br>
+Messaging, routing, and remembering, coordinated by your clone, Michael, who you talk to. Local-first and open source.</p>
+<h3>→ <a href="https://munderdiffl.in/" rel="nofollow"><strong>munderdiffl.in</strong></a> · see it in action, then grab a build below</h3>
+<hr>
+<h2>What's new in 0.4.5</h2>
+<p><strong>The release that fixes the things you trusted and were quietly wrong.</strong> Cost reporting was off<br>
+by more than half after a restart, semantic memory never worked on Apple Silicon, and agents<br>
+could not talk to each other reliably. All three are fixed. Plus weekday scheduling, clickable<br>
+paths everywhere, one editor instead of two, and 23 community pull requests.</p>
+<ul>
+<li><strong>Costs are reported right.</strong> The telemetry counter reset on every app restart while the<br>
+session id stayed the same, so the floor under reported spend by a wide margin. It is now folded<br>
+from the ledger, with a separate session figure kept alongside.</li>
+<li><strong>Semantic memory works on Apple Silicon.</strong> CoreML overflowed the quantized embedding graph,<br>
+every vector came back NaN, and chroma rejected every upsert. Embeddings are pinned to CPU<br>
+on macOS.</li>
+<li><strong>Agents talk to each other reliably.</strong> An inbox wake watchdog, no more stale nudges, mail to<br>
+a missing inbox is bounced and logged instead of dropped, a capped steer queue, atomic<br>
+webhook dispatch, and PROTOCOL.md refreshes on boot.</li>
+<li><strong>Workers are reliable to hire.</strong> Spawn, teardown, floor cards, and engine availability are<br>
+all checked before a hire is committed.</li>
+<li><strong>The renderer runs inside Chromium's sandbox.</strong></li>
+<li><strong>Windows agents quit when the app does.</strong></li>
+<li><strong>Restart to update no longer gets stuck</strong> when a running agent makes the app refuse to quit.</li>
+<li><strong>Triggers run on weekdays at a time of day,</strong> not just on an interval, and they are DST safe.</li>
+<li><strong>Focus mode</strong> survives a restart and you can edit an agent from inside it.</li>
+<li><strong>Every path in terminal output is clickable.</strong> Markdown previews, source opens in the editor,<br>
+images and unknown types reveal in Finder or Explorer.</li>
+<li><strong>One editor.</strong> The fullscreen file overlay is gone, everything opens in the IDE, and the git<br>
+rail is collapsed by default.</li>
+<li><strong>Updating is one click.</strong> The title-bar badge downloads the build for your machine and tells<br>
+you how to install it, it says <code class="notranslate">latest</code> once a check confirms you are current, and the first<br>
+run after an update opens that release's page.</li>
+<li><strong>Settings opens with a card</strong> carrying your version, your plan, and a way back to these notes.</li>
+<li><strong>Terminals follow the window theme,</strong> Gemini CLI and Cursor Agent join the engine list, and<br>
+Michael hires on his own terms with editable agent names.</li>
+</ul>
+<h3>A note on Pro</h3>
+<p>v0.5.0 launches with a Pro version alongside the community version. Community stays free, stays<br>
+open, and keeps getting updates. Pro ships with new features and integrations, with more posted<br>
+throughout the year, and it stays ahead of Community, for power users who want the full potential<br>
+of coding agents and agent harnesses. The Pro roadmap also includes a mobile app. The first 100 people on the<br>
+Founders' Wall get a month of Pro free, then 50% off the annual plan.</p>
+<h3>Thanks</h3>
+<p>23 community pull requests landed in this release. Thank you to everyone who opened one,<br>
+reviewed one, or filed the bug that led to one. The full list is in CHANGELOG.md.</p>
+
+&lt;style&gt;
+  /* Self-contained on purpose. This page is rendered by the app people already
+     have (0.4.4), whose frame knows nothing about the landing site palette, so
+     every token, font and shadow is declared here rather than inherited. */
+  <a class="user-mention notranslate" data-hovercard-type="organization" data-hovercard-url="/orgs/import/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/import">@import</a> url("https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600;700&amp;display=swap");
+  :root {
+    --paper: #FFFDF7; --cream: #F5F2E8; --cream-2: #F5ECD7; --white: #FFFFFF;
+    --ink: #1B1B1B; --ink-dim: #57544C; --ink-faint: #8A867A;
+    --yellow: #FFCA54; --sky: #72C2DF; --maroon: #B23A4E;
+    --lilac: #E4DEFB; --peach: #FBDDBE; --mint: #D6F3E1; --sky-soft: #DCEFF7;
+    --line: rgba(27,27,27,0.16);
+    --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --sans: "Geist", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  html, body { height: 100%; margin: 0; }
+  body { overflow: hidden; background: var(--paper); color: var(--ink); font-family: var(--sans);
+         font-size: 14.5px; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+  * { box-sizing: border-box; }
+
+  /* Two pages, no JavaScript. Radio inputs plus :checked ~ sibling selectors do
+     the paging; a  is a real click target inside the sandbox. */
+  .pg { position: absolute; opacity: 0; pointer-events: none; }
+  .stage { height: 100%; position: relative; }
+  .page { display: none; height: 100%; flex-direction: column; position: relative;
+          padding: clamp(20px, 3.6vw, 32px) clamp(20px, 4vw, 34px) clamp(14px, 2.2vw, 20px); }
+  #pg1:checked ~ .stage .p1,
+  #pg2:checked ~ .stage .p2 { display: flex; }
+  <a class="user-mention notranslate" data-hovercard-type="organization" data-hovercard-url="/orgs/media/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/media">@media</a> (prefers-reduced-motion: no-preference) {
+    #pg1:checked ~ .stage .p1,
+    #pg2:checked ~ .stage .p2 { animation: rise .38s cubic-bezier(.2,.7,.3,1) both; }
+    <a class="user-mention notranslate" data-hovercard-type="organization" data-hovercard-url="/orgs/Keyframes/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/Keyframes">@Keyframes</a> rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+  }
+  .content { flex: 1; min-height: 0; overflow-y: auto; padding: 0 12px 10px 0; }
+  .content::-webkit-scrollbar { width: 8px; }
+  .content::-webkit-scrollbar-thumb { background: var(--ink); }
+  .content::-webkit-scrollbar-track { background: var(--cream); }
+  .p1 .content { display: flex; flex-direction: column; justify-content: center; }
+
+  /* Dotted paper grid behind the hero page, same as the site. */
+  .p1 { background: radial-gradient(var(--ink-faint) 1px, transparent 1px) 0 0 / 22px 22px var(--paper); }
+  .p1::before { content: ""; position: absolute; inset: 0; pointer-events: none;
+                background: radial-gradient(ellipse at 50% 40%, rgba(255,253,247,0) 25%, var(--paper) 85%); }
+  .p1 &gt; * { position: relative; }
+
+  .eyebrow { font-family: var(--mono); font-size: 11px; font-weight: 500; letter-spacing: .26em;
+             text-transform: uppercase; color: var(--ink-faint); margin: 0 0 12px; }
+  h1 { font-family: var(--mono); font-weight: 600; letter-spacing: -.04em; line-height: 1.06;

--- a/test/release-notes.test.cjs
+++ b/test/release-notes.test.cjs
@@ -238,3 +238,86 @@ test('options are honoured so a roomier surface can ask for more', () => {
   assert.equal(summarizeReleaseNotes(body, { maxBullets: 2 }).length, 2);
   assert.ok(total(summarizeReleaseNotes(body, { maxChars: 60 })) <= 60);
 });
+
+/**
+ * The CSS leak, pinned against GitHub's REAL rendered output.
+ *
+ * v0.4.5 shipped a restart prompt that read `{ box-sizing: border-box; }` and
+ * nothing else. Every test above passes on hand-written markdown and every one
+ * of them passed while that was live, because the string that reaches this
+ * function on the updater's own path is not markdown at all: electron-updater
+ * builds its notes from `releases.atom`, which is GitHub's RENDERED html.
+ *
+ * So the fixture is a genuine slice of that feed, saved verbatim, not written
+ * by hand. Anything hand-written here would reproduce the same blind spot that
+ * let this ship twice.
+ */
+test('a real rendered release feed never digests to CSS', () => {
+  const rendered = fs.readFileSync(
+    path.resolve(__dirname, 'fixtures', 'release-atom-v0.4.5.html'), 'utf8'
+  );
+  const digest = summarizeReleaseNotes(rendered);
+
+  assert.ok(digest.length > 0, 'the feed has prose in it; something must come out');
+  for (const line of digest) {
+    assert.doesNotMatch(line, /box-sizing/, 'the 0.4.5 bug, verbatim');
+    assert.doesNotMatch(line, /\{[^}]*:[^}]*[;}]/, `a CSS declaration reached the toast: ${line}`);
+    assert.doesNotMatch(line, /^@(media|keyframes|import|supports)\b/i, `an at-rule reached the toast: ${line}`);
+    assert.doesNotMatch(line, /^<?style>?/i, `the style tag itself reached the toast: ${line}`);
+    assert.doesNotMatch(line, /&(amp|lt|gt|quot|#39);/, `an unresolved html entity reached the toast: ${line}`);
+  }
+});
+
+test('CSS is dropped by structure, in every shape the renderer produces', () => {
+  const news = '## What\'s new\n\nThe thing you wanted works now.\n';
+
+  // A whole rule on one line. This exact shape is a markdown bullet, which is
+  // why it beat the release: `* ` is the universal selector AND a list marker.
+  assert.deepEqual(
+    summarizeReleaseNotes(`${news}\n* { box-sizing: border-box; }\n`),
+    ['The thing you wanted works now.']
+  );
+  // A selector opening a block whose declarations are on later lines.
+  assert.deepEqual(
+    summarizeReleaseNotes(`${news}\n:root {\n  --paper: #FFFDF7;\n  --ink: #1B1B1B;\n}\n`),
+    ['The thing you wanted works now.']
+  );
+  // Nested at-rules: a single "skip to the next }" stops one rule too early.
+  assert.deepEqual(
+    summarizeReleaseNotes(`${news}\n@media (min-width: 40em) {\n  .p1 { display: flex; }\n}\n`),
+    ['The thing you wanted works now.']
+  );
+  // GitHub renders `@media` as a USER MENTION, so on that path an at-rule never
+  // starts its own line — it starts with an anchor. Tags are stripped for the
+  // structural test, which is the only reason this one is caught.
+  assert.deepEqual(
+    summarizeReleaseNotes(`${news}\n<a class="user-mention" href="/media">@media</a> (min-width: 40em) {\n  .p1 { display: flex; }\n}\n`),
+    ['The thing you wanted works now.']
+  );
+  // Comments read as sentences ("Two pages, no JavaScript…") and span lines, so
+  // they are the one kind of CSS that looks exactly like release prose.
+  assert.deepEqual(
+    summarizeReleaseNotes(`${news}\n/* Self-contained on purpose.\n   Two pages, no JavaScript. */\n`),
+    ['The thing you wanted works now.']
+  );
+});
+
+test('prose that merely mentions CSS is not mistaken for it', () => {
+  // The filter is structural on purpose. A release note is allowed to talk
+  // about the code it changed, and this is the line the narrow rules protect.
+  const digest = summarizeReleaseNotes(
+    "## What's new\n\n- Panels now use `display: flex`, so a long agent name wraps instead of clipping.\n"
+  );
+  assert.equal(digest.length, 1);
+  assert.match(digest[0], /display: flex/);
+});
+
+test('html entities are resolved, and resolved once', () => {
+  // `&` in the product tagline reached the toast as `&amp;` for two releases.
+  assert.equal(stripMarkdown('Codex, Grok &amp; Copilot'), 'Codex, Grok & Copilot');
+  // Entities are decoded BEFORE tags are stripped, so an escaped tag becomes a
+  // tag again and then goes — otherwise `<style>` survives as literal text.
+  assert.equal(stripMarkdown('&lt;style&gt;body{color:red}'), 'body{color:red}');
+  // Decoding must not run twice: `&amp;lt;` is a literal `&lt;`, not a `<`.
+  assert.equal(stripMarkdown('&amp;lt;'), '&lt;');
+});

--- a/tools/check-release-digest.cjs
+++ b/tools/check-release-digest.cjs
@@ -1,0 +1,62 @@
+'use strict';
+/**
+ * What the update toast will actually say, run against GitHub's LIVE feed.
+ *
+ * Not a unit test and deliberately not in the test run: it makes a network call
+ * and its answer changes when someone edits a release. Its job is the one thing
+ * a fixture cannot do — tell you what real users are being shown right now.
+ *
+ * The string it reads is `releases.atom`, because that is what electron-updater
+ * hands the digest on the `downloaded` path (GitHubProvider → computeReleaseNotes
+ * → the newest entry's <content>). It is GitHub's RENDERED markdown, not the
+ * release body, and testing against the body instead is how a CSS reset shipped
+ * as 0.4.5's "What's new".
+ *
+ *   node tools/check-release-digest.cjs          # newest release
+ *   node tools/check-release-digest.cjs --all    # every entry in the feed
+ */
+const https = require('node:https');
+const path = require('node:path');
+const loadTs = require(path.resolve(__dirname, '..', 'test', 'load-ts.cjs'));
+const { summarizeReleaseNotes } = loadTs('src/shared/releaseNotes.ts');
+
+const FEED = 'https://github.com/chaitanyagiri/munder-difflin/releases.atom';
+const unescapeXml = (s) => s
+  .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"')
+  .replace(/&#39;/g, "'").replace(/&amp;/g, '&');
+
+function get(url, done) {
+  https.get(url, { headers: { 'User-Agent': 'munder-difflin-digest-check' } }, (res) => {
+    if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+      res.resume();
+      return get(res.headers.location, done);
+    }
+    let body = '';
+    res.setEncoding('utf8');
+    res.on('data', (d) => { body += d; });
+    res.on('end', () => done(null, body));
+  }).on('error', (e) => done(e));
+}
+
+get(FEED, (err, feed) => {
+  if (err) { console.error('could not read the feed:', err.message); process.exit(1); }
+  const entries = feed.split('<entry>').slice(1);
+  const wanted = process.argv.includes('--all') ? entries : entries.slice(0, 1);
+  let leaked = false;
+  for (const entry of wanted) {
+    const title = (entry.match(/<title>([^<]*)<\/title>/) || [, '?'])[1];
+    const m = entry.match(/<content type="html">([\s\S]*?)<\/content>/);
+    const digest = summarizeReleaseNotes(m ? unescapeXml(m[1]) : '');
+    console.log(`\n${title} — what the toast shows:`);
+    if (digest.length === 0) console.log('   (nothing — the toast renders no block at all)');
+    digest.forEach((line, i) => console.log(`   ${i + 1}. ${line}`));
+    for (const line of digest) {
+      if (/\{[^}]*:[^}]*[;}]/.test(line) || /^@(media|keyframes|import|supports)\b/i.test(line)) {
+        console.log(`   ^^ CSS reached the toast on line ${digest.indexOf(line) + 1}`);
+        leaked = true;
+      }
+    }
+  }
+  console.log(leaked ? '\nFAIL: stylesheet text is reaching users.' : '\nOK: no CSS in the digest.');
+  process.exit(leaked ? 1 : 0);
+});


### PR DESCRIPTION
> **DO NOT MERGE.** Opened for review only, at the founder's instruction. The
> evidence check below is expected to be red and is deliberately not waived —
> see the last section.

0.4.5 shipped a restart prompt whose "What's new" read `{ box-sizing: border-box; }`,
and a first-run release page that could not fire on the release that introduced it.
Both are fixed here, from both ends, and an update no longer waits on a button press
that most people never make.

## What was actually wrong

Three faults in one path.

**`autoInstallOnAppQuit` was false.** A downloaded update sat there until someone
pressed "restart to update", and was replaced by the next one if they never did.
Measured on the existing install base, only 41.7% took 0.4.4 within four days while
56.7% stayed on 0.4.3. Quitting the app is now the install trigger. The explicit
restart is still the fast path and still the only thing that interrupts; nothing
installs under a running app.

**The first-run check could never fire on the release that introduced it.** The
version stamp shipped *in* 0.4.5, so every user upgrading from 0.4.4 arrived with no
stamp, took the `previous &&` branch, and was read as a brand-new install.
`telemetry-install-id` has been minted on first run since 0.4.2, so finding one with
no stamp beside it proves an older build already ran in this profile. Installs with
telemetry off have no id and stay quiet, which is the honest answer: they cannot be
told apart from a genuinely new install.

**`update-downloaded` trusted `info.releaseNotes`.** electron-updater builds those
from `releases.atom` — GitHub's *rendered* markdown. HTML comments do not survive
rendering, so a `<!-- drop -->` never can, and a `<style>` block leaves its
declarations behind as prose. The notes are now read from the release itself,
unrendered. A failed read leaves no notes at all, deliberately: a missing digest
beats a digest made of somebody's stylesheet.

Also: only a packaged build writes the stamp. Dev shares its user-data directory with
the installed app, and a dev run stamping the new version hours before the real
upgrade made that upgrade read as no change at all.

## And the same fault from the other end

The digest now drops stylesheet text by structure, so CSS cannot win again whichever
path feeds it. Four shapes, all live in our own feed:

- a whole rule on one line — `* { box-sizing: border-box; }` is character for
  character a markdown bullet, `*` being both the universal selector and a list
  marker, and it was the **only** bullet-shaped line in a 766 line feed;
- a selector opening a block with declarations on later lines (`:root {`), tracked by
  brace depth so nested at-rules do not stop the skip one rule early;
- CSS comments, which span lines and read as sentences ("Two pages, no JavaScript…"),
  the one kind of CSS indistinguishable from release prose by content;
- at-rules, which GitHub renders as **user mentions** — `@media` arrives as an anchor
  to a real account, which is also why `@keyframes` came back as `@Keyframes`, that
  being GitHub's casing for the org of that name. So an at-rule never starts its own
  line there, and the structural test runs against the line's text, not its markup.

Entities are decoded too, and decoded first: `&` in the tagline reached the toast as
`&amp;` for two releases, and an escaped `&lt;style&gt;` has to become a tag again
before the tag strip can remove it.

The filter is deliberately narrow. A bullet that mentions `display: flex` survives,
and there is a test that says so.

## Before

Run against the live `releases.atom`, which is the exact string a 0.4.4 client digests:

```
v0.4.5 →  1. { box-sizing: border-box; }
v0.4.4 →  1. Munder Difflin v0.4.4 A local hive of … Grok &amp; Copilot…
          2. page { display: none; height: 100%; flex-direction: column; padding: clamp(24px…
          3. content { flex: 1; min-height: 0; overflow-y: auto; } .center {…
```

## After

Same feed, same function, this branch:

```
v0.4.5 →  1. Munder Difflin v0.4.5 A local hive of Claude Code, Antigravity, Codex,
             Gemini, Cursor, Grok & Copilot agents…
          2. Munder Difflin · v0.4.5 Thank you for being here early. Every bug you
             filed, every PR you sent, every floor…
          3. Also new Triggers Schedule on weekdays at a time of day Not…

v0.4.4 →  1. Munder Difflin v0.4.4 A local hive of Claude Code, Antigravity, Codex,
             Grok & Copilot agents that run…
          2. Munder Difflin 0.4.4 The release where Windows finally joined the floor —
             and the first run stopped quietly…
          3. Start → The headline Agents can talk to each other on Windows…
```

## Testing

`npm run test:focused` — 556 pass, 0 fail. `npm run typecheck` — clean on both
projects. Four new tests, and the fixture is a **verbatim slice of GitHub's rendered
feed**, not hand-written. Every existing test in that file passes on hand-written
markdown, and every one of them passed while the CSS prompt was live. A hand-written
fixture would reproduce the same blind spot that let this ship twice.

## Why the evidence check is red and not waived

There is a real visible surface here: the toast's "What's new" block. An honest
before/after of it needs two builds side by side, which I have not produced. The
`no-visual-change` label would therefore be dishonest — the standard is whether a
rendered surface changed, not whether capturing it is convenient, and this one
changed. The check staying red is also a useful second lock while this must not
merge. It should be satisfied with a real screenshot pair before anyone considers
merging, not labelled away.

## Not in this PR

`RELEASE.md` still has to be rewritten for 0.4.6 through the release-body rules, or
0.4.6 reintroduces the CSS prompt on day one — the digest always reads the newest
release. That work is tracked separately.
