### PR TITLE
feat(settings): move the save button into the modal footer beside close

### DIFF
--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1237,10 +1237,6 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                               {brkHardStop ? 'kill on trip' : 'steer first'}
                             </PixelButton>
                           </div>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                            <PixelButton variant="secondary" size="sm" onClick={saveBudget}>save</PixelButton>
-                            {budgetNote && <span style={{ fontSize: 12, color: 'var(--cth-mint)' }}>{budgetNote}</span>}
-                          </div>
                         </div>
                       </div>
                     </>
@@ -2026,10 +2022,16 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
               <div style={{
                 borderTop: '2px solid var(--cth-ink-300)',
                 padding: '10px 16px',
-                display: 'flex', justifyContent: 'flex-end',
+                display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 8,
                 background: 'var(--cth-cream-50)'
               }}>
+                {activeSection === 'Autonomy & Budgets' && budgetNote && (
+                  <span style={{ fontSize: 12, color: 'var(--cth-mint)' }}>{budgetNote}</span>
+                )}
                 <PixelButton variant="secondary" size="md" onClick={onClose}>close</PixelButton>
+                {activeSection === 'Autonomy & Budgets' && (
+                  <PixelButton variant="primary" size="md" onClick={saveBudget}>save</PixelButton>
+                )}
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary

**Problem:** In Settings → Autonomy & Budgets, the `save` button sat inline at the bottom of the panel content, far from the `close` button in the window's footer bar. This makes it easy to miss, and is not intuitive as have the save button in the footer.

**Solution:** `save` now sits in the footer, immediately to the right of `close`, matching the rest of the app. The "saved" confirmation message moves with it, so the feedback still appears next to the button that produced it. Nothing about *what* gets saved changed — only where the button lives.

## TLDR for developers

One file, `src/renderer/src/components/SettingsModal.tsx`, 12 lines:

- Removed the inline row that held `<PixelButton size="sm" onClick={saveBudget}>save</PixelButton>` plus the `budgetNote` span from the bottom of the Autonomy & Budgets panel.
- The shared footer gains `alignItems: 'center', gap: 8` and two `activeSection === 'Autonomy & Budgets'`-gated children rendered around the untouched `close` button: the `budgetNote` span before it, the `save` button after it.
- `save` is `variant="primary"` / `size="md"` rather than the `secondary`/`sm` it carried inline, because that is what the right-hand footer action uses in `EditAgentModal` (`save changes`) and `AddAgentModal` (`spawn`).

Why gated rather than always-on: the other six sections have no single section-wide save action — they save inline per field group or on blur — so an unconditional footer `save` would need a handler invented for each of them. Gating keeps the change to the one section that already had a section-wide `saveBudget`.

`saveBudget` itself, the note's 1.5s auto-clear, and all form state are untouched.

## What & why

Settings was the only modal in the app whose footer held a lone `close`. `EditAgentModal`, `AddAgentModal`, and `QuitWarningModal` all use the same footer shape — dismiss on the left, action on the right, `justifyContent: 'flex-end'`, `gap: 8`, `size="md"` — so this brings Settings in line with the established pattern rather than inventing a new one.

The footer is shared by all seven settings sections, so both new children are gated on the active section: only Autonomy & Budgets shows `save`, and the other six sections keep a lone `close` exactly as before. There is precedent for a context-dependent footer in `OnboardingWizard`, which varies its footer buttons by `step`.



This came out of the discussion in #263, where I suggested moving the button. To be explicit though: **this PR does not fix #263.** That toggle saves itself on click and never needed the `save` button — the persistence bug there is a stale-prop issue in the modal's field seeding, which this PR does not touch. Root cause written up in https://github.com/chaitanyagiri/munder-difflin/issues/263#issuecomment-5401958435.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
<img width="899" height="679" alt="Screenshot 2026-08-24 at 4 36 53 PM" src="https://github.com/user-attachments/assets/0b2e32ea-e914-4d3d-af3c-a4796d775e77" />

<!-- screenshot: inline `save` at the bottom of the Autonomy & Budgets panel, lone `close` in the footer -->

### After
<img width="878" height="592" alt="Screenshot 2026-08-24 at 5 14 31 PM" src="https://github.com/user-attachments/assets/8fb4a83a-8c8b-4e45-9e54-f53ccba2dfd9" />

<!-- screenshot: footer reads `close` `save`, inline save gone -->

## How I tested it

- OS: macOS 15 (Darwin 25.5.0), Electron 32.3.3, Node 22.23.2
- Steps:
  1. `npm run dev`, opened Settings → Autonomy & Budgets.
  2. Set FLOOR TOKEN BUDGET, TOKEN VELOCITY, REPEATED-TOOL LIMIT and ERROR-STORM LIMIT, clicked the footer `save`, and confirmed all four values were written to `config.json` (`costCapTokens: 111111`, `tokenVelocityPerMin: 2222`, `repeatedToolLimit: 33`, `errorStormLimit: 44`) — so the relocated button invokes `saveBudget` exactly as the inline one did.
  3. Clicked through General, Prerequisites, Agents & Models, Connections, Voice and Memory & Knowledge to confirm each still shows a lone `close` with no `save`.
  4. Confirmed the mint "saved" note renders to the left of `close` after a save and clears on its existing 1.5s timer.
  5. `npm run typecheck` → clean. `npm run test:focused` → 552 passing, 0 failing. `npm run build` → succeeds.

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [ ] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.


