### PR TITLE
fix(config): announce every config write so Settings stops showing stale values

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -621,19 +621,11 @@ function normalizeStoredHomes(cfg: HarnessConfig): HarnessConfig {
   return cfg;
 }
 
-/** Every persisted config write is announced here.
+/** Announces every saved setting, so a screen showing one can update.
  *
- *  The renderer holds the config as a snapshot loaded once at start-up, so
- *  before this existed a write reached disk but nothing told the UI, and any
- *  view seeded from that snapshot kept showing the pre-write value until the
- *  app restarted. Settings was the visible casualty: a toggle wrote correctly,
- *  then re-read the stale snapshot on reopen and displayed the old state (#263).
- *
- *  This sits on `persistConfig` rather than on `writeConfig` deliberately —
- *  `writeConfig` is one of 23 callers across the main process, and Slack,
- *  freeflow and notifications each persist through their own path. The file
- *  write is the only point every one of them has in common, so subscribing here
- *  is the difference between "the fields we remembered" and "all of them". */
+ *  Settings, Slack, voice and notifications each save by their own route, and
+ *  all of them end up writing the file below — so one subscription here covers
+ *  every setting rather than the ones anybody remembered to wire up. */
 type ConfigWriteListener = (next: HarnessConfig) => void;
 const configWriteListeners = new Set<ConfigWriteListener>();
 
@@ -646,19 +638,15 @@ function persistConfig(next: HarnessConfig): HarnessConfig {
   const p = configPath();
   mkdirSync(dirname(p), { recursive: true });
   writeFileSync(p, JSON.stringify(next, null, 2), 'utf8');
-  // Subscribers get the config in the same shape `readConfig` hands out, NOT the
-  // object we just wrote. They are the second source feeding a renderer that also
-  // calls config:get, and a patch touching one nested key persists a half-filled
-  // sub-object — `withTriggerDefaults` is what deep-fills it on the way out, so
-  // skipping it here would let a consumer read `undefined` from a trigger it had
-  // read a number from a moment earlier. The migration is deliberately not run:
-  // it persists, and it has already been applied to the config this patch built on.
+  // Saving one setting stores only that setting, so fill the rest back in first:
+  // subscribers must see the same complete config a read gives them, never a
+  // half-filled one. Skip the migration — it saves in its own right, and has
+  // already run against what this change was built on.
   const view = normalizeStoredHomes(withTriggerDefaults({ ...DEFAULTS, ...next }));
-  // A listener is a renderer send, which can fail while a window is closing.
-  // The config is already on disk by this point, so a throwing subscriber must
-  // neither fail the write for its caller nor starve the subscribers after it.
+  // The change is already saved, so one failed subscriber must not fail the save
+  // for its caller, nor stop the subscribers after it.
   for (const listener of configWriteListeners) {
-    try { listener(view); } catch { /* a broken listener is not a failed write */ }
+    try { listener(view); } catch { /* a broken listener is not a failed save */ }
   }
   return next;
 }
@@ -728,8 +716,7 @@ export function setAgentTokenCap(agentId: unknown, tokenCap: unknown): HarnessCo
 /** Wipe the persisted config back to first-run defaults so the app boots into
  *  onboarding again. Used by the "reset & start over" flow. */
 export function resetConfig(): HarnessConfig {
-  // Routed through persistConfig so the reset announces itself like any other
-  // write; the bytes written are the same DEFAULTS as before.
+  // Saved like any other change, so a reset announces itself too.
   persistConfig({ ...DEFAULTS });
   // Drop the migration latch too: the file on disk is back to `triggersMigratedV1:
   // false`, and a latch left set would keep the flag from ever being written again

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -621,10 +621,37 @@ function normalizeStoredHomes(cfg: HarnessConfig): HarnessConfig {
   return cfg;
 }
 
+/** Every persisted config write is announced here.
+ *
+ *  The renderer holds the config as a snapshot loaded once at start-up, so
+ *  before this existed a write reached disk but nothing told the UI, and any
+ *  view seeded from that snapshot kept showing the pre-write value until the
+ *  app restarted. Settings was the visible casualty: a toggle wrote correctly,
+ *  then re-read the stale snapshot on reopen and displayed the old state (#263).
+ *
+ *  This sits on `persistConfig` rather than on `writeConfig` deliberately —
+ *  `writeConfig` is one of 23 callers across the main process, and Slack,
+ *  freeflow and notifications each persist through their own path. The file
+ *  write is the only point every one of them has in common, so subscribing here
+ *  is the difference between "the fields we remembered" and "all of them". */
+type ConfigWriteListener = (next: HarnessConfig) => void;
+const configWriteListeners = new Set<ConfigWriteListener>();
+
+export function onConfigWritten(listener: ConfigWriteListener): () => void {
+  configWriteListeners.add(listener);
+  return () => { configWriteListeners.delete(listener); };
+}
+
 function persistConfig(next: HarnessConfig): HarnessConfig {
   const p = configPath();
   mkdirSync(dirname(p), { recursive: true });
   writeFileSync(p, JSON.stringify(next, null, 2), 'utf8');
+  // A listener is a renderer send, which can fail while a window is closing.
+  // The config is already on disk by this point, so a throwing subscriber must
+  // neither fail the write for its caller nor starve the subscribers after it.
+  for (const listener of configWriteListeners) {
+    try { listener(next); } catch { /* a broken listener is not a failed write */ }
+  }
   return next;
 }
 
@@ -693,9 +720,9 @@ export function setAgentTokenCap(agentId: unknown, tokenCap: unknown): HarnessCo
 /** Wipe the persisted config back to first-run defaults so the app boots into
  *  onboarding again. Used by the "reset & start over" flow. */
 export function resetConfig(): HarnessConfig {
-  const p = configPath();
-  mkdirSync(dirname(p), { recursive: true });
-  writeFileSync(p, JSON.stringify(DEFAULTS, null, 2), 'utf8');
+  // Routed through persistConfig so the reset announces itself like any other
+  // write; the bytes written are the same DEFAULTS as before.
+  persistConfig({ ...DEFAULTS });
   // Drop the migration latch too: the file on disk is back to `triggersMigratedV1:
   // false`, and a latch left set would keep the flag from ever being written again
   // in this process. The migration itself is a no-op on defaults either way.

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -646,11 +646,19 @@ function persistConfig(next: HarnessConfig): HarnessConfig {
   const p = configPath();
   mkdirSync(dirname(p), { recursive: true });
   writeFileSync(p, JSON.stringify(next, null, 2), 'utf8');
+  // Subscribers get the config in the same shape `readConfig` hands out, NOT the
+  // object we just wrote. They are the second source feeding a renderer that also
+  // calls config:get, and a patch touching one nested key persists a half-filled
+  // sub-object — `withTriggerDefaults` is what deep-fills it on the way out, so
+  // skipping it here would let a consumer read `undefined` from a trigger it had
+  // read a number from a moment earlier. The migration is deliberately not run:
+  // it persists, and it has already been applied to the config this patch built on.
+  const view = normalizeStoredHomes(withTriggerDefaults({ ...DEFAULTS, ...next }));
   // A listener is a renderer send, which can fail while a window is closing.
   // The config is already on disk by this point, so a throwing subscriber must
   // neither fail the write for its caller nor starve the subscribers after it.
   for (const listener of configWriteListeners) {
-    try { listener(next); } catch { /* a broken listener is not a failed write */ }
+    try { listener(view); } catch { /* a broken listener is not a failed write */ }
   }
   return next;
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,7 +14,7 @@ import { resolveCommand as resolveCliCommand } from './shellEnv';
 import { initAutoUpdater, abortPendingRestart } from './updater';
 import { RealtimeFloorWatcher } from './realtimeFloorWatcher';
 import {
-  readConfig, writeConfig, setAgentTokenCap, resetConfig, ensureHarnessHome, ensureClaudePermissionsAccepted,
+  readConfig, writeConfig, setAgentTokenCap, resetConfig, onConfigWritten, ensureHarnessHome, ensureClaudePermissionsAccepted,
   modelForRole, OPS_STANDUP_MISSION, HEARTBEAT_MISSION, COMPACT_MAINTENANCE_MISSION, type HarnessConfig, type ScheduledMission
 } from './config';
 import { listDir, readFileText, readFileBinary, writeFileText, statAbs, expandTilde } from './fs';
@@ -5159,6 +5159,16 @@ app.on('before-quit', (e) => {
     mainWindow.focus();
     mainWindow.webContents.send('app:closeRequested', { ptyCount: count });
   }
+});
+
+// Keep the renderer's copy of the config current. The renderer loads the config
+// once at start-up and hands it down as a prop, so without this a write reached
+// disk while every view seeded from that prop kept rendering the pre-write value
+// until the next launch (#263). Subscribing to the write itself covers Slack,
+// freeflow, notifications and the rest, each of which persists by its own route.
+onConfigWritten((next) => {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainWindow.webContents.send('config:changed', next);
 });
 
 app.on('window-all-closed', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5161,11 +5161,8 @@ app.on('before-quit', (e) => {
   }
 });
 
-// Keep the renderer's copy of the config current. The renderer loads the config
-// once at start-up and hands it down as a prop, so without this a write reached
-// disk while every view seeded from that prop kept rendering the pre-write value
-// until the next launch (#263). Subscribing to the write itself covers Slack,
-// freeflow, notifications and the rest, each of which persists by its own route.
+// The window loads the config once at start-up, so tell it when a setting is
+// saved — otherwise it keeps showing the values it started with.
 onConfigWritten((next) => {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   mainWindow.webContents.send('config:changed', next);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5161,11 +5161,13 @@ app.on('before-quit', (e) => {
   }
 });
 
-// The window loads the config once at start-up, so tell it when a setting is
-// saved — otherwise it keeps showing the values it started with.
-onConfigWritten((next) => {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  mainWindow.webContents.send('config:changed', next);
+// Every window loads the config once at start-up, so tell them all when a
+// setting is saved — a floor left out would keep showing what it opened with.
+onConfigWritten((config) => {
+  for (const w of allWindows) {
+    if (w.isDestroyed() || w.webContents.isDestroyed()) continue;
+    w.webContents.send('config:changed', config);
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -931,8 +931,7 @@ const api = {
     ipcRenderer.invoke('hire:openFile'),
 
   // ─── Config changes ──────────────────────────────────────────────────────
-  /** Fired after every persisted config write, with the config as written, so a
-   *  renderer holding it as state never drifts from what is on disk. */
+  /** Fired whenever a setting is saved, with the full updated config. */
   onConfigChanged: (cb: (config: HarnessConfig) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, config: HarnessConfig) => cb(config);
     ipcRenderer.on('config:changed', listener);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -930,6 +930,15 @@ const api = {
   }> =>
     ipcRenderer.invoke('hire:openFile'),
 
+  // ─── Config changes ──────────────────────────────────────────────────────
+  /** Fired after every persisted config write, with the config as written, so a
+   *  renderer holding it as state never drifts from what is on disk. */
+  onConfigChanged: (cb: (config: HarnessConfig) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, config: HarnessConfig) => cb(config);
+    ipcRenderer.on('config:changed', listener);
+    return () => ipcRenderer.removeListener('config:changed', listener);
+  },
+
   // ─── Quit confirmation ───────────────────────────────────────────────────
   onCloseRequested: (cb: (info: { ptyCount: number }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, info: { ptyCount: number }) => cb(info);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -125,6 +125,11 @@ export function App() {
   // (solo-hold threshold, aborts on any other key). See freeflow/holdOption.ts.
   useHoldOptionToTalk();
 
+  // The config is loaded once above and handed down as a prop, so anything that
+  // writes it — Settings, Slack, freeflow, onboarding — has to be able to tell us,
+  // or those views keep rendering the value from start-up (#263).
+  useEffect(() => window.cth.onConfigChanged(setConfig), []);
+
   // Quit warning subscription
   useEffect(() => window.cth.onCloseRequested((info) => setQuitWarn(info)), []);
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -125,9 +125,8 @@ export function App() {
   // (solo-hold threshold, aborts on any other key). See freeflow/holdOption.ts.
   useHoldOptionToTalk();
 
-  // The config is loaded once above and handed down as a prop, so anything that
-  // writes it — Settings, Slack, freeflow, onboarding — has to be able to tell us,
-  // or those views keep rendering the value from start-up (#263).
+  // Config subscription — the copy loaded above would otherwise go stale the
+  // moment anything saves a setting.
   useEffect(() => window.cth.onConfigChanged(setConfig), []);
 
   // Quit warning subscription

--- a/test/config-write-notify.test.cjs
+++ b/test/config-write-notify.test.cjs
@@ -23,18 +23,25 @@ const { writeConfig, readConfig, onConfigWritten, setAgentTokenCap, resetConfig 
 
 test.after(() => fs.rmSync(userData, { recursive: true, force: true }));
 
+// The app has a config on disk and reads it during start-up, which is what runs
+// the one-shot trigger migration. Reproduce both here before any test subscribes,
+// so these compare a write against a settled config rather than racing the
+// migration — on a bare directory readConfig short-circuits and never runs it.
+writeConfig({});
+readConfig();
+
+
 test('a config write notifies subscribers with the persisted config', () => {
   const seen = [];
   const off = onConfigWritten((next) => seen.push(next));
 
-  const returned = writeConfig({ orchestratorMaySpawn: true });
+  writeConfig({ orchestratorMaySpawn: true });
 
   // A single logical write can persist more than once — reading the config runs
-  // any pending migration, which persists in its own right. The contract is
-  // that subscribers end up holding what the caller was handed back, not that
-  // exactly one notification arrives.
+  // any pending migration, which persists in its own right. The contract is what
+  // subscribers end up holding, not that exactly one notification arrives.
   assert.ok(seen.length >= 1);
-  assert.deepEqual(seen[seen.length - 1], returned);
+  assert.deepEqual(seen[seen.length - 1], readConfig());
   assert.equal(seen[seen.length - 1].orchestratorMaySpawn, true);
   off();
 });
@@ -47,10 +54,10 @@ test('a token-cap write notifies too, not just writeConfig', () => {
   const seen = [];
   const off = onConfigWritten((next) => seen.push(next));
 
-  const returned = setAgentTokenCap('jim', 100);
+  setAgentTokenCap('jim', 100);
 
   assert.ok(seen.length >= 1);
-  assert.deepEqual(seen[seen.length - 1], returned);
+  assert.deepEqual(seen[seen.length - 1], readConfig());
   assert.equal(seen[seen.length - 1].agentTokenCaps.jim, 100);
   off();
 });
@@ -94,4 +101,19 @@ test('a listener that throws neither fails the write nor starves the next listen
   assert.equal(readConfig().autoMode, true);
   assert.ok(reached.length >= 1);
   offBad(); offGood();
+});
+
+// The renderer keeps one `config` in state fed from two sources: config:get and
+// this notification. If they disagree in shape, a consumer reads a deep-filled
+// object one moment and a half-filled one the next. A patch that touches part of
+// a trigger is where that bites, because the merge on the way in is one level
+// deep (see withTriggerDefaults).
+test('subscribers receive the same shape a config read returns', () => {
+  const seen = [];
+  const off = onConfigWritten((next) => seen.push(next));
+
+  writeConfig({ contextTrigger: { compact: { enabled: true } } });
+
+  assert.deepEqual(seen[seen.length - 1], readConfig());
+  off();
 });

--- a/test/config-write-notify.test.cjs
+++ b/test/config-write-notify.test.cjs
@@ -1,0 +1,97 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+// config.ts resolves its file through Electron's app.getPath(). Point that one
+// dependency at a throwaway userData root so this test never touches the real
+// application config.
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'md-config-notify-'));
+const electron = require.resolve('electron');
+require.cache[electron] = {
+  id: electron,
+  filename: electron,
+  loaded: true,
+  exports: { app: { getPath: () => userData } }
+};
+
+const { writeConfig, readConfig, onConfigWritten, setAgentTokenCap, resetConfig } = loadTs('src/main/config.ts');
+
+test.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+
+test('a config write notifies subscribers with the persisted config', () => {
+  const seen = [];
+  const off = onConfigWritten((next) => seen.push(next));
+
+  const returned = writeConfig({ orchestratorMaySpawn: true });
+
+  // A single logical write can persist more than once — reading the config runs
+  // any pending migration, which persists in its own right. The contract is
+  // that subscribers end up holding what the caller was handed back, not that
+  // exactly one notification arrives.
+  assert.ok(seen.length >= 1);
+  assert.deepEqual(seen[seen.length - 1], returned);
+  assert.equal(seen[seen.length - 1].orchestratorMaySpawn, true);
+  off();
+});
+
+// Not every field is written through writeConfig — agent token caps, and the
+// reset flow below, each persist by their own route. Subscribing at the file
+// write is what makes them all announce; these two tests are what stop a future
+// refactor from quietly moving the hook back up into writeConfig.
+test('a token-cap write notifies too, not just writeConfig', () => {
+  const seen = [];
+  const off = onConfigWritten((next) => seen.push(next));
+
+  const returned = setAgentTokenCap('jim', 100);
+
+  assert.ok(seen.length >= 1);
+  assert.deepEqual(seen[seen.length - 1], returned);
+  assert.equal(seen[seen.length - 1].agentTokenCaps.jim, 100);
+  off();
+});
+
+test('resetting the config notifies as well', () => {
+  const seen = [];
+  const off = onConfigWritten((next) => seen.push(next));
+
+  resetConfig();
+
+  // Listeners receive the config as PERSISTED. resetConfig hands its caller a
+  // trigger-enriched view of the same defaults, so the two differ by design and
+  // this asserts the reset reached subscribers rather than equality with it.
+  assert.ok(seen.length >= 1);
+  assert.equal(seen[seen.length - 1].onboardingComplete, false);
+  off();
+});
+
+test('unsubscribing stops the notifications', () => {
+  const seen = [];
+  const off = onConfigWritten((next) => seen.push(next));
+  writeConfig({ notifications: true });
+  const countWhileSubscribed = seen.length;
+  assert.ok(countWhileSubscribed >= 1);
+
+  off();
+  writeConfig({ notifications: false });
+
+  assert.equal(seen.length, countWhileSubscribed);
+});
+
+test('a listener that throws neither fails the write nor starves the next listener', () => {
+  const reached = [];
+  const offBad = onConfigWritten(() => { throw new Error('window is gone'); });
+  const offGood = onConfigWritten((next) => reached.push(next));
+
+  // The write itself must still return normally and still land on disk.
+  const returned = writeConfig({ autoMode: true });
+
+  assert.equal(returned.autoMode, true);
+  assert.equal(readConfig().autoMode, true);
+  assert.ok(reached.length >= 1);
+  offBad(); offGood();
+});

--- a/test/config-write-notify.test.cjs
+++ b/test/config-write-notify.test.cjs
@@ -23,10 +23,8 @@ const { writeConfig, readConfig, onConfigWritten, setAgentTokenCap, resetConfig 
 
 test.after(() => fs.rmSync(userData, { recursive: true, force: true }));
 
-// The app has a config on disk and reads it during start-up, which is what runs
-// the one-shot trigger migration. Reproduce both here before any test subscribes,
-// so these compare a write against a settled config rather than racing the
-// migration — on a bare directory readConfig short-circuits and never runs it.
+// A real app has a config on disk and reads it at start-up, which settles the
+// one-shot migration. Do the same first, so no test below races it.
 writeConfig({});
 readConfig();
 
@@ -37,19 +35,16 @@ test('a config write notifies subscribers with the persisted config', () => {
 
   writeConfig({ orchestratorMaySpawn: true });
 
-  // A single logical write can persist more than once — reading the config runs
-  // any pending migration, which persists in its own right. The contract is what
-  // subscribers end up holding, not that exactly one notification arrives.
+  // What subscribers end up holding is the contract; one save can legitimately
+  // write more than once, so the number of notifications is not.
   assert.ok(seen.length >= 1);
   assert.deepEqual(seen[seen.length - 1], readConfig());
   assert.equal(seen[seen.length - 1].orchestratorMaySpawn, true);
   off();
 });
 
-// Not every field is written through writeConfig — agent token caps, and the
-// reset flow below, each persist by their own route. Subscribing at the file
-// write is what makes them all announce; these two tests are what stop a future
-// refactor from quietly moving the hook back up into writeConfig.
+// Token caps and the reset below each save by their own route. These two keep
+// the announcement where every route passes through it.
 test('a token-cap write notifies too, not just writeConfig', () => {
   const seen = [];
   const off = onConfigWritten((next) => seen.push(next));
@@ -68,9 +63,8 @@ test('resetting the config notifies as well', () => {
 
   resetConfig();
 
-  // Listeners receive the config as PERSISTED. resetConfig hands its caller a
-  // trigger-enriched view of the same defaults, so the two differ by design and
-  // this asserts the reset reached subscribers rather than equality with it.
+  // A reset hands its caller a slightly fuller view than it stores, so check the
+  // reset reached subscribers rather than comparing the two.
   assert.ok(seen.length >= 1);
   assert.equal(seen[seen.length - 1].onboardingComplete, false);
   off();
@@ -103,11 +97,9 @@ test('a listener that throws neither fails the write nor starves the next listen
   offBad(); offGood();
 });
 
-// The renderer keeps one `config` in state fed from two sources: config:get and
-// this notification. If they disagree in shape, a consumer reads a deep-filled
-// object one moment and a half-filled one the next. A patch that touches part of
-// a trigger is where that bites, because the merge on the way in is one level
-// deep (see withTriggerDefaults).
+// The window fills one copy of the config from both a read and this
+// announcement, so a screen must never get a fuller answer from one than the
+// other. Saving part of a setting is where that would show.
 test('subscribers receive the same shape a config read returns', () => {
   const seen = [];
   const off = onConfigWritten((next) => seen.push(next));


### PR DESCRIPTION
## Summary

**Problem:** Settings would save your change to disk correctly, and then show you the old value the next time you opened it. Most of the time that was a cosmetic annoyance that cleared when you restarted the app. But two of the circuit-breaker fields went further and *deleted* the value you had saved — the field came back blank, a blank means "no value", so the next save wiped it. And the "Who can add agents" toggle looked like it flat-out refused to change: because it flips relative to what is shown on screen, the first click after reopening Settings wrote back the value that was already saved, doing nothing visible.

**Solution:** The app now tells the interface whenever a setting is written, so what you see always matches what is stored. Change a setting, close Settings, open it again — it shows what you set. One click on a toggle does what one click should do. Nothing gets erased.

## TLDR for developers

The renderer loads the config once (`App.tsx:90`) and passes it down as a prop. Nothing informed it when a write landed, so any view seeded from that prop rendered the start-up snapshot until relaunch — `SettingsModal.tsx:444-446` already documented this as known.

- **`src/main/config.ts`** — added `onConfigWritten(listener)`, notified from `persistConfig`. Placement is the point: `writeConfig` is one of **23** `writeConfig` callers in the main process, and Slack, freeflow and notifications each persist by their own route. `persistConfig` is the one place they all pass through, which is the difference between fixing the fields we happened to enumerate and fixing all of them. Listener errors are swallowed — a listener is a renderer send that can fail while a window closes, and the config is already on disk by then, so a throwing subscriber must not fail the write or starve the subscribers after it.
- **`resetConfig`** now routes through `persistConfig` instead of writing the file itself, so it announces like any other write. Same bytes on disk.
- **`src/main/index.ts`** — forwards each write to **every live window** as `config:changed`. Floor windows load the same renderer and hold their own copy of the config, and `mainWindow` is reassigned on focus, so sending to the primary alone would have left other floors stale and made the recipient depend on focus order.
- **`src/preload/index.ts`** — `onConfigChanged`, mirroring the existing `onCloseRequested` / `onHireImport` subscription shape.
- **`src/renderer/src/App.tsx`** — one `useEffect` keeping `config` current.

Subscribers are handed the config in the shape `readConfig` returns, not the object passed to `persistConfig`. The renderer feeds one `config` state from two sources — `config:get` and this notification — and `config:get` is deep-filled and home-normalised. A patch touching one nested key persists a half-filled sub-object, so without this a component could read `contextTrigger.compact.minContextPct` as a number from a read and `undefined` from a notification moments later; `config.ts:492-505` already documents that hazard. The migration is deliberately not run on that path: it persists, and it has already been applied to the config the patch was built on.

Why this shape rather than patching the re-seed effect: `SettingsModal` seeds **28** fields from the prop and its effect re-reads only **14**, so 14 displayed the stale value. Adding the missing 14 setters would have fixed today's list and left the same two-list drift that produced the bug — every new field would still need registering twice. Making the prop authoritative removes the class.

`SettingsModal`'s re-seed effect is deliberately left alone. With the prop current it is redundant, but deleting it is a separate change and does not belong in a bug fix.

## What & why

Fixes [#263](https://github.com/chaitanyagiri/munder-difflin/issues/263). The report there listed three things as "Not established" — whether the write never persisted, whether it persisted but was not read on that path, or whether it was display-only. It is the second: the write always persisted, and the display read a stale snapshot. Affected set is the 14 prop-seeded fields the re-seed effect never re-reads, including `orchestratorMaySpawn` (the toggle in the original report), `autoCompactOn`, `autoUpdateOn`, `telemetryOn`, and the four breaker fields.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
<img width="1512" height="982" alt="Screenshot 2026-08-24 at 6 37 30 PM" src="https://github.com/user-attachments/assets/345834a6-8aac-4e04-8bd9-b8fcc272bf79" />

```
set REPEATED-TOOL LIMIT = 7, save   -> disk: repeatedToolLimit = 7      OK
close + reopen Settings             -> field shows: (blank)             WRONG
save again, touching nothing        -> disk: repeatedToolLimit gone     DATA LOSS

toggle "who can add agents"
  UI showed "me and Michael"        |  disk = false   <- already diverged
  click 1 -> "only me"              |  disk = false   <- wrote what was there
  click 2 -> "me and Michael"       |  disk = true    <- took two clicks
```

### After
<img width="893" height="627" alt="Screenshot 2026-08-24 at 6 38 13 PM" src="https://github.com/user-attachments/assets/7a260647-f3ee-4108-9a9b-b683881ca825" />


```
set REPEATED-TOOL LIMIT = 55, save  -> disk: repeatedToolLimit = 55     OK
close + reopen Settings             -> field shows: 55                  FIXED
save again, touching nothing        -> disk: repeatedToolLimit = 55     FIXED

toggle "who can add agents"
  UI "me and Michael"               |  disk = true    <- agree
  click once -> "only me"           |  disk = false   <- one click, agree
  close + reopen -> "only me"       |  disk = false   <- agree
```

## How I tested it

- OS: macOS 15 (Darwin 25.5.0), Electron 32.3.3, Node 22.23.2
- Steps:
  1. Added `test/config-write-notify.test.cjs` — six tests over the public interface: a write notifies with the persisted config; a token-cap write notifies too (proving the hook sits at the choke point rather than on `writeConfig`); a reset notifies; unsubscribing stops delivery; a listener that throws neither fails the write nor starves the next listener; and subscribers receive the same shape a read returns. The last of those was written failing after a review pass and drove the hydration fix in 34adb6d. The resetConfig test was written failing first and drove routing it through `persistConfig`.
  2. Ran the app and drove Settings over CDP for the before/after transcripts above, checking the rendered value against `config.json` on disk at every step.
  3. Confirmed the broadcast actually reaches the renderer by subscribing to `onConfigChanged` in the page and observing the payload arrive on a write.
  4. Verified the notification carries the deep-filled shape by writing a partial trigger patch (`contextTrigger.compact.enabled` only) and observing the subscriber receive all 5 keys of `compact` rather than the 1 that was persisted.
  5. Opened a second floor window and confirmed a save made in one arrives in both.
  6. `npm run typecheck` clean; `npm run test:focused` 558 passing, 0 failing (552 before, plus the 6 new); `npm run build` succeeds.

One note on the suite: `test/hive-task-mutation.test.cjs` failed once during a full run with `ENOTEMPTY` while removing its own git temp dir. It passes 3/3 in isolation both with and without this branch's changes, and the full suite passed clean on re-run — a cleanup race under parallel execution, unrelated to this change.

## Discord (optional)

Discord:

## Checklist

- [ ] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts. (No new UI in this PR.)
- [ ] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.



---

### Known adjacent issue, deliberately not fixed here

`window.cth.updateConfig()` resolves with `writeConfig`'s return value, which is the raw persisted object rather than the read shape — so `AddAgentModal` (`:302`, `:317`, `:481`, `:490`) can push a half-filled config into the same `config` state via `onConfigChange`. That predates this PR and is the same class of bug; it wants either hydrating the IPC handler's return or routing those call sites through the notification. Left alone to keep this change to one thing — happy to file it separately.

