### PR TITLE
Scope the localStorage roster fallback to the hive that wrote it

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3310,6 +3310,7 @@ ipcMain.handle('git:checkout', async (_evt, cwd: unknown, ref: unknown, detach: 
 // instead of flashing an empty floor and then filling in.
 // (`roster` itself is constructed earlier so HookServer can read standing goals.)
 ipcMain.on('roster:readSync', (evt) => { evt.returnValue = roster.read(); });
+ipcMain.on('config:homeSync', (evt) => { evt.returnValue = readConfig().harnessHome ?? null; });
 ipcMain.handle('roster:read', () => roster.read());
 ipcMain.handle('roster:write', (_evt, snap: unknown) => roster.write(snap));
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1343,6 +1343,12 @@ const api = {
   rosterReadSync: (): RosterSnapshot | null => {
     try { return ipcRenderer.sendSync('roster:readSync') ?? null; } catch { return null; }
   },
+  /** Which hive is open, synchronously — same boot-time constraint as
+   *  `rosterReadSync`, and read in the same breath: the store has to know which
+   *  hive its localStorage keys belong to before it decides to trust them. */
+  harnessHomeSync: (): string | null => {
+    try { return ipcRenderer.sendSync('config:homeSync') ?? null; } catch { return null; }
+  },
   /** Mirror the roster to disk. Debounced by the caller; main keeps the previous
    *  contents as a backup and refuses a first write that would empty a full file. */
   rosterWrite: (snap: RosterSnapshot): Promise<{ ok: boolean; skipped?: string; error?: string }> =>

--- a/src/renderer/src/store/rosterSource.ts
+++ b/src/renderer/src/store/rosterSource.ts
@@ -1,0 +1,60 @@
+/** Which store the roster is loaded FROM at boot — the file beside the hive, or
+ *  this origin's localStorage.
+ *
+ *  Split out of store.ts because it is the one decision that has to be right on
+ *  every launch and cannot be observed from the UI when it is wrong: the roster
+ *  just appears, and nothing says where it came from.
+ *
+ *  localStorage is partitioned by ORIGIN, not by hive. Every hive this app ever
+ *  opens shares exactly one of them, so it can only ever hold the roster of
+ *  whichever hive wrote it last. Adopting it into a DIFFERENT hive is how one
+ *  workspace's team turns up in another — restorable entries and all, each one
+ *  still carrying the `cwd` of the workspace it was hired in. */
+
+export interface RosterCounts {
+  agents: unknown[];
+  archived: unknown[];
+  restorable: unknown[];
+}
+
+export interface RosterSourceInput {
+  /** `<harnessHome>/roster.json` as read at boot, or `null` when there is none. */
+  fileRoster: RosterCounts | null;
+  /** The hive this window is opening. `null` before onboarding picks one. */
+  currentHome: string | null;
+  /** The hive localStorage was last written for, or `null` when it predates the
+   *  stamp (an install that upgraded into this behaviour). */
+  storedHome: string | null;
+}
+
+export interface RosterSource {
+  /** Load the slices out of the file. */
+  useFileRoster: boolean;
+  /** Load the slices out of localStorage — and, on a first run, seed the file
+   *  from them. False means BOTH stores are ignored and the floor starts empty. */
+  useLocalFallback: boolean;
+}
+
+/** An empty file must never win over a populated localStorage: that is the
+ *  "opened the packaged build once and my floor went blank" failure the mirror
+ *  exists to prevent (the two origins do not share a localStorage, the file is
+ *  what bridges them). A genuine delete-all clears both, so nothing resurrects. */
+function fileHasRoster(file: RosterCounts | null): boolean {
+  return !!file
+    && file.agents.length + file.archived.length + file.restorable.length > 0;
+}
+
+export function chooseRosterSource({
+  fileRoster,
+  currentHome,
+  storedHome
+}: RosterSourceInput): RosterSource {
+  if (fileHasRoster(fileRoster)) return { useFileRoster: true, useLocalFallback: false };
+
+  // No file roster, so the only candidate left is localStorage — which is worth
+  // reading only if it was written for THIS hive. `null` is the pre-stamp case:
+  // an install whose localStorage predates the stamp is adopted once, because
+  // refusing it would blank the floor of everyone upgrading.
+  const belongsHere = storedHome === null || currentHome === null || storedHome === currentHome;
+  return { useFileRoster: false, useLocalFallback: belongsHere };
+}

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -17,6 +17,7 @@ import { isCompactionCommand } from '@shared/providerAutomation';
 import { preferredAgentRole } from '@shared/agentRole';
 import { isInboxNudge } from '@shared/hiveNudge';
 import { refocusAfterRemoval, focusOnLoad, restoreFocus } from './focusMode';
+import { chooseRosterSource } from './rosterSource';
 
 export type ToolKind =
   | 'Read' | 'Edit' | 'Write' | 'Bash' | 'WebFetch' | 'WebSearch'
@@ -341,6 +342,8 @@ const LS_ARCHIVED = 'cth.archivedAgents';
 const LS_RESTORABLE = 'cth.restorableAgents';
 const LS_SELECTED = 'cth.selectedId';
 const LS_QUEUES = 'cth.messageQueues';
+/** Which hive this origin's roster keys were last written for. See rosterSource.ts. */
+const LS_ROSTER_HOME = 'cth.rosterHome';
 const LS_FOCUS_MODE = 'cth.prefersFocusMode';
 
 // Fields that are large or transient — not worth persisting across reloads.
@@ -365,12 +368,28 @@ const fileRoster = (() => {
   try { return window.cth?.rosterReadSync?.() ?? null; } catch { return null; }
 })();
 
-/** Prefer the shared file, but only when it actually holds a roster. An empty
- *  file must never win over a populated localStorage — that is exactly the
- *  "opened the build once and my floor went blank" failure this is here to
- *  prevent. A genuine delete-all clears both stores, so nothing resurrects. */
-const useFileRoster = !!fileRoster
-  && fileRoster.agents.length + fileRoster.archived.length + fileRoster.restorable.length > 0;
+/** Which hive we are opening, and which one this origin's localStorage was last
+ *  written for. Both read synchronously, for the same reason the roster is: the
+ *  store is built at module load, so an async answer would arrive too late. */
+const currentHome = (() => {
+  try { return window.cth?.harnessHomeSync?.() ?? null; } catch { return null; }
+})();
+const storedHome = (() => {
+  try { return window.localStorage.getItem(LS_ROSTER_HOME); } catch { return null; }
+})();
+
+const { useFileRoster, useLocalFallback } = chooseRosterSource({
+  fileRoster,
+  currentHome,
+  storedHome
+});
+
+/** Claim this origin's roster keys for the hive we just opened. Written even
+ *  when nothing loaded: from here on localStorage describes THIS hive, so the
+ *  next hive we open knows not to adopt it. */
+try {
+  if (currentHome) window.localStorage.setItem(LS_ROSTER_HOME, currentHome);
+} catch { /* noop */ }
 
 /** The renderer's running copy of what should be on disk. Kept as a mutable
  *  mirror updated slice-by-slice rather than read back out of the store, because
@@ -449,12 +468,14 @@ function touchesDurableAgentField(patch: Partial<Agent>): boolean {
 }
 
 /** The persisted list for one slice: the shared file when it has a roster,
- *  otherwise this origin's localStorage. Returns [] on anything malformed. */
+ *  otherwise this origin's localStorage — but only when that localStorage was
+ *  written for this hive. Returns [] on anything malformed. */
 function persistedSlice(
   key: string,
   fromFile: unknown[] | undefined
 ): PersistedAgent[] {
   if (useFileRoster) return Array.isArray(fromFile) ? (fromFile as PersistedAgent[]) : [];
+  if (!useLocalFallback) return [];
   try {
     const raw = window.localStorage.getItem(key);
     if (!raw) return [];
@@ -557,7 +578,9 @@ function loadPersistedQueues(): Record<string, QueuedMessage[]> {
   try {
     const parsed = useFileRoster
       ? (fileRoster?.queues as Record<string, QueuedMessage[]> | undefined)
-      : JSON.parse(window.localStorage.getItem(LS_QUEUES) ?? 'null') as Record<string, QueuedMessage[]> | null;
+      : useLocalFallback
+        ? JSON.parse(window.localStorage.getItem(LS_QUEUES) ?? 'null') as Record<string, QueuedMessage[]> | null
+        : null;
     if (!parsed || typeof parsed !== 'object') return {};
     // Defensively keep only well-formed entries.
     const out: Record<string, QueuedMessage[]> = {};
@@ -574,7 +597,9 @@ function loadPersistedQueues(): Record<string, QueuedMessage[]> {
 
 function loadPersistedSelectedId(agents: Agent[]): string | null {
   try {
-    const id = useFileRoster ? fileRoster?.selectedId : window.localStorage.getItem(LS_SELECTED);
+    const id = useFileRoster
+      ? fileRoster?.selectedId
+      : useLocalFallback ? window.localStorage.getItem(LS_SELECTED) : null;
     return id && agents.some((a) => a.id === id) ? id : (agents[0]?.id ?? null);
   } catch {
     return agents[0]?.id ?? null;
@@ -628,7 +653,7 @@ rosterMirror.selectedId = initialSelectedId;
 // First run with the file: seed it from this origin's localStorage. Only when
 // there is something to seed — writing an empty file here would hand a blank
 // roster to the other side, which is precisely the outcome being designed out.
-if (!useFileRoster && rosterMirror.agents.length + rosterMirror.archived.length + rosterMirror.restorable.length > 0) {
+if (useLocalFallback && rosterMirror.agents.length + rosterMirror.archived.length + rosterMirror.restorable.length > 0) {
   scheduleRosterFlush();
 }
 

--- a/test/roster-source.test.cjs
+++ b/test/roster-source.test.cjs
@@ -1,0 +1,101 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { chooseRosterSource } = loadTs('src/renderer/src/store/rosterSource.ts');
+
+const HIVE_A = '/hives/a';
+const HIVE_B = '/hives/b';
+
+const file = (counts = {}) => ({
+  agents: [], archived: [], restorable: [], ...counts
+});
+const someone = { id: 'agent-1', name: 'Dwight', cwd: HIVE_A };
+
+// --- the file wins whenever it has a roster --------------------------------
+
+test('a populated roster file is used, whatever localStorage says', () => {
+  const src = chooseRosterSource({
+    fileRoster: file({ agents: [someone] }),
+    currentHome: HIVE_A,
+    storedHome: HIVE_B
+  });
+  assert.deepEqual(src, { useFileRoster: true, useLocalFallback: false });
+});
+
+test('a file holding only archived or only restorable entries still counts', () => {
+  for (const slice of ['archived', 'restorable']) {
+    const src = chooseRosterSource({
+      fileRoster: file({ [slice]: [someone] }),
+      currentHome: HIVE_A,
+      storedHome: HIVE_A
+    });
+    assert.equal(src.useFileRoster, true, `${slice}-only roster should win`);
+  }
+});
+
+// --- the localStorage fallback is scoped to one hive -----------------------
+// localStorage is partitioned by origin, so all hives share one. Reading it in
+// a hive it was not written for is what carried a whole team — restorable
+// entries and their `cwd` — from one workspace into the next.
+
+test('localStorage is adopted in the hive it was written for', () => {
+  const src = chooseRosterSource({
+    fileRoster: null, currentHome: HIVE_A, storedHome: HIVE_A
+  });
+  assert.deepEqual(src, { useFileRoster: false, useLocalFallback: true });
+});
+
+test('localStorage is NOT adopted in a different hive', () => {
+  const src = chooseRosterSource({
+    fileRoster: null, currentHome: HIVE_B, storedHome: HIVE_A
+  });
+  assert.deepEqual(src, { useFileRoster: false, useLocalFallback: false },
+    'a brand-new hive must open on an empty floor, not on the last one');
+});
+
+test('an empty roster file does not license a cross-hive read', () => {
+  // The empty-guard says an empty file must not beat localStorage. It must not
+  // turn into permission to read ANOTHER hive's localStorage either.
+  const src = chooseRosterSource({
+    fileRoster: file(), currentHome: HIVE_B, storedHome: HIVE_A
+  });
+  assert.equal(src.useLocalFallback, false);
+});
+
+test('an empty roster file still yields to localStorage in its own hive', () => {
+  const src = chooseRosterSource({
+    fileRoster: file(), currentHome: HIVE_A, storedHome: HIVE_A
+  });
+  assert.deepEqual(src, { useFileRoster: false, useLocalFallback: true });
+});
+
+// --- upgrading, and the dev ↔ packaged origin split ------------------------
+
+test('an unstamped localStorage is adopted once', () => {
+  // Everyone upgrading into this has agents in localStorage and no stamp yet.
+  // Refusing that read would blank their floor on the first launch.
+  const src = chooseRosterSource({
+    fileRoster: null, currentHome: HIVE_A, storedHome: null
+  });
+  assert.equal(src.useLocalFallback, true);
+});
+
+test('an origin with no roster of its own reads nothing and loses nothing', () => {
+  // The packaged build on its first launch: its own localStorage is empty and
+  // unstamped, so the fallback is allowed — and returns nothing. The roster
+  // comes back from the file, which is what the mirror is for.
+  const src = chooseRosterSource({
+    fileRoster: file({ agents: [someone] }), currentHome: HIVE_A, storedHome: null
+  });
+  assert.equal(src.useFileRoster, true);
+});
+
+test('no hive selected yet falls back rather than dropping the roster', () => {
+  const src = chooseRosterSource({
+    fileRoster: null, currentHome: null, storedHome: HIVE_A
+  });
+  assert.equal(src.useLocalFallback, true);
+});


### PR DESCRIPTION
## What & why

`localStorage` is partitioned by **origin**, so every hive this app opens shares exactly one of them — it can only ever hold the roster of whichever hive wrote it last. `store.ts` falls back to it whenever `<harnessHome>/roster.json` has no roster, without asking which hive that localStorage was written for.

A brand-new hive has no `roster.json`, so it takes that branch and rehydrates the *previous* workspace's `cth.agents` / `cth.archivedAgents` / `cth.restorableAgents`. The seed flush at the bottom of the module then writes them into the new hive's `roster.json`, and from the next launch the leak is on disk and self-sustaining. The rehydrated entries keep their original `cwd`, so the agents that spawn in the new hive are pointed at the old project's files — a cross-project write hazard, not only a cosmetic roster leak.

This stamps the hive the keys were written for (`cth.rosterHome`) and reads the fallback only when it matches. The decision moves into a small pure module so it can be tested. An *unstamped* localStorage is still adopted once, so anyone upgrading into this keeps their floor; and the dev ↔ packaged origin bridge the mirror exists for is untouched, because that path runs through `roster.json` (`useFileRoster`), not through this fallback.

Closes #236

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

Two parts under each heading: the screenshot is the suite, run for real both ways; the text under it is the packaged-build reproduction that started this. Paths in it are redacted — `hive-A` is the workspace that already had a team, `hive-B` a config folder created minutes earlier and entirely empty — and agent ids are masked. Both runs are the same steps, same machine, same app version.

### Before
![before — the suite red under main's rule](https://raw.githubusercontent.com/raifemre/munder-difflin/pr-evidence/evidence-before.png)

*`main`'s rule, expressed as the predicate this PR now tests: two cases fail, and they are exactly the leak.*

And how it shows up in the app:

Open `hive-A`, then create and open `hive-B`. `hive-B` was empty on disk. Its `hive/registry.json` seconds after the first launch:

```
NAME     ROLE    CWD
Michael  god     /…/hive-B
worker-1 worker  /…/hive-A     ← rehydrated, still pointed at the other project
worker-2 worker  /…/hive-A
worker-3 worker  /…/hive-A
worker-4 worker  /…/hive-A
worker-5 worker  /…/hive-A
worker-6 worker  /…/hive-A
```

`hive/log.jsonl` — the god spawns, then the whole previous roster ~1s later, on every open:

```
{"kind":"spawn","id":"god",…,"cwd":"/…/hive-B"}
{"kind":"spawn","id":"<masked>",…,"cwd":"/…/hive-A"}
… ×6
```

And `hive-B/roster.json`, which the app wrote itself, now carries the other workspace's six restorable entries with their full spawn recipes (`command`, `cwd`, standing goal text).


### After
![after — the same suite green with the fallback scoped](https://raw.githubusercontent.com/raifemre/munder-difflin/pr-evidence/evidence-after.png)

*The same nine cases with the fallback scoped.*

And the same steps in the app:

`hive-B/roster.json`:

```json
{"version":1,"agents":[{"id":"michael","name":"Michael","isGod":true,"cwd":"/…/hive-B"}],
 "archived":[],"restorable":[],"queues":{},"selectedId":"michael"}
```

`hive/registry.json` — one entry, in the right place:

```
NAME     ROLE  CWD
Michael  god   /…/hive-B
```

`hive/log.jsonl` — app start, one god spawn, nothing else. `hive-A` is unchanged and still opens with its full team, because its non-empty `roster.json` wins before the fallback is ever consulted.


## How I tested it

- OS: macOS 15 (Darwin 25.5.0, Apple silicon)
- Steps:
  1. Reproduced on the packaged build twice, including into a folder created seconds before opening it — the previous workspace's six agents spawned both times, with the other project's `cwd`.
  2. Confirmed the carrier is *persisted* localStorage and not in-memory state: `config:changeHome` calls `app.relaunch()` / `app.exit(0)`, so the renderer is brand new on the other side of a hive switch and the roster still came back.
  3. Clearing the `cth.*` keys and repeating the steps produced a clean floor — which is the same thing this patch does automatically, and only for the hive that does not own those keys.
  4. `npm run test:focused` — 557 passing, plus the 9 new ones. (`test/update-download-asset.test.cjs` fails in my checkout only because I installed with `--ignore-scripts`, so the Electron binary was never downloaded; it is unrelated to this change.)
  5. `npm run typecheck` — clean (node + web).
  6. `npm run build` — succeeds.

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts. (No UI in this change.)
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`. (No art.)
