### PR TITLE
feat(layout): horizontal split option — floor on top, terminal below

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -385,8 +385,9 @@ export function App() {
             data-tip={splitOrientation === 'horizontal'
               ? 'Side-by-side layout'
               : 'Stacked layout — floor on top'}
-            aria-label="Toggle split orientation"
-            aria-pressed={splitOrientation === 'horizontal'}
+            aria-label={splitOrientation === 'horizontal'
+              ? 'Switch to side-by-side layout'
+              : 'Switch to stacked layout — floor on top'}
             style={{
               display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
               width: 28, height: 28, padding: 0,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -54,7 +54,10 @@ export function App() {
   const fullscreenAgentId = useStore(s => s.fullscreenAgentId);
   const appThemeNow = useAppTheme();
   const sidebarWidth = useStore(s => s.sidebarWidth);
-  const setSidebarWidth = useStore(s => s.setSidebarWidth);
+  const sidebarHeight = useStore(s => s.sidebarHeight);
+  const splitOrientation = useStore(s => s.splitOrientation);
+  const setSidebarSize = useStore(s => s.setSidebarSize);
+  const toggleSplitOrientation = useStore(s => s.toggleSplitOrientation);
   const ideOpen = useStore(s => s.ideOpen);
   const setIdeOpen = useStore(s => s.setIdeOpen);
 
@@ -79,6 +82,7 @@ export function App() {
   const [quitWarn, setQuitWarn] = useState<{ ptyCount: number } | null>(null);
   const [closing, setClosing] = useState<ClosingTimeState | null>(null);
   const [vpWidth, setVpWidth] = useState<number>(window.innerWidth);
+  const [vpHeight, setVpHeight] = useState<number>(window.innerHeight);
 
   // Deep link into Settings from anywhere in the tree. Settings' open state is
   // local to App, so a nested control (e.g. "set it now" beside a disabled Talk
@@ -245,9 +249,13 @@ export function App() {
     useStore.getState().restoreFocusMode();
   }, [config?.onboardingComplete, agents]);
 
-  // Track viewport width for splitter clamping
+  // Track viewport size for splitter clamping — both axes, since the split
+  // divider can run either way and each clamps against its own extent.
   useEffect(() => {
-    const onResize = () => setVpWidth(window.innerWidth);
+    const onResize = () => {
+      setVpWidth(window.innerWidth);
+      setVpHeight(window.innerHeight);
+    };
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
@@ -362,6 +370,35 @@ export function App() {
         >
           <GearGlyph />
         </button>
+        {/* Split orientation. Hidden — not disabled — while focus mode is on:
+            focus mode hides the floor entirely, so there is no split to orient
+            and a greyed control would be asking the user to work out why. The
+            focus-mode button sitting immediately to its right already explains
+            where the floor went. The two are deliberately separate controls:
+            focus mode owns HOW MANY panes, this owns HOW THEY SIT. Folding them
+            into one cycling control would force a user to pass through a layout
+            they do not want, and would desync the moment Esc left focus mode. */}
+        {!fullscreenAgentId && (
+          <button
+            className="cth-titlebar-nodrag cth-tip"
+            onClick={toggleSplitOrientation}
+            data-tip={splitOrientation === 'horizontal'
+              ? 'Side-by-side layout'
+              : 'Stacked layout — floor on top'}
+            aria-label="Toggle split orientation"
+            aria-pressed={splitOrientation === 'horizontal'}
+            style={{
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              width: 28, height: 28, padding: 0,
+              background: 'var(--cth-paper-100)',
+              boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
+              border: 'none', borderRadius: 2, cursor: 'pointer',
+              color: 'var(--cth-ink-900)'
+            }}
+          >
+            {splitOrientation === 'horizontal' ? <SplitVerticalGlyph /> : <SplitHorizontalGlyph />}
+          </button>
+        )}
         {/* Fullscreen. The title bar is chrome, not canvas, so these two use
             clean stroke icons rather than the 16x16 pixel set the rest of the UI
             is drawn in — at 16-18px a pixel-grid glyph reads as a rendering
@@ -393,8 +430,11 @@ export function App() {
       </div>
 
       <div style={{
-        flex: 1, minHeight: 0,
+        flex: 1, minHeight: 0, minWidth: 0,
         display: 'flex',
+        // The divider's axis IS the flex direction: a vertical divider lays the
+        // panes out in a row, a horizontal one stacks them in a column.
+        flexDirection: splitOrientation === 'horizontal' ? 'column' : 'row',
         padding: 16,
         gap: 0
       }}>
@@ -427,14 +467,18 @@ export function App() {
         </div>
 
         <SidebarSplitter
-          width={sidebarWidth}
-          onChange={setSidebarWidth}
-          viewportWidth={vpWidth}
+          size={splitOrientation === 'horizontal' ? sidebarHeight : sidebarWidth}
+          onChange={(px) => setSidebarSize(px, splitOrientation === 'horizontal' ? vpHeight : vpWidth)}
+          orientation={splitOrientation}
+          viewport={splitOrientation === 'horizontal' ? vpHeight : vpWidth}
         />
 
         <div style={{
-          width: sidebarWidth, flexShrink: 0,
-          minHeight: 0, display: 'flex', flexDirection: 'column'
+          ...(splitOrientation === 'horizontal'
+            ? { height: sidebarHeight }
+            : { width: sidebarWidth }),
+          flexShrink: 0,
+          minHeight: 0, minWidth: 0, display: 'flex', flexDirection: 'column'
         }}>
           {agent ? (
             <AgentDetailPanel agent={agent} />
@@ -539,6 +583,26 @@ function ExpandGlyph() {
   return (
     <Glyph>
       <path d="M6.2 3H3v3.2M9.8 3H13v3.2M6.2 13H3V9.8M9.8 13H13V9.8" />
+    </Glyph>
+  );
+}
+
+/** Two panes side by side — what clicking gets you, i.e. the VERTICAL divider. */
+function SplitVerticalGlyph() {
+  return (
+    <Glyph>
+      <path d="M2.5 3.5h11v9h-11z" />
+      <path d="M8 3.5v9" />
+    </Glyph>
+  );
+}
+
+/** Two panes stacked — the HORIZONTAL divider, floor above the terminal. */
+function SplitHorizontalGlyph() {
+  return (
+    <Glyph>
+      <path d="M2.5 3.5h11v9h-11z" />
+      <path d="M2.5 8h11" />
     </Glyph>
   );
 }

--- a/src/renderer/src/components/SidebarSplitter.tsx
+++ b/src/renderer/src/components/SidebarSplitter.tsx
@@ -1,33 +1,50 @@
 import { useEffect, useRef, useState } from 'react';
+import { clampSidebarSize, SIDEBAR_DEFAULT, type SplitOrientation } from '@/store/splitLayout';
 
 export interface SidebarSplitterProps {
-  /** Current sidebar width in px. */
-  width: number;
-  /** Called with the new width (already clamped externally). */
+  /** Current sidebar size in px — width when vertical, height when horizontal. */
+  size: number;
+  /** Called with the new size. Clamping happens here AND in the store, because
+   *  the store is also reached by the orientation flip and the persisted restore. */
   onChange: (px: number) => void;
-  /** Containing viewport width — used to clamp delta to a sane max. */
-  viewportWidth: number;
-  min?: number;
-  max?: number;
+  /** Which axis divides the panes. See `splitLayout.SplitOrientation`. */
+  orientation: SplitOrientation;
+  /** Containing viewport extent along the SPLIT axis — window width when
+   *  vertical, window height when horizontal. Used to reserve the floor's room. */
+  viewport: number;
 }
 
 /**
- * Vertical drag handle. Sits between the floor canvas (left) and the sidebar
- * (right). Drag left → wider sidebar. Cursor + pixel-stripe affordance.
+ * Drag handle between the floor canvas and the agent sidebar.
+ *
+ * One component serves both axes rather than two near-identical ones: the drag
+ * maths is the same subtraction on a different coordinate, and splitting it in
+ * two is how the two copies drift. Everything axis-dependent is resolved from
+ * `orientation` up front and then used symmetrically.
+ *
+ * The sidebar is the pane AFTER the handle in both orientations (right when
+ * vertical, below when horizontal), so dragging back toward the origin — left,
+ * or up — always grows it. That keeps the gesture's meaning identical across a
+ * flip, which is what stops the flip feeling like a different app.
  */
-export function SidebarSplitter({
-  width, onChange, viewportWidth, min = 320, max = 1200
-}: SidebarSplitterProps) {
-  const startRef = useRef<{ clientX: number; width: number } | null>(null);
+export function SidebarSplitter({ size, onChange, orientation, viewport }: SidebarSplitterProps) {
+  const horizontal = orientation === 'horizontal';
+  const startRef = useRef<{ pos: number; size: number } | null>(null);
   const [active, setActive] = useState(false);
+  // App passes an inline closure (it forwards the viewport), so `onChange` is a
+  // fresh function on every render — and a drag re-renders on every frame. Held
+  // in a ref so the listener effect below depends only on primitives and does
+  // not tear down / re-register the window listeners mid-gesture.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
       if (!startRef.current) return;
-      const delta = startRef.current.clientX - e.clientX; // left drag = positive delta → grow sidebar
-      const clampMax = Math.min(max, Math.max(min, viewportWidth - 360));
-      const next = Math.min(clampMax, Math.max(min, startRef.current.width + delta));
-      onChange(next);
+      // Drag toward the origin (left / up) = positive delta = grow the sidebar.
+      const pos = horizontal ? e.clientY : e.clientX;
+      const delta = startRef.current.pos - pos;
+      onChangeRef.current(clampSidebarSize(startRef.current.size + delta, orientation, viewport));
     };
     const onUp = () => {
       startRef.current = null;
@@ -39,47 +56,51 @@ export function SidebarSplitter({
     if (active) {
       window.addEventListener('mousemove', onMove);
       window.addEventListener('mouseup', onUp);
-      document.body.style.cursor = 'ew-resize';
+      document.body.style.cursor = horizontal ? 'ns-resize' : 'ew-resize';
     }
     return () => {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };
-  }, [active, viewportWidth, min, max, onChange]);
+  }, [active, horizontal, orientation, viewport]);
+
+  // The 2px rule runs ALONG the handle; the three hash marks run ACROSS it.
+  const rule = horizontal
+    ? { left: 0, right: 0, top: 4, height: 2 }
+    : { top: 0, bottom: 0, left: 4, width: 2 };
+  const grip = horizontal
+    ? { left: '50%', top: 2, transform: 'translateX(-50%)', width: 24, height: 6, flexDirection: 'row' as const }
+    : { top: '50%', left: 2, transform: 'translateY(-50%)', width: 6, height: 24, flexDirection: 'column' as const };
+  const mark = horizontal ? { width: 2 } : { height: 2 };
 
   return (
     <div
       onMouseDown={(e) => {
-        startRef.current = { clientX: e.clientX, width };
+        startRef.current = { pos: horizontal ? e.clientY : e.clientX, size };
         setActive(true);
         e.preventDefault();
       }}
-      onDoubleClick={() => onChange(420)}
+      onDoubleClick={() => onChange(SIDEBAR_DEFAULT[orientation])}
       title="Drag to resize · double-click to reset"
       style={{
-        width: 10,
-        cursor: 'ew-resize',
+        ...(horizontal ? { height: 10 } : { width: 10 }),
+        cursor: horizontal ? 'ns-resize' : 'ew-resize',
         flexShrink: 0,
         position: 'relative',
         background: active ? 'var(--cth-cream-300)' : 'transparent'
       }}
     >
-      {/* The visible 2px stripe with hash marks in the middle */}
       <div style={{
-        position: 'absolute',
-        top: 0, bottom: 0, left: 4,
-        width: 2,
+        position: 'absolute', ...rule,
         background: active ? 'var(--cth-ink-900)' : 'var(--cth-ink-300)'
       }} />
       <div style={{
-        position: 'absolute',
-        top: '50%', left: 2, transform: 'translateY(-50%)',
-        width: 6, height: 24,
-        display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
+        position: 'absolute', ...grip,
+        display: 'flex', justifyContent: 'space-between'
       }}>
-        <span style={{ height: 2, background: 'var(--cth-ink-900)' }} />
-        <span style={{ height: 2, background: 'var(--cth-ink-900)' }} />
-        <span style={{ height: 2, background: 'var(--cth-ink-900)' }} />
+        <span style={{ ...mark, background: 'var(--cth-ink-900)' }} />
+        <span style={{ ...mark, background: 'var(--cth-ink-900)' }} />
+        <span style={{ ...mark, background: 'var(--cth-ink-900)' }} />
       </div>
     </div>
   );

--- a/src/renderer/src/store/splitLayout.ts
+++ b/src/renderer/src/store/splitLayout.ts
@@ -1,0 +1,104 @@
+/**
+ * Split-pane geometry — the floor pane and the agent sidebar, and which axis
+ * divides them.
+ *
+ * Pure and React-free so the clamp rules are unit-testable: every number here is
+ * a layout invariant the splitter drag, the orientation flip and the persisted
+ * restore all have to agree on, and they used to agree only by all calling the
+ * same inline `Math.min(...)`.
+ *
+ * ORIENTATION NAMES THE DIVIDER, not the stacking. `vertical` is a vertical
+ * divider — panes side by side, sidebar on the RIGHT, sized by WIDTH.
+ * `horizontal` is a horizontal divider — panes stacked, sidebar BELOW the floor,
+ * sized by HEIGHT. This matches how every editor names its splits; naming it
+ * after the stacking instead reads backwards to anyone who has used one.
+ */
+
+export type SplitOrientation = 'vertical' | 'horizontal';
+
+/**
+ * Smallest useful sidebar, per orientation.
+ *
+ * These are NOT the same number, because the sidebar holds a terminal and a
+ * terminal's two axes are not interchangeable: 320px of width is about 40
+ * columns (below which agent output wraps into soup), while 240px of height is
+ * about 15 rows — cramped but genuinely usable, and a user who flips to
+ * horizontal is usually doing it precisely to give the terminal the full width
+ * and is happy to trade rows for columns.
+ */
+export const SIDEBAR_MIN: Record<SplitOrientation, number> = {
+  vertical: 320,
+  horizontal: 240
+};
+
+/** Absolute ceiling, independent of viewport — stops a restored value from a
+ *  much larger display swallowing the whole window on a smaller one. Higher for
+ *  horizontal because window heights and widths are not comparable scales. */
+export const SIDEBAR_MAX: Record<SplitOrientation, number> = {
+  vertical: 1200,
+  horizontal: 2000
+};
+
+/**
+ * Room the FLOOR pane always keeps.
+ *
+ * The office map is 544x352 — a 1.55:1 landscape image — and the camera does a
+ * contain-fit (`Camera.getMinZoom` takes the min of the two axis ratios), so
+ * whichever axis is over-provisioned becomes dead letterbox space.
+ *
+ * 360 horizontal-axis pixels is the long-standing vertical-split floor. 180 is
+ * the horizontal one: at 180px tall the fit is height-limited and the floor
+ * renders ~279x180, which still reads as a floor with recognisable avatars.
+ * Reusing 360 here would have made the strip layout — the whole point of the
+ * horizontal split — impossible to drag to.
+ */
+export const FLOOR_MIN: Record<SplitOrientation, number> = {
+  vertical: 360,
+  horizontal: 180
+};
+
+/**
+ * Opening size per orientation, and the double-click reset target.
+ *
+ * Deliberately NOT one shared number. The two orientations size different edges
+ * of different panes, so carrying one scalar across a flip turns a 420px-wide
+ * sidebar into a 420px-tall one — which in horizontal mode is a small terminal
+ * under a huge floor, the exact inverse of what the flip was asked for. Each
+ * orientation therefore remembers its own size (see `sidebarWidth` /
+ * `sidebarHeight` in the store).
+ */
+export const SIDEBAR_DEFAULT: Record<SplitOrientation, number> = {
+  vertical: 420,
+  horizontal: 620
+};
+
+/**
+ * Confine a sidebar size to what the current orientation and viewport allow.
+ *
+ * Order matters: the floor's reserved room is applied as a max, but never below
+ * the sidebar's own min — on a viewport too small to satisfy both, the sidebar
+ * min wins and the floor is the pane that gives. The alternative (floor wins)
+ * collapses the terminal to nothing, and the terminal is the pane carrying the
+ * work.
+ */
+export function clampSidebarSize(
+  px: number,
+  orientation: SplitOrientation,
+  viewport: number
+): number {
+  const min = SIDEBAR_MIN[orientation];
+  const roomMax = Math.max(min, viewport - FLOOR_MIN[orientation]);
+  const max = Math.min(SIDEBAR_MAX[orientation], roomMax);
+  const n = Number.isFinite(px) ? Math.round(px) : SIDEBAR_DEFAULT[orientation];
+  return Math.min(max, Math.max(min, n));
+}
+
+/** The other orientation. */
+export function flipOrientation(o: SplitOrientation): SplitOrientation {
+  return o === 'vertical' ? 'horizontal' : 'vertical';
+}
+
+/** Narrow an untrusted persisted value (localStorage) to an orientation. */
+export function parseOrientation(v: unknown): SplitOrientation {
+  return v === 'horizontal' ? 'horizontal' : 'vertical';
+}

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -18,6 +18,10 @@ import { preferredAgentRole } from '@shared/agentRole';
 import { isInboxNudge } from '@shared/hiveNudge';
 import { refocusAfterRemoval, focusOnLoad, restoreFocus } from './focusMode';
 import { chooseRosterSource } from './rosterSource';
+import {
+  clampSidebarSize, flipOrientation, parseOrientation,
+  SIDEBAR_DEFAULT, SIDEBAR_MIN, SIDEBAR_MAX, type SplitOrientation
+} from './splitLayout';
 
 export type ToolKind =
   | 'Read' | 'Edit' | 'Write' | 'Bash' | 'WebFetch' | 'WebSearch'
@@ -207,6 +211,12 @@ interface State {
    *  fallback for anything that genuinely has no particular agent in mind. */
   ideAgentId: string | null;
   sidebarWidth: number;
+  /** Sidebar HEIGHT, used only while `splitOrientation === 'horizontal'`.
+   *  Kept beside sidebarWidth rather than replacing it so each orientation
+   *  remembers its own size across flips — see splitLayout.SIDEBAR_DEFAULT. */
+  sidebarHeight: number;
+  /** Which axis divides the floor pane from the agent sidebar. */
+  splitOrientation: SplitOrientation;
   sidebarTab: SidebarTab;
   godStatus: GodStatus;
   /** Per-agent outgoing message queue (agent id → messages awaiting delivery).
@@ -334,7 +344,11 @@ interface State {
    *  then falls back to the selection and says so in its title). */
   setIdeOpen: (open: boolean, agentId?: string | null) => void;
   setIdeInitialFile: (path: string | null) => void;
-  setSidebarWidth: (px: number) => void;
+  /** Resize the sidebar along the CURRENT orientation's axis. Writes
+   *  sidebarWidth or sidebarHeight accordingly; the caller never picks. */
+  setSidebarSize: (px: number, viewport: number) => void;
+  /** Flip the divider axis. Each orientation keeps its own remembered size. */
+  toggleSplitOrientation: () => void;
   setSidebarTab: (tab: SidebarTab) => void;
   /** Drop persisted agents whose PTY is no longer alive in the main process.
    *  Called once at startup so a renderer reload (e.g. after the laptop sleeps)
@@ -343,6 +357,8 @@ interface State {
 }
 
 const LS_SIDEBAR_WIDTH = 'cth.sidebarWidth';
+const LS_SIDEBAR_HEIGHT = 'cth.sidebarHeight';
+const LS_SPLIT_ORIENTATION = 'cth.splitOrientation';
 const LS_SIDEBAR_TAB = 'cth.sidebarTab';
 const LS_AGENTS = 'cth.agents';
 const LS_ARCHIVED = 'cth.archivedAgents';
@@ -616,9 +632,23 @@ const initialSidebarWidth = (() => {
   try {
     const v = window.localStorage.getItem(LS_SIDEBAR_WIDTH);
     const n = v ? parseInt(v, 10) : NaN;
-    if (!Number.isNaN(n) && n >= 320 && n <= 1200) return n;
+    if (!Number.isNaN(n) && n >= SIDEBAR_MIN.vertical && n <= SIDEBAR_MAX.vertical) return n;
   } catch { /* noop */ }
-  return 420;
+  return SIDEBAR_DEFAULT.vertical;
+})();
+const initialSidebarHeight = (() => {
+  try {
+    const v = window.localStorage.getItem(LS_SIDEBAR_HEIGHT);
+    const n = v ? parseInt(v, 10) : NaN;
+    if (!Number.isNaN(n) && n >= SIDEBAR_MIN.horizontal && n <= SIDEBAR_MAX.horizontal) return n;
+  } catch { /* noop */ }
+  return SIDEBAR_DEFAULT.horizontal;
+})();
+const initialSplitOrientation: SplitOrientation = (() => {
+  try {
+    return parseOrientation(window.localStorage.getItem(LS_SPLIT_ORIENTATION));
+  } catch { /* noop */ }
+  return 'vertical';
 })();
 const initialSidebarTab: SidebarTab = (() => {
   try {
@@ -688,6 +718,8 @@ export const useStore = create<State>((set, get) => ({
   ideOpen: false,
   ideAgentId: null,
   sidebarWidth: initialSidebarWidth,
+  sidebarHeight: initialSidebarHeight,
+  splitOrientation: initialSplitOrientation,
   sidebarTab: initialSidebarTab,
   godStatus: 'booting',
   messageQueues: initialQueues,
@@ -1024,10 +1056,20 @@ export const useStore = create<State>((set, get) => ({
   // a caller that passes nothing.
   setIdeOpen: (open, agentId) => set({ ideOpen: open, ideAgentId: open ? (agentId ?? null) : null }),
   setIdeInitialFile: (path) => set({ ideInitialFile: path }),
-  setSidebarWidth: (px) => {
-    const clamped = Math.min(1200, Math.max(320, Math.round(px)));
-    try { window.localStorage.setItem(LS_SIDEBAR_WIDTH, String(clamped)); } catch { /* noop */ }
-    set({ sidebarWidth: clamped });
+  setSidebarSize: (px, viewport) => {
+    const orientation = get().splitOrientation;
+    const clamped = clampSidebarSize(px, orientation, viewport);
+    const key = orientation === 'horizontal' ? LS_SIDEBAR_HEIGHT : LS_SIDEBAR_WIDTH;
+    try { window.localStorage.setItem(key, String(clamped)); } catch { /* noop */ }
+    set(orientation === 'horizontal' ? { sidebarHeight: clamped } : { sidebarWidth: clamped });
+  },
+  toggleSplitOrientation: () => {
+    const next = flipOrientation(get().splitOrientation);
+    try { window.localStorage.setItem(LS_SPLIT_ORIENTATION, next); } catch { /* noop */ }
+    // Only the axis changes here. The new orientation's size is whatever it was
+    // last left at (or its default), so flipping back and forth is lossless —
+    // deriving one from the other would silently overwrite the user's other layout.
+    set({ splitOrientation: next });
   },
   setSidebarTab: (tab) => {
     try { window.localStorage.setItem(LS_SIDEBAR_TAB, tab); } catch { /* noop */ }

--- a/test/split-layout.test.cjs
+++ b/test/split-layout.test.cjs
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * Split-pane geometry.
+ *
+ * The clamp is reached by three callers that never see each other — the splitter
+ * drag, the orientation flip, and the persisted-size restore on boot — so the
+ * invariants below are the only thing keeping them agreeing. The one that used
+ * to be inline (`Math.min(1200, Math.max(320, px))`) silently assumed a vertical
+ * divider, which is exactly the assumption a horizontal split breaks.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  clampSidebarSize, flipOrientation, parseOrientation,
+  SIDEBAR_MIN, SIDEBAR_MAX, FLOOR_MIN, SIDEBAR_DEFAULT
+} = loadTs('src/renderer/src/store/splitLayout.ts');
+
+// — the pre-existing vertical behaviour must not move —
+
+test('vertical keeps the historical 320..1200 bounds', () => {
+  assert.equal(clampSidebarSize(10, 'vertical', 1920), 320);
+  assert.equal(clampSidebarSize(99999, 'vertical', 4000), 1200);
+  assert.equal(clampSidebarSize(420, 'vertical', 1920), 420);
+});
+
+test('vertical still reserves 360px of floor, as it always did', () => {
+  // The old inline rule was `Math.min(max, Math.max(min, viewportWidth - 360))`.
+  assert.equal(clampSidebarSize(9999, 'vertical', 1000), 640);
+});
+
+// — the horizontal axis is NOT the vertical one with different numbers —
+
+test('horizontal allows a shorter sidebar than vertical allows a narrow one', () => {
+  // 240px of terminal height is ~15 rows: usable. 240px of WIDTH is not.
+  assert.equal(clampSidebarSize(0, 'horizontal', 1200), SIDEBAR_MIN.horizontal);
+  assert.ok(SIDEBAR_MIN.horizontal < SIDEBAR_MIN.vertical);
+});
+
+test('horizontal reserves only 180px for the floor, so a thin strip is reachable', () => {
+  // The whole point of the flip: drag the floor down to a strip. Reusing the
+  // vertical 360 reserve would have made the target layout impossible.
+  assert.equal(clampSidebarSize(9999, 'horizontal', 1000), 820);
+  assert.ok(FLOOR_MIN.horizontal < FLOOR_MIN.vertical);
+});
+
+// — the squeeze: which pane gives when both minima cannot be met —
+
+test('on a viewport too small for both, the sidebar min wins and the floor gives', () => {
+  // 400px tall cannot satisfy 240 sidebar + 180 floor (=420). The terminal is
+  // the pane carrying the work, so it keeps its floor; the office shrinks.
+  assert.equal(clampSidebarSize(9999, 'horizontal', 400), SIDEBAR_MIN.horizontal);
+  assert.equal(clampSidebarSize(0, 'horizontal', 400), SIDEBAR_MIN.horizontal);
+});
+
+test('the clamp never returns below the min, whatever the viewport', () => {
+  for (const o of ['vertical', 'horizontal']) {
+    for (const vp of [0, 1, 200, 500, 1000, 4000]) {
+      assert.ok(clampSidebarSize(-999, o, vp) >= SIDEBAR_MIN[o], `${o}@${vp}`);
+      assert.ok(clampSidebarSize(99999, o, vp) >= SIDEBAR_MIN[o], `${o}@${vp}`);
+    }
+  }
+});
+
+test('a non-finite size falls back to the orientation default, not NaN', () => {
+  // A corrupt localStorage value must not propagate into a style property:
+  // `width: NaN` silently collapses the pane to zero. Infinity is treated as
+  // the same class of garbage as NaN rather than as "as large as possible" —
+  // a restore that meant 620 should not silently become a maximised pane.
+  for (const o of ['vertical', 'horizontal']) {
+    assert.equal(clampSidebarSize(NaN, o, 1920), SIDEBAR_DEFAULT[o]);
+    assert.equal(clampSidebarSize(Infinity, o, 1920), SIDEBAR_DEFAULT[o]);
+    assert.equal(clampSidebarSize(-Infinity, o, 1920), SIDEBAR_DEFAULT[o]);
+  }
+});
+
+test('the size is always an integer — a fractional px blurs the pixel-art floor', () => {
+  assert.equal(clampSidebarSize(420.7, 'vertical', 1920), 421);
+  assert.equal(Number.isInteger(clampSidebarSize(613.2, 'horizontal', 1400)), true);
+});
+
+// — flipping is lossless —
+
+test('flip is its own inverse', () => {
+  assert.equal(flipOrientation('vertical'), 'horizontal');
+  assert.equal(flipOrientation('horizontal'), 'vertical');
+  assert.equal(flipOrientation(flipOrientation('vertical')), 'vertical');
+});
+
+test('each orientation has its own default, so a flip cannot inherit the other axis', () => {
+  // Sharing one scalar turns a 420px-WIDE sidebar into a 420px-TALL one, which
+  // in horizontal mode is a tiny terminal under a huge floor — the inverse of
+  // what the user asked for by flipping.
+  assert.notEqual(SIDEBAR_DEFAULT.vertical, SIDEBAR_DEFAULT.horizontal);
+});
+
+// — untrusted persisted input —
+
+test('parseOrientation defaults anything unrecognised to vertical', () => {
+  assert.equal(parseOrientation('horizontal'), 'horizontal');
+  assert.equal(parseOrientation('vertical'), 'vertical');
+  for (const junk of [null, undefined, '', 'HORIZONTAL', 'row', 0, {}, []]) {
+    assert.equal(parseOrientation(junk), 'vertical', JSON.stringify(junk));
+  }
+});


### PR DESCRIPTION
## What & why

The floor/sidebar divider was hard-coded vertical in three separate places: `SidebarSplitter` read `clientX` and set `ew-resize`, `App` laid the panes out in a flex row, and the store held a single `sidebarWidth` scalar. There was no orientation setting anywhere.

That is the wrong shape for the floor. The office map is 544×352 (1.55:1) and `Camera.getMinZoom` contain-fits it, so a tall narrow pane is width-limited and letterboxes the rest. On the 1895×1194 window below, the floor pane is 788×1020 and the map renders 788×510 — half the column is dead space — while the terminal is confined to the remaining ~1085px.

Stacking the panes gives the terminal the full window width: ~1085px → ~1863px, roughly 70% more columns for agent output. The floor renders at the same 788×510; its unused space just moves from vertical bands to side bars. On a taller, narrower window the floor gains as well.

This adds the option and changes nothing by default — `vertical` stays the default and is byte-for-byte the previous behaviour.

Closes #311

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
![Before — side-by-side split, floor letterboxed, terminal ~1085px](https://raw.githubusercontent.com/ketan0095/munder-difflin/pr-evidence/before-vertical.png)
Side-by-side (today's only layout), 1895×1194. Floor pane 788×1020, map rendered 788×510 — note the black bands above and below it. Terminal ~1085px wide.

### After
![After — horizontal split, terminal full width ~1863px](https://raw.githubusercontent.com/ketan0095/munder-difflin/pr-evidence/after-horizontal.png)
Same window, same size, same theme, same session, after clicking the new toggle. Floor becomes a strip; terminal is full width at ~1863px.

## How I tested it

- OS: macOS 15 (Darwin 25.5.0), Apple Silicon
- Steps:
  - `npm run typecheck` — clean, node + web
  - `npm run test:focused` — 563 pass, 0 fail (552 existing + 11 new in `test/split-layout.test.cjs`)
  - `npm run build` — clean
  - Ran the production build and flipped the toggle both ways; dragged the divider in both orientations; double-clicked to reset in both; entered and left focus mode; quit and relaunched to confirm the orientation and both pane sizes persist.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts.
- [ ] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`. *(n/a — no new art; the two glyphs are stroke paths matching the existing `ExpandGlyph`/`CollapseGlyph`.)*

## Notes for the reviewer

**Why the toggle is its own button and not folded into focus mode.** They are independent axes: focus mode owns *how many* panes, orientation owns *how they sit*. A single cycling control would force a user through a layout they don't want to reach the one they do, and would desync the moment `Esc` left focus mode. The button is hidden — not disabled — while focus mode is on, since there is no split to orient and the focus button beside it already explains where the floor went.

**Why each orientation keeps its own size.** Carrying one scalar across a flip turns a 420px-wide sidebar into a 420px-tall one — a small terminal under a huge floor, the inverse of what the flip was asked for. `sidebarWidth` and `sidebarHeight` are stored separately.

**Why the minima differ per orientation.** The sidebar holds a terminal and its axes are not interchangeable: 320px of width is ~40 columns, below which output wraps badly; 240px of height is ~15 rows, cramped but usable. The floor's reserve also drops 360 → 180, or the strip layout this exists for would be impossible to drag to.

**No refit plumbing was needed.** `OfficeFloor`'s `ResizeObserver` already calls `camera.setViewSize` (which refits), and `PtyTerminalView`'s observes the terminal host, so both panes re-fit themselves on the flip. Worth knowing: `Camera.setViewSize` only refits while `manualOverride` is false, and that is always true today because `focusOn()` — its only writer — is currently unreachable. If `focusOn` is ever wired up, the flip will need an explicit `fitToScreen()`.

**One pre-existing interaction.** `cth.prefersFocusMode` restores focus mode on launch, so quitting in focus mode reopens in it with the orientation button hidden until `Esc`. Not introduced here, but it is the one way the button can appear to be missing.
