### PR TITLE
fix: don't enqueue /compact for an undeliverable agent, latch at deli…

### DIFF
--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -337,6 +337,15 @@ export function useHive(config: HarnessConfig | null): void {
   // listPtys on exactly the cadence the drain needs, and one reading keeps the
   // two loops from disagreeing about whether an agent is quiet.
   const ptyLastOutput = useRef<Record<string, number>>({});
+    /** How long this terminal has been silent, or null when we have no reading
+   *  (never polled, PTY gone, or it has emitted nothing at all). canDeliverToAgent
+   *  fails closed on null — unmeasured silence is not evidence of silence.
+   *  Hook-level (not effect-local) because both the drain effect and the
+   *  context-trigger effect gate delivery through the same check. */
+  const ptyQuietMs = (ptyId: string, now: number): number | null => {
+    const last = ptyLastOutput.current[ptyId];
+    return typeof last === 'number' && last > 0 ? now - last : null;
+  };
   // #5C/#7C.4 — latest circuit-breaker level per agent. When 'constrained'/
   // 'stopped' the avatar is pinned to 'looping' and hook events must NOT flip it
   // back to 'working' (the flicker the spec calls out); only a genuine Stop clears it.
@@ -772,13 +781,6 @@ export function useHive(config: HarnessConfig | null): void {
     const inFlight = new Set<string>();
     const sendFailures: Record<string, number> = {};
 
-    /** How long this terminal has been silent, or null when we have no reading
-     *  (never polled, PTY gone, or it has emitted nothing at all). canDeliverToAgent
-     *  fails closed on null — unmeasured silence is not evidence of silence. */
-    const ptyQuietMs = (ptyId: string, now: number): number | null => {
-      const last = ptyLastOutput.current[ptyId];
-      return typeof last === 'number' && last > 0 ? now - last : null;
-    };
 
     // Send the front of `srcId`'s queue into `target`'s pty (verbatim or wrapped),
     // gated on the target being idle, free of interactive menus, and off
@@ -920,8 +922,13 @@ export function useHive(config: HarnessConfig | null): void {
         // the one inside dispatch would have changed nothing.
         if (!a.ptyId || !canDeliverToAgent(a.status, ptyQuietMs(a.ptyId, now), QUIESCE_IDLE_MS)) continue;
         if (!messageQueues[a.id]?.length) continue;
-        void dispatch(a.id, a).then(({ sent, message }) => {
+                void dispatch(a.id, a).then(({ sent, message }) => {
           if (sent && message?.slack) void ensureSlackCard(message);
+          // Write the compact latch only once delivery genuinely happened — see
+          // the comment in fire() above.
+          if (sent && message?.compactUsed !== undefined) {
+            lastCompactUsed.current[a.id] = message.compactUsed;
+          }
         });
       }
     };
@@ -1076,10 +1083,18 @@ export function useHive(config: HarnessConfig | null): void {
   useEffect(() => {
     if (!config?.onboardingComplete) return;
 
-    const fire = (action: 'compact' | 'clear', rule: ContextRule): void => {
+       const fire = (action: 'compact' | 'clear', rule: ContextRule): void => {
       const { agents, messageQueues, enqueueMessage } = useStore.getState();
+      const now = Date.now();
       for (const a of agents) {
         if (!a.ptyId) continue;
+        // Gate #109-2: don't enqueue a context command for an agent that cannot
+        // currently receive one (e.g. god 'blocked' on a human prompt). Enqueuing
+        // anyway left a stuck /compact at the head of the queue that dedupe then
+        // collapsed every subsequent hourly attempt against, forever — the exact
+        // same check the drain itself uses immediately before typing, so a
+        // command is never queued in a state the drain would refuse to deliver.
+        if (!canDeliverToAgent(a.status, ptyQuietMs(a.ptyId, now), QUIESCE_IDLE_MS)) continue;
         const provider = inferAgentProvider(a.command, a.provider);
         const command = action === 'clear'
           ? clearCommandForProvider(provider, rule.message)
@@ -1108,12 +1123,16 @@ export function useHive(config: HarnessConfig | null): void {
         // state those thresholds cannot reason about, because nothing they could do
         // would ever change it. /clear needs no equivalent — the queue drain zeroes
         // the store reading when it lands.
-        const used = a.contextTokens ?? 0;
-        if (action === 'compact') {
-          if (lastCompactUsed.current[a.id] === used) continue;
-          lastCompactUsed.current[a.id] = used;
-        }
-        enqueueMessage(a.id, command);
+               const used = a.contextTokens ?? 0;
+        if (action === 'compact' && lastCompactUsed.current[a.id] === used) continue;
+        // The latch is written at successful DELIVERY (see the flush() dispatch
+        // callback below), not here. Writing it at enqueue time recorded
+        // "already compacted at N tokens" for a compaction that might never
+        // actually happen — e.g. blocked by the gate just above, or a failed
+        // send — silently latching out every future attempt at that count.
+        // compactUsed rides on the queued message so the delivery site knows
+        // which count to latch.
+        enqueueMessage(a.id, command, action === 'compact' ? { compactUsed: used } : undefined);
       }
     };
 

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -146,6 +146,13 @@ export interface QueuedMessage {
    *  from, and delivering it afterwards costs a full turn to discover nothing is
    *  there. Declarative (a string, not a closure) so it survives persistQueues. */
   precondition?: 'inbox-nonempty';
+    /** Token count captured when a /compact was enqueued for this agent, carried
+   *  through to the point of successful delivery so the "already compacted at
+   *  N tokens" latch (see useHive) can be written there instead of at enqueue
+   *  time. Enqueue time is too early: a /compact stuck behind an undeliverable
+   *  status would otherwise latch out every future compact attempt for a
+   *  compaction that never actually happened. */
+  compactUsed?: number;
 }
 
 // 'files' retired in v0.3.4 (the per-agent IDE button superseded it) — a
@@ -292,7 +299,7 @@ interface State {
   /** Park a message for an agent. Returns nothing; the flush loop delivers it.
    *  `meta.instruction`, when set, is what gets typed into the PTY instead of
    *  `text` (UI/card surfaces still show `text`). */
-  enqueueMessage: (agentId: string, text: string, meta?: { slack?: { channel: string; thread_ts: string }; instruction?: string; precondition?: QueuedMessage['precondition'] }) => void;
+    enqueueMessage: (agentId: string, text: string, meta?: { slack?: { channel: string; thread_ts: string }; instruction?: string; precondition?: QueuedMessage['precondition']; compactUsed?: number }) => void;
   /** Drop a single queued message (user removed it, or it was just delivered). */
   removeQueuedMessage: (agentId: string, messageId: string) => void;
   /** "Send now" while floor auto-delivery is paused: marks the message manual
@@ -888,11 +895,12 @@ export const useStore = create<State>((set, get) => ({
       if (isInboxNudge(trimmed) && queued.some((m) => isInboxNudge(m.text))) {
         return s;
       }
-      const msg: QueuedMessage = {
+            const msg: QueuedMessage = {
         id: newQueuedId(), text: trimmed, ts: Date.now(),
         ...(meta?.slack ? { slack: meta.slack } : {}),
         ...(meta?.instruction ? { instruction: meta.instruction } : {}),
-        ...(meta?.precondition ? { precondition: meta.precondition } : {})
+        ...(meta?.precondition ? { precondition: meta.precondition } : {}),
+        ...(meta?.compactUsed !== undefined ? { compactUsed: meta.compactUsed } : {})
       };
       const messageQueues = { ...s.messageQueues, [agentId]: [...(s.messageQueues[agentId] ?? []), msg] };
       persistQueues(messageQueues);


### PR DESCRIPTION
Fixes #255. God can sit 'blocked' on a human prompt for hours, which is exactly when the hourly compaction trigger fires. The trigger enqueued /compact unconditionally, so it got stuck at the head of god's queue forever (blocked never becomes deliverable on its own), and the dedupe check then silently swallowed every subsequent hourly attempt against the stuck item. Two changes: (1) fire() now checks canDeliverToAgent before enqueueing, the same gate the drain itself uses immediately before typing, so nothing is queued in a state the drain would refuse to deliver. (2) the lastCompactUsed latch moves from enqueue-time to successful-delivery-time (via a new compactUsed field carried on the queued message), since writing it at enqueue recorded a compaction that may never have happened, permanently latching out future attempts at that token count.

## What & why

Fixes #255. God can sit 'blocked' on a human prompt for hours, which is exactly when the hourly compaction trigger fires. The trigger enqueued /compact unconditionally, so it got stuck at the head of god's queue forever, and the dedupe check then silently swallowed every subsequent hourly attempt against the stuck item. Two changes: (1) fire() now checks canDeliverToAgent before enqueueing, the same gate the drain itself uses immediately before typing. (2) the lastCompactUsed latch moves from enqueue-time to successful-delivery-time, since writing it at enqueue recorded a compaction that may never have happened.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
![Before](https://github.com/user-attachments/assets/2903b74d-77a5-4a43-8408-93c33ba64364)

On `main` right now, `fire()` (the hourly compaction trigger) enqueues `/compact` for god unconditionally, with no check on whether god can currently receive it. God's `blocked` status (waiting on a human prompt) never becomes deliverable on its own, so once stuck the dedupe check silently swallows every subsequent hourly attempt forever. The latch is also written at enqueue time, recording "already compacted" for a compaction that never happened.

`useHive.ts`, lines 1113–1116 on `main`:

```typescript
          if (lastCompactUsed.current[a.id] === used) continue;
          lastCompactUsed.current[a.id] = used;
        }
        enqueueMessage(a.id, command);
```

No deliverability check anywhere before this enqueue.

### After
![After 1](https://github.com/user-attachments/assets/0af462ec-5408-467a-94a4-414bcf0c554b)

`fire()` now gates the enqueue on `canDeliverToAgent` — the exact same check the drain uses immediately before typing into a terminal — so nothing is queued in a state the drain would refuse to deliver. The `lastCompactUsed` latch write moves out of `fire()` entirely and into the successful-delivery callback in `flush()`, guarded on the new `compactUsed` field carried on the queued message.

![After 2](https://github.com/user-attachments/assets/23cf4871-d728-47de-8fc5-14363b6a8db8)

![After 3](https://github.com/user-attachments/assets/4ab546d1-987f-433f-a7c8-b31a3cab37e2)

![After 4](https://github.com/user-attachments/assets/1cf9c377-6093-4063-9981-7ffdceff4811)

![After 5](https://github.com/user-attachments/assets/56d80dea-1392-4a44-8da0-bd00dcb35c93)

![After 6](https://github.com/user-attachments/assets/520c36f7-86b5-4d5b-9684-9631196b97ad)

![After 7](https://github.com/user-attachments/assets/c4101d65-a595-4cab-96ca-163b84cade13)

![After 8](https://github.com/user-attachments/assets/e4293797-85d6-4707-b4d9-06fd287e42f4)

## How I tested it

- OS: windows 11
- Steps:
  1. npm install --ignore-scripts
  2. npm run typecheck — clean
  3. node --test test/*.test.cjs — 536 pass, 11 fail (all pre-existing on main before this change — Windows path-separator issues tracked in #253, plus 2 Electron-native test files that don't run under --ignore-scripts; none touch queueDelivery.ts, useHive.ts, or store.ts)
  4. Confirmed the safety property from the issue, canDeliverToAgent('blocked', 60_000, 4_000) === false, is already covered by test/queue-delivery.test.cjs, and the fix reuses that exact function at the new call site rather than reimplementing the check
  5. Was NOT able to get a full Electron app run going on Windows to manually reproduce the god-blocked-during-hourly-trigger scenario end-to-end (node-pty/better-sqlite3 need a Clang toolchain not set up here) — flagged this explicitly for the maintainer below

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [ ] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts.
- [ ] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`.