### PR TITLE
Pricing: PRO $39 + TEAMS $149/seat with live calculator, wall founding-100 perks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -683,6 +683,8 @@
   }
   .pg-label small { font-family: var(--font-body); font-weight: 400; font-size: 0.82rem; letter-spacing: 0; color: var(--faint); }
   .plans2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: stretch; flex: 1; }
+  .pgroup.wide { grid-column: 1 / -1; }
+  .plans2.plans3 { grid-template-columns: repeat(3, 1fr); }
   .plan > .btn { margin-top: auto; align-self: stretch; text-align: center; justify-content: center; }
   .pgroup > .seat-box { margin: -2px 4px 16px; }
   /* seat slider */
@@ -696,6 +698,7 @@
   .seat-scale { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 0.64rem; color: var(--faint); padding: 0 2px; }
   .seat-scale span.on { color: var(--accent); font-weight: 700; }
   @media (max-width: 1000px) { .pgroups { grid-template-columns: 1fr; } }
+  @media (max-width: 900px)  { .plans2.plans3 { grid-template-columns: 1fr; } }
   @media (max-width: 620px)  { .plans2 { grid-template-columns: 1fr; } }
 
   /* ------- FOR THE PROJECT — Founding Supporter strip ------- */
@@ -1600,10 +1603,10 @@
 <section id="pricing">
   <div class="wrap center">
     <span class="kicker">PRICING</span>
-    <h2>Your clone is free. Two services make it unstoppable.</h2>
+    <h2>Your clone is free. Plans for power users and teams.</h2>
     <p class="lead" style="margin:18px auto 0">
-      The app is open source and runs on your laptop forever. On top of it we sell
-      exactly two things — use either, both, or neither.
+      The app is open source and runs on your laptop forever. Paid plans add the
+      24/7 sandbox and the team network — take either, both, or neither.
     </p>
     <div class="svcs">
       <div class="svc rv">
@@ -1624,9 +1627,9 @@
       </div>
     </div>
     <div class="pgroups">
-      <div class="pgroup rv">
+      <div class="pgroup rv wide">
         <span class="pg-label">FOR YOU <small>one person, one clone</small></span>
-        <div class="plans2">
+        <div class="plans2 plans3">
           <div class="plan">
             <span class="plan-name">SOLO</span>
             <span class="svc-chips"><span class="off">LOCAL ONLY</span></span>
@@ -1639,19 +1642,30 @@
             <a class="btn primary" data-download href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download</a>
           </div>
           <div class="plan">
-            <span class="plan-name">SOLO + CLOUD</span>
-            <span class="svc-chips"><span>CLOUD</span></span>
-            <span class="plan-price">Indie<small>agents run on our cloud</small></span>
+            <span class="plan-name">PRO</span>
+            <span class="svc-chips"><span class="off">LOCAL ONLY</span></span>
+            <span class="plan-price">$20<small>/month · or $199/year — built for power users (individuals)</small></span>
             <ul>
               <li>Everything in Solo</li>
-              <li>Dedicated sandbox VM — your clone keeps working with the lid closed</li>
+              <li>Pro workflows, memory &amp; the multi-agent floor</li>
+              <li>Local-first — runs on your machine</li>
+            </ul>
+            <a class="btn" href="mailto:girichaitanya11@gmail.com?subject=Munder%20Difflin%20PRO">Get PRO</a>
+          </div>
+          <div class="plan">
+            <span class="plan-name">PRO + 24/7 SANDBOX</span>
+            <span class="svc-chips"><span>CLOUD</span></span>
+            <span class="plan-price">$99<small>/month · or $1,000/year</small></span>
+            <ul>
+              <li>Everything in PRO</li>
+              <li>Dedicated 24/7 sandbox VM — your clone keeps working with the lid closed</li>
               <li>Switch local ⇄ cloud anytime</li>
             </ul>
-            <a class="btn" href="mailto:girichaitanya11@gmail.com?subject=Munder%20Difflin%20—%20Indie%20(Solo%20%2B%20Cloud)">Contact us</a>
+            <a class="btn" href="mailto:girichaitanya11@gmail.com?subject=Munder%20Difflin%20PRO%20%2B%2024%2F7%20Sandbox">Get PRO + Sandbox</a>
           </div>
         </div>
       </div>
-      <div class="pgroup rv">
+      <div class="pgroup rv wide">
         <span class="pg-label">FOR YOUR TEAM <small>every member gets a clone</small></span>
         <div class="seat-box">
           <span class="seat-top"><span>TEAM SIZE · APPLIES TO BOTH PLANS</span><b id="seatLabel">up to 10 seats</b></span>
@@ -1660,8 +1674,9 @@
         </div>
         <div class="plans2">
           <div class="plan">
+            <span class="plan-name">TEAMS</span>
             <span class="svc-chips"><span>NETWORK</span></span>
-            <span class="plan-price">Teams Lite<small>agents use our network</small></span>
+            <span class="plan-price">$39<small>/seat/month · network &amp; collaboration, no sandbox</small></span>
             <ul>
               <li>E2E-encrypted clone-to-clone messaging</li>
               <li>Shared org knowledge base</li>
@@ -1672,17 +1687,29 @@
           </div>
           <div class="plan hot">
             <span class="flag">ALWAYS&nbsp;ON</span>
+            <span class="plan-name">TEAMS + 24/7 SANDBOX</span>
             <span class="svc-chips"><span>CLOUD</span><span>NETWORK</span></span>
-            <span class="plan-price">Teams PRO<small>agents use our network + run on our cloud</small></span>
+            <span class="plan-price">$149<small>/seat/month</small></span>
             <ul>
-              <li>Everything in Teams Lite</li>
-              <li>Dedicated sandbox VM per clone</li>
+              <li>Everything in Teams</li>
+              <li>Dedicated 24/7 sandbox VM per clone</li>
               <li>The whole floor ships with laptops closed</li>
               <li>Hosted org knowledge base, in your controlled environment</li>
             </ul>
             <a class="btn primary" id="ctaBoth" href="https://cal.com/chaitanya-giri-w3wrwi/munder-difflin-teams-demo" target="_blank" rel="noopener">Contact us</a>
           </div>
         </div>
+      </div>
+    </div>
+    <div class="support-strip rv" id="credits">
+      <div>
+        <span class="ss-label">ADD-ON <small>on any sandbox plan</small></span>
+        <h3>Sandbox compute credits</h3>
+        <p>Burst capacity when you need extra always-on days: <b>10 credits = 1 day</b>
+        of 24/7 sandbox runtime. Sold in multiples of 10.</p>
+      </div>
+      <div class="ss-cta">
+        <a class="btn ghost" href="mailto:girichaitanya11@gmail.com?subject=Sandbox%20compute%20credits">Buy credits</a>
       </div>
     </div>
     <!-- The name reaches the wall through the Razorpay Payment Page's

--- a/docs/index.html
+++ b/docs/index.html
@@ -686,6 +686,7 @@
   .pgroup.wide { grid-column: 1 / -1; }
   .plans2.plans3 { grid-template-columns: repeat(3, 1fr); }
   .plan > .btn { margin-top: auto; align-self: stretch; text-align: center; justify-content: center; }
+  .pgroup > .plan { flex: 1; } /* both pricing cards stretch to the taller one */
   .pgroup > .seat-box { margin: -2px 4px 16px; }
   /* seat slider */
   .seat-box { display: grid; gap: 6px; margin: 2px 0 4px; }
@@ -695,8 +696,27 @@
   }
   .seat-box .seat-top b { color: var(--accent); font-size: 0.78rem; letter-spacing: 0.04em; }
   .seat-box input[type="range"] { width: 100%; accent-color: var(--accent); cursor: pointer; margin: 0; }
+  .seat-ctl { display: flex; gap: 10px; align-items: center; }
+  .seat-ctl input[type="range"] { flex: 1; }
+  .seat-ctl input[type="text"] {
+    width: 88px; background: var(--surface-2); color: var(--ink);
+    border: 1px solid var(--border-strong); border-radius: 8px;
+    padding: 6px 8px; font-family: var(--font-mono); font-size: 0.85rem; text-align: center;
+  }
+  .seat-ctl input[type="text"]:hover, .seat-ctl input[type="text"]:focus { border-color: var(--accent-line); outline: none; }
   .seat-scale { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 0.64rem; color: var(--faint); padding: 0 2px; }
   .seat-scale span.on { color: var(--accent); font-weight: 700; }
+  /* plan configurators (compute/storage adders) */
+  .cfg { display: grid; gap: 6px; margin: 2px 0; }
+  .cfg label { font-family: var(--font-mono); font-weight: 600; font-size: 0.66rem; letter-spacing: 0.12em; color: var(--faint); margin-top: 4px; }
+  .cfg label small { letter-spacing: 0.04em; text-transform: none; }
+  .cfg select {
+    background: var(--surface-2); color: var(--ink);
+    border: 1px solid var(--border-strong); border-radius: 8px;
+    padding: 8px 10px; font-family: var(--font-body); font-size: 0.85rem; cursor: pointer;
+  }
+  .cfg select:hover, .cfg select:focus { border-color: var(--accent-line); outline: none; }
+  .plan-total { font-family: var(--font-mono); font-weight: 700; font-size: 0.95rem; color: var(--accent); }
   @media (max-width: 1000px) { .pgroups { grid-template-columns: 1fr; } }
   @media (max-width: 900px)  { .plans2.plans3 { grid-template-columns: 1fr; } }
   @media (max-width: 620px)  { .plans2 { grid-template-columns: 1fr; } }
@@ -1603,113 +1623,82 @@
 <section id="pricing">
   <div class="wrap center">
     <span class="kicker">PRICING</span>
-    <h2>Your clone is free. Plans for power users and teams.</h2>
+    <h2>Plans for power users and teams.</h2>
     <p class="lead" style="margin:18px auto 0">
       The app is open source and runs on your laptop forever. Paid plans add the
-      24/7 sandbox and the team network — take either, both, or neither.
+      24/7 sandbox and the team network.
     </p>
-    <div class="svcs">
-      <div class="svc rv">
-        <span class="svc-tag">SERVICE 01 · CLOUD</span>
-        <h3>☁️ A place for your clone to run</h3>
-        <p>A dedicated sandbox VM per clone, in your controlled environment. Close
-        the laptop — your clone keeps its terminals open, keeps shipping, keeps
-        answering. Switch back to local anytime.</p>
-        <span class="fine">solves: "does my laptop need to stay on?"</span>
-      </div>
-      <div class="svc rv">
-        <span class="svc-tag">SERVICE 02 · NETWORK</span>
-        <h3>🔗 A wire between your team's clones</h3>
-        <p>End-to-end encrypted clone-to-clone messaging across teammates'
-        laptops, plus the shared org knowledge base. Your clone can ask Dwight's
-        clone — and answer for you when you're away.</p>
-        <span class="fine">solves: "can our clones work together?"</span>
-      </div>
-    </div>
     <div class="pgroups">
-      <div class="pgroup rv wide">
+      <div class="pgroup rv">
         <span class="pg-label">FOR YOU <small>one person, one clone</small></span>
-        <div class="plans2 plans3">
-          <div class="plan">
-            <span class="plan-name">SOLO</span>
-            <span class="svc-chips"><span class="off">LOCAL ONLY</span></span>
-            <span class="plan-price">Free<small>open source · MIT</small></span>
-            <ul>
-              <li>Your clone, on your machine</li>
-              <li>Wraps the agent CLIs you already use</li>
-              <li>Personal memory &amp; workflows</li>
-            </ul>
-            <a class="btn primary" data-download href="https://github.com/chaitanyagiri/munder-difflin/releases/latest"><span class="ic">⤓</span> Download</a>
+        <div class="plan">
+          <span class="plan-name">PRO</span>
+          <span class="svc-chips"><span>CLOUD</span></span>
+          <span class="plan-price">$39<small>/month · for individuals</small></span>
+          <ul>
+            <li>Everything in the free app — memory, workflows, the multi-agent floor</li>
+            <li><b>24/7 sandbox included:</b> shared CPU · 1GB RAM · 20GB storage — your clone keeps shipping with the lid closed</li>
+            <li>Switch local ⇄ cloud anytime</li>
+            <li><b>First 100 <a href="/wall.html">Founding Supporters</a>:</b> 50% off + 1 month free</li>
+          </ul>
+          <div class="cfg">
+            <label for="proCompute">ADD COMPUTE <small>(billed monthly with the plan)</small></label>
+            <select id="proCompute">
+              <option data-add="0" selected>Included — Shared 1× CPU · 1GB RAM</option>
+              <option data-add="9">Shared 2× CPU · 2GB RAM — +$9/mo</option>
+              <option data-add="25">Shared 4× CPU · 4GB RAM — +$25/mo</option>
+              <option data-add="39">Dedicated 1× CPU · 2GB RAM — +$39/mo</option>
+              <option data-add="59">Shared 8× CPU · 8GB RAM — +$59/mo</option>
+            </select>
+            <label for="proStorage">ADD STORAGE</label>
+            <select id="proStorage">
+              <option data-add="0" selected>Included — 20GB volume</option>
+              <option data-add="8">50GB volume — +$8/mo</option>
+              <option data-add="20">100GB volume — +$20/mo</option>
+              <option data-add="58">250GB volume — +$58/mo</option>
+            </select>
           </div>
-          <div class="plan">
-            <span class="plan-name">PRO</span>
-            <span class="svc-chips"><span class="off">LOCAL ONLY</span></span>
-            <span class="plan-price">$20<small>/month · or $199/year — built for power users (individuals)</small></span>
-            <ul>
-              <li>Everything in Solo</li>
-              <li>Pro workflows, memory &amp; the multi-agent floor</li>
-              <li>Local-first — runs on your machine</li>
-            </ul>
-            <a class="btn" href="mailto:girichaitanya11@gmail.com?subject=Munder%20Difflin%20PRO">Get PRO</a>
-          </div>
-          <div class="plan">
-            <span class="plan-name">PRO + 24/7 SANDBOX</span>
-            <span class="svc-chips"><span>CLOUD</span></span>
-            <span class="plan-price">$99<small>/month · or $1,000/year</small></span>
-            <ul>
-              <li>Everything in PRO</li>
-              <li>Dedicated 24/7 sandbox VM — your clone keeps working with the lid closed</li>
-              <li>Switch local ⇄ cloud anytime</li>
-            </ul>
-            <a class="btn" href="mailto:girichaitanya11@gmail.com?subject=Munder%20Difflin%20PRO%20%2B%2024%2F7%20Sandbox">Get PRO + Sandbox</a>
-          </div>
+          <span class="plan-total" id="proTotal">$39/month</span>
+          <a class="btn primary" href="/wall.html">Get PRO</a>
         </div>
       </div>
-      <div class="pgroup rv wide">
-        <span class="pg-label">FOR YOUR TEAM <small>every member gets a clone</small></span>
-        <div class="seat-box">
-          <span class="seat-top"><span>TEAM SIZE · APPLIES TO BOTH PLANS</span><b id="seatLabel">up to 10 seats</b></span>
-          <input type="range" id="seatRange" min="0" max="4" step="1" value="0" aria-label="team size in seats" />
-          <span class="seat-scale"><span class="on">10</span><span>20</span><span>50</span><span>100</span><span>100+</span></span>
-        </div>
-        <div class="plans2">
-          <div class="plan">
-            <span class="plan-name">TEAMS</span>
-            <span class="svc-chips"><span>NETWORK</span></span>
-            <span class="plan-price">$39<small>/seat/month · network &amp; collaboration, no sandbox</small></span>
-            <ul>
-              <li>E2E-encrypted clone-to-clone messaging</li>
-              <li>Shared org knowledge base</li>
-              <li>Clone coordination protocol</li>
-              <li>Secure Org Network license</li>
-            </ul>
-            <a class="btn" id="ctaNet" href="https://cal.com/chaitanya-giri-w3wrwi/munder-difflin-teams-demo" target="_blank" rel="noopener">Contact us</a>
+      <div class="pgroup rv">
+        <span class="pg-label">FOR YOUR TEAM <small>per seat · every member gets a clone</small></span>
+        <div class="plan hot">
+          <span class="flag">ALWAYS&nbsp;ON</span>
+          <span class="plan-name">TEAMS</span>
+          <span class="svc-chips"><span>CLOUD</span><span>NETWORK</span></span>
+          <span class="plan-price">$149<small>/seat/month</small></span>
+          <ul>
+            <li>E2E-encrypted clone-to-clone messaging + shared org knowledge base</li>
+            <li><b>24/7 sandbox per seat:</b> shared 8× CPU · 8GB RAM · 100GB storage</li>
+            <li>The whole floor ships with laptops closed</li>
+          </ul>
+          <div class="seat-box">
+            <span class="seat-top"><span>TEAM SIZE</span></span>
+            <div class="seat-ctl">
+              <input type="range" id="seatRange" min="2" max="100" step="1" value="2" aria-label="team size in seats" />
+              <input type="text" inputmode="numeric" id="seatInput" value="2 seats" aria-label="team size, exact number" />
+            </div>
           </div>
-          <div class="plan hot">
-            <span class="flag">ALWAYS&nbsp;ON</span>
-            <span class="plan-name">TEAMS + 24/7 SANDBOX</span>
-            <span class="svc-chips"><span>CLOUD</span><span>NETWORK</span></span>
-            <span class="plan-price">$149<small>/seat/month</small></span>
-            <ul>
-              <li>Everything in Teams</li>
-              <li>Dedicated 24/7 sandbox VM per clone</li>
-              <li>The whole floor ships with laptops closed</li>
-              <li>Hosted org knowledge base, in your controlled environment</li>
-            </ul>
-            <a class="btn primary" id="ctaBoth" href="https://cal.com/chaitanya-giri-w3wrwi/munder-difflin-teams-demo" target="_blank" rel="noopener">Contact us</a>
+          <div class="cfg">
+            <label for="teamCompute">ADD COMPUTE <small>(per seat, billed monthly)</small></label>
+            <select id="teamCompute">
+              <option data-add="0" selected>Included — Shared 8× CPU · 8GB RAM</option>
+              <option data-add="55">Dedicated 2× CPU · 8GB RAM — +$55/mo</option>
+              <option data-add="59">Shared 8× CPU · 16GB RAM — +$59/mo</option>
+              <option data-add="175">Dedicated 4× CPU · 16GB RAM — +$175/mo</option>
+            </select>
+            <label for="teamStorage">ADD STORAGE <small>(per seat)</small></label>
+            <select id="teamStorage">
+              <option data-add="0" selected>Included — 100GB volume</option>
+              <option data-add="38">250GB volume — +$38/mo</option>
+              <option data-add="100">500GB volume — +$100/mo</option>
+            </select>
           </div>
+          <span class="plan-total" id="teamTotal">$298/month · 2 seats × $149</span>
+          <a class="btn primary" id="ctaBoth" href="https://cal.com/chaitanya-giri-w3wrwi/munder-difflin-teams-demo" target="_blank" rel="noopener">Contact us</a>
         </div>
-      </div>
-    </div>
-    <div class="support-strip rv" id="credits">
-      <div>
-        <span class="ss-label">ADD-ON <small>on any sandbox plan</small></span>
-        <h3>Sandbox compute credits</h3>
-        <p>Burst capacity when you need extra always-on days: <b>10 credits = 1 day</b>
-        of 24/7 sandbox runtime. Sold in multiples of 10.</p>
-      </div>
-      <div class="ss-cta">
-        <a class="btn ghost" href="mailto:girichaitanya11@gmail.com?subject=Sandbox%20compute%20credits">Buy credits</a>
       </div>
     </div>
     <!-- The name reaches the wall through the Razorpay Payment Page's
@@ -1719,7 +1708,8 @@
         <span class="ss-label">FOR THE PROJECT <small>keep it free for everyone</small></span>
         <h3>Founding Supporter — your name on the Wall</h3>
         <p>$20, one time. A permanent brass plaque on the
-        <a href="/wall.html">Founders' Wall</a>. Munder Difflin stays free for everyone.</p>
+        <a href="/wall.html">Founders' Wall</a> — and the first 100 get 50% off PRO plus a
+        free month of PRO. Munder Difflin stays free for everyone.</p>
       </div>
       <div class="ss-cta">
         <a class="btn primary" data-support="wall" href="https://rzp.io/rzp/munder-difflin" target="_blank" rel="noopener">Claim your plaque</a>
@@ -2793,21 +2783,42 @@
 
 
 <script>
-  // pricing seat slider → label; team CTAs book the enterprise discovery call
-  // (cal.com), so the slider no longer rewrites their hrefs
+  // pricing calculator: team-size slider + exact-entry box + per-plan
+  // compute/storage adders update the displayed totals live. Adder values
+  // live in each option's data-add. Seats clamp to 2–100; the input box is
+  // the single readout ("N seats"), synced from whichever control moved.
   (function () {
-    var r = document.getElementById('seatRange');
-    if (!r) return;
-    var stops = ['10', '20', '50', '100', '100+'];
-    var lbl = document.getElementById('seatLabel');
-    var marks = document.querySelectorAll('.seat-scale span');
-    function upd() {
-      var i = +r.value, v = stops[i];
-      lbl.textContent = (v === '100+' ? '100+ seats' : 'up to ' + v + ' seats');
-      marks.forEach(function (el, j) { el.classList.toggle('on', j === i); });
+    function add(id) {
+      var el = document.getElementById(id);
+      return el ? +(el.options[el.selectedIndex].dataset.add || 0) : 0;
     }
-    r.addEventListener('input', upd);
-    upd();
+    function money(n) { return '$' + n.toLocaleString('en-US'); }
+    var range = document.getElementById('seatRange');
+    var input = document.getElementById('seatInput');
+    function clamp(v) { return isNaN(v) ? 2 : Math.min(100, Math.max(2, v)); }
+    function upd(source) {
+      // read seats from the control that just moved — reading the other one
+      // is how the slider used to snap back and look dead
+      var s = source === range ? clamp(+range.value)
+                               : clamp(parseInt(String(input.value).replace(/[^0-9]/g, ''), 10));
+      if (source !== input) input.value = s + ' seats'; // don't fight the user mid-typing
+      if (source !== range) range.value = s;
+      var pt = document.getElementById('proTotal');
+      if (pt) pt.textContent = money(39 + add('proCompute') + add('proStorage')) + '/month';
+      var per = 149 + add('teamCompute') + add('teamStorage');
+      document.getElementById('teamTotal').textContent =
+        money(per * s) + '/month · ' + s + ' seats × ' + money(per);
+    }
+    if (range) range.addEventListener('input', function () { upd(range); });
+    if (input) {
+      input.addEventListener('input', function () { upd(input); });
+      input.addEventListener('change', function () { upd(null); }); // normalize to "N seats" on commit
+    }
+    ['proCompute', 'proStorage', 'teamCompute', 'teamStorage'].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener('input', function () { upd(null); });
+    });
+    upd(null);
   })();
 
   // theme toggle — icon swap is pure CSS off data-theme (see .theme-toggle svg)

--- a/docs/wall.html
+++ b/docs/wall.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>The Founders' Wall — Munder Difflin</title>
-<meta name="description" content="The Founding Supporters who keep Munder Difflin free and open source for everyone. One brass plaque each, $20, one time." />
+<meta name="description" content="The Founding Supporters who keep Munder Difflin free and open source for everyone. One brass plaque each, $20, one time — first 100 get 50% off PRO and a free month." />
 <link rel="canonical" href="https://munderdiffl.in/wall.html" />
 <link rel="icon" type="image/svg+xml" href="./logo.svg" />
 <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32.png" />
@@ -298,7 +298,8 @@
     <p class="lead">
       Munder Difflin is free and open source, for everyone, forever. That's possible
       because of the people on this wall — <b id="wallCount">the Founding Supporters</b>.
-      One brass plaque each. Permanent.
+      One brass plaque each. Permanent. And the first 100 get
+      <b>50% off Munder Difflin PRO, plus one month free</b>.
     </p>
 
     <div class="wallboard">
@@ -321,8 +322,14 @@
       <span class="price">$20 · ONE TIME</span>
       <p>A permanent engraved plaque on this wall. Munder Difflin stays free
       for everyone — this is what keeps it that way.</p>
+      <p><b>First 100 supporters only:</b> 50% off the
+      <a href="/#pricing">PRO plan</a> (that’s $19.50/mo instead of $39), and your
+      first month of PRO free. Your discount code and free-trial details are sent to
+      the <b>email address you use when joining the wall</b> — watch for them after
+      your plaque goes up.</p>
       <div class="btn-row">
         <a class="btn primary lg" data-support="wall" href="https://rzp.io/rzp/munder-difflin" target="_blank" rel="noopener">Get on the wall</a>
+        <a class="btn ghost lg" href="mailto:girichaitanya11@gmail.com?subject=Munder%20Difflin%20—%20Founders%27%20Wall">Contact us</a>
       </div>
       <span class="fine">Type the name you want engraved into the <b>“Name (as you want it
       engraved)”</b> field on the Razorpay page — it appears here within 24 hours.
@@ -380,7 +387,7 @@
       a.target = '_blank'; a.rel = 'noopener';
       a.setAttribute('data-support', 'wall');
       var no = document.createElement('span'); no.className = 'no';
-      no.textContent = 'PLAQUE Nº ' + pad3(n) + ' · OPEN';
+      no.textContent = 'PLAQUE Nº ' + pad3(n) + ' OF 100 · OPEN';
       var nm = document.createElement('span'); nm.className = 'nm';
       nm.textContent = 'Your name here';
       var dt = document.createElement('span'); dt.className = 'dt';
@@ -427,7 +434,13 @@
       for (var i = 0; i < list.length; i++) {
         try { grid.appendChild(plaque(list[i], i + 1)); } catch (e) { /* skip a bad entry, keep the wall up */ }
       }
-      grid.appendChild(openSlot(list.length + 1));
+      // founding terms are capped at the first 100 plaques
+      var note = document.getElementById('wallNote');
+      if (list.length >= 100) {
+        if (note) note.textContent = 'All 100 founding spots are claimed.';
+      } else {
+        grid.appendChild(openSlot(list.length + 1));
+      }
       if (countEl) {
         countEl.textContent = list.length === 1
           ? '1 Founding Supporter'


### PR DESCRIPTION
Founder-directed pricing launch (2026-08-23). Replaces the 'Contact us' placeholder tiers with two sellable plans.

## What changes
- **PRO — $39/mo** (individuals): includes the basic 24/7 fly.io sandbox — spec on the card: shared 1× CPU · 1GB RAM · 20GB storage. CTA goes to the Founders' Wall.
- **TEAMS — $149/seat/mo**: network features + shared 8× CPU · 8GB RAM · 100GB storage per seat.
- **Live calculator**: seat slider (2–100) + exact-entry box, per-plan compute/storage adder dropdowns; totals update from any control. Adders priced ~1.5–1.7× fly.io cost (thinner margin than the plans, per founder).
- Credits concept removed; the two service cards removed; equal-height cards.
- **Wall**: first-100 founding perks — 50% off PRO + 1 free month, details emailed to the checkout address; plaques show 'OF 100', wall closes at 100; Contact us button added.

## Unit economics (fly.io published rates + Razorpay fees)
- PRO $39: COGS ≈ $10.50 → **~73% gross margin**
- TEAMS $149/seat: COGS ≈ $66–73 → **~52–55% gross margin**
- Adders carry ~33–45% margin by design; boosts cap at shared-8× self-serve (performance tier would sink the plans).

## Notes
- Adders bill **monthly** with the plan — hourly metering needs billing infra we don't have yet (flagged to founder, accepted as v2).
- Churn discipline required ops-side: stopped volumes still bill ($15/mo per abandoned 100GB volume) — deprovision cancelled seats same-day.
- CTAs are still mailto/cal.com — no Razorpay pages exist for these tiers yet; that's the launch blocker, not this PR.
- Previewed locally with the founder over several iterations before this PR.