### PR TITLE
fix(test): hive-hook-node races its own stdin write and fails on EPIPE

### DIFF
--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -68,6 +68,12 @@ async function run(cmd, env) {
     const child = spawn('/bin/sh', ['-c', cmd], { env, stdio: ['pipe', 'pipe', 'pipe'] });
     let stderr = '';
     child.stderr.on('data', (d) => { stderr += d; });
+    // These commands are EXPECTED to exit before the payload lands — the control
+    // case below asserts `node "<shim>"` exits 127 under a stripped PATH. A child
+    // that is already gone makes this write EPIPE, and an unhandled 'error' on
+    // stdin rejects the test rather than the command under test failing. The exit
+    // code is what this helper reports, so a lost write is not a lost signal.
+    child.stdin.on('error', () => { /* child exited before reading stdin */ });
     child.stdin.end(JSON.stringify({ hook_event_name: 'Stop', session_id: 's1' }));
     child.on('close', (code) => resolve({ code, stderr }));
   });

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -73,7 +73,13 @@ async function run(cmd, env) {
     // that is already gone makes this write EPIPE, and an unhandled 'error' on
     // stdin rejects the test rather than the command under test failing. The exit
     // code is what this helper reports, so a lost write is not a lost signal.
-    child.stdin.on('error', () => { /* child exited before reading stdin */ });
+    // Narrow on purpose: EPIPE is the expected one and is swallowed, anything
+    // else (EACCES, ERR_STREAM_DESTROYED) is surfaced through the stderr this
+    // helper already returns, so an unexpected stdin fault names itself instead
+    // of vanishing.
+    child.stdin.on('error', (e) => {
+      if (e.code !== 'EPIPE') stderr += `stdin: ${e.message}\n`;
+    });
     child.stdin.end(JSON.stringify({ hook_event_name: 'Stop', session_id: 's1' }));
     child.on('close', (code) => resolve({ code, stderr }));
   });


### PR DESCRIPTION
## What & why

`test/hive-hook-node.test.cjs` fails on Linux with `write EPIPE`. The fault is
in the test's own `run()` helper, not in anything it tests: it writes a hook
payload to a child's stdin without an `'error'` listener, and the test
deliberately runs commands that exit immediately — its own control case asserts
that `node "<shim>"` exits **127** under a stripped PATH. When that child is
gone before the write lands, the unhandled EPIPE rejects the whole test.

Adding the listener is enough. The helper reports the child's exit **code**,
which is what every assertion keys on, so a write that never lands loses
nothing.

It is timing-dependent, which is probably why it has gone unreported: on an idle
machine the write usually wins. On a loaded one it does not.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
![before](https://raw.githubusercontent.com/LavaDMan/munder-difflin/pr-evidence/pr/pr310-before.png)

On unmodified `main`, Ubuntu 24.04.4 / Node v24.13.1, under load. The file
alone, **4 of 5 runs fail** — run 5 passing is the race being a race:

```
$ for i in 1 2 3 4 5; do node --test test/hive-hook-node.test.cjs; done
  run 1: exit=1   pass 4   fail 1
  run 2: exit=1   pass 4   fail 1
  run 3: exit=1   pass 4   fail 1
  run 4: exit=1   pass 4   fail 1
  run 5: exit=0   pass 5   fail 0     <- won the race
```

with:

```
✖ a hook fires with NO node on PATH, and its payload reaches HIVE_SOCK
  Error: write EPIPE
      at Socket.end (node:net:737:31)
      at .../test/hive-hook-node.test.cjs:71:17
    errno: -32, code: 'EPIPE', syscall: 'write'
```

Line 71 is `child.stdin.end(...)` inside `run()`.

Across sessions I measured the full suite failing 4 of 5 runs on the same
machine, and the file alone failing 5 of 5 at higher load. **The pass rate moves
with machine load**, which is the point: CI may well be green while this is
broken for contributors.

### After
![after](https://raw.githubusercontent.com/LavaDMan/munder-difflin/pr-evidence/pr/pr310-after.png)

Same machine, same load, one added listener. The file, **10 of 10 pass**, and
the full suite **3 of 3 fully green at 552/552**.

### Gate

```
npm run typecheck     → 0
npm run test:focused  → 552/552, exit 0
npm run build         → 0
```

## Testing

Linux only (Ubuntu 24.04.4, Node v24.13.1). The test already skips on `win32`.
The change is a no-op wherever the write currently wins the race — it only stops
an expected EPIPE from failing the test.

## Note

Independent of #309 and cuts from `main`, so the two can merge in either order.
With both applied the suite is 560/560.
