### PR TITLE
perf(floor): make the floor's motion frame-rate independent, then cap it at 20 fps

### DIFF
--- a/src/renderer/src/scene/office/Camera.ts
+++ b/src/renderer/src/scene/office/Camera.ts
@@ -1,11 +1,19 @@
 import { Container } from 'pixi.js';
+import { timeScaledLerp } from './easing';
 
 // Simplified port of shahar061/the-office (office/engine/camera.ts).
 // Phase targeting is dropped (we have no project phases); kept: fit-to-screen,
 // map-edge clamping, smooth lerp, a manual focus(), and nudgeToward() used to
 // pan toward the selected agent.
 
+// Authored as a fraction of the remaining distance per frame, at REF_HZ.
 const LERP_SPEED = 0.08;
+// The rate that fraction was tuned against. Applied raw, a per-frame constant
+// makes the camera's easing depend on the display: it converges twice as fast on
+// a 120 Hz ProMotion panel as on a 60 Hz one, and would crawl the moment anything
+// capped the frame rate. Converting it to the equivalent per-second decay (below)
+// gives the same wall-clock easing at any rate.
+const REF_HZ = 60;
 
 export class Camera {
   private container: Container;
@@ -73,9 +81,14 @@ export class Camera {
   }
 
   update(dt: number): void {
-    this.currentX += (this.targetX - this.currentX) * LERP_SPEED;
-    this.currentY += (this.targetY - this.currentY) * LERP_SPEED;
-    this.currentZoom += (this.targetZoom - this.currentZoom) * LERP_SPEED;
+    // Same easing curve, expressed against elapsed time rather than frame count.
+    // dt is clamped upstream by Pixi's minFPS, so a floor that was paused for an
+    // hour resumes with k near 1 (the camera snaps to its target) rather than
+    // jumping past it.
+    const k = timeScaledLerp(LERP_SPEED, dt, REF_HZ);
+    this.currentX += (this.targetX - this.currentX) * k;
+    this.currentY += (this.targetY - this.currentY) * k;
+    this.currentZoom += (this.targetZoom - this.currentZoom) * k;
 
     if (this.nudgeDuration > 0) {
       this.nudgeElapsed += dt;

--- a/src/renderer/src/scene/office/Character.ts
+++ b/src/renderer/src/scene/office/Character.ts
@@ -1,6 +1,6 @@
 import { Container, Graphics, Texture } from 'pixi.js';
 import { CharacterSprite, type Direction, type AnimState } from './CharacterSprite';
-import { findPath } from './pathfinding';
+import { advanceAlongPath, findPath } from './pathfinding';
 import type { TiledMapRenderer } from './TiledMapRenderer';
 import { ThoughtBubble } from './ThoughtBubble';
 
@@ -553,6 +553,12 @@ export class Character {
     this.thoughtBubble.update(dt);
     if (!this.isVisible) return;
 
+    // The walk/idle cycle now rides the floor's clock rather than Ticker.shared
+    // (see CharacterSprite), so it stops with the floor and never animates faster
+    // than the scene is drawn. An invisible character returns above and freezes,
+    // which is what we want.
+    this.sprite.advance(dt);
+
     // Working agents stay seated; between tasks they wander the office.
     // A cheer, a watering or a cigar holds roaming so the effect plays in place.
     const heldByFx = this.cheerT >= 0 || this.waterT >= 0 || this.smokeT >= 0;
@@ -790,25 +796,29 @@ export class Character {
       return;
     }
 
-    const target = this.path[0];
+    // Spend the whole frame's movement, crossing as many waypoints as it covers.
+    // Reaching a tile used to cost the REST of that frame's movement (the old
+    // `dist < 1` branch snapped and returned), which is a stall every time a
+    // character crosses a tile boundary. At 120 fps that is one frame in forty and
+    // nobody sees it; at 20 fps it is one frame in seven and the character visibly
+    // limps. Distance per second is now a function of elapsed time alone.
     const ts = this.mapRenderer.tileSize;
-    const targetPx = target.x * ts + ts / 2;
-    const targetPy = target.y * ts + ts;
-    const dx = targetPx - this.px;
-    const dy = targetPy - this.py;
-    const dist = Math.sqrt(dx * dx + dy * dy);
+    const fromX = this.px;
+    const fromY = this.py;
+    const step = advanceAlongPath(
+      this.px, this.py, this.path,
+      (tile) => ({ x: tile.x * ts + ts / 2, y: tile.y * ts + ts }),
+      SPEED * dt
+    );
+    this.px = step.x;
+    this.py = step.y;
+    if (step.consumed > 0) this.path.splice(0, step.consumed);
 
-    if (dist < 1) {
-      this.px = targetPx;
-      this.py = targetPy;
-      this.path.shift();
-      return;
+    const dx = this.px - fromX;
+    const dy = this.py - fromY;
+    if (dx !== 0 || dy !== 0) {
+      this.direction = Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up');
     }
-
-    const step = Math.min(SPEED * dt, dist);
-    this.px += (dx / dist) * step;
-    this.py += (dy / dist) * step;
-    this.direction = Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up');
     this.sprite.setAnimation('walk', this.direction);
     this.sprite.setPosition(this.px, this.py);
   }

--- a/src/renderer/src/scene/office/CharacterSprite.ts
+++ b/src/renderer/src/scene/office/CharacterSprite.ts
@@ -1,4 +1,4 @@
-import { AnimatedSprite, Container, Graphics, Texture } from 'pixi.js';
+import { AnimatedSprite, Container, Graphics, Texture, type Ticker } from 'pixi.js';
 
 export type Direction = 'down' | 'up' | 'right' | 'left';
 export type AnimState = 'walk' | 'type' | 'read' | 'idle';
@@ -43,6 +43,15 @@ export class CharacterSprite {
     this.sprite = new AnimatedSprite(initialFrames);
     this.sprite.anchor.set(0.5, 1);
     this.sprite.animationSpeed = this.frameSpeed;
+    // Pixi's AnimatedSprite defaults to autoUpdate, which subscribes it to
+    // Ticker.shared — a SECOND requestAnimationFrame loop, running at the display's
+    // full rate whatever the floor's own ticker is capped to, and still running
+    // while the floor is paused behind a fullscreen terminal or the IDE. On a floor
+    // of twenty agents that is twenty sprite updates 120 times a second producing
+    // texture swaps the renderer never draws. Drive it from the scene's own tick
+    // instead, so the walk cycle shares one clock with everything else: capped with
+    // the floor, and stopped with it.
+    this.sprite.autoUpdate = false;
     this.sprite.play();
     // Anchor is (0.5, 1): in container space the sprite spans x∈[-w/2, w/2],
     // y∈[-h, 0] (feet at the origin). Used by the seated leg-crop mask.
@@ -82,6 +91,18 @@ export class CharacterSprite {
     this.cropMask.visible = true;
     this.sprite.mask = this.cropMask;
   }
+
+  /** Advance the walk/idle cycle by `dt` seconds.
+   *
+   *  AnimatedSprite.update() reads exactly one field off what it is handed —
+   *  `deltaTime`, in 60 Hz frames — so a reused scratch object drives it without
+   *  allocating per character per frame or owning a second Ticker. */
+  advance(dt: number): void {
+    CharacterSprite.beat.deltaTime = dt * 60;
+    this.sprite.update(CharacterSprite.beat);
+  }
+
+  private static readonly beat = { deltaTime: 0 } as unknown as Ticker;
 
   private getFrames(direction: Direction, anim: AnimState): Texture[] {
     const row = DIRECTION_ROW[direction];

--- a/src/renderer/src/scene/office/OfficeFloor.tsx
+++ b/src/renderer/src/scene/office/OfficeFloor.tsx
@@ -79,6 +79,36 @@ interface Runtime {
  *  reads like real work completed when none did. */
 const CHEER_MIN_BUSY_MS = 60_000;
 
+/** Frame-rate ceiling for the office scene.
+ *
+ *  Measured on a live floor, interleaved up and back down in one session so the
+ *  agents' own varying workload cancels rather than being credited to the cap
+ *  (% of one CPU core, renderer process / GPU process):
+ *
+ *    uncapped (120 Hz)   26.7 / 16.9
+ *    60 fps              19.7 /  9.3
+ *    30 fps              15.1 /  6.6
+ *    20 fps              12.7 /  5.8
+ *    15 fps              12.7 /  5.7
+ *
+ *  20 and 15 are the same number, which is what picks the default: below about 20
+ *  there is nothing left to take, because what remains is React, the terminals and
+ *  compositing, none of which is this ticker. Going lower buys nothing and only
+ *  costs smoothness.
+ *
+ *  Be honest about the trade: 120 fps IS smoother, and the floor at 20 does not
+ *  look identical. What a lower cap does not change is SPEED — after the motion
+ *  fixes below (Character.updateWalk, Camera.update), everything covers the same
+ *  ground per second and simply does it in fewer steps.
+ *
+ *  Smoothness is worth trading here because this is ambient decoration that never
+ *  stops: an idle office nobody is tracking, redrawn as fast as the display will
+ *  accept for as long as the app is open, with a camera that never even pans
+ *  (fitToScreen sets its target once and nothing else moves it). Uncapped it was
+ *  the app's largest continuous cost, and on a laptop a continuous cost is
+ *  battery. A novelty animation should not be why a machine runs hot. */
+const FLOOR_MAX_FPS = 20;
+
 /** What an avatar mutters per errand, picked at random. */
 const ERRAND_THOUGHTS: Record<ErrandKind, readonly string[]> = {
   water:     ['watering the plants 🌿', 'giving the plants a drink', 'they grow so fast'],
@@ -1696,6 +1726,21 @@ export function OfficeFloor() {
         }
       };
       app.ticker.add(onTick);
+      // Cap the frame rate. Pixi's ticker follows requestAnimationFrame, which on a
+      // ProMotion Mac means 120 Hz: the whole scene re-renders 120 times a second at
+      // `resolution: 2` (four times the pixels of a logical one), and onTick above
+      // runs every character and every subsystem that often. Measured on a 16-inch
+      // MacBook Pro, rAF delivers 120.5 fps, so that is exactly twice the work a
+      // 60 Hz machine does for a floor nobody can see move any faster.
+      //
+      // Nothing on the floor is worth that. Every animation here is authored in
+      // seconds against ticker.deltaMS, so capping changes how SMOOTH the motion is
+      // and never how fast anything happens — the exceptions were the camera's
+      // per-frame lerp and the walk's per-frame waypoint, both fixed at their source
+      // (see Camera.update and Character.updateWalk). Without those a capped floor
+      // would take five seconds to settle its fit after a window resize instead of
+      // 1.6, and its characters would walk at 83% speed.
+      app.ticker.maxFPS = FLOOR_MAX_FPS;
       // init() is async: the floor may already be behind a fullscreen terminal by
       // the time we get here, and app.init() starts the ticker itself.
       if (pausedRef.current) app.ticker.stop();

--- a/src/renderer/src/scene/office/easing.ts
+++ b/src/renderer/src/scene/office/easing.ts
@@ -1,0 +1,26 @@
+/**
+ * Frame-rate-independent easing.
+ *
+ * The office scene eases the camera by moving a fixed FRACTION of the remaining
+ * distance each frame. That is the usual shortcut and it has the usual bug: the
+ * result depends on how often frames happen. The same constant converges twice as
+ * fast on a 120 Hz ProMotion panel as on a 60 Hz one, and slows down again the
+ * moment the ticker is capped.
+ *
+ * Converting the per-frame fraction to a per-second decay fixes both. Keeping a
+ * fraction `f` of the distance each frame leaves `(1 - f)^frames` after that many
+ * frames, so the elapsed-time equivalent is `1 - (1 - f)^(dt * refHz)`.
+ */
+
+/**
+ * @param perFrame fraction of the remaining distance to cover in one frame at `refHz` (0..1)
+ * @param dt       seconds elapsed since the last frame
+ * @param refHz    the rate `perFrame` was tuned against
+ * @returns        the fraction to cover for this frame, easing identically at any rate
+ */
+export function timeScaledLerp(perFrame: number, dt: number, refHz = 60): number {
+  if (!(dt > 0)) return 0;                 // no time passed (or NaN): no movement
+  if (perFrame <= 0) return 0;
+  if (perFrame >= 1) return 1;             // "snap" stays a snap at every rate
+  return 1 - Math.pow(1 - perFrame, dt * refHz);
+}

--- a/src/renderer/src/scene/office/pathfinding.ts
+++ b/src/renderer/src/scene/office/pathfinding.ts
@@ -64,3 +64,59 @@ function reconstructPath(parent: Map<string, Point>, start: Point, goal: Point):
 
   return path;
 }
+
+export interface PathStep {
+  /** New position after spending the movement budget. */
+  x: number;
+  y: number;
+  /** Waypoints fully reached this frame — splice this many off the front. */
+  consumed: number;
+  /** Budget left unspent because the path ran out. */
+  leftover: number;
+}
+
+/**
+ * Walk `budget` pixels along a path, crossing as many waypoints as the budget
+ * covers.
+ *
+ * The crossing part is the point. Advancing one waypoint per frame and dropping
+ * the rest of the budget makes a character's speed depend on the frame rate: it
+ * loses a frame of movement every time it reaches a tile, which at 120 fps is
+ * 2.5% of the frames and invisible, and at 20 fps is one frame in seven and reads
+ * as a limp. Spending the whole budget every frame makes distance travelled a
+ * function of elapsed time only, which is what lets the floor's frame rate be
+ * capped without the walk cycle changing character.
+ *
+ * `toPixel` converts a path waypoint to the pixel point the sprite aims at, and
+ * is called only for the waypoints actually examined (usually one).
+ */
+export function advanceAlongPath<T>(
+  x: number,
+  y: number,
+  path: readonly T[],
+  toPixel: (waypoint: T) => { x: number; y: number },
+  budget: number
+): PathStep {
+  let remaining = Math.max(0, budget);
+  let consumed = 0;
+  for (const waypoint of path) {
+    const target = toPixel(waypoint);
+    const dx = target.x - x;
+    const dy = target.y - y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist <= remaining) {
+      // Reached it. Land exactly on the waypoint and carry the rest onward, so
+      // a corner costs the distance to it and never a whole frame.
+      x = target.x;
+      y = target.y;
+      remaining -= dist;
+      consumed++;
+      continue;
+    }
+    x += (dx / dist) * remaining;
+    y += (dy / dist) * remaining;
+    remaining = 0;
+    break;
+  }
+  return { x, y, consumed, leftover: remaining };
+}

--- a/test/frame-rate-easing.test.cjs
+++ b/test/frame-rate-easing.test.cjs
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { timeScaledLerp } = loadTs('src/renderer/src/scene/office/easing.ts');
+
+// The office camera used to move a fixed fraction of the remaining distance per
+// FRAME, which quietly made its easing a function of the display: the same pan
+// finished twice as fast on a 120 Hz ProMotion panel as on a 60 Hz one, and would
+// have crawled once the floor's ticker was capped. These pin the conversion.
+
+const PER_FRAME = 0.08; // the camera's LERP_SPEED
+
+/** Distance still remaining after easing for `seconds` at `hz`. */
+function remainingAfter(seconds, hz) {
+  const dt = 1 / hz;
+  let remaining = 1;
+  for (let t = 0; t < seconds - 1e-9; t += dt) remaining -= remaining * timeScaledLerp(PER_FRAME, dt);
+  return remaining;
+}
+
+test('one frame at the reference rate is the authored fraction', () => {
+  // Not assert.equal: the round trip through pow() lands a float ulp away.
+  assert.ok(Math.abs(timeScaledLerp(PER_FRAME, 1 / 60) - PER_FRAME) < 1e-12);
+});
+
+test('the same wall-clock easing comes out at 30, 60 and 120 Hz', () => {
+  const at60 = remainingAfter(1, 60);
+  for (const hz of [30, 120, 144]) {
+    assert.ok(Math.abs(remainingAfter(1, hz) - at60) < 1e-9,
+      `${hz} Hz drifted from 60 Hz: ${remainingAfter(1, hz)} vs ${at60}`);
+  }
+});
+
+test('a capped frame rate no longer slows the camera down', () => {
+  // The bug, stated as a test: the raw per-frame constant covers half as much
+  // ground in a second when the frame rate halves.
+  const raw = (hz) => { let r = 1; for (let i = 0; i < hz; i++) r -= r * PER_FRAME; return r; };
+  assert.ok(raw(60) > raw(120), 'sanity: the raw constant is rate-dependent');
+  assert.ok(Math.abs(remainingAfter(1, 60) - remainingAfter(1, 120)) < 1e-9,
+    'the scaled version is not');
+});
+
+test('no time elapsed means no movement', () => {
+  assert.equal(timeScaledLerp(PER_FRAME, 0), 0);
+  assert.equal(timeScaledLerp(PER_FRAME, -1), 0);
+  assert.equal(timeScaledLerp(PER_FRAME, NaN), 0);
+});
+
+test('a long stall eases toward the target without overshooting it', () => {
+  // Pixi clamps elapsedMS to minFPS, but the maths must hold anyway: a resumed
+  // floor should snap to the target, never sail past it.
+  for (const dt of [1, 10, 3600]) {
+    const k = timeScaledLerp(PER_FRAME, dt);
+    assert.ok(k > 0.99 && k <= 1, `dt=${dt}s produced ${k}`);
+  }
+});
+
+test('the degenerate fractions stay degenerate at every rate', () => {
+  assert.equal(timeScaledLerp(0, 1 / 60), 0);
+  assert.equal(timeScaledLerp(1, 1 / 120), 1);
+});

--- a/test/walk-frame-rate.test.cjs
+++ b/test/walk-frame-rate.test.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { advanceAlongPath } = loadTs('src/renderer/src/scene/office/pathfinding.ts');
+
+// An office character walks a tile path at a fixed px/sec. It used to advance at
+// most ONE waypoint per frame and throw away the rest of that frame's movement,
+// which made its speed a function of the frame rate: a stall every time it
+// crossed a tile. At 120 fps that is one frame in forty. At 20 fps it is one in
+// seven, and it reads as the character limping. These pin distance travelled to
+// elapsed time and nothing else.
+
+const TILE = 16;
+const SPEED = 48;                                   // px/sec, Character.ts
+const toPixel = (t) => ({ x: t.x * TILE + TILE / 2, y: t.y * TILE + TILE });
+const straightPath = (n) => Array.from({ length: n }, (_, i) => ({ x: i + 1, y: 0 }));
+
+/** Walk for `seconds` at `fps` and report how far along the path we got. */
+function walk(fps, seconds, pathLength = 40) {
+  const path = straightPath(pathLength);
+  const start = toPixel({ x: 0, y: 0 });
+  let { x, y } = start;
+  const dt = 1 / fps;
+  for (let i = 0; i < Math.round(seconds * fps); i++) {
+    const step = advanceAlongPath(x, y, path, toPixel, SPEED * dt);
+    x = step.x; y = step.y;
+    if (step.consumed > 0) path.splice(0, step.consumed);
+  }
+  return Math.hypot(x - start.x, y - start.y);
+}
+
+/** The old one-waypoint-per-frame rule, kept here as the thing being fixed. */
+function walkOneWaypointPerFrame(fps, seconds, pathLength = 40) {
+  const path = straightPath(pathLength);
+  const start = toPixel({ x: 0, y: 0 });
+  let { x, y } = start;
+  const dt = 1 / fps;
+  for (let i = 0; i < Math.round(seconds * fps); i++) {
+    const target = toPixel(path[0]);
+    const dx = target.x - x, dy = target.y - y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < 1) { x = target.x; y = target.y; path.shift(); continue; }
+    const step = Math.min(SPEED * dt, dist);
+    x += (dx / dist) * step; y += (dy / dist) * step;
+  }
+  return Math.hypot(x - start.x, y - start.y);
+}
+
+test('a character covers the same ground per second at any frame rate', () => {
+  const at120 = walk(120, 2);
+  for (const fps of [60, 30, 20, 15]) {
+    const drift = Math.abs(walk(fps, 2) - at120);
+    assert.ok(drift < 0.001, `${fps} fps drifted ${drift.toFixed(3)}px from 120 fps`);
+  }
+});
+
+test('two seconds of walking is twice one second of it', () => {
+  for (const fps of [120, 20]) {
+    assert.ok(Math.abs(walk(fps, 2) - 2 * walk(fps, 1)) < 0.001, `${fps} fps is not linear in time`);
+  }
+});
+
+test('the old rule really did slow down as the frame rate dropped', () => {
+  // Guards the regression: if someone reinstates one-waypoint-per-frame, the
+  // test above starts failing and this one explains why it mattered.
+  const fast = walkOneWaypointPerFrame(120, 2);
+  const slow = walkOneWaypointPerFrame(20, 2);
+  assert.ok(slow < fast * 0.95,
+    `expected the old rule to lose ground at 20 fps (120fps: ${fast.toFixed(1)}px, 20fps: ${slow.toFixed(1)}px)`);
+});
+
+test('a frame that spans several waypoints crosses all of them', () => {
+  const path = straightPath(5);
+  // Three tiles' worth of budget in a single frame.
+  const step = advanceAlongPath(toPixel({ x: 0, y: 0 }).x, toPixel({ x: 0, y: 0 }).y, path, toPixel, TILE * 3);
+  assert.equal(step.consumed, 3);
+  assert.equal(step.leftover, 0);
+});
+
+test('running out of path returns the unspent budget instead of overshooting', () => {
+  const path = straightPath(1);
+  const start = toPixel({ x: 0, y: 0 });
+  const step = advanceAlongPath(start.x, start.y, path, toPixel, TILE * 10);
+  assert.equal(step.consumed, 1);
+  assert.equal(step.x, toPixel({ x: 1, y: 0 }).x, 'lands exactly on the last waypoint');
+  assert.ok(step.leftover > 0, 'and reports what it could not spend');
+});
+
+test('an empty path consumes nothing and moves nowhere', () => {
+  const step = advanceAlongPath(10, 20, [], toPixel, 999);
+  assert.deepEqual({ x: step.x, y: step.y, consumed: step.consumed }, { x: 10, y: 20, consumed: 0 });
+});


### PR DESCRIPTION
## What & why

Pixi's ticker follows `requestAnimationFrame` and nothing capped it. On a ProMotion
Mac that means the office scene ran at 120 fps — I measured 120.5 on a 16-inch
MacBook Pro. Every frame runs `onTick` over every character and all six floor
subsystems, then redraws the whole scene onto a `resolution: 2` canvas.

That is the app's largest continuous cost, and it is spent on ambient decoration: an
idle office that nobody is tracking, animating as fast as the display will accept for
as long as the app is open, whether or not anyone is looking at it. On a laptop a
continuous cost is battery, and this one is heavy enough to be felt.

Capping it turned out to be the easy part. It exposed two places where motion was a
function of the **frame rate** rather than of elapsed time, and both had to be fixed
first — which is why this is one change and not three. Capping without them ships
visible regressions:

**1. Characters limped.** `Character.updateWalk` advanced at most one path waypoint per
frame, and reaching a tile threw away the rest of that frame's movement. Characters
cross a tile three times a second, so the stall rate tracks the frame rate:

| cap | stalled frames | actual walking speed |
|---|---|---|
| 120 fps | 3% | ~100% |
| 60 fps | 5% | 100% |
| 30 fps | 8% | 92% |
| 20 fps | 13% | 83% |

At 120 fps that is one frame in forty and nobody sees it. Capped, it is one in eight,
held on screen for 50ms, and it reads as the character speeding up and slowing down.
It also means characters were walking at 83% of the speed the code asks for. The walk
now spends its whole movement budget each frame, crossing as many waypoints as that
covers and landing exactly on each one.

**2. The camera's easing depended on the display.** `Camera.update` moved a fixed
fraction of the remaining distance *per frame*, ignoring `dt`. That is already a bug on
`main` — the same pan finishes twice as fast on a 120 Hz panel as on a 60 Hz one — and
capped, a window resize would have taken five seconds to settle its fit instead of 1.6.
The fraction is now the equivalent per-second decay.

**3. The walk cycle ignored the cap entirely.** `CharacterSprite` left Pixi's
`AnimatedSprite` on its default `autoUpdate`, which subscribes it to `Ticker.shared` —
a second `requestAnimationFrame` loop that no cap on the app's ticker touches, and that
kept animating every character while the floor was paused behind a fullscreen terminal
or the IDE. It is driven from the scene's tick now. Being straight about this one: it is
a consistency fix, not a saving. Measured against itself, interleaved three times, it is
~0.3% of a core — inside the noise. It earns its place because it makes the claim in this
PR's title true, and because the existing pause optimisation was silently leaking through it.

The first two are pure functions with tests pinning them equal across frame rates,
including one that reproduces the old walk rule losing ground so nobody reinstates it.
Distance travelled per second is now identical at 120, 60, 30, 20, 15, 12 and 10 fps to
four decimal places.

With motion no longer tied to the frame rate, the cap is free to be low. The floor is
ambient: nobody reacts to it, and the camera never pans (`fitToScreen` sets its target
once, there is no drag or wheel zoom, and `focusOn()` has no callers).

![What each cap costs](https://raw.githubusercontent.com/L422Y/munder-difflin/assets/askme-markdown/evidence/floor-fps/cpu-sweep.png)

20 and 15 measure the same, which is what picks the default: what is left below 20 is
React, the terminals and compositing, none of which is this ticker, so going lower buys
nothing and only costs smoothness. The cap is a named constant carrying the
measurements, so moving it is a one-line decision with the evidence next to it.

This does not touch the existing pause logic, which already stops the ticker entirely
behind a fullscreen terminal, behind the IDE, or on a hidden window. This is about what
the floor costs while you are looking at it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI
- [x] Performance

## Evidence

Measured on a live floor with agents working, not a synthetic scene. `%CPU` here is a
CPU-time delta over a 22-second window, not `ps`'s lifetime average, which is useless
for this. Conditions were interleaved and walked up and back down in a single session
(uncapped → 60 → 30 → 20 → 15 → 15 → 20 → 30 → 60 → uncapped) so drift in the floor's own
workload cancels instead of being credited to the change. Same window, same agents,
same machine, minutes apart. Each dot is one sample window.

### Before
![Uncapped: renderer 26.7%, GPU 16.9%](https://raw.githubusercontent.com/L422Y/munder-difflin/assets/askme-markdown/evidence/floor-fps/cpu-before.png)

### After
![Capped at 20 fps: renderer 12.7%, GPU 5.8%](https://raw.githubusercontent.com/L422Y/munder-difflin/assets/askme-markdown/evidence/floor-fps/cpu-after.png)

52% off the renderer process and 66% off the GPU process, continuously, for as long as
the app is open.

To be straight about the trade rather than sell it: **120 fps is smoother, and the floor
at 20 does not look identical.** What a lower cap does not change is *speed* — after the
fixes above, everything covers the same ground per second and simply does it in fewer
steps. Smoothness is the thing being traded, deliberately, because a novelty animation
that never stops is not worth the power it was drawing.

## How I tested it

- OS: macOS (Darwin 25.3), Node 24, 16-inch MacBook Pro (120 Hz Liquid Retina XDR).

- Steps:
  - `npm run typecheck`, `npm run test:focused` (564 pass, 12 of them new), `npm run build`.
  - Measured the display's real rAF rate rather than assuming it: 120.5 fps.
  - Ran the sweep above against a running dev build, toggling only `FLOOR_MAX_FPS`.
  - Watched the floor at each cap for walking, coffee runs, errands, thought bubbles and
    message envelopes. The limp at low frame rates is what led to the walk fix; with it
    in, 20 fps is where I stopped being able to tell, and it measures the same as 15, so
    there was no reason to go lower.
  - Read Pixi's `Ticker.update` and simulated its `maxFPS` gate against a 120 Hz frame
    stream. It emits a periodic long frame at every capped rate (at 20 fps: a 58 ms frame
    among 50 ms ones). Harmless, because everything on the floor is driven by
    `deltaMS` — but it is the reason the walk stall had to go, since a stall is not.

Not done: verified on a 60 Hz display, where the cap should be close to a no-op, or on
Windows and Linux.

## Discord (optional)

Discord: l422y

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. The two motion fixes are not unrelated work bundled in —
      capping the frame rate without them ships a visible regression in each.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts. (No UI added.)
- [ ] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`. (No art.)
