### PR TITLE
build: scope postinstall electron-rebuild to better-sqlite3 (stop force-rebuilding node-pty)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
-    # Build exercises the native node-pty rebuild; allowed to fail without blocking.
+    # Build exercises the native better-sqlite3 Electron rebuild; allowed to fail without blocking.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ participating, you agree to uphold it.
   Cross-platform smoke-testing and fixes are still very welcome (see
   [Good first areas](#good-first-areas)).
 - **Node.js 18+** and npm.
-- A **C/C++ toolchain** to build `node-pty`'s native addon. On macOS:
+- A **C/C++ toolchain** to build `better-sqlite3` for Electron (and, on Linux
+  only, `node-pty` — it ships prebuilds for macOS/Windows but not Linux). On macOS:
   ```bash
   xcode-select --install
   ```
@@ -31,15 +32,17 @@ participating, you agree to uphold it.
 ```bash
 git clone <your-fork-url> munder-difflin
 cd munder-difflin
-npm install        # postinstall rebuilds node-pty against Electron's ABI
+npm install        # postinstall rebuilds better-sqlite3 against Electron's ABI
 npm run dev        # live-reloading Electron build
 ```
 
 > [!IMPORTANT]
-> **The most common setup failure is the native `node-pty` rebuild.** The
-> `postinstall` script runs `electron-rebuild` so `node-pty` matches Electron's
-> ABI. If you see a "wrong ELF/Mach-O" or "NODE_MODULE_VERSION" error at launch,
-> re-run `npm install` (which re-triggers `postinstall`) after confirming your
+> **The most common setup failure is a native-module rebuild.** The
+> `postinstall` script runs `electron-rebuild --only better-sqlite3` so it
+> matches Electron's ABI (`node-pty` is Node-API and runs from its shipped
+> prebuilds — on Linux npm compiles it from source at install). If you see a
+> "wrong ELF/Mach-O" or "NODE_MODULE_VERSION" error at launch, re-run
+> `npm install` (which re-triggers `postinstall`) after confirming your
 > C/C++ toolchain is installed.
 
 ## Evidence is mandatory

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
 
 - **macOS, Windows, or Linux**.
 - **Node.js 18+** and npm.
-- A **C/C++ toolchain** for `node-pty`'s native addon — on macOS, install Xcode Command Line Tools:
+- A **C/C++ toolchain** to build `better-sqlite3` for Electron (and `node-pty` on Linux, which has
+  no prebuilds there) — on macOS, install Xcode Command Line Tools:
   ```bash
   xcode-select --install
   ```
@@ -190,7 +191,7 @@ terminal/event plane, and [`DESIGN.md`](./DESIGN.md) for the visual system.
 ```bash
 git clone https://github.com/chaitanyagiri/munder-difflin.git
 cd munder-difflin
-npm install        # postinstall rebuilds node-pty against Electron's ABI
+npm install        # postinstall rebuilds better-sqlite3 against Electron's ABI
 npm run dev        # launches the Electron app with hot reload
 ```
 
@@ -205,8 +206,9 @@ npm run preview    # preview the production build
 npm run typecheck  # type-check the node (main/preload) and web (renderer) projects
 ```
 
-> If `node-pty` fails to load after an Electron upgrade, re-run `npm install` (the `postinstall` hook
-> runs `electron-rebuild` against the current Electron ABI).
+> If `better-sqlite3` fails to load after an Electron upgrade, re-run `npm install` (the `postinstall`
+> hook runs `electron-rebuild --only better-sqlite3` against the current Electron ABI; `node-pty` is
+> Node-API and doesn't need an Electron-specific build).
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munder-difflin",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munder-difflin",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "hasInstallScript": true,
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "electron-vite build && npm run copy:main-assets",
     "copy:main-assets": "node tools/copy-main-assets.cjs",
     "preview": "electron-vite preview",
-    "postinstall": "electron-rebuild -f && node tools/ensure-pty-perms.cjs && node tools/patch-node-pty-conpty.cjs",
+    "postinstall": "electron-rebuild -f --only better-sqlite3 && node tools/ensure-pty-perms.cjs && node tools/patch-node-pty-conpty.cjs",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",


### PR DESCRIPTION
## What & why

The `postinstall` runs `electron-rebuild -f`, which force-rebuilds **every** native module. But `node-pty` 1.1.0 is Node-API (`node-addon-api ^7`) and ships complete prebuilds (`win32-x64`/`arm64` with conpty + winpty binaries, `darwin-x64`/`arm64` with `spawn-helper`), so it needs no Electron-ABI rebuild — and its loader (`lib/utils.js`: `build/Release` → `build/Debug` → `prebuilds/<platform>-<arch>`) already ends up running the prebuild anyway, as the header comment in `tools/ensure-pty-perms.cjs` documents. Forcing the rebuild is exactly what the "most common setup failure" warning in CONTRIBUTING is about: on Windows, winpty's vcxproj requires the VS "Spectre-mitigated libs" component (MSB8040) and its gyp configure runs `cd shared && GetCommitHash.bat`, which breaks under the `NoDefaultCurrentDirectoryInExePath=1` hardening some environments set.

`better-sqlite3` is V8/NAN and genuinely does need the Electron rebuild — so scope the rebuild to it:

```
electron-rebuild -f --only better-sqlite3 && node tools/ensure-pty-perms.cjs && node tools/patch-node-pty-conpty.cjs
```

Cross-platform notes:

- **Windows / macOS** — node-pty runs from its shipped prebuilds (as before). `tools/ensure-pty-perms.cjs` walks `build/Release|Debug`, `prebuilds/*`, and `bin/*` for `spawn-helper`, so its macOS fix-up is unaffected.
- **Linux** — node-pty ships no Linux prebuilds; npm's own install step (`node scripts/prebuild.js || node-gyp rebuild`) already compiles it from source, and being Node-API that build loads fine under Electron. Toolchain requirements there are unchanged.
- **Packaging** — unaffected: `electron-builder.yml` has `npmRebuild: true`, so `npm run dist` / the release workflow still rebuilds natives for the target exactly as today.
- Also syncs the stale `package-lock.json` version stamp the 0.4.5 bump left behind (0.4.4 → 0.4.5) and updates the README/CONTRIBUTING/ci.yml comments that described the old behavior.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] Build / CI

## Evidence

Verified on Windows 10 Pro (VS2022 **without** Spectre-mitigated libs, `NoDefaultCurrentDirectoryInExePath=1` set), Node 20.20.2 / npm 10.8.2 — i.e. a machine where main's postinstall cannot complete.

### Before
![before — forced node-pty electron-rebuild fails](https://raw.githubusercontent.com/cyberfalcon-us/munder-difflin/evidence-postinstall-scoped-rebuild/before-node-pty-rebuild-fails.png)

The node-pty Electron rebuild that `electron-rebuild -f` forces (isolated here with `--only node-pty` for a fast repro) fails before it can even configure — and with the hardening var unset it fails at MSB8040 instead. Either way `npm install` on main dies here.

### After
![after — scoped rebuild install + PTY roundtrip verified](https://raw.githubusercontent.com/cyberfalcon-us/munder-difflin/evidence-postinstall-scoped-rebuild/after-scoped-rebuild-pty-verified.png)

Clean checkout (`node_modules` deleted), same shell, same hardening var still set: `npm install` completes end-to-end with the scoped rebuild, `npm run dev` boots (better-sqlite3 loads at startup), and a PTY spawned through the app's own `pty:spawn` IPC does a full write/read roundtrip off the win32-x64 prebuild. The dev app running after that install:

![after — dev app onboarding screen](https://raw.githubusercontent.com/cyberfalcon-us/munder-difflin/evidence-postinstall-scoped-rebuild/app-onboarding-after-scoped-install.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
