### PR TITLE
fix(hooks): add typed hook event payload contract

### DIFF
--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -18,6 +18,7 @@ import type { HarnessConfig } from './config';
 import type { ControlRegistry } from './control';
 import type { CircuitBreaker } from './breaker';
 import { estimateCostUsd } from './pricing';
+import { validateHookEvent } from '../shared/hookEvents';
 
 interface HookPayload {
   hook_event_name?: string;
@@ -326,7 +327,7 @@ export class HookServer {
   }
 
   private emit(agentId: string | undefined, event: string, p: HookPayload, blocked = false): void {
-    this.getWebContents()?.send('hive:hookEvent', {
+    const payload = {
       agentId,
       event,
       tool: p.tool_name,
@@ -334,6 +335,11 @@ export class HookServer {
       source: p.source,
       message: p.message,
       blocked
-    });
+    };
+    if (!validateHookEvent(payload)) {
+      console.warn('[hive] rejected invalid hook event:', event);
+      return;
+    }
+    this.getWebContents()?.send('hive:hookEvent', payload);
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,8 @@ import type { ToolStatus } from '../shared/toolCatalog';
 export type { ToolStatus } from '../shared/toolCatalog';
 import type { HeroPayload } from '../shared/heroPayload';
 export type { HeroPayload } from '../shared/heroPayload';
+import type { HookEvent } from '../shared/hookEvents';
+export type { HookEvent } from '../shared/hookEvents';
 import type { LocalSkill, CatalogSkill } from '../main/skills';
 export type { LocalSkill, CatalogSkill } from '../main/skills';
 import type {
@@ -845,9 +847,9 @@ const api = {
     ipcRenderer.invoke('hive:send', msg, from),
 
   onHiveHookEvent: (
-    cb: (e: { agentId?: string; event: string; tool?: string; notificationType?: string; source?: string; message?: string; blocked?: boolean }) => void
+    cb: (e: HookEvent) => void
   ): (() => void) => {
-    const listener = (_e: IpcRendererEvent, payload: { agentId?: string; event: string; tool?: string; notificationType?: string; source?: string; message?: string; blocked?: boolean }) => cb(payload);
+    const listener = (_e: IpcRendererEvent, payload: HookEvent) => cb(payload);
     ipcRenderer.on('hive:hookEvent', listener);
     return () => ipcRenderer.removeListener('hive:hookEvent', listener);
   },

--- a/src/shared/hookEvents.ts
+++ b/src/shared/hookEvents.ts
@@ -1,0 +1,30 @@
+/** Renderer-facing hook event shared across the Electron IPC boundary. */
+export interface HookEvent {
+  agentId?: string;
+  event: string;
+  tool?: string;
+  notificationType?: string;
+  source?: string;
+  message?: string;
+  blocked?: boolean;
+}
+
+const OPTIONAL_STRING_FIELDS = ['tool', 'notificationType', 'source', 'message'] as const;
+
+/** Validate an untrusted payload before it crosses the Electron IPC boundary. */
+export function validateHookEvent(value: unknown): value is HookEvent {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.event !== 'string' || candidate.event.length === 0) return false;
+  if (
+    candidate.agentId !== undefined &&
+    (typeof candidate.agentId !== 'string' || candidate.agentId.length === 0)
+  ) return false;
+
+  for (const field of OPTIONAL_STRING_FIELDS) {
+    if (candidate[field] !== undefined && typeof candidate[field] !== 'string') return false;
+  }
+
+  return candidate.blocked === undefined || typeof candidate.blocked === 'boolean';
+}

--- a/test/hook-event-contract.test.cjs
+++ b/test/hook-event-contract.test.cjs
@@ -1,0 +1,50 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { validateHookEvent } = loadTs('src/shared/hookEvents.ts');
+
+test('accepts valid hook event payloads', () => {
+  assert.equal(validateHookEvent({
+    agentId: 'jim-1',
+    event: 'PreToolUse',
+    tool: 'Bash',
+    notificationType: 'permission',
+    source: 'claude',
+    message: 'Running a command',
+    blocked: false
+  }), true);
+});
+
+test('accepts optional agent ids and open provider event names', () => {
+  assert.equal(validateHookEvent({ event: 'Stop' }), true);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'Unknown' }), true);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'FutureProviderEvent' }), true);
+});
+
+test('rejects payloads missing a valid event name', () => {
+  assert.equal(validateHookEvent({ agentId: 'jim-1' }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: '' }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 42 }), false);
+});
+
+test('rejects malformed optional fields', () => {
+  assert.equal(validateHookEvent({ agentId: '', event: 'Stop' }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'PreToolUse', tool: 42 }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'Stop', blocked: 'false' }), false);
+  assert.equal(validateHookEvent(null), false);
+});
+
+test('main and preload share the hook event contract', () => {
+  const root = path.resolve(__dirname, '..');
+  const main = fs.readFileSync(path.join(root, 'src/main/hooks.ts'), 'utf8');
+  const preload = fs.readFileSync(path.join(root, 'src/preload/index.ts'), 'utf8');
+
+  assert.match(main, /validateHookEvent.*shared\/hookEvents|shared\/hookEvents.*validateHookEvent/s);
+  assert.match(preload, /HookEvent.*shared\/hookEvents|shared\/hookEvents.*HookEvent/s);
+  assert.match(preload, /payload: HookEvent/);
+});


### PR DESCRIPTION
## What & why

Hook events currently cross the Electron main, preload, and renderer boundary with the payload shape defined separately at the IPC boundary. As more hook providers and lifecycle events are added, those definitions can drift and make otherwise valid provider events harder to evolve safely.

This change introduces a shared `HookEvent` contract, uses it across the existing IPC path, and adds lightweight runtime shape validation before delivery. It keeps the current hook routing behavior intact, including optional `agentId` values and forward compatible event names such as `Unknown` or future provider events.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

Clean `upstream/main` baseline at `3f5c27416a089fa7f4603450657cb929883f4be1`:

```text
npm run test:focused

tests 549
pass 536
fail 11
skipped 2
```

The main branch does not have the shared hook event contract or the 5 hook contract regression tests added by this PR.

The existing 11 failures reproduce on clean `upstream/main`. They cover path assumptions, CLI and source assertions, plus two Electron suites that cannot start because the local Electron binary is not installed correctly.

### After

`fix/hook-event-ipc-types`:

```text
npm run test:focused

tests 554
pass 541
fail 11
skipped 2
```

This branch adds 5 hook contract regression tests and all 5 pass.

The same 11 baseline failures remain unchanged, so this change introduces no new test failures.

The new coverage also confirms that the existing provider behavior stays intact:

```text
Unknown                 => accepted
FutureProviderEvent     => accepted
agentId omitted         => accepted
malformed optional data => rejected
```

## How I tested it

- OS: Windows, Node.js v24.13.0
- Steps:
  1. Checked out clean `upstream/main` at `3f5c27416a089fa7f4603450657cb929883f4be1`.
  2. Ran `npm run test:focused` to establish the upstream baseline.
  3. Switched to `fix/hook-event-ipc-types`.
  4. Rebased the branch onto the same `upstream/main`.
  5. Ran `npm run typecheck`.
  6. Ran `npm run test:focused`.
  7. Ran `npm run build`.
  8. Compared the feature branch failures against the clean upstream baseline.
  9. Confirmed all 5 new hook contract tests pass with no additional failures.
  10. Confirmed unknown and future provider event names are still accepted.
  11. Confirmed `agentId` remains optional.

Results:

```text
npm run typecheck
PASS

npm run build
PASS

clean upstream/main:
549 tests
536 passed
11 failed
2 skipped

feature branch:
554 tests
541 passed
11 failed
2 skipped
```

The 11 `test:focused` failures are identical on the clean upstream baseline and this branch.

Two of those suites report:

```text
Error: Electron failed to install correctly,
please delete node_modules/electron and try installing again
```

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.

`npm run test:focused` is left unchecked because the full suite is not green on clean `upstream/main` in this environment. This branch reproduces the same 11 baseline failures while adding 5 passing hook contract tests and no new failures.