### PR TITLE
docs(wall): mark the first-100 founder offer as annual-only

### DIFF
--- a/docs/wall.html
+++ b/docs/wall.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>The Founders' Wall — Munder Difflin</title>
-<meta name="description" content="The Founding Supporters who keep Munder Difflin free and open source for everyone. One brass plaque each, $20, one time — first 100 get 50% off PRO and a free month." />
+<meta name="description" content="The Founding Supporters who keep Munder Difflin free and open source for everyone. One brass plaque each, $20, one time — first 100 get 50% off PRO on an annual plan and a free month." />
 <link rel="canonical" href="https://munderdiffl.in/wall.html" />
 <link rel="icon" type="image/svg+xml" href="./logo.svg" />
 <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32.png" />
@@ -299,7 +299,7 @@
       Munder Difflin is free and open source, for everyone, forever. That's possible
       because of the people on this wall — <b id="wallCount">the Founding Supporters</b>.
       One brass plaque each. Permanent. And the first 100 get
-      <b>50% off Munder Difflin PRO, plus one month free</b>.
+      <b>50% off Munder Difflin PRO on an annual plan, plus one month free</b>.
     </p>
 
     <div class="wallboard">
@@ -323,8 +323,7 @@
       <p>A permanent engraved plaque on this wall. Munder Difflin stays free
       for everyone — this is what keeps it that way.</p>
       <p><b>First 100 supporters only:</b> 50% off the
-      <a href="/#pricing">PRO plan</a> (that’s $19.50/mo instead of $39), and your
-      first month of PRO free. Your discount code and free-trial details are sent to
+      <a href="/#pricing">PRO plan</a> on an annual subscription. That is $19.50/mo billed annually, instead of $39/mo. Plus your first month of PRO free. Annual plans only. The discount does not apply to monthly billing. Your discount code and free-trial details are sent to
       the <b>email address you use when joining the wall</b> — watch for them after
       your plaque goes up.</p>
       <div class="btn-row">


### PR DESCRIPTION
## What

The first-100 Founding Supporter offer on `docs/wall.html` advertised **50% off PRO ($19.50/mo instead of $39)** with no mention that the discount is **annual-only**. The founder confirmed it applies to the annual plan only, not monthly billing. This adds the annual-only wording in the three places that stated the offer.

Founder-supplied copy, used verbatim (no rewording, no dashes, no marketing register added).

## The three changes, as they now read

1. **Meta description** (search results / link previews): `...first 100 get 50% off PRO on an annual plan and a free month.`
2. **Hero line**: `...the first 100 get 50% off Munder Difflin PRO on an annual plan, plus one month free`
3. **Join card**: `First 100 supporters only: 50% off the PRO plan on an annual subscription. That is $19.50/mo billed annually, instead of $39/mo. Plus your first month of PRO free. Annual plans only. The discount does not apply to monthly billing.`

## Scope / safety

- Only `docs/wall.html` is touched. No pricing, plaque price ($20), Razorpay link, wall data, or styling changed. `docs/index.html` untouched.
- Branched off current `origin/main` (`b26eb82`); the stale `Documents/Personal` checkout was **not** used. Verified the source string `$19.50/mo instead of $39` was present before editing.
- The `PRO plan` link and the existing "discount code / email" trailing sentence are preserved.

## One open question for the founder (deliberately not decided here)

No **annual total** was added. `$19.50 x 12 = $234`, but the pricing page separately advertises PRO at **$200/year** with the sandbox billed on top, so printing $234 here could create a new inconsistency between two public pages. Left out on purpose; say the word if you want a number and which one.

## ⚠️ Do not merge or deploy

This is a live public page. Opened for founder review only, per instruction. **Do not merge, do not deploy** until the founder signs off on the wording.
