### PR TITLE
fix(copilot): bind the GitHub host to the agent's repo so *.ghe.com agents stop getting a github.com token

### DIFF
--- a/src/main/git.ts
+++ b/src/main/git.ts
@@ -144,6 +144,18 @@ export async function isRepo(cwd: string): Promise<boolean> {
   return res.ok && res.stdout.trim() === 'true';
 }
 
+/** The fetch URL of a remote (default `origin`), or null when there is no such
+ *  remote — or no repo at all. Used at spawn time to learn WHICH GitHub an agent
+ *  is sitting in, so a `*.ghe.com` worker is not handed a github.com credential
+ *  (shared/githubHost.ts). Short timeout and null-on-failure: this is a hint that
+ *  refines a spawn, never a gate that can block one. `--get` is deliberate — it
+ *  reads the config file and, unlike `git remote get-url`, never touches the
+ *  network. */
+export async function getRemoteUrl(cwd: string, remote = 'origin'): Promise<string | null> {
+  const res = await runGit(cwd, ['config', '--get', `remote.${remote}.url`], 3000);
+  return res.ok && res.stdout.trim() ? res.stdout.trim() : null;
+}
+
 const MAX_DIFF_BYTES = 2 * 1024 * 1024; // 2 MB — keep the diff view responsive
 
 /** A file's two sides for a working-tree-vs-HEAD diff. `head` is the committed

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,7 +22,7 @@ import { normalizeWeekly, weeklyDelayMs } from '../shared/weeklySchedule';
 import {
   getBranch, getStatus, getLog, getBranches, getAheadBehind, isRepo, getDiff, mainRepoRoot,
   addWorktree, removeWorktree, worktreeHasUnintegratedWork, worktreeIsGcSafe,
-  getLogGraph, getCommitFiles, getFileAtRev, compareRefs, listWorktrees, checkoutRef
+  getLogGraph, getCommitFiles, getFileAtRev, compareRefs, listWorktrees, checkoutRef, getRemoteUrl
 } from './git';
 import { HiveManager, type AgentMeta, type HiveMessage, type HiveTask } from './hive';
 import { HookServer } from './hooks';
@@ -76,6 +76,7 @@ import {
   installInfoForProvider,
   type AgentProvider
 } from '../shared/agentProvider';
+import { planCopilotGithubEnv, describeGithubEnvPlan } from '../shared/githubHost';
 import { buildMissingCliScript, chooseInstallRung } from './cliInstall';
 import { detectNodeVersion, nodeIsUsable, resolveNodeInstaller } from './nodeInstall';
 import { toolCatalog, type ToolStatus } from '../shared/toolCatalog';
@@ -2877,6 +2878,32 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       extra.OPENCODE_CONFIG_CONTENT = JSON.stringify(oc);
     }
     opts.env = { ...(opts.env ?? {}), ...extra };
+  }
+  // ── GitHub host binding for Copilot agents (GHE Cloud, *.ghe.com) ───────────
+  // The Copilot CLI resolves its host and its token from separate, unrelated
+  // env lookups, so a github.com PAT in GH_TOKEN — which `gh` exports and which
+  // any dotcom checkout on this machine leaves lying around — is transmitted to
+  // `api.<tenant>.ghe.com`, where it can only ever 401. Worse, that env token
+  // outranks the correctly-scoped keyring credential the user already logged in
+  // with, so the CLI fails while holding the right key. Bind the host to THIS
+  // agent's repo and hand the child only a credential actually scoped to it;
+  // when nothing is, hand it none so the keyring wins.
+  //
+  // Copilot-only on purpose. Every other engine authenticates elsewhere, and
+  // rewriting GH_* for all of them is a much bigger blast radius than the bug.
+  // github.com is untouched: the plan comes back empty for a dotcom host, so the
+  // default path is byte-for-byte what it was.
+  if (provider === 'copilot') {
+    const remoteUrl = await getRemoteUrl(opts.cwd).catch(() => null);
+    const plan = planCopilotGithubEnv({ env: process.env, remoteUrl });
+    if (Object.keys(plan.set).length > 0 || plan.omit.length > 0) {
+      // The plan sits UNDER opts.env: an explicit per-agent override still wins.
+      opts.env = { ...plan.set, ...(opts.env ?? {}) };
+      opts.omitEnv = [...(opts.omitEnv ?? []), ...plan.omit];
+      // Names only, never values — this line is what people paste into issues,
+      // and it answers the questions a bare "Authentication failed" does not.
+      console.log(`[copilot] ${describeGithubEnvPlan(plan)}`);
+    }
   }
   // Codex Remote is daemon-based (there is no `/remote-control` slash command).
   // Start/enable the daemon under this agent's isolated CODEX_HOME and connect

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2900,10 +2900,13 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       // The plan sits UNDER opts.env: an explicit per-agent override still wins.
       opts.env = { ...plan.set, ...(opts.env ?? {}) };
       opts.omitEnv = [...(opts.omitEnv ?? []), ...plan.omit];
-      // Names only, never values — this line is what people paste into issues,
-      // and it answers the questions a bare "Authentication failed" does not.
-      console.log(`[copilot] ${describeGithubEnvPlan(plan)}`);
     }
+    // Logged for EVERY copilot spawn, including the dotcom one that changes
+    // nothing. Silence would be ambiguous in exactly the situation this line
+    // exists for: someone staring at "Authentication failed" cannot tell a host
+    // that resolved to github.com from a resolution that never ran. Names only,
+    // never values — this is what people paste into issues.
+    console.log(`[copilot] ${describeGithubEnvPlan(plan)}`);
   }
   // Codex Remote is daemon-based (there is no `/remote-control` slash command).
   // Start/enable the daemon under this agent's isolated CODEX_HOME and connect

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -60,6 +60,10 @@ export interface SpawnOptions {
   rows?: number;
   /** Extra environment for the child (merged over the resolved shell env). */
   env?: Record<string, string>;
+  /** Names to DELETE from the inherited environment before the child sees them.
+   *  `env` can only add; this is for a value whose mere presence is the bug — a
+   *  github.com token inherited into a `*.ghe.com` agent (see githubHost.ts). */
+  omitEnv?: string[];
   /** When set, run this string as a VISIBLE shell script instead of resolving/
    *  spawning `command`. Used by the missing-CLI auto-install path: the script
    *  (a banner + an install command) streams to the same Terminal tab. Routed
@@ -640,10 +644,11 @@ export class PtyManager {
         cols: opts.cols ?? 100,
         rows: opts.rows ?? 30,
         cwd: opts.cwd,
-        // Inherited env minus the parent Claude session's identity markers,
-        // then the app's defaults and locale, then per-agent values — see
-        // ptyEnv.ts for why the strip exists and why it is prefix-based.
-        env: buildPtyEnv(process.env, userPath, opts.env)
+        // Inherited env minus the parent Claude session's identity markers and
+        // minus anything the spawn asked to omit, then the app's defaults and
+        // locale, then per-agent values — see ptyEnv.ts for why the strips exist
+        // and why the Claude one is prefix-based.
+        env: buildPtyEnv(process.env, userPath, opts.env, process.platform, opts.omitEnv)
       });
 
       // Capture THIS session object so the proc's callbacks can tell whether the

--- a/src/main/ptyEnv.ts
+++ b/src/main/ptyEnv.ts
@@ -5,8 +5,9 @@
  *
  * The layering rule, bottom to top:
  *   1. the inherited environment, minus the parent Claude session's identity
+ *      and minus any name the caller asked to `omit`
  *   2. the app's own defaults (PATH, terminal identity, locale)
- *   3. per-agent values (`opts.env`) — always win, even over the strip below
+ *   3. per-agent values (`opts.env`) — always win, even over the strips below
  */
 
 /**
@@ -43,20 +44,34 @@ const CLAUDE_CONFIG_KEEP = new Set([
   'CLAUDE_CODE_USE_VERTEX'
 ]);
 
+/**
+ * Names the caller wants GONE from the child rather than overwritten (`omitEnv`).
+ * `agentEnv` can only ever ADD a value, and for a credential that is the wrong
+ * tool: handing a `*.ghe.com` agent an EMPTY GH_TOKEN is not the same as handing
+ * it no GH_TOKEN, and "a token scoped to another host must not reach this child"
+ * only has one honest implementation. See shared/githubHost.ts for the caller.
+ *
+ * The strip applies to layer 1 ONLY, exactly like the Claude-marker strip above:
+ * an explicit `agentEnv` value for the same name still wins, so a deliberate
+ * per-agent override can never be silently erased by an omit list.
+ */
 export function buildPtyEnv(
   parentEnv: NodeJS.ProcessEnv,
   userPath: string,
   agentEnv?: Record<string, string>,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  omitEnv?: string[]
 ): Record<string, string> {
   // Layer 1 — inherit, minus the parent session's Claude identity. Only this
   // layer is stripped: a marker set deliberately via `agentEnv` below survives,
   // so per-agent environment overrides (and future per-agent env features)
   // cannot be silently wiped by the strip.
+  const omit = new Set(omitEnv ?? []);
   const inherited: Record<string, string> = {};
   for (const [k, v] of Object.entries(parentEnv)) {
     if (v === undefined) continue;
     if (CLAUDE_MARKER_RE.test(k) && !CLAUDE_CONFIG_KEEP.has(k)) continue;
+    if (omit.has(k)) continue;
     inherited[k] = v;
   }
   return {

--- a/src/shared/githubHost.ts
+++ b/src/shared/githubHost.ts
@@ -1,0 +1,339 @@
+/**
+ * Which GitHub an agent is talking to, and which credential is allowed to reach
+ * it.
+ *
+ * "GHE" here means **GitHub Enterprise Cloud with data residency** — tenant
+ * hosts on `*.ghe.com` (`microsoft.ghe.com`), not self-hosted GHES and not
+ * github.com. A tenant is a completely separate identity plane: its API is
+ * `api.<tenant>.ghe.com`, its repos are `https://<tenant>.ghe.com/<org>/<repo>`,
+ * and a github.com token means NOTHING to it. There is no shared session.
+ *
+ * The failure this module exists to stop: the Copilot CLI resolves its host and
+ * its token independently. The token is the first non-empty of
+ * COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN with no idea which host is
+ * active — so a github.com PAT sitting in GH_TOKEN (which `gh` and half the CI
+ * templates on earth set) is transmitted to `api.<tenant>.ghe.com`, and the env
+ * token silently outranks the correctly-scoped keyring credential. The tenant
+ * answers `401 unauthorized: AuthenticateToken authentication failed`, the model
+ * catalog comes back empty, and the user sees a generic "Authentication failed"
+ * that names neither the host nor the token.
+ *
+ * We spawn `copilot` as a child, so the fix we own is the ENVIRONMENT we hand
+ * it: bind the host to the agent's own repo, and let through only a credential
+ * that was actually scoped to that host.
+ *
+ * Shared between main and renderer; keep it dependency-free (no electron, no
+ * node builtins) so the resolution stays a pure function and is testable
+ * off-process.
+ */
+
+/** Hosts that are github.com by another name. `api.` included because a stray
+ *  COPILOT_GH_HOST=api.github.com must not be mistaken for an enterprise host. */
+const DOTCOM_HOSTS = new Set(['github.com', 'www.github.com', 'api.github.com']);
+
+/** Where the active host came from. Surfaced in the diagnostic line: "which
+ *  host, and who said so" is the first question when a 401 shows up. */
+export type GithubHostSource = 'COPILOT_GH_HOST' | 'GH_HOST' | 'git-remote' | 'default';
+
+export interface GithubHost {
+  /** Bare hostname, lowercased: `github.com`, `microsoft.ghe.com`. */
+  host: string;
+  /**
+   * Scheme + host, NEVER a path. The Copilot CLI keys its keyring credential on
+   * a string of this shape, and the observed key
+   * (`https://microsoft.ghe.com/bic/:marclundgren`) carries the ORG PATH too —
+   * so two orgs on one tenant get two entries for one identity. We cannot
+   * rewrite its keychain from here, but everything we hand it is normalized to
+   * the origin so we never contribute a path-bearing key.
+   */
+  origin: string;
+  source: GithubHostSource;
+  /** Tenant-scoped GitHub Enterprise Cloud (`*.ghe.com`). */
+  gheCloud: boolean;
+  /** Anything that is not github.com — `*.ghe.com` tenants and GHES alike. */
+  enterprise: boolean;
+}
+
+/** Lowercase, drop a trailing root dot, drop a port. Empty → null. */
+function normalizeHost(raw: string | null | undefined): string | null {
+  const host = (raw ?? '').trim().toLowerCase().replace(/\.$/, '').replace(/:\d+$/, '');
+  return host || null;
+}
+
+/**
+ * The hostname a git remote points at, for every remote shape git accepts:
+ *
+ *   https://microsoft.ghe.com/bic/repo.git      → microsoft.ghe.com
+ *   https://user:tok@microsoft.ghe.com/bic/r    → microsoft.ghe.com
+ *   ssh://git@microsoft.ghe.com/bic/repo.git    → microsoft.ghe.com
+ *   git@microsoft.ghe.com:bic/repo.git          → microsoft.ghe.com
+ *
+ * Returns null for anything that is not a network remote (a local path, a
+ * `file://` URL, an unparseable string). A null here is not an error: it just
+ * means the repo tells us nothing about the host and we fall through to the
+ * default.
+ */
+export function parseGitRemoteHost(remote: string | null | undefined): string | null {
+  const raw = (remote ?? '').trim();
+  if (!raw) return null;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
+    try {
+      return normalizeHost(new URL(raw).hostname);
+    } catch {
+      return null;
+    }
+  }
+  // scp-like `[user@]host:path`. The dot requirement is what keeps a Windows
+  // clone path (`C:\src\repo`) from being read as a host named "c".
+  const scp = /^(?:[^@/]+@)?([^:/]+\.[^:/]+):/.exec(raw);
+  return scp ? normalizeHost(scp[1]) : null;
+}
+
+/** A host as written in an env var, which operators spell both ways
+ *  (`microsoft.ghe.com` and `https://microsoft.ghe.com/`). */
+function hostFromEnvValue(value: string | undefined): string | null {
+  const raw = (value ?? '').trim();
+  if (!raw) return null;
+  if (/:\/\//.test(raw)) {
+    try {
+      return normalizeHost(new URL(raw).hostname);
+    } catch {
+      return null;
+    }
+  }
+  return normalizeHost(raw.split('/')[0]);
+}
+
+/** Tenant-scoped Enterprise Cloud. Bare `ghe.com` is not a tenant. */
+export function isGheCloudHost(host: string): boolean {
+  const h = normalizeHost(host);
+  return !!h && h !== 'ghe.com' && h.endsWith('.ghe.com');
+}
+
+export function isDotcomHost(host: string): boolean {
+  const h = normalizeHost(host);
+  return !!h && DOTCOM_HOSTS.has(h);
+}
+
+/** Scheme + host, never a path — see `GithubHost.origin`. */
+export function normalizeGithubOrigin(hostOrUrl: string): string {
+  const host = hostFromEnvValue(hostOrUrl);
+  return `https://${host ?? 'github.com'}`;
+}
+
+function describeHost(host: string, source: GithubHostSource): GithubHost {
+  const h = normalizeHost(host) ?? 'github.com';
+  return {
+    host: h,
+    origin: `https://${h}`,
+    source,
+    gheCloud: isGheCloudHost(h),
+    enterprise: !isDotcomHost(h)
+  };
+}
+
+/**
+ * The active host, in precedence order:
+ *
+ *   1. COPILOT_GH_HOST   — the CLI's own override, so it wins here too
+ *   2. GH_HOST           — the `gh` convention, same reason
+ *   3. the agent's git remote
+ *   4. github.com
+ *
+ * An explicitly exported host beats an inferred one on purpose: an operator who
+ * exported GH_HOST=github.com inside a tenant checkout is doing that
+ * deliberately, and silently overriding them would be its own bug. Steps 1 and 2
+ * are exactly what the CLI already does; step 3 is the new signal, and it is the
+ * one that makes `cd`-ing between a github.com repo and a tenant repo work with
+ * no env juggling.
+ */
+export function resolveGithubHost(opts: {
+  env: Record<string, string | undefined>;
+  remoteUrl?: string | null;
+}): GithubHost {
+  const fromCopilot = hostFromEnvValue(opts.env.COPILOT_GH_HOST);
+  if (fromCopilot) return describeHost(fromCopilot, 'COPILOT_GH_HOST');
+  const fromGh = hostFromEnvValue(opts.env.GH_HOST);
+  if (fromGh) return describeHost(fromGh, 'GH_HOST');
+  const fromRemote = parseGitRemoteHost(opts.remoteUrl);
+  if (fromRemote) return describeHost(fromRemote, 'git-remote');
+  return describeHost('github.com', 'default');
+}
+
+/**
+ * Token env vars the Copilot CLI reads, in ITS order. Host-agnostic every one of
+ * them: nothing in the name says which GitHub the value belongs to, which is the
+ * whole bug.
+ */
+export const COPILOT_TOKEN_ENV = ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'] as const;
+
+/**
+ * `gh`'s enterprise variable. Non-dotcom BY DEFINITION, so unlike the three
+ * above it can be trusted for an enterprise host without further evidence.
+ *
+ * It is deliberately NOT forwarded under this name to a `*.ghe.com` tenant:
+ * against tenant cloud `GH_ENTERPRISE_TOKEN` returns 401 (the variable targets
+ * GHES), while GH_TOKEN authenticates. So on a tenant we carry its VALUE over
+ * into GH_TOKEN and drop the name.
+ */
+export const GH_ENTERPRISE_TOKEN = 'GH_ENTERPRISE_TOKEN';
+
+export interface DroppedToken {
+  name: string;
+  reason: string;
+}
+
+export interface GithubEnvPlan {
+  host: GithubHost;
+  /** Env to set on the child, over the inherited environment. */
+  set: Record<string, string>;
+  /** Env names to delete from the INHERITED environment before the child sees them. */
+  omit: string[];
+  /**
+   * Where the credential the child will use comes from: an env var name, or
+   * null meaning "we handed it nothing on purpose" — the CLI then falls back to
+   * the keyring credential for this host, which is the correctly-scoped one and
+   * which an env token would otherwise have outranked.
+   */
+  tokenSource: string | null;
+  dropped: DroppedToken[];
+}
+
+/**
+ * Decide the child's GitHub environment for `host`.
+ *
+ * **github.com is untouched.** When the active host is dotcom this returns an
+ * empty plan — no set, no omit — so the default path behaves exactly as it did
+ * before this module existed. Every branch below is enterprise-only.
+ *
+ * Precedence for an enterprise host, highest first:
+ *
+ *   1. COPILOT_GITHUB_TOKEN  — but only when the shell also names this host
+ *   2. GH_ENTERPRISE_TOKEN   — non-dotcom by definition, always eligible
+ *   3. GH_TOKEN              — only when the shell also names this host
+ *   4. GITHUB_TOKEN          — only when the shell also names this host
+ *   5. nothing → the CLI's keyring credential for this host
+ *
+ * "the shell also names this host" means COPILOT_GH_HOST or GH_HOST resolves to
+ * the SAME host. That is the only evidence available that a host-agnostic
+ * variable was meant for a tenant, and requiring it is what stops a github.com
+ * PAT from being posted to `api.<tenant>.ghe.com`.
+ */
+export function planGithubEnvForHost(
+  host: GithubHost,
+  env: Record<string, string | undefined>
+): GithubEnvPlan {
+  const value = (name: string): string => (env[name] ?? '').trim();
+  const present = (name: string): boolean => value(name).length > 0;
+
+  if (!host.enterprise) {
+    // Report the source for the diagnostic, but change nothing.
+    const source = COPILOT_TOKEN_ENV.find(present) ?? null;
+    return { host, set: {}, omit: [], tokenSource: source, dropped: [] };
+  }
+
+  // Did the operator aim this shell at this host?
+  const declaredHost =
+    hostFromEnvValue(env.COPILOT_GH_HOST) ?? hostFromEnvValue(env.GH_HOST) ?? null;
+  const shellNamesThisHost = declaredHost === host.host;
+
+  const dropped: DroppedToken[] = [];
+  let tokenSource: string | null = null;
+  let token = '';
+
+  const consider = (name: string, eligible: boolean, reason: string): void => {
+    if (!present(name)) return;
+    if (!eligible) {
+      dropped.push({ name, reason });
+      return;
+    }
+    if (!tokenSource) {
+      tokenSource = name;
+      token = value(name);
+      return;
+    }
+    dropped.push({ name, reason: `outranked by ${tokenSource}` });
+  };
+
+  const mismatch = declaredHost
+    ? `scoped to ${declaredHost}, not ${host.host}`
+    : `host-agnostic and no COPILOT_GH_HOST/GH_HOST names ${host.host}`;
+
+  consider('COPILOT_GITHUB_TOKEN', shellNamesThisHost, mismatch);
+  consider(GH_ENTERPRISE_TOKEN, true, '');
+  consider('GH_TOKEN', shellNamesThisHost, mismatch);
+  consider('GITHUB_TOKEN', shellNamesThisHost, mismatch);
+
+  // Bind the host explicitly, so the CLI and any `gh` the agent shells out to
+  // agree with the repo it is sitting in rather than with an ambient default.
+  const set: Record<string, string> = {
+    COPILOT_GH_HOST: host.host,
+    GH_HOST: host.host
+  };
+  const omit: string[] = [];
+
+  if (tokenSource) {
+    if (host.gheCloud) {
+      // Tenant cloud authenticates with GH_TOKEN; GH_ENTERPRISE_TOKEN 401s. Carry
+      // the value over under the name that works and retire the other names so
+      // nothing stale is left for the CLI to prefer.
+      set.GH_TOKEN = token;
+      for (const name of [...COPILOT_TOKEN_ENV, GH_ENTERPRISE_TOKEN]) {
+        if (name !== 'GH_TOKEN' && present(name)) omit.push(name);
+      }
+    } else {
+      // GHES: leave the variable that carried the token alone (GH_ENTERPRISE_TOKEN
+      // is the correct name there) and retire only the ones we rejected.
+      for (const d of dropped) if (!omit.includes(d.name)) omit.push(d.name);
+    }
+  } else {
+    // Nothing in the environment is scoped to this host. Strip all of it so the
+    // CLI reaches its keyring credential for this tenant instead of being
+    // pre-empted by a token that cannot possibly work.
+    for (const name of [...COPILOT_TOKEN_ENV, GH_ENTERPRISE_TOKEN]) {
+      if (present(name)) omit.push(name);
+    }
+  }
+
+  return { host, set, omit, tokenSource, dropped };
+}
+
+/** The whole resolution in one step: repo remote in, child environment out. */
+export function planCopilotGithubEnv(opts: {
+  env: Record<string, string | undefined>;
+  remoteUrl?: string | null;
+}): GithubEnvPlan {
+  return planGithubEnvForHost(resolveGithubHost(opts), opts.env);
+}
+
+/**
+ * One log line naming the four things you need to debug a GitHub 401 and which
+ * the generic "Authentication failed" names none of: the active host, where the
+ * host came from, which variable supplied the credential, and what we refused to
+ * send.
+ *
+ * Token VALUES never appear here — only variable names. This string goes to the
+ * app log, which people paste into issues.
+ */
+export function describeGithubEnvPlan(plan: GithubEnvPlan): string {
+  const parts = [`host=${plan.host.host} (${plan.host.source})`];
+  if (plan.tokenSource) {
+    const via =
+      plan.host.gheCloud && plan.tokenSource !== 'GH_TOKEN'
+        ? `${plan.tokenSource}->GH_TOKEN`
+        : plan.tokenSource;
+    parts.push(`token=${via}`);
+  } else {
+    parts.push('token=keyring (no host-scoped token in env)');
+  }
+  if (plan.dropped.length) {
+    parts.push(`dropped=${plan.dropped.map((d) => `${d.name} (${d.reason})`).join(', ')}`);
+  }
+  // Actionable, because the drop is occasionally not what the operator wanted:
+  // someone who really did export a tenant token under a host-agnostic name has
+  // exactly one way to say so, and this is where they find out what it is.
+  if (!plan.tokenSource && plan.dropped.length) {
+    parts.push(`— export COPILOT_GH_HOST=${plan.host.host} to declare an env token for this host`);
+  }
+  return parts.join(' ');
+}

--- a/test/github-host.test.cjs
+++ b/test/github-host.test.cjs
@@ -1,0 +1,236 @@
+'use strict';
+
+/**
+ * A `*.ghe.com` tenant is a separate identity plane: a github.com token means
+ * nothing to `api.<tenant>.ghe.com`, and the Copilot CLI's token lookup has no
+ * idea which host is active — so a GH_TOKEN left over from a dotcom checkout was
+ * being posted to the tenant, 401ing while the correctly-scoped keyring
+ * credential sat unused. These tests pin the rule that fixes it: the host comes
+ * from the agent's own repo unless an env var says otherwise, and a host-agnostic
+ * token variable only reaches an enterprise host when the shell named that host.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  parseGitRemoteHost,
+  isGheCloudHost,
+  isDotcomHost,
+  normalizeGithubOrigin,
+  resolveGithubHost,
+  planGithubEnvForHost,
+  planCopilotGithubEnv,
+  describeGithubEnvPlan
+} = loadTs('src/shared/githubHost.ts');
+
+const TENANT = 'microsoft.ghe.com';
+const TENANT_REMOTE = `https://${TENANT}/bic/munder-difflin.git`;
+const DOTCOM_PAT = 'ghp_dotcom_pat_that_must_never_reach_a_tenant';
+
+// ── Remote parsing ───────────────────────────────────────────────────────────
+
+test('every remote shape git accepts yields the same tenant host', () => {
+  for (const remote of [
+    `https://${TENANT}/bic/repo.git`,
+    `https://user:tok@${TENANT}/bic/repo`,
+    `ssh://git@${TENANT}/bic/repo.git`,
+    `git@${TENANT}:bic/repo.git`,
+    `HTTPS://${TENANT.toUpperCase()}/bic/repo`
+  ]) {
+    assert.equal(parseGitRemoteHost(remote), TENANT, remote);
+  }
+});
+
+test('a non-network remote tells us nothing, and says so as null', () => {
+  for (const remote of ['', null, undefined, '/srv/git/repo.git', '../sibling', 'C:\\src\\repo']) {
+    assert.equal(parseGitRemoteHost(remote), null, String(remote));
+  }
+});
+
+// ── Host classification ──────────────────────────────────────────────────────
+
+test('tenant hosts are enterprise cloud; github.com and bare ghe.com are not', () => {
+  assert.equal(isGheCloudHost(TENANT), true);
+  assert.equal(isGheCloudHost('ghe.com'), false, 'bare ghe.com is not a tenant');
+  assert.equal(isGheCloudHost('github.com'), false);
+  assert.equal(isDotcomHost('github.com'), true);
+  assert.equal(isDotcomHost('api.github.com'), true, 'api.github.com must not read as enterprise');
+  assert.equal(isDotcomHost(TENANT), false);
+});
+
+test('an origin is scheme+host and never carries the org path', () => {
+  // The CLI keyed a credential on `https://microsoft.ghe.com/bic/:user` — host
+  // PLUS org — so two orgs on one tenant meant two entries for one identity.
+  assert.equal(normalizeGithubOrigin(`https://${TENANT}/bic/repo`), `https://${TENANT}`);
+  assert.equal(normalizeGithubOrigin(TENANT), `https://${TENANT}`);
+  assert.equal(resolveGithubHost({ env: {}, remoteUrl: TENANT_REMOTE }).origin, `https://${TENANT}`);
+});
+
+// ── Host precedence ──────────────────────────────────────────────────────────
+
+test('host precedence: COPILOT_GH_HOST, then GH_HOST, then the repo, then dotcom', () => {
+  const remoteUrl = TENANT_REMOTE;
+  assert.deepEqual(
+    (({ host, source }) => ({ host, source }))(
+      resolveGithubHost({ env: { COPILOT_GH_HOST: 'a.ghe.com', GH_HOST: 'b.ghe.com' }, remoteUrl })
+    ),
+    { host: 'a.ghe.com', source: 'COPILOT_GH_HOST' }
+  );
+  assert.equal(resolveGithubHost({ env: { GH_HOST: 'b.ghe.com' }, remoteUrl }).host, 'b.ghe.com');
+  assert.equal(resolveGithubHost({ env: {}, remoteUrl }).source, 'git-remote');
+  assert.equal(resolveGithubHost({ env: {}, remoteUrl: null }).host, 'github.com');
+});
+
+test('a host env var is understood whether written bare or as a URL', () => {
+  assert.equal(resolveGithubHost({ env: { GH_HOST: `https://${TENANT}/` } }).host, TENANT);
+  assert.equal(resolveGithubHost({ env: { GH_HOST: `  ${TENANT}  ` } }).host, TENANT);
+});
+
+// ── The bug, and the fix ─────────────────────────────────────────────────────
+
+test('a dotcom PAT in GH_TOKEN never reaches a tenant, and the keyring takes over', () => {
+  // The exact repro: a tenant checkout with a valid github.com PAT exported.
+  const plan = planCopilotGithubEnv({
+    env: { GH_TOKEN: DOTCOM_PAT },
+    remoteUrl: TENANT_REMOTE
+  });
+  assert.equal(plan.host.host, TENANT);
+  assert.ok(plan.omit.includes('GH_TOKEN'), 'the mismatched token must be removed, not overwritten');
+  assert.equal(plan.tokenSource, null, 'nothing in env is scoped here → fall through to the keyring');
+  assert.ok(!Object.values(plan.set).includes(DOTCOM_PAT), 'the PAT must not be forwarded under any name');
+  // And the child is pointed at the tenant rather than an ambient default.
+  assert.equal(plan.set.COPILOT_GH_HOST, TENANT);
+  assert.equal(plan.set.GH_HOST, TENANT);
+});
+
+test('every host-agnostic token variable is stripped on a tenant, not just GH_TOKEN', () => {
+  const plan = planCopilotGithubEnv({
+    env: { GH_TOKEN: 'a', GITHUB_TOKEN: 'b', COPILOT_GITHUB_TOKEN: 'c', GH_ENTERPRISE_TOKEN: '' },
+    remoteUrl: TENANT_REMOTE
+  });
+  for (const name of ['GH_TOKEN', 'GITHUB_TOKEN', 'COPILOT_GITHUB_TOKEN']) {
+    assert.ok(plan.omit.includes(name), `${name} must not reach the tenant`);
+  }
+});
+
+test('naming the tenant in the shell is what makes a host-agnostic token eligible', () => {
+  const plan = planCopilotGithubEnv({
+    env: { COPILOT_GH_HOST: TENANT, GH_TOKEN: 'tenant-token' },
+    remoteUrl: TENANT_REMOTE
+  });
+  assert.equal(plan.tokenSource, 'GH_TOKEN');
+  assert.equal(plan.set.GH_TOKEN, 'tenant-token');
+  assert.ok(!plan.omit.includes('GH_TOKEN'));
+});
+
+test('an explicitly exported host wins over the repo, and its token comes with it', () => {
+  // Someone who exports GH_HOST inside a tenant checkout means it. The token
+  // follows the shell's declared host, not the directory they happen to be in.
+  const plan = planCopilotGithubEnv({
+    env: { GH_HOST: 'other.ghe.com', GH_TOKEN: 'other-tenant-token' },
+    remoteUrl: TENANT_REMOTE
+  });
+  assert.equal(plan.host.host, 'other.ghe.com');
+  assert.equal(plan.tokenSource, 'GH_TOKEN');
+  assert.equal(plan.set.GH_TOKEN, 'other-tenant-token');
+});
+
+test('a token declared for a different host is refused, and the reason names both', () => {
+  // Reached through the by-host entry point, which is what a caller with a host
+  // from somewhere other than the environment (a future per-agent setting) uses.
+  const host = resolveGithubHost({ env: {}, remoteUrl: TENANT_REMOTE });
+  const plan = planGithubEnvForHost(host, { GH_HOST: 'other.ghe.com', GH_TOKEN: DOTCOM_PAT });
+  assert.equal(plan.tokenSource, null);
+  assert.deepEqual(plan.dropped, [
+    { name: 'GH_TOKEN', reason: `scoped to other.ghe.com, not ${TENANT}` }
+  ]);
+});
+
+test('GH_ENTERPRISE_TOKEN is eligible on a tenant with no host declared, and rides in as GH_TOKEN', () => {
+  // Practical quirk: against tenant cloud, GH_ENTERPRISE_TOKEN 401s (it targets
+  // GHES) while GH_TOKEN authenticates. Carry the value, drop the name.
+  const plan = planCopilotGithubEnv({
+    env: { GH_ENTERPRISE_TOKEN: 'ent-token', GH_TOKEN: DOTCOM_PAT },
+    remoteUrl: TENANT_REMOTE
+  });
+  assert.equal(plan.tokenSource, 'GH_ENTERPRISE_TOKEN');
+  assert.equal(plan.set.GH_TOKEN, 'ent-token');
+  assert.ok(plan.omit.includes('GH_ENTERPRISE_TOKEN'), 'the name that 401s must not survive');
+  assert.ok(!Object.values(plan.set).includes(DOTCOM_PAT));
+});
+
+test('GH_ENTERPRISE_TOKEN is ignored on github.com', () => {
+  const plan = planCopilotGithubEnv({
+    env: { GH_ENTERPRISE_TOKEN: 'ent-token', GH_TOKEN: DOTCOM_PAT },
+    remoteUrl: 'https://github.com/chaitanyagiri/munder-difflin.git'
+  });
+  assert.deepEqual(plan.omit, []);
+  assert.deepEqual(plan.set, {});
+});
+
+test('no dotcom host survives in a tenant spawn environment', () => {
+  // The harness-side analogue of "assert no dotcom host is contacted while a
+  // *.ghe.com host is active": nothing we hand the child may point at dotcom.
+  const plan = planCopilotGithubEnv({
+    env: { GH_HOST: 'github.com', COPILOT_GH_HOST: TENANT, GH_TOKEN: 'tenant-token' },
+    remoteUrl: TENANT_REMOTE
+  });
+  for (const [name, value] of Object.entries(plan.set)) {
+    assert.ok(!/github\.com/i.test(value), `${name}=${value} still points at dotcom`);
+  }
+});
+
+// ── github.com must not regress ──────────────────────────────────────────────
+
+test('github.com is left exactly as it was: no set, no omit', () => {
+  for (const env of [
+    { GH_TOKEN: DOTCOM_PAT },
+    { GITHUB_TOKEN: DOTCOM_PAT },
+    { COPILOT_GITHUB_TOKEN: DOTCOM_PAT },
+    {}
+  ]) {
+    for (const remoteUrl of ['https://github.com/o/r.git', 'git@github.com:o/r.git', null]) {
+      const plan = planCopilotGithubEnv({ env, remoteUrl });
+      assert.deepEqual(plan.set, {}, JSON.stringify({ env, remoteUrl }));
+      assert.deepEqual(plan.omit, [], JSON.stringify({ env, remoteUrl }));
+    }
+  }
+});
+
+test('the dotcom plan still reports its token source, in the CLI\'s own order', () => {
+  const plan = planCopilotGithubEnv({
+    env: { GH_TOKEN: 'a', GITHUB_TOKEN: 'b', COPILOT_GITHUB_TOKEN: 'c' },
+    remoteUrl: null
+  });
+  assert.equal(plan.tokenSource, 'COPILOT_GITHUB_TOKEN');
+});
+
+// ── The diagnostic ───────────────────────────────────────────────────────────
+
+test('the diagnostic names host, source, token variable and refusals — and no secrets', () => {
+  const line = describeGithubEnvPlan(
+    planCopilotGithubEnv({ env: { GH_TOKEN: DOTCOM_PAT }, remoteUrl: TENANT_REMOTE })
+  );
+  assert.match(line, /host=microsoft\.ghe\.com \(git-remote\)/);
+  assert.match(line, /token=keyring/);
+  assert.match(line, /dropped=GH_TOKEN/);
+  assert.ok(!line.includes(DOTCOM_PAT), 'a token value must never be logged');
+});
+
+test('the diagnostic shows the carry-over when a token changes variable', () => {
+  const secret = 'enterprise-token-value';
+  const line = describeGithubEnvPlan(
+    planCopilotGithubEnv({ env: { GH_ENTERPRISE_TOKEN: secret }, remoteUrl: TENANT_REMOTE })
+  );
+  assert.match(line, /token=GH_ENTERPRISE_TOKEN->GH_TOKEN/);
+  assert.ok(!line.includes(secret), 'a token value must never be logged');
+});
+
+test('when every token was refused, the diagnostic says how to declare one', () => {
+  const line = describeGithubEnvPlan(
+    planCopilotGithubEnv({ env: { GH_TOKEN: DOTCOM_PAT }, remoteUrl: TENANT_REMOTE })
+  );
+  assert.match(line, /export COPILOT_GH_HOST=microsoft\.ghe\.com/);
+});

--- a/test/pty-env.test.cjs
+++ b/test/pty-env.test.cjs
@@ -109,3 +109,37 @@ test('locale: UTF-8 defaults on darwin, the user\'s exported locale wins, win32 
   assert.ok(!('LANG' in win));
   assert.ok(!('LC_CTYPE' in win));
 });
+
+test('omitEnv deletes an inherited name outright, rather than blanking it', () => {
+  // A github.com token inherited into a `*.ghe.com` agent is a value whose mere
+  // presence is the bug: the Copilot CLI prefers it over the correctly-scoped
+  // keyring credential and posts it to a tenant that can only 401. An empty
+  // GH_TOKEN is not the same thing as no GH_TOKEN, so this really removes it.
+  const env = buildPtyEnv(
+    { GH_TOKEN: 'ghp_dotcom', GITHUB_TOKEN: 'also_dotcom', HOME: '/Users/x' },
+    '/bin',
+    { COPILOT_GH_HOST: 'microsoft.ghe.com' },
+    'darwin',
+    ['GH_TOKEN', 'GITHUB_TOKEN']
+  );
+  assert.ok(!('GH_TOKEN' in env), 'omitted names must be absent, not empty');
+  assert.ok(!('GITHUB_TOKEN' in env));
+  assert.equal(env.COPILOT_GH_HOST, 'microsoft.ghe.com');
+  assert.equal(env.HOME, '/Users/x', 'the rest of the environment is untouched');
+});
+
+test('a deliberate per-agent value outranks the omit list, like the Claude strip', () => {
+  const env = buildPtyEnv(
+    { GH_TOKEN: 'inherited' },
+    '/bin',
+    { GH_TOKEN: 'scoped-to-this-host' },
+    'darwin',
+    ['GH_TOKEN']
+  );
+  assert.equal(env.GH_TOKEN, 'scoped-to-this-host');
+});
+
+test('no omit list means no change', () => {
+  const env = buildPtyEnv({ GH_TOKEN: 'keep' }, '/bin', undefined, 'darwin');
+  assert.equal(env.GH_TOKEN, 'keep');
+});


### PR DESCRIPTION
## What & why

A Copilot agent spawned in a **GitHub Enterprise Cloud** tenant checkout
(`microsoft.ghe.com` — tenant cloud with data residency, not GHES, not github.com)
fails with `401 unauthorized: AuthenticateToken authentication failed` and an empty
model catalog, even when the user is correctly signed in to that tenant.

The Copilot CLI resolves its **host** and its **token** from two unrelated env lookups.
The token is the first non-empty of `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`
with no awareness of which host is active — so a github.com PAT sitting in `GH_TOKEN`
(which `gh` exports, and which any dotcom checkout on the machine leaves lying around)
is transmitted to `api.<tenant>.ghe.com`, where it can only ever 401. It also silently
outranks the correctly-scoped keyring credential, so the CLI fails while holding the
right key. A tenant is a fully separate identity plane; tokens are not portable between
it and github.com in either direction.

We spawn `copilot` as a child PTY, so the part of this we own is **the environment we
hand it**. At spawn time a copilot agent now:

- resolves its host from `COPILOT_GH_HOST` → `GH_HOST` → **its own git remote** → `github.com`
  (the remote is the new signal; it is what makes `cd`-ing between a dotcom repo and a
  tenant repo work with no re-login and no env juggling);
- binds `COPILOT_GH_HOST`/`GH_HOST` so the CLI — and any `gh` the agent shells out to —
  agrees with the repo it is sitting in rather than an ambient default;
- passes through **only a credential actually scoped to that host**. `GH_ENTERPRISE_TOKEN`
  joins the lookup for non-dotcom hosts and is carried over **as `GH_TOKEN`**, because
  against tenant cloud `GH_ENTERPRISE_TOKEN` itself returns 401 (that variable targets GHES);
- **removes** every GitHub token from the child when nothing in the environment is scoped
  to the host, rather than blanking it, so the keyring credential wins;
- logs one line naming the active host, where the host came from, which variable supplied
  the credential, and what was refused and why. Token values never appear in it.

Precedence, documented in `githubHost.ts` and pinned by tests — enterprise host, highest first:
`COPILOT_GITHUB_TOKEN` → `GH_ENTERPRISE_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN` → keyring.
The three host-agnostic names are only eligible when `COPILOT_GH_HOST`/`GH_HOST` names that
same host, which is the only evidence available that they were meant for a tenant.

**github.com is untouched.** For a dotcom host the plan comes back empty — no set, no omit —
so the default path is what it always was. That is asserted directly by a test.

Scoped to the `copilot` provider on purpose: every other engine authenticates elsewhere, and
rewriting `GH_*` for all of them is a much larger blast radius than the bug.

<details>
<summary>What this deliberately does <b>not</b> fix (upstream-only)</summary>

Three items from the original report live inside the Copilot CLI and cannot be reached from
the harness: normalizing its keyring account key to scheme+host (the observed key,
`https://microsoft.ghe.com/bic/:user`, carries the **org path**, so two orgs on one tenant
become two entries for one identity), turning `model_count: 0` into a distinct actionable
error instead of a generic "Authentication failed", and a `copilot auth status` diagnostic.
The log line added here covers the harness-side half of the diagnostic gap.
</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

Same repro on both sides: a checkout whose remote is `https://microsoft.ghe.com/bic/…`, a
github.com PAT exported as `GH_TOKEN`, and a `copilot` agent spawned into it. The images are
the real output of a repro harness that builds the child environment through the actual
`buildPtyEnv` code path on each branch — only the branch differs.

### Before
![Before — a github.com PAT is handed to the tenant](https://raw.githubusercontent.com/marclundgren/munder-difflin/evidence/copilot-ghe-host-token/before.png)

The child gets `GH_TOKEN=ghp_…`, no host is bound, and the CLI defaults to `github.com` while
the repo is a tenant. That dotcom PAT is what reaches `api.microsoft.ghe.com` — the 401.

### After
![After — the host is bound to the repo and no dotcom credential is forwarded](https://raw.githubusercontent.com/marclundgren/munder-difflin/evidence/copilot-ghe-host-token/after.png)

The host is bound to the repo's tenant, the mismatched PAT is removed rather than blanked so
the CLI falls through to its keyring entry for that tenant, and the log line says exactly
what happened and how to override it.

## How I tested it

- **OS:** Linux (WSL2, Ubuntu), Node 26.3.0
- **Steps:**
  1. `npm run typecheck` — clean (both the node and web TS projects).
  2. `npm run test:focused` — **553 tests, 549 pass, 4 fail**. Those 4 are pre-existing and
     environmental, not from this change: an identical run on `main` with the same
     `node_modules` gives **531 tests, 527 pass, the same 4 fail**
     (`hive-runtime-path`, `update-download-asset`, `win-cmd-shim` — this checkout was
     installed with `--ignore-scripts`, so `node-pty`'s native module was never rebuilt and
     Electron was never downloaded). The 22 new tests are the whole delta.
  3. `npm run build` — succeeds (electron-vite build + main-asset copy).
  4. Ran the repro harness above on `main` and on this branch to produce the two images.
- **New tests:** `test/github-host.test.cjs` (19) covers remote parsing for every remote
  shape git accepts, host classification and precedence, the dotcom-PAT-into-a-tenant case,
  the `GH_ENTERPRISE_TOKEN` carry-over, that no value we set points at dotcom while a tenant
  is active, that github.com produces an empty plan for every token combination, and that the
  diagnostic never contains a token value. `test/pty-env.test.cjs` (+3) covers the new
  `omitEnv` layer: an omitted name is **absent**, not empty, and a deliberate per-agent value
  still outranks the omit list.

I do not have access to a `*.ghe.com` tenant, so the end-to-end "model catalog loads" leg is
not something I can show. The evidence above is the part that is verifiable from here: which
host is bound, and which credential does and does not reach the child.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes (see the note on the 4 pre-existing failures above).
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no new UI in this PR.
- [x] If I added art, it's my own or compatibly licensed — no art in this PR.
