### PR TITLE
fix(hooks): add typed hook event payload contract

### DIFF
--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -18,6 +18,7 @@ import type { HarnessConfig } from './config';
 import type { ControlRegistry } from './control';
 import type { CircuitBreaker } from './breaker';
 import { estimateCostUsd } from './pricing';
+import { validateHookEvent } from '../shared/hookEvents';
 
 interface HookPayload {
   hook_event_name?: string;
@@ -326,7 +327,7 @@ export class HookServer {
   }
 
   private emit(agentId: string | undefined, event: string, p: HookPayload, blocked = false): void {
-    this.getWebContents()?.send('hive:hookEvent', {
+    const payload = {
       agentId,
       event,
       tool: p.tool_name,
@@ -334,6 +335,11 @@ export class HookServer {
       source: p.source,
       message: p.message,
       blocked
-    });
+    };
+    if (!validateHookEvent(payload)) {
+      console.warn('[hive] rejected invalid hook event:', event);
+      return;
+    }
+    this.getWebContents()?.send('hive:hookEvent', payload);
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,8 @@ import type { ToolStatus } from '../shared/toolCatalog';
 export type { ToolStatus } from '../shared/toolCatalog';
 import type { HeroPayload } from '../shared/heroPayload';
 export type { HeroPayload } from '../shared/heroPayload';
+import type { HookEvent } from '../shared/hookEvents';
+export type { HookEvent } from '../shared/hookEvents';
 import type { LocalSkill, CatalogSkill } from '../main/skills';
 export type { LocalSkill, CatalogSkill } from '../main/skills';
 import type {
@@ -845,9 +847,9 @@ const api = {
     ipcRenderer.invoke('hive:send', msg, from),
 
   onHiveHookEvent: (
-    cb: (e: { agentId?: string; event: string; tool?: string; notificationType?: string; source?: string; message?: string; blocked?: boolean }) => void
+    cb: (e: HookEvent) => void
   ): (() => void) => {
-    const listener = (_e: IpcRendererEvent, payload: { agentId?: string; event: string; tool?: string; notificationType?: string; source?: string; message?: string; blocked?: boolean }) => cb(payload);
+    const listener = (_e: IpcRendererEvent, payload: HookEvent) => cb(payload);
     ipcRenderer.on('hive:hookEvent', listener);
     return () => ipcRenderer.removeListener('hive:hookEvent', listener);
   },

--- a/src/shared/hookEvents.ts
+++ b/src/shared/hookEvents.ts
@@ -1,0 +1,30 @@
+/** Renderer-facing hook event shared across the Electron IPC boundary. */
+export interface HookEvent {
+  agentId?: string;
+  event: string;
+  tool?: string;
+  notificationType?: string;
+  source?: string;
+  message?: string;
+  blocked?: boolean;
+}
+
+const OPTIONAL_STRING_FIELDS = ['tool', 'notificationType', 'source', 'message'] as const;
+
+/** Validate an untrusted payload before it crosses the Electron IPC boundary. */
+export function validateHookEvent(value: unknown): value is HookEvent {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.event !== 'string' || candidate.event.length === 0) return false;
+  if (
+    candidate.agentId !== undefined &&
+    (typeof candidate.agentId !== 'string' || candidate.agentId.length === 0)
+  ) return false;
+
+  for (const field of OPTIONAL_STRING_FIELDS) {
+    if (candidate[field] !== undefined && typeof candidate[field] !== 'string') return false;
+  }
+
+  return candidate.blocked === undefined || typeof candidate.blocked === 'boolean';
+}

--- a/test/hook-event-contract.test.cjs
+++ b/test/hook-event-contract.test.cjs
@@ -1,0 +1,50 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { validateHookEvent } = loadTs('src/shared/hookEvents.ts');
+
+test('accepts valid hook event payloads', () => {
+  assert.equal(validateHookEvent({
+    agentId: 'jim-1',
+    event: 'PreToolUse',
+    tool: 'Bash',
+    notificationType: 'permission',
+    source: 'claude',
+    message: 'Running a command',
+    blocked: false
+  }), true);
+});
+
+test('accepts optional agent ids and open provider event names', () => {
+  assert.equal(validateHookEvent({ event: 'Stop' }), true);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'Unknown' }), true);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'FutureProviderEvent' }), true);
+});
+
+test('rejects payloads missing a valid event name', () => {
+  assert.equal(validateHookEvent({ agentId: 'jim-1' }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: '' }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 42 }), false);
+});
+
+test('rejects malformed optional fields', () => {
+  assert.equal(validateHookEvent({ agentId: '', event: 'Stop' }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'PreToolUse', tool: 42 }), false);
+  assert.equal(validateHookEvent({ agentId: 'jim-1', event: 'Stop', blocked: 'false' }), false);
+  assert.equal(validateHookEvent(null), false);
+});
+
+test('main and preload share the hook event contract', () => {
+  const root = path.resolve(__dirname, '..');
+  const main = fs.readFileSync(path.join(root, 'src/main/hooks.ts'), 'utf8');
+  const preload = fs.readFileSync(path.join(root, 'src/preload/index.ts'), 'utf8');
+
+  assert.match(main, /validateHookEvent.*shared\/hookEvents|shared\/hookEvents.*validateHookEvent/s);
+  assert.match(preload, /HookEvent.*shared\/hookEvents|shared\/hookEvents.*HookEvent/s);
+  assert.match(preload, /payload: HookEvent/);
+});


### PR DESCRIPTION
## What & why

Hook events currently cross the Electron main, preload, and renderer boundary with the payload shape defined separately at the IPC boundary. As more hook providers and lifecycle events are added, those definitions can drift and make otherwise valid provider events harder to evolve safely.

This change introduces a shared `HookEvent` contract, uses it across the existing IPC path, and adds lightweight runtime shape validation before delivery. It keeps the current hook routing behavior intact, including optional `agentId` values and forward compatible event names such as `Unknown` and future provider events.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
<img width="847" height="306" alt="2026-08-24-032815" src="https://github.com/user-attachments/assets/3f3e708a-65d3-4640-91ff-60f76c5825e8" />

On clean `upstream/main`, the same contract probe shows that the hook IPC path does not have a shared `HookEvent` contract. The preload still defines the payload shape inline, and the main process sends `hive:hookEvent` without shared payload validation.

### After
<img width="844" height="359" alt="2026-08-24-032923" src="https://github.com/user-attachments/assets/6629509b-5b52-402a-848a-f051aed72db2" />

Running the same probe on this branch now passes. The main process and preload use the same `HookEvent` contract, payload shape validation happens before IPC delivery, unknown provider events are still accepted, and `agentId` stays optional.

Both screenshots use the same temporary local probe against the clean upstream baseline and this branch. The probe is only there to make the before and after behavior easy to verify. The committed regression coverage lives in `test/hook-event-contract.test.cjs`.

## How I tested it

- OS: Windows 10
- Node: v22.22.3
- Steps:
  1. Checked out clean `upstream/main` at `9e99edc982de4424872260efd00ebc76fdc8dfcf`.
  2. Ran `npm run test:focused` to establish the upstream baseline.
  3. Switched to `fix/hook-event-ipc-types`.
  4. Rebased the branch onto the same `upstream/main`.
  5. Ran `npm run typecheck`.
  6. Ran `npm run test:focused`.
  7. Ran `npm run build`.
  8. Ran the same local hook contract probe against both the clean baseline and the feature branch.
  9. Confirmed all 5 new hook contract tests pass with no additional failures.
  10. Confirmed unknown and future provider event names are still accepted.
  11. Confirmed `agentId` stays optional.

Results:

```text
npm run typecheck
PASS

npm run build
PASS

clean upstream/main:
549 tests
536 passed
11 failed
2 skipped

feature branch:
554 tests
541 passed
11 failed
2 skipped
```

This branch adds 5 tests and all 5 pass. The same 11 `test:focused` failures reproduce on clean `upstream/main`, so this change does not add any new test failures.

Two of the existing baseline suites report:

```text
Error: Electron failed to install correctly,
please delete node_modules/electron and try installing again
```

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts`, with no ad hoc colors,
      spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.

`npm run test:focused` is left unchecked because the full suite is not green on clean `upstream/main` in this environment. This branch reproduces the same 11 baseline failures, adds 5 passing hook contract tests, and introduces no new failures.