### PR TITLE
fix(hive): record why an agent died — forward the exit signal and keep a crash tail

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -546,7 +546,12 @@ export class HiveManager {
 
     // Keep the churny/ephemeral live files out of the hive git repo.
     const gitignore = join(root, '.gitignore');
-    const want = ['fleet.json', 'hooks.sock', 'cost-ledger.jsonl', '.DS_Store'];
+    // `crashes/` holds raw PTY output from abnormal agent exits. It is
+    // DELIBERATELY ignored: that output is whatever the provider printed, which
+    // can include tokens, paths and prompt fragments, and the hive repo is
+    // committed on every change — a secret written there would be permanent.
+    // log.jsonl gets the structured, non-sensitive fields; the dump stays local.
+    const want = ['fleet.json', 'hooks.sock', 'cost-ledger.jsonl', 'crashes/', '.DS_Store'];
     let lines: string[] = [];
     if (existsSync(gitignore)) { try { lines = readFileSync(gitignore, 'utf8').split('\n'); } catch { lines = []; } }
     const missing = want.filter((w) => !lines.includes(w));
@@ -2226,6 +2231,66 @@ export class HiveManager {
       .sort()
       .map((f) => { try { return JSON.parse(readFileSync(join(dir, f), 'utf8')) as HiveMessage; } catch { return null; } })
       .filter((m): m is HiveMessage => m !== null);
+  }
+
+  /**
+   * Record an agent's process exit so a death has a durable cause.
+   *
+   * Before this, an agent killed by its provider crashing was archived with
+   * `{kind:'archive', agentId, archived:true}` and NOTHING else — no exit code,
+   * no signal, no output. A two-second SIGILL death and a completed agent were
+   * indistinguishable in the only record the hive keeps, and the crash banner
+   * lived solely in a UI terminal pane. Observed live 2026-08-24: Michael's
+   * `claude` CLI panicked 923ms into startup and left no trace on disk.
+   *
+   * Split by design:
+   *   - log.jsonl  gets structured, non-sensitive fields (code, signal, path).
+   *   - crashes/   gets the raw tail, and is gitignored — see ensureHive.
+   * A normal exit writes nothing at all; this is a diagnostic, not an audit log.
+   */
+  recordAgentExit(
+    agentId: string,
+    info: { exitCode?: number; signal?: number; tail?: string; command?: string }
+  ): void {
+    const root = this.root();
+    if (!root) return;
+    const { exitCode, signal, tail, command } = info;
+    // A signal means killed (SIGILL/SIGSEGV/SIGKILL); node-pty reports exitCode 0
+    // in that case, so signal must be checked independently of the code.
+    const abnormal = (typeof signal === 'number' && signal !== 0) || (typeof exitCode === 'number' && exitCode !== 0);
+    if (!abnormal) return;
+
+    let tailPath: string | null = null;
+    if (tail && tail.length) {
+      try {
+        const dir = join(root, 'crashes');
+        mkdirSync(dir, { recursive: true });
+        // Colons are illegal in filenames on Windows and awkward everywhere.
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const safeId = agentId.replace(/[^A-Za-z0-9._-]/g, '_');
+        const p = join(dir, `${stamp}-${safeId}.log`);
+        const header = [
+          `agent:    ${agentId}`,
+          `exitCode: ${String(exitCode)}`,
+          `signal:   ${String(signal)}`,
+          command ? `command:  ${command}` : null,
+          `captured: ${new Date().toISOString()}`,
+          `--- last ${tail.length} bytes of pty output ---`,
+          ''
+        ].filter(Boolean).join('\n');
+        writeFileSync(p, header + tail, 'utf8');
+        tailPath = p;
+      } catch { /* a diagnostic must never break teardown */ }
+    }
+
+    this.appendLog({
+      kind: 'agent-exit',
+      agentId,
+      exitCode: exitCode ?? null,
+      signal: signal ?? null,
+      abnormal: true,
+      tailPath
+    });
   }
 
   // — log —

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -575,7 +575,23 @@ function removeWorkerScratch(workerId: string): void {
 // SAME pty/window (no user click). Provider-agnostic. Idempotent by construction: the
 // relaunch carries `noAutoInstall`, so the installer can never fire (let alone loop) a
 // second time — a binary that's somehow still missing just spawns and exits normally.
-ptyManager.setExitHandler((id, exitCode) => {
+ptyManager.setExitHandler((id, exitCode, info) => {
+  // Record an ABNORMAL death before teardown — teardownPty drops the
+  // pty->agent mapping, so after it runs we can no longer say WHOSE process
+  // died. Only abnormal exits are recorded (recordAgentExit returns early on a
+  // clean one), so this adds no noise to a normal archive.
+  try {
+    const dyingAgent = ptyToAgent.get(id);
+    if (dyingAgent) {
+      hive.recordAgentExit(dyingAgent, {
+        exitCode,
+        signal: info?.signal,
+        tail: info?.tail,
+        command: info?.command
+      });
+    }
+  } catch (e) { console.error('[pty] recordAgentExit failed:', e); }
+
   const pending = pendingInstallRelaunch.get(id);
   if (pending) {
     pendingInstallRelaunch.delete(id);

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -29,6 +29,20 @@ export function withHiveRuntimeFallback(path: string, hiveRoot?: string): string
   return [...entries, dir].join(delimiter);
 }
 
+/** How much trailing PTY output to retain per session for crash diagnostics.
+ *  Big enough for a stack trace or a panic banner, small enough that N idle
+ *  agents cost kilobytes, not megabytes. */
+const TAIL_MAX = 8192;
+
+/** What the exit handler is told about a process that just died. Passed by
+ *  value because the session is deleted from the map before the handler runs. */
+export interface PtyExitInfo {
+  signal?: number;
+  tail?: string;
+  command?: string;
+  cwd?: string;
+}
+
 interface PtySession {
   id: string;
   proc: pty.IPty;
@@ -46,6 +60,13 @@ interface PtySession {
    *  file) and the idle handshake that gates god's PTY nudge (never type into a
    *  PTY that produced output in the last few seconds = mid-stream). */
   lastOutputAt: number;
+  /** A bounded ring of the most recent output bytes, kept ONLY so an abnormal
+   *  exit can say what was on screen when the process died. A provider that
+   *  crashes on startup (Bun SIGILL, a missing shared library, an auth failure)
+   *  prints its explanation and vanishes; without this the explanation exists
+   *  nowhere but a terminal pane the operator may never have been looking at.
+   *  Capped at TAIL_MAX so a chatty agent cannot grow it without bound. */
+  tail: string;
   /** True after the child has emitted at least one frame. Automation waits for
    *  this before typing, so startup prompts cannot outrun the TUI subscription. */
   hasOutput: boolean;
@@ -309,7 +330,8 @@ export class PtyManager {
    *  externally), so the main process can run the SAME lifecycle teardown
    *  (archive, worktree removal, map cleanup) that the explicit kill() path
    *  runs. Best-effort — set once by the main process. */
-  private exitHandler: ((id: string, exitCode?: number) => void) | null = null;
+  private exitHandler:
+    ((id: string, exitCode?: number, info?: PtyExitInfo) => void) | null = null;
 
   /** The default/fallback output sink — set to the PRIMARY window. Used only for
    *  sessions with no recorded owner; owned sessions route to their owner. */
@@ -345,7 +367,9 @@ export class PtyManager {
    *  onExit after the session is cleaned up. The exit code is forwarded so the
    *  handler can distinguish a clean exit (e.g. a successful first-time CLI
    *  install → auto restart-and-continue) from a crash. */
-  setExitHandler(handler: (id: string, exitCode?: number) => void): void {
+  setExitHandler(
+    handler: (id: string, exitCode?: number, info?: PtyExitInfo) => void
+  ): void {
     this.exitHandler = handler;
   }
 
@@ -661,6 +685,7 @@ export class PtyManager {
         command: resolved,
         lastOutputAt: Date.now(),
         hasOutput: false,
+        tail: '',
         owner
       };
       this.sessions.set(opts.id, session);
@@ -671,6 +696,9 @@ export class PtyManager {
         if (this.sessions.get(opts.id) !== session) return;
         session.hasOutput = true;
         session.lastOutputAt = Date.now();
+        // Keep only the trailing window; slice AFTER appending so a single
+        // oversized write still leaves us its end (the part that explains a death).
+        session.tail = (session.tail + data).slice(-TAIL_MAX);
         // Route to the session's owner window (multi-window owner routing).
         this.safeSend(`pty:data:${opts.id}`, data, session.owner);
       });
@@ -682,7 +710,21 @@ export class PtyManager {
         this.sessions.delete(opts.id);
         // Natural exit must run the same lifecycle teardown as an explicit kill.
         // Guarded so a teardown error can never crash node-pty's exit callback.
-        try { this.exitHandler?.(opts.id, exitCode); } catch { /* never throw out of onExit */ }
+        // `signal` is forwarded, not dropped: a provider killed by SIGILL/SIGSEGV
+        // exits with code 0 and a non-zero signal, so an exitCode-only handler
+        // cannot tell a crash from a clean finish. `tail` carries whatever the
+        // process printed on its way out.
+        // The session is already out of `sessions` by now, so anything the
+        // handler needs about the dead process must be handed to it here —
+        // it cannot look the session up any more.
+        try {
+          this.exitHandler?.(opts.id, exitCode, {
+            signal,
+            tail: session.tail,
+            command: session.command,
+            cwd: session.cwd
+          });
+        } catch { /* never throw out of onExit */ }
       });
 
       return { ok: true };

--- a/test/agent-exit-record.test.cjs
+++ b/test/agent-exit-record.test.cjs
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * An agent killed by its provider crashing used to leave NO durable cause.
+ *
+ * Observed live on 2026-08-24: a `claude` CLI panicked 923 ms into startup
+ * (Bun, SIGILL) and the hive recorded exactly
+ *   {"kind":"archive","agentId":"god","archived":true}
+ * — no exit code, no signal, no output. The crash banner existed only in a UI
+ * terminal pane. A two-second death and a completed agent were indistinguishable
+ * in the only record the hive keeps.
+ *
+ * `recordAgentExit` fixes that. These tests pin the three properties that make
+ * it useful and safe:
+ *   1. a signal-death is recorded even though its exit code is 0;
+ *   2. a CLEAN exit records nothing (a diagnostic, not an audit log);
+ *   3. the raw output goes to a GITIGNORED file, never into log.jsonl —
+ *      the hive repo is committed on every change, so a token captured from
+ *      provider output would otherwise be permanent.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-exit-'));
+}
+
+function readLog(home) {
+  const p = path.join(home, 'hive', 'log.jsonl');
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+async function freshHive(t) {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
+  return { home, hive };
+}
+
+test('a signal death is recorded even though its exit code is 0', async (t) => {
+  const { home, hive } = await freshHive(t);
+
+  // SIGILL is exactly the shape that bit us: node-pty reports exitCode 0 and a
+  // non-zero signal, so an exitCode-only check calls this a clean finish.
+  hive.recordAgentExit('a1', { exitCode: 0, signal: 4, tail: 'panic: Illegal instruction\n' });
+
+  const rows = readLog(home).filter((r) => r.kind === 'agent-exit');
+  assert.equal(rows.length, 1, 'a signal death must be recorded');
+  assert.equal(rows[0].agentId, 'a1');
+  assert.equal(rows[0].signal, 4);
+  assert.equal(rows[0].exitCode, 0);
+  assert.equal(rows[0].abnormal, true);
+});
+
+test('a non-zero exit code is recorded', async (t) => {
+  const { home, hive } = await freshHive(t);
+  hive.recordAgentExit('a1', { exitCode: 127, tail: 'claude: command not found\n' });
+
+  const rows = readLog(home).filter((r) => r.kind === 'agent-exit');
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].exitCode, 127);
+  assert.equal(rows[0].signal, null);
+});
+
+test('a CLEAN exit records nothing — this is a diagnostic, not an audit log', async (t) => {
+  const { home, hive } = await freshHive(t);
+
+  hive.recordAgentExit('a1', { exitCode: 0, signal: 0, tail: 'goodbye\n' });
+  hive.recordAgentExit('a1', { exitCode: 0, tail: 'goodbye\n' });
+  hive.recordAgentExit('a1', {});
+
+  assert.equal(readLog(home).filter((r) => r.kind === 'agent-exit').length, 0);
+});
+
+test('raw output goes to a gitignored crashes/ file, NOT into log.jsonl', async (t) => {
+  const { home, hive } = await freshHive(t);
+
+  // A plausible secret in provider output. It must reach the dump file and must
+  // NOT reach log.jsonl, which the hive commits.
+  const secret = 'sk-ant-EXAMPLE-NOT-A-REAL-KEY-000';
+  hive.recordAgentExit('a1', { exitCode: 0, signal: 11, tail: `boom ${secret}\n`, command: '/usr/bin/claude --model x' });
+
+  const rows = readLog(home).filter((r) => r.kind === 'agent-exit');
+  assert.equal(rows.length, 1);
+
+  const raw = fs.readFileSync(path.join(home, 'hive', 'log.jsonl'), 'utf8');
+  assert.ok(!raw.includes(secret), 'log.jsonl must never carry raw provider output');
+
+  const tailPath = rows[0].tailPath;
+  assert.ok(tailPath, 'the row must point at the dump');
+  const dump = fs.readFileSync(tailPath, 'utf8');
+  assert.ok(dump.includes(secret), 'the dump keeps the output that explains the death');
+  assert.ok(dump.includes('signal:   11'), 'the dump carries a header naming the signal');
+  assert.ok(dump.includes('/usr/bin/claude --model x'), 'and the command that died');
+
+  // The dump must live under crashes/, which ensureHive gitignores.
+  assert.equal(path.basename(path.dirname(tailPath)), 'crashes');
+  const ignore = fs.readFileSync(path.join(home, 'hive', '.gitignore'), 'utf8');
+  assert.ok(ignore.split('\n').includes('crashes/'), 'crashes/ must be gitignored');
+});
+
+test('a death is still recorded when there is no output to dump', async (t) => {
+  const { home, hive } = await freshHive(t);
+  hive.recordAgentExit('a1', { exitCode: 0, signal: 9, tail: '' });
+
+  const rows = readLog(home).filter((r) => r.kind === 'agent-exit');
+  assert.equal(rows.length, 1, 'losing the output must not lose the fact of the death');
+  assert.equal(rows[0].signal, 9);
+  assert.equal(rows[0].tailPath, null);
+});

--- a/test/agent-exit-signal-e2e.test.cjs
+++ b/test/agent-exit-signal-e2e.test.cjs
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * End-to-end: a PTY whose process dies by SIGNAL must reach the exit handler
+ * with that signal AND with the output it printed on the way out.
+ *
+ * The unit tests for `recordAgentExit` call it directly. This one drives the
+ * real `PtyManager`, because the original defect was NOT in the recording — it
+ * was that `signal` never left `pty.ts`. `onExit` had `{ exitCode, signal }` in
+ * hand and forwarded only `exitCode`, so every caller downstream was blind to
+ * signal deaths by construction.
+ *
+ * The scenario is the one observed live on 2026-08-24: a provider that prints
+ * a panic and dies of SIGILL, which node-pty reports as exitCode 0 + signal 4.
+ * An exitCode-only handler sees "0" and calls that a clean finish.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { PtyManager } = loadTs('src/main/pty.ts');
+
+const POSIX = process.platform !== 'win32';
+
+function waitForExit(mgr) {
+  return new Promise((resolve) => {
+    mgr.setExitHandler((id, exitCode, info) => resolve({ id, exitCode, info }));
+  });
+}
+
+test('a SIGILL death forwards the signal and the output that explains it', { skip: !POSIX }, async () => {
+  const mgr = new PtyManager();
+  const done = waitForExit(mgr);
+
+  // Print a recognisable banner, flush it, then kill ourselves with SIGILL —
+  // the exact shape of the crash that motivated this change.
+  const res = mgr.spawn({
+    id: 'e2e-sigill',
+    cwd: process.cwd(),
+    command: '/bin/sh',
+    args: ['-c', 'echo "panic(main thread): Illegal instruction"; sleep 0.2; kill -ILL $$']
+  });
+  assert.equal(res.ok, true, `spawn failed: ${res.error}`);
+
+  const { id, exitCode, info } = await done;
+  assert.equal(id, 'e2e-sigill');
+
+  // THE REGRESSION GUARD: signal must survive the trip out of pty.ts.
+  assert.equal(info.signal, 4, 'SIGILL (4) must be forwarded, not dropped');
+
+  // And the exit code alone must NOT be what a caller keys on — this asserts
+  // the very trap the old handler fell into.
+  assert.notEqual(
+    typeof info.signal === 'number' && info.signal !== 0 ? 'abnormal' : 'clean',
+    'clean',
+    'a signal death must not classify as clean'
+  );
+
+  assert.match(info.tail ?? '', /Illegal instruction/, 'the dying output must be captured');
+  assert.equal(typeof info.command, 'string', 'the command must be passed by value');
+  assert.ok((info.command ?? '').length > 0, 'the session is deleted before the handler, so command cannot be looked up later');
+});
+
+test('a clean exit reports no signal', { skip: !POSIX }, async () => {
+  const mgr = new PtyManager();
+  const done = waitForExit(mgr);
+
+  const res = mgr.spawn({
+    id: 'e2e-clean',
+    cwd: process.cwd(),
+    command: '/bin/sh',
+    args: ['-c', 'echo done; exit 0']
+  });
+  assert.equal(res.ok, true, `spawn failed: ${res.error}`);
+
+  const { exitCode, info } = await done;
+  assert.equal(exitCode, 0);
+  assert.ok(!info.signal, 'a clean exit must not report a signal');
+});
+
+test('a non-zero exit is reported as a code, not a signal', { skip: !POSIX }, async () => {
+  const mgr = new PtyManager();
+  const done = waitForExit(mgr);
+
+  const res = mgr.spawn({
+    id: 'e2e-code',
+    cwd: process.cwd(),
+    command: '/bin/sh',
+    args: ['-c', 'echo "command not found"; exit 127']
+  });
+  assert.equal(res.ok, true, `spawn failed: ${res.error}`);
+
+  const { exitCode, info } = await done;
+  assert.equal(exitCode, 127);
+  assert.ok(!info.signal);
+  assert.match(info.tail ?? '', /command not found/);
+});


### PR DESCRIPTION
## What & why

When an agent's provider CLI dies, the hive keeps no reason. The whole durable
record of the death is `{"kind":"archive","agentId":"god","archived":true}` — no
exit code, no signal, no output — so an agent that crashed two seconds after
spawning is indistinguishable from one that finished its work. The crash text
lives only in the UI terminal pane and is gone when it scrolls.

The cause is upstream of the recording: `pty.ts` receives `{ exitCode, signal }`
from node-pty, sends both to the renderer, and forwards only `exitCode` to
`exitHandler`. A process killed by a signal exits with **code 0** and a non-zero
signal, so every consumer in the main process was blind to signal deaths by
construction.

This forwards the signal, keeps a bounded tail of what the process printed, and
writes both down — splitting them so the raw output never enters the hive's git
history.

Closes #308

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

### Design notes

- **`PtyExitInfo` is passed by value on purpose.** `onExit` deletes the session
  from `sessions` *before* calling the handler, so a handler that tried to look
  the command up via `list()` would always get `undefined`. (I wrote that
  version first, then found it.)
- **The tail is capped at 8 KB** and sliced after append, so a single oversized
  write still leaves its end — the part that explains a death.
- **`log.jsonl` gets structured fields; `crashes/` gets the raw tail, and is
  added to the hive's `.gitignore`.** The hive is a git repo committed on every
  change, and the tail is whatever the provider printed — tokens, paths, prompt
  fragments. A secret written into `log.jsonl` would be permanent. There is a
  test asserting a fake key reaches the dump and never the log.
- **A clean exit records nothing.** This is a diagnostic, not an audit log, and
  a normal archive should stay quiet.

## Evidence

### Before
![before](https://raw.githubusercontent.com/LavaDMan/munder-difflin/pr-evidence/pr/pr309-before.png)

The tests in this PR, run against **unpatched `hive.ts` and `pty.ts`** (checked
out from the tag, patch reverted) — they fail for the reason they were written:

```
$ git show <tag>:src/main/hive.ts > src/main/hive.ts     # revert the fix
$ node --test test/agent-exit-record.test.cjs
✖ a signal death is recorded even though its exit code is 0
✖ a non-zero exit code is recorded
✖ a CLEAN exit records nothing — this is a diagnostic, not an audit log
✖ raw output goes to a gitignored crashes/ file, NOT into log.jsonl
✖ a death is still recorded when there is no output to dump
ℹ tests 5   ℹ pass 0   ℹ fail 5
exit 1

$ git show <tag>:src/main/pty.ts > src/main/pty.ts       # revert the fix
$ node --test test/agent-exit-signal-e2e.test.cjs
✖ a SIGILL death forwards the signal and the output that explains it
✖ a clean exit reports no signal
✖ a non-zero exit is reported as a code, not a signal
ℹ tests 3   ℹ pass 0   ℹ fail 3
exit 1
```

And the real-world shape of it — the hive's entire record of an agent that
crashed on startup and never ran:

```
15:53:16  app-start   version 0.4.5, packaged=false
15:53:18  spawn       agentId=god name=Michael isGod=true
15:53:20  archive     agentId=god archived=true
```

while the terminal pane (and nothing on disk) showed:

```
panic(main thread): Illegal instruction at address 0x52D6A9F
─ process exited (code 0, signal 4) ─
```

### After
![after](https://raw.githubusercontent.com/LavaDMan/munder-difflin/pr-evidence/pr/pr309-after.png)

Same tests, patch applied:

```
$ node --test test/agent-exit-record.test.cjs test/agent-exit-signal-e2e.test.cjs
✔ a signal death is recorded even though its exit code is 0
✔ a non-zero exit code is recorded
✔ a CLEAN exit records nothing — this is a diagnostic, not an audit log
✔ raw output goes to a gitignored crashes/ file, NOT into log.jsonl
✔ a death is still recorded when there is no output to dump
✔ a SIGILL death forwards the signal and the output that explains it
✔ a clean exit reports no signal
✔ a non-zero exit is reported as a code, not a signal
ℹ tests 8   ℹ pass 8   ℹ fail 0
exit 0
```

The e2e test drives the real `PtyManager` against a process that prints a panic
banner and then `kill -ILL $$` — the exact shape of the crash that motivated
this — and asserts the signal survives the trip out of `pty.ts`.

What the hive now records for that same death:

```json
{"ts":…,"kind":"agent-exit","agentId":"god","exitCode":0,"signal":4,
 "abnormal":true,"tailPath":"…/hive/crashes/2026-08-24T…-god.log"}
```

and `crashes/…-god.log`:

```
agent:    god
exitCode: 0
signal:   4
command:  /home/…/claude --model … --permission-mode bypassPermissions
captured: 2026-08-24T…
--- last N bytes of pty output ---
panic(main thread): Illegal instruction at address 0x52D6A9F
```

### Gate

Run on this branch, rebased on current `main`:

```
npm run typecheck     → 0
npm run build         → 0
npm run test:focused  → 560 tests, 559 pass, 1 fail
```

The suite goes from 552 to 560 tests. **The one failure is pre-existing and
unrelated** — `hive-hook-node.test.cjs` races its own stdin write and fails on
EPIPE on Linux. It fails identically on unmodified `main`. Fixed separately in
the companion PR; with both applied the suite is 560/560.

## Testing

- Linux (Ubuntu 24.04.4, kernel 7.0.0-30, x86_64), Node v24.13.1, Electron
  32.3.3, Claude Code 2.1.241.
- **Not tested on macOS or Windows.** The signal path is POSIX; both new test
  files skip on `win32`. `recordAgentExit` itself is platform-agnostic, and the
  crash-dump filename already replaces `:` so it is Windows-safe, but I have not
  run it there.
