### PR TITLE
feat(settings): let people choose the office floor's frame rate

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -316,6 +316,14 @@ export interface HarnessConfig {
    *  `tvShowOffices` is on; otherwise the office theme is used. Unbuilt show
    *  themes fall back to 'office' in the loader. */
   officeTheme?: 'office' | 'friends' | 'brooklyn99' | 'siliconvalley' | 'got' | 'hogwarts';
+  /** Frame-rate ceiling for the pixel office scene, in fps. 0 = uncapped, which
+   *  means the scene follows the display and costs twice as much on a 120 Hz
+   *  panel as on a 60 Hz one. The floor is ambient decoration that animates for as
+   *  long as the app is open, so the default is deliberately low; the option
+   *  exists because smoothness is a real thing to want, and on a desktop the power
+   *  it costs may not matter. Unrecognised values fall back to the default —
+   *  see FLOOR_FPS_CHOICES in src/shared/floorFps.ts for the supported set. */
+  floorMaxFps?: number;
   /** Per-CLI-provider local/self-hosted base URL (Ollama/LM Studio/vLLM, …) for the
    *  OpenCode/Crush/pi/qwen engines; applied at spawn (config-injection or proxy
    *  upstream). API KEYS are NOT stored here — they live write-only in the secret
@@ -448,6 +456,7 @@ const DEFAULTS: HarnessConfig = {
   multiWindow: true,
   tvShowOffices: false,
   officeTheme: 'office',
+  floorMaxFps: 20,
   slackEnabled: false,
   slackSigningSecret: undefined,
   slackBotToken: undefined,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -321,6 +321,8 @@ export interface HarnessConfig {
   tvShowOffices?: boolean;
   /** Active office map/cast theme (honored only when tvShowOffices is on). */
   officeTheme?: 'office' | 'friends' | 'brooklyn99' | 'siliconvalley' | 'got' | 'hogwarts';
+  /** Frame-rate ceiling for the office scene, in fps (0 = uncapped). */
+  floorMaxFps?: number;
   /** Per-CLI-provider local/self-hosted base URL (Ollama/LM Studio/vLLM, …) for the
    *  OpenCode/Crush/pi/qwen engines; applied at spawn. API KEYS are NOT stored here —
    *  they live write-only in the secret broker. */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { useStore, selectedAgent } from '@/store/store';
 import { startMockLoop, stopMockLoop } from '@/store/mockEvents';
 import type { HarnessConfig } from '@/store/config';
 import { DEFAULT_ORG_TRIGGER } from '@shared/triggers';
+import { resolveFloorFps } from '@shared/floorFps';
 import { OfficeFloor } from '@/scene/office/OfficeFloor';
 import { useHive } from '@/hooks/useHive';
 import { MemoryPanel } from '@/components/MemoryPanel';
@@ -100,6 +101,9 @@ export function App() {
       // Mirror the active office theme so OfficeFloor renders it (gated on the
       // tvShowOffices flag; off = always the office). Settings keeps this synced.
       useStore.getState().setOfficeTheme(c.tvShowOffices ? (c.officeTheme ?? 'office') : 'office');
+      // Mirror the floor's frame-rate ceiling. Settings writes config; this is what
+      // makes the running scene pick the new rate up without a restart.
+      useStore.getState().setFloorMaxFps(resolveFloorFps((c as HarnessConfig).floorMaxFps));
       // Mirror the triggers so Settings → Connections and the Command Center's
       // Triggers tab read one list, not two copies that drift — whichever surface
       // saves calls these same setters and the other repaints. No extra IPC: main

--- a/src/renderer/src/components/FloorFpsPicker.tsx
+++ b/src/renderer/src/components/FloorFpsPicker.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import type { HarnessConfig } from '@/store/config';
+import { useStore } from '@/store/store';
+import { FLOOR_FPS_CHOICES, resolveFloorFps } from '@shared/floorFps';
+
+/**
+ * Settings → General → "Floor frame rate": how fast the pixel office redraws.
+ *
+ * The office animates for as long as the app is open, so its frame rate is the
+ * app's largest continuous cost and, on a laptop, its largest continuous battery
+ * draw. The default is low for that reason. This exists because smoothness is a
+ * legitimate thing to want, and on a desktop the power may simply not matter.
+ *
+ * Applying is instant and reversible: the store mirror drives the live Pixi
+ * ticker, so the floor repaints at the new rate as soon as you click. There is
+ * nothing destructive here and nothing to confirm.
+ */
+export function FloorFpsPicker({ config }: { config: HarnessConfig }) {
+  const stored = resolveFloorFps(config.floorMaxFps);
+  const [current, setCurrent] = useState<number>(stored);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState('');
+  const setFloorMaxFps = useStore((s) => s.setFloorMaxFps);
+
+  const choose = async (fps: number) => {
+    if (busy || fps === current) return;
+    setBusy(true);
+    setNote('');
+    const previous = current;
+    // Optimistic: the scene picks the rate up from the store immediately, so the
+    // click and the repaint happen together rather than after a round trip.
+    setCurrent(fps);
+    setFloorMaxFps(fps);
+    try {
+      await window.cth.updateConfig({ floorMaxFps: fps });
+    } catch {
+      setCurrent(previous);
+      setFloorMaxFps(previous);
+      setNote('Could not save that — the floor is back on the previous rate.');
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 18 }}>
+      <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 8, color: 'var(--cth-ink-500)' }}>
+        FLOOR FRAME RATE
+      </div>
+      <div style={{ fontSize: 12, lineHeight: '17px', color: 'var(--cth-ink-700)' }}>
+        How fast the office redraws. It does not change how fast anything moves — the floor's
+        motion runs on elapsed time, so a character covers the same ground per second at every
+        setting and simply does it in fewer steps. It changes how smooth that looks, and what the
+        scene costs while the app sits open.
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {FLOOR_FPS_CHOICES.map((choice) => {
+          const active = choice.fps === current;
+          return (
+            <button
+              key={choice.fps}
+              onClick={() => void choose(choice.fps)}
+              disabled={busy}
+              style={{
+                display: 'flex', alignItems: 'baseline', gap: 10, width: '100%',
+                padding: '7px 9px', textAlign: 'left', cursor: busy ? 'default' : 'pointer',
+                border: 'none',
+                background: active ? 'var(--cth-lilac-light, #ece2f5)' : 'var(--cth-paper-100)',
+                boxShadow: `inset 0 0 0 ${active ? 2 : 1}px var(--cth-ink-${active ? '700' : '100'})`,
+                fontFamily: 'var(--cth-font-mono)', fontSize: 13, color: 'var(--cth-ink-900)'
+              }}
+            >
+              <span style={{ minWidth: 74 }}>{choice.label}</span>
+              <span style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>{choice.note}</span>
+            </button>
+          );
+        })}
+      </div>
+      {note && (
+        <div style={{ fontSize: 11, color: 'var(--cth-coral)' }}>{note}</div>
+      )}
+      <div style={{ fontSize: 11, color: 'var(--cth-ink-300)', lineHeight: '15px' }}>
+        Measured on a 120 Hz display: uncapped the floor costs 26.7% of a CPU core plus 16.9% of the
+        GPU process; at the default it is 12.7% and 5.8%. Yours will differ — a 60 Hz display is
+        already doing half the work of a 120 Hz one before any of this applies.
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -17,6 +17,7 @@ import { SettingsHeroCard } from './SettingsHeroCard';
 import { SetupPanel } from './SetupPanel';
 import { Icon } from './Icon';
 import { OfficeThemePicker } from './OfficeThemePicker';
+import { FloorFpsPicker } from './FloorFpsPicker';
 import { McpDefaultsSettings } from './McpDefaultsSettings';
 import { IntegrationsRegistry } from './IntegrationsRegistry';
 import { AiEnginesSettings } from './AiEnginesSettings';
@@ -1048,6 +1049,9 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       {/* Office Theme — TV-show office maps (experimental; flag tvShowOffices, default off) */}
                       <OfficeThemePicker config={config} />
+
+                      {/* Floor frame rate — what the always-on office scene costs */}
+                      <FloorFpsPicker config={config} />
                     </>
                   )}
 

--- a/src/renderer/src/scene/office/Camera.ts
+++ b/src/renderer/src/scene/office/Camera.ts
@@ -1,11 +1,19 @@
 import { Container } from 'pixi.js';
+import { timeScaledLerp } from './easing';
 
 // Simplified port of shahar061/the-office (office/engine/camera.ts).
 // Phase targeting is dropped (we have no project phases); kept: fit-to-screen,
 // map-edge clamping, smooth lerp, a manual focus(), and nudgeToward() used to
 // pan toward the selected agent.
 
+// Authored as a fraction of the remaining distance per frame, at REF_HZ.
 const LERP_SPEED = 0.08;
+// The rate that fraction was tuned against. Applied raw, a per-frame constant
+// makes the camera's easing depend on the display: it converges twice as fast on
+// a 120 Hz ProMotion panel as on a 60 Hz one, and would crawl the moment anything
+// capped the frame rate. Converting it to the equivalent per-second decay (below)
+// gives the same wall-clock easing at any rate.
+const REF_HZ = 60;
 
 export class Camera {
   private container: Container;
@@ -73,9 +81,14 @@ export class Camera {
   }
 
   update(dt: number): void {
-    this.currentX += (this.targetX - this.currentX) * LERP_SPEED;
-    this.currentY += (this.targetY - this.currentY) * LERP_SPEED;
-    this.currentZoom += (this.targetZoom - this.currentZoom) * LERP_SPEED;
+    // Same easing curve, expressed against elapsed time rather than frame count.
+    // dt is clamped upstream by Pixi's minFPS, so a floor that was paused for an
+    // hour resumes with k near 1 (the camera snaps to its target) rather than
+    // jumping past it.
+    const k = timeScaledLerp(LERP_SPEED, dt, REF_HZ);
+    this.currentX += (this.targetX - this.currentX) * k;
+    this.currentY += (this.targetY - this.currentY) * k;
+    this.currentZoom += (this.targetZoom - this.currentZoom) * k;
 
     if (this.nudgeDuration > 0) {
       this.nudgeElapsed += dt;

--- a/src/renderer/src/scene/office/Character.ts
+++ b/src/renderer/src/scene/office/Character.ts
@@ -1,6 +1,6 @@
 import { Container, Graphics, Texture } from 'pixi.js';
 import { CharacterSprite, type Direction, type AnimState } from './CharacterSprite';
-import { findPath } from './pathfinding';
+import { advanceAlongPath, findPath } from './pathfinding';
 import type { TiledMapRenderer } from './TiledMapRenderer';
 import { ThoughtBubble } from './ThoughtBubble';
 
@@ -553,6 +553,12 @@ export class Character {
     this.thoughtBubble.update(dt);
     if (!this.isVisible) return;
 
+    // The walk/idle cycle now rides the floor's clock rather than Ticker.shared
+    // (see CharacterSprite), so it stops with the floor and never animates faster
+    // than the scene is drawn. An invisible character returns above and freezes,
+    // which is what we want.
+    this.sprite.advance(dt);
+
     // Working agents stay seated; between tasks they wander the office.
     // A cheer, a watering or a cigar holds roaming so the effect plays in place.
     const heldByFx = this.cheerT >= 0 || this.waterT >= 0 || this.smokeT >= 0;
@@ -790,25 +796,29 @@ export class Character {
       return;
     }
 
-    const target = this.path[0];
+    // Spend the whole frame's movement, crossing as many waypoints as it covers.
+    // Reaching a tile used to cost the REST of that frame's movement (the old
+    // `dist < 1` branch snapped and returned), which is a stall every time a
+    // character crosses a tile boundary. At 120 fps that is one frame in forty and
+    // nobody sees it; at 20 fps it is one frame in seven and the character visibly
+    // limps. Distance per second is now a function of elapsed time alone.
     const ts = this.mapRenderer.tileSize;
-    const targetPx = target.x * ts + ts / 2;
-    const targetPy = target.y * ts + ts;
-    const dx = targetPx - this.px;
-    const dy = targetPy - this.py;
-    const dist = Math.sqrt(dx * dx + dy * dy);
+    const fromX = this.px;
+    const fromY = this.py;
+    const step = advanceAlongPath(
+      this.px, this.py, this.path,
+      (tile) => ({ x: tile.x * ts + ts / 2, y: tile.y * ts + ts }),
+      SPEED * dt
+    );
+    this.px = step.x;
+    this.py = step.y;
+    if (step.consumed > 0) this.path.splice(0, step.consumed);
 
-    if (dist < 1) {
-      this.px = targetPx;
-      this.py = targetPy;
-      this.path.shift();
-      return;
+    const dx = this.px - fromX;
+    const dy = this.py - fromY;
+    if (dx !== 0 || dy !== 0) {
+      this.direction = Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up');
     }
-
-    const step = Math.min(SPEED * dt, dist);
-    this.px += (dx / dist) * step;
-    this.py += (dy / dist) * step;
-    this.direction = Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up');
     this.sprite.setAnimation('walk', this.direction);
     this.sprite.setPosition(this.px, this.py);
   }

--- a/src/renderer/src/scene/office/CharacterSprite.ts
+++ b/src/renderer/src/scene/office/CharacterSprite.ts
@@ -1,4 +1,4 @@
-import { AnimatedSprite, Container, Graphics, Texture } from 'pixi.js';
+import { AnimatedSprite, Container, Graphics, Texture, type Ticker } from 'pixi.js';
 
 export type Direction = 'down' | 'up' | 'right' | 'left';
 export type AnimState = 'walk' | 'type' | 'read' | 'idle';
@@ -43,6 +43,15 @@ export class CharacterSprite {
     this.sprite = new AnimatedSprite(initialFrames);
     this.sprite.anchor.set(0.5, 1);
     this.sprite.animationSpeed = this.frameSpeed;
+    // Pixi's AnimatedSprite defaults to autoUpdate, which subscribes it to
+    // Ticker.shared — a SECOND requestAnimationFrame loop, running at the display's
+    // full rate whatever the floor's own ticker is capped to, and still running
+    // while the floor is paused behind a fullscreen terminal or the IDE. On a floor
+    // of twenty agents that is twenty sprite updates 120 times a second producing
+    // texture swaps the renderer never draws. Drive it from the scene's own tick
+    // instead, so the walk cycle shares one clock with everything else: capped with
+    // the floor, and stopped with it.
+    this.sprite.autoUpdate = false;
     this.sprite.play();
     // Anchor is (0.5, 1): in container space the sprite spans x∈[-w/2, w/2],
     // y∈[-h, 0] (feet at the origin). Used by the seated leg-crop mask.
@@ -82,6 +91,18 @@ export class CharacterSprite {
     this.cropMask.visible = true;
     this.sprite.mask = this.cropMask;
   }
+
+  /** Advance the walk/idle cycle by `dt` seconds.
+   *
+   *  AnimatedSprite.update() reads exactly one field off what it is handed —
+   *  `deltaTime`, in 60 Hz frames — so a reused scratch object drives it without
+   *  allocating per character per frame or owning a second Ticker. */
+  advance(dt: number): void {
+    CharacterSprite.beat.deltaTime = dt * 60;
+    this.sprite.update(CharacterSprite.beat);
+  }
+
+  private static readonly beat = { deltaTime: 0 } as unknown as Ticker;
 
   private getFrames(direction: Direction, anim: AnimState): Texture[] {
     const row = DIRECTION_ROW[direction];

--- a/src/renderer/src/scene/office/OfficeFloor.tsx
+++ b/src/renderer/src/scene/office/OfficeFloor.tsx
@@ -79,36 +79,6 @@ interface Runtime {
  *  reads like real work completed when none did. */
 const CHEER_MIN_BUSY_MS = 60_000;
 
-/** Frame-rate ceiling for the office scene.
- *
- *  Measured on a live floor, interleaved up and back down in one session so the
- *  agents' own varying workload cancels rather than being credited to the cap
- *  (% of one CPU core, renderer process / GPU process):
- *
- *    uncapped (120 Hz)   26.7 / 16.9
- *    60 fps              19.7 /  9.3
- *    30 fps              15.1 /  6.6
- *    20 fps              12.7 /  5.8
- *    15 fps              12.7 /  5.7
- *
- *  20 and 15 are the same number, which is what picks the default: below about 20
- *  there is nothing left to take, because what remains is React, the terminals and
- *  compositing, none of which is this ticker. Going lower buys nothing and only
- *  costs smoothness.
- *
- *  Be honest about the trade: 120 fps IS smoother, and the floor at 20 does not
- *  look identical. What a lower cap does not change is SPEED — after the motion
- *  fixes below (Character.updateWalk, Camera.update), everything covers the same
- *  ground per second and simply does it in fewer steps.
- *
- *  Smoothness is worth trading here because this is ambient decoration that never
- *  stops: an idle office nobody is tracking, redrawn as fast as the display will
- *  accept for as long as the app is open, with a camera that never even pans
- *  (fitToScreen sets its target once and nothing else moves it). Uncapped it was
- *  the app's largest continuous cost, and on a laptop a continuous cost is
- *  battery. A novelty animation should not be why a machine runs hot. */
-const FLOOR_MAX_FPS = 20;
-
 /** What an avatar mutters per errand, picked at random. */
 const ERRAND_THOUGHTS: Record<ErrandKind, readonly string[]> = {
   water:     ['watering the plants 🌿', 'giving the plants a drink', 'they grow so fast'],
@@ -231,6 +201,16 @@ export function OfficeFloor() {
     return () => document.removeEventListener('visibilitychange', onVis);
   }, []);
   const paused = !!fullscreenAgentId || ideOpen || docHidden;
+  // The frame-rate ceiling (Settings → General; see @shared/floorFps for what
+  // each rate costs). Applied to the LIVE ticker, so changing it repaints at the
+  // new rate immediately instead of waiting for a scene rebuild.
+  const floorMaxFps = useStore((s) => s.floorMaxFps);
+  const maxFpsRef = useRef(floorMaxFps);
+  useEffect(() => {
+    maxFpsRef.current = floorMaxFps;
+    const ticker = appRef.current?.ticker;
+    if (ticker) ticker.maxFPS = floorMaxFps;
+  }, [floorMaxFps]);
   // Read inside init(), which finishes asynchronously and would otherwise start a
   // ticker the effect below had already been asked to stop.
   const pausedRef = useRef(paused);
@@ -1740,7 +1720,7 @@ export function OfficeFloor() {
       // (see Camera.update and Character.updateWalk). Without those a capped floor
       // would take five seconds to settle its fit after a window resize instead of
       // 1.6, and its characters would walk at 83% speed.
-      app.ticker.maxFPS = FLOOR_MAX_FPS;
+      app.ticker.maxFPS = maxFpsRef.current;
       // init() is async: the floor may already be behind a fullscreen terminal by
       // the time we get here, and app.init() starts the ticker itself.
       if (pausedRef.current) app.ticker.stop();

--- a/src/renderer/src/scene/office/OfficeFloor.tsx
+++ b/src/renderer/src/scene/office/OfficeFloor.tsx
@@ -79,6 +79,36 @@ interface Runtime {
  *  reads like real work completed when none did. */
 const CHEER_MIN_BUSY_MS = 60_000;
 
+/** Frame-rate ceiling for the office scene.
+ *
+ *  Measured on a live floor, interleaved up and back down in one session so the
+ *  agents' own varying workload cancels rather than being credited to the cap
+ *  (% of one CPU core, renderer process / GPU process):
+ *
+ *    uncapped (120 Hz)   26.7 / 16.9
+ *    60 fps              19.7 /  9.3
+ *    30 fps              15.1 /  6.6
+ *    20 fps              12.7 /  5.8
+ *    15 fps              12.7 /  5.7
+ *
+ *  20 and 15 are the same number, which is what picks the default: below about 20
+ *  there is nothing left to take, because what remains is React, the terminals and
+ *  compositing, none of which is this ticker. Going lower buys nothing and only
+ *  costs smoothness.
+ *
+ *  Be honest about the trade: 120 fps IS smoother, and the floor at 20 does not
+ *  look identical. What a lower cap does not change is SPEED — after the motion
+ *  fixes below (Character.updateWalk, Camera.update), everything covers the same
+ *  ground per second and simply does it in fewer steps.
+ *
+ *  Smoothness is worth trading here because this is ambient decoration that never
+ *  stops: an idle office nobody is tracking, redrawn as fast as the display will
+ *  accept for as long as the app is open, with a camera that never even pans
+ *  (fitToScreen sets its target once and nothing else moves it). Uncapped it was
+ *  the app's largest continuous cost, and on a laptop a continuous cost is
+ *  battery. A novelty animation should not be why a machine runs hot. */
+const FLOOR_MAX_FPS = 20;
+
 /** What an avatar mutters per errand, picked at random. */
 const ERRAND_THOUGHTS: Record<ErrandKind, readonly string[]> = {
   water:     ['watering the plants 🌿', 'giving the plants a drink', 'they grow so fast'],
@@ -1696,6 +1726,21 @@ export function OfficeFloor() {
         }
       };
       app.ticker.add(onTick);
+      // Cap the frame rate. Pixi's ticker follows requestAnimationFrame, which on a
+      // ProMotion Mac means 120 Hz: the whole scene re-renders 120 times a second at
+      // `resolution: 2` (four times the pixels of a logical one), and onTick above
+      // runs every character and every subsystem that often. Measured on a 16-inch
+      // MacBook Pro, rAF delivers 120.5 fps, so that is exactly twice the work a
+      // 60 Hz machine does for a floor nobody can see move any faster.
+      //
+      // Nothing on the floor is worth that. Every animation here is authored in
+      // seconds against ticker.deltaMS, so capping changes how SMOOTH the motion is
+      // and never how fast anything happens — the exceptions were the camera's
+      // per-frame lerp and the walk's per-frame waypoint, both fixed at their source
+      // (see Camera.update and Character.updateWalk). Without those a capped floor
+      // would take five seconds to settle its fit after a window resize instead of
+      // 1.6, and its characters would walk at 83% speed.
+      app.ticker.maxFPS = FLOOR_MAX_FPS;
       // init() is async: the floor may already be behind a fullscreen terminal by
       // the time we get here, and app.init() starts the ticker itself.
       if (pausedRef.current) app.ticker.stop();

--- a/src/renderer/src/scene/office/easing.ts
+++ b/src/renderer/src/scene/office/easing.ts
@@ -1,0 +1,26 @@
+/**
+ * Frame-rate-independent easing.
+ *
+ * The office scene eases the camera by moving a fixed FRACTION of the remaining
+ * distance each frame. That is the usual shortcut and it has the usual bug: the
+ * result depends on how often frames happen. The same constant converges twice as
+ * fast on a 120 Hz ProMotion panel as on a 60 Hz one, and slows down again the
+ * moment the ticker is capped.
+ *
+ * Converting the per-frame fraction to a per-second decay fixes both. Keeping a
+ * fraction `f` of the distance each frame leaves `(1 - f)^frames` after that many
+ * frames, so the elapsed-time equivalent is `1 - (1 - f)^(dt * refHz)`.
+ */
+
+/**
+ * @param perFrame fraction of the remaining distance to cover in one frame at `refHz` (0..1)
+ * @param dt       seconds elapsed since the last frame
+ * @param refHz    the rate `perFrame` was tuned against
+ * @returns        the fraction to cover for this frame, easing identically at any rate
+ */
+export function timeScaledLerp(perFrame: number, dt: number, refHz = 60): number {
+  if (!(dt > 0)) return 0;                 // no time passed (or NaN): no movement
+  if (perFrame <= 0) return 0;
+  if (perFrame >= 1) return 1;             // "snap" stays a snap at every rate
+  return 1 - Math.pow(1 - perFrame, dt * refHz);
+}

--- a/src/renderer/src/scene/office/pathfinding.ts
+++ b/src/renderer/src/scene/office/pathfinding.ts
@@ -64,3 +64,59 @@ function reconstructPath(parent: Map<string, Point>, start: Point, goal: Point):
 
   return path;
 }
+
+export interface PathStep {
+  /** New position after spending the movement budget. */
+  x: number;
+  y: number;
+  /** Waypoints fully reached this frame — splice this many off the front. */
+  consumed: number;
+  /** Budget left unspent because the path ran out. */
+  leftover: number;
+}
+
+/**
+ * Walk `budget` pixels along a path, crossing as many waypoints as the budget
+ * covers.
+ *
+ * The crossing part is the point. Advancing one waypoint per frame and dropping
+ * the rest of the budget makes a character's speed depend on the frame rate: it
+ * loses a frame of movement every time it reaches a tile, which at 120 fps is
+ * 2.5% of the frames and invisible, and at 20 fps is one frame in seven and reads
+ * as a limp. Spending the whole budget every frame makes distance travelled a
+ * function of elapsed time only, which is what lets the floor's frame rate be
+ * capped without the walk cycle changing character.
+ *
+ * `toPixel` converts a path waypoint to the pixel point the sprite aims at, and
+ * is called only for the waypoints actually examined (usually one).
+ */
+export function advanceAlongPath<T>(
+  x: number,
+  y: number,
+  path: readonly T[],
+  toPixel: (waypoint: T) => { x: number; y: number },
+  budget: number
+): PathStep {
+  let remaining = Math.max(0, budget);
+  let consumed = 0;
+  for (const waypoint of path) {
+    const target = toPixel(waypoint);
+    const dx = target.x - x;
+    const dy = target.y - y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist <= remaining) {
+      // Reached it. Land exactly on the waypoint and carry the rest onward, so
+      // a corner costs the distance to it and never a whole frame.
+      x = target.x;
+      y = target.y;
+      remaining -= dist;
+      consumed++;
+      continue;
+    }
+    x += (dx / dist) * remaining;
+    y += (dy / dist) * remaining;
+    remaining = 0;
+    break;
+  }
+  return { x, y, consumed, leftover: remaining };
+}

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -121,6 +121,8 @@ export interface HarnessConfig {
   tvShowOffices?: boolean;
   /** Active office map/cast theme (honored only when tvShowOffices is on). */
   officeTheme?: 'office' | 'friends' | 'brooklyn99' | 'siliconvalley' | 'got' | 'hogwarts';
+  /** Frame-rate ceiling for the office scene, in fps (0 = uncapped). */
+  floorMaxFps?: number;
   /** Per-CLI-provider local/self-hosted base URL (Ollama/LM Studio/vLLM, …) for the
    *  OpenCode/Crush/pi/qwen engines; applied at spawn. API KEYS are NOT stored here —
    *  they live write-only in the secret broker. */

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -16,6 +16,7 @@ import { DEFAULT_ORG_TRIGGER, type OrgTriggerConfig, type WebhookTrigger } from 
 import { isCompactionCommand } from '@shared/providerAutomation';
 import { preferredAgentRole } from '@shared/agentRole';
 import { isInboxNudge } from '@shared/hiveNudge';
+import { FLOOR_FPS_DEFAULT, resolveFloorFps } from '@shared/floorFps';
 import { refocusAfterRemoval, focusOnLoad, restoreFocus } from './focusMode';
 
 export type ToolKind =
@@ -271,6 +272,10 @@ interface State {
   /** Mirror of the active office theme (set by App on config load + by Settings
    *  on switch). OfficeFloor depends on this and rebuilds the scene on change. */
   officeTheme: ThemeId;
+  /** Frame-rate ceiling for the office scene, in fps (0 = uncapped). Mirrors
+   *  config.floorMaxFps so OfficeFloor can react without re-reading config. */
+  floorMaxFps: number;
+  setFloorMaxFps: (fps: number) => void;
   setOfficeTheme: (theme: ThemeId) => void;
   /** Mirror of config.webhookTriggers — the inbound HTTP endpoints. Webhooks are
    *  editable from BOTH Settings → Connections and the Triggers tab, so neither
@@ -850,6 +855,8 @@ export const useStore = create<State>((set, get) => ({
   setHasOpenAiKey: (has) => set({ hasOpenAiKey: has }),
   officeTheme: 'office',
   setOfficeTheme: (theme) => set({ officeTheme: theme }),
+  floorMaxFps: FLOOR_FPS_DEFAULT,
+  setFloorMaxFps: (fps) => set({ floorMaxFps: resolveFloorFps(fps) }),
   webhookTriggers: [],
   setWebhookTriggers: (list) => set({ webhookTriggers: list }),
   // A copy, not the shared DEFAULT_ORG_TRIGGER instance — main takes the same

--- a/src/shared/floorFps.ts
+++ b/src/shared/floorFps.ts
@@ -1,0 +1,61 @@
+/**
+ * Frame-rate choices for the pixel office scene.
+ *
+ * The floor is ambient decoration: an idle office nobody is tracking, animating
+ * for as long as the app is open whether or not anyone is looking at it. Pixi's
+ * ticker follows requestAnimationFrame, so left uncapped it runs at whatever the
+ * display offers — 120 fps on a ProMotion Mac, which is twice the work a 60 Hz
+ * machine does for the same scene.
+ *
+ * Measured on a live floor, interleaved up and back down in one session so the
+ * agents' own varying workload cancels (% of one CPU core, renderer / GPU):
+ *
+ *   uncapped (120 Hz)   26.7 / 16.9
+ *   60 fps              19.7 /  9.3
+ *   30 fps              15.1 /  6.6
+ *   20 fps              12.7 /  5.8
+ *   15 fps              12.7 /  5.7
+ *
+ * 20 and 15 are the same number. That is why the default is 20 and not lower:
+ * below about 20 there is nothing left to take, because what remains is React,
+ * the terminals and compositing, none of which is the scene's ticker — so
+ * dropping to 15 buys nothing and only costs smoothness.
+ *
+ * The rate does not change how fast anything MOVES — the floor's motion is a
+ * function of elapsed time, so a character covers the same ground per second at
+ * every setting and simply does it in fewer steps. It changes how SMOOTH that
+ * motion looks, which is a real thing to want and the reason this is a choice
+ * rather than a constant. The default is low because on a laptop a continuous
+ * cost is battery, and a novelty animation should not be why a machine runs hot.
+ */
+
+export interface FloorFpsChoice {
+  /** Ceiling in fps. 0 means uncapped: follow the display. */
+  fps: number;
+  label: string;
+  /** One-line consequence, shown beside the label in Settings. */
+  note: string;
+}
+
+export const FLOOR_FPS_DEFAULT = 20;
+
+export const FLOOR_FPS_CHOICES: readonly FloorFpsChoice[] = [
+  { fps: 15, label: '15 fps',   note: 'no cheaper than 20 in practice' },
+  { fps: 20, label: '20 fps',   note: 'default — the floor costs about half' },
+  { fps: 30, label: '30 fps',   note: 'smoother, about a fifth more CPU' },
+  { fps: 60, label: '60 fps',   note: 'smooth, at roughly 1.5× the default' },
+  { fps: 0,  label: 'Uncapped', note: 'follows the display; twice the cost at 120 Hz' }
+];
+
+/**
+ * Coerce a stored value into a supported rate.
+ *
+ * Anything unrecognised falls back to the default rather than being trusted:
+ * a hand-edited config should not be able to pin the scene at 240 fps or at
+ * something Pixi will clamp (below its own minFPS, movement silently slows).
+ */
+export function resolveFloorFps(value: unknown): number {
+  return typeof value === 'number' && FLOOR_FPS_CHOICES.some((choice) => choice.fps === value)
+    ? value
+    : FLOOR_FPS_DEFAULT;
+}

--- a/test/floor-fps.test.cjs
+++ b/test/floor-fps.test.cjs
@@ -1,0 +1,43 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { FLOOR_FPS_CHOICES, FLOOR_FPS_DEFAULT, resolveFloorFps } =
+  loadTs('src/shared/floorFps.ts');
+
+// The office scene's frame rate is user-settable, which means the value reaching
+// Pixi's ticker comes off disk and cannot be trusted. Anything unrecognised has
+// to land on the default rather than be passed through: below Pixi's own minFPS
+// the ticker clamps elapsed time and every character silently walks slow, and a
+// hand-edited 240 would reinstate exactly the cost this setting exists to cap.
+
+test('every offered rate survives the round trip', () => {
+  for (const choice of FLOOR_FPS_CHOICES) {
+    assert.equal(resolveFloorFps(choice.fps), choice.fps, `${choice.label} was rejected`);
+  }
+});
+
+test('the default is one of the offered rates', () => {
+  assert.ok(FLOOR_FPS_CHOICES.some((c) => c.fps === FLOOR_FPS_DEFAULT));
+});
+
+test('uncapped is offered, and is zero — the value Pixi reads as no cap', () => {
+  assert.ok(FLOOR_FPS_CHOICES.some((c) => c.fps === 0));
+});
+
+test('anything else falls back to the default', () => {
+  for (const bad of [240, 1, -30, 22.5, NaN, Infinity, '30', null, undefined, {}, []]) {
+    assert.equal(resolveFloorFps(bad), FLOOR_FPS_DEFAULT,
+      `${String(bad)} should not have been accepted`);
+  }
+});
+
+test('the choices are unique and each carries a label and a note', () => {
+  const rates = FLOOR_FPS_CHOICES.map((c) => c.fps);
+  assert.equal(new Set(rates).size, rates.length, 'a rate is listed twice');
+  for (const c of FLOOR_FPS_CHOICES) {
+    assert.ok(c.label && c.note, `${c.fps} is missing its label or note`);
+  }
+});

--- a/test/frame-rate-easing.test.cjs
+++ b/test/frame-rate-easing.test.cjs
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { timeScaledLerp } = loadTs('src/renderer/src/scene/office/easing.ts');
+
+// The office camera used to move a fixed fraction of the remaining distance per
+// FRAME, which quietly made its easing a function of the display: the same pan
+// finished twice as fast on a 120 Hz ProMotion panel as on a 60 Hz one, and would
+// have crawled once the floor's ticker was capped. These pin the conversion.
+
+const PER_FRAME = 0.08; // the camera's LERP_SPEED
+
+/** Distance still remaining after easing for `seconds` at `hz`. */
+function remainingAfter(seconds, hz) {
+  const dt = 1 / hz;
+  let remaining = 1;
+  for (let t = 0; t < seconds - 1e-9; t += dt) remaining -= remaining * timeScaledLerp(PER_FRAME, dt);
+  return remaining;
+}
+
+test('one frame at the reference rate is the authored fraction', () => {
+  // Not assert.equal: the round trip through pow() lands a float ulp away.
+  assert.ok(Math.abs(timeScaledLerp(PER_FRAME, 1 / 60) - PER_FRAME) < 1e-12);
+});
+
+test('the same wall-clock easing comes out at 30, 60 and 120 Hz', () => {
+  const at60 = remainingAfter(1, 60);
+  for (const hz of [30, 120, 144]) {
+    assert.ok(Math.abs(remainingAfter(1, hz) - at60) < 1e-9,
+      `${hz} Hz drifted from 60 Hz: ${remainingAfter(1, hz)} vs ${at60}`);
+  }
+});
+
+test('a capped frame rate no longer slows the camera down', () => {
+  // The bug, stated as a test: the raw per-frame constant covers half as much
+  // ground in a second when the frame rate halves.
+  const raw = (hz) => { let r = 1; for (let i = 0; i < hz; i++) r -= r * PER_FRAME; return r; };
+  assert.ok(raw(60) > raw(120), 'sanity: the raw constant is rate-dependent');
+  assert.ok(Math.abs(remainingAfter(1, 60) - remainingAfter(1, 120)) < 1e-9,
+    'the scaled version is not');
+});
+
+test('no time elapsed means no movement', () => {
+  assert.equal(timeScaledLerp(PER_FRAME, 0), 0);
+  assert.equal(timeScaledLerp(PER_FRAME, -1), 0);
+  assert.equal(timeScaledLerp(PER_FRAME, NaN), 0);
+});
+
+test('a long stall eases toward the target without overshooting it', () => {
+  // Pixi clamps elapsedMS to minFPS, but the maths must hold anyway: a resumed
+  // floor should snap to the target, never sail past it.
+  for (const dt of [1, 10, 3600]) {
+    const k = timeScaledLerp(PER_FRAME, dt);
+    assert.ok(k > 0.99 && k <= 1, `dt=${dt}s produced ${k}`);
+  }
+});
+
+test('the degenerate fractions stay degenerate at every rate', () => {
+  assert.equal(timeScaledLerp(0, 1 / 60), 0);
+  assert.equal(timeScaledLerp(1, 1 / 120), 1);
+});

--- a/test/walk-frame-rate.test.cjs
+++ b/test/walk-frame-rate.test.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { advanceAlongPath } = loadTs('src/renderer/src/scene/office/pathfinding.ts');
+
+// An office character walks a tile path at a fixed px/sec. It used to advance at
+// most ONE waypoint per frame and throw away the rest of that frame's movement,
+// which made its speed a function of the frame rate: a stall every time it
+// crossed a tile. At 120 fps that is one frame in forty. At 20 fps it is one in
+// seven, and it reads as the character limping. These pin distance travelled to
+// elapsed time and nothing else.
+
+const TILE = 16;
+const SPEED = 48;                                   // px/sec, Character.ts
+const toPixel = (t) => ({ x: t.x * TILE + TILE / 2, y: t.y * TILE + TILE });
+const straightPath = (n) => Array.from({ length: n }, (_, i) => ({ x: i + 1, y: 0 }));
+
+/** Walk for `seconds` at `fps` and report how far along the path we got. */
+function walk(fps, seconds, pathLength = 40) {
+  const path = straightPath(pathLength);
+  const start = toPixel({ x: 0, y: 0 });
+  let { x, y } = start;
+  const dt = 1 / fps;
+  for (let i = 0; i < Math.round(seconds * fps); i++) {
+    const step = advanceAlongPath(x, y, path, toPixel, SPEED * dt);
+    x = step.x; y = step.y;
+    if (step.consumed > 0) path.splice(0, step.consumed);
+  }
+  return Math.hypot(x - start.x, y - start.y);
+}
+
+/** The old one-waypoint-per-frame rule, kept here as the thing being fixed. */
+function walkOneWaypointPerFrame(fps, seconds, pathLength = 40) {
+  const path = straightPath(pathLength);
+  const start = toPixel({ x: 0, y: 0 });
+  let { x, y } = start;
+  const dt = 1 / fps;
+  for (let i = 0; i < Math.round(seconds * fps); i++) {
+    const target = toPixel(path[0]);
+    const dx = target.x - x, dy = target.y - y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < 1) { x = target.x; y = target.y; path.shift(); continue; }
+    const step = Math.min(SPEED * dt, dist);
+    x += (dx / dist) * step; y += (dy / dist) * step;
+  }
+  return Math.hypot(x - start.x, y - start.y);
+}
+
+test('a character covers the same ground per second at any frame rate', () => {
+  const at120 = walk(120, 2);
+  for (const fps of [60, 30, 20, 15]) {
+    const drift = Math.abs(walk(fps, 2) - at120);
+    assert.ok(drift < 0.001, `${fps} fps drifted ${drift.toFixed(3)}px from 120 fps`);
+  }
+});
+
+test('two seconds of walking is twice one second of it', () => {
+  for (const fps of [120, 20]) {
+    assert.ok(Math.abs(walk(fps, 2) - 2 * walk(fps, 1)) < 0.001, `${fps} fps is not linear in time`);
+  }
+});
+
+test('the old rule really did slow down as the frame rate dropped', () => {
+  // Guards the regression: if someone reinstates one-waypoint-per-frame, the
+  // test above starts failing and this one explains why it mattered.
+  const fast = walkOneWaypointPerFrame(120, 2);
+  const slow = walkOneWaypointPerFrame(20, 2);
+  assert.ok(slow < fast * 0.95,
+    `expected the old rule to lose ground at 20 fps (120fps: ${fast.toFixed(1)}px, 20fps: ${slow.toFixed(1)}px)`);
+});
+
+test('a frame that spans several waypoints crosses all of them', () => {
+  const path = straightPath(5);
+  // Three tiles' worth of budget in a single frame.
+  const step = advanceAlongPath(toPixel({ x: 0, y: 0 }).x, toPixel({ x: 0, y: 0 }).y, path, toPixel, TILE * 3);
+  assert.equal(step.consumed, 3);
+  assert.equal(step.leftover, 0);
+});
+
+test('running out of path returns the unspent budget instead of overshooting', () => {
+  const path = straightPath(1);
+  const start = toPixel({ x: 0, y: 0 });
+  const step = advanceAlongPath(start.x, start.y, path, toPixel, TILE * 10);
+  assert.equal(step.consumed, 1);
+  assert.equal(step.x, toPixel({ x: 1, y: 0 }).x, 'lands exactly on the last waypoint');
+  assert.ok(step.leftover > 0, 'and reports what it could not spend');
+});
+
+test('an empty path consumes nothing and moves nowhere', () => {
+  const step = advanceAlongPath(10, 20, [], toPixel, 999);
+  assert.deepEqual({ x: step.x, y: step.y, consumed: step.consumed }, { x: 10, y: 20, consumed: 0 });
+});


### PR DESCRIPTION
## What & why

> **Stacked on #273.** That PR caps the floor's frame rate and is the first commit here;
> this PR is the second. Review #273 first — once it merges, this diff is just the
> setting.

#273 lands the frame-rate ceiling as a constant. A constant is the wrong shape for it.
Smoothness is a legitimate thing to want, the cost of wanting it depends on hardware
nobody in this repo can see, and on a desktop that is never on battery the power may
simply not matter. Picking one rate for everyone decides that on their behalf.

Settings → General now offers **15 / 20 / 30 / 60 / uncapped**, each labelled with what
it costs rather than a bare number, so the choice can be made without reading the
source. Applying is instant and reversible: the store mirror drives the live Pixi
ticker, so the floor repaints at the new rate on click. Nothing here is destructive and
there is nothing to confirm.

**The default stays 20**, because it measures the same as 15 on the machine this was
profiled on — the cheapest rate that is not needlessly choppy. The full table lives in
`src/shared/floorFps.ts` next to the choices it justifies, so the numbers and the
options cannot drift apart.

**On validation.** This value reaches Pixi's ticker off disk, so it is not trusted.
Anything unrecognised falls back to the default: a hand-edited rate below Pixi's own
`minFPS` makes the ticker clamp elapsed time, which silently slows every character
down rather than failing, and a hand-edited 240 would reinstate exactly the cost the
setting exists to cap. `resolveFloorFps` is a pure function with tests covering the
offered rates, the fallbacks, and that uncapped stays `0` — the value Pixi reads as
no cap.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

The same Settings → General section, same window, same dark theme, rendered from the
real component.

### Before
![Settings General: the section ends, with no frame-rate control](https://raw.githubusercontent.com/L422Y/munder-difflin/assets/askme-markdown/evidence/floor-fps/setting-before.png)

### After
![Settings General: a Floor frame rate control offering 15, 20, 30, 60 and uncapped, with 20 selected](https://raw.githubusercontent.com/L422Y/munder-difflin/assets/askme-markdown/evidence/floor-fps/setting-after.png)

## How I tested it

- OS: macOS (Darwin 25.3), Node 24, 16-inch MacBook Pro (120 Hz Liquid Retina XDR).

- Steps:
  - `npm run typecheck`, `npm run test:focused` (569 pass, 5 of them new), `npm run build`.
  - Restarted the app and confirmed the new default reaches disk: `config.json` comes
    back with `"floorMaxFps": 20`.
  - Confirmed the value actually reaches the ticker, by toggling **only** the store
    mirror on a running dev build and measuring the floor (% of one core, renderer /
    GPU, 22-second windows, alternated twice):

    | store value | renderer | GPU |
    |---|---|---|
    | uncapped | 25.8, 25.6 | 15.9, 11.8 |
    | 20 fps | 14.7, 10.3 | 7.0, 4.9 |

    No restart and no scene rebuild between those — the ticker picks the new ceiling up
    from the store effect, which is the behaviour the picker relies on to apply on click.
  - For the screenshots: mounted the real `FloorFpsPicker` in a throwaway page outside
    the repo against a stubbed `window.cth`, with the app's own `tokens.css` and
    `global.css`. It is the real component and the real stylesheet, not the whole
    Electron window, so the Settings chrome around it is not in frame.

  - Clicked the control in the running app. The floor changes rate immediately, and the
    choice is on disk by the time the click lands: `config.json` came back with the
    newly-picked rate, written seconds earlier. Read, apply and write are all confirmed
    against a real build.

Not done: verified on a 60 Hz display, where every rate above 60 collapses to the same
thing, or on Windows and Linux.

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change** — the setting. The cap itself is #273.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — the picker uses the paper,
      ink and lilac tokens and the display/mono faces, no ad-hoc values.
- [ ] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`. (No art.)
