### PR TITLE
fix(terminal): only run the fit/fonts settle cascade on first open (#314)

### DIFF
--- a/src/renderer/src/components/PtyTerminalView.tsx
+++ b/src/renderer/src/components/PtyTerminalView.tsx
@@ -147,6 +147,11 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
     entry.term.options.theme = THEMES[ptyThemeRef.current];
     entry.term.options.fontSize = fontSizeRef.current;
     attachTerminal(entry, container);
+    // Only the terminal's true first open needs the settle cascade below (the
+    // delayed refits + web-font re-measure). Latched before scheduling so a
+    // reattach can never replay it — see TerminalEntry.settled.
+    const isFirstAttach = !entry.settled;
+    entry.settled = true;
     entry.onData = (chunk) => onStreamDataRef.current?.(chunk);
     entry.onPrompt = (text) => onUserPromptRef.current?.(text);
 
@@ -209,25 +214,33 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
     // until the host has a real size, so a terminal mounted under an inactive
     // tab simply waits for the ResizeObserver below to fire the first fit.
     requestAnimationFrame(() => requestAnimationFrame(() => tryFit(true)));
-    const retries = [setTimeout(() => tryFit(true), 60), setTimeout(() => tryFit(true), 240)];
-    if (typeof document !== 'undefined' && document.fonts?.ready) {
-      document.fonts.ready
-        .then(() => {
-          // xterm measures the character cell ONCE at open(); if VT323 hadn't
-          // loaded yet, that cached cell is the fallback font's size, so every
-          // fit() proposes the wrong column count and the WebGL glyph atlas is
-          // rastered at the wrong metrics — the banner renders oversized until a
-          // manual resize. Re-applying the font + clearing the texture atlas
-          // forces a re-measure / re-raster with the real font, then we refit.
-          try {
-            const fam = entry.term.options.fontFamily;
-            entry.term.options.fontFamily = fam;
-            entry.term.options.fontSize = fontSizeRef.current;
-            entry.term.clearTextureAtlas?.();
-          } catch { /* noop */ }
-          tryFit(true);
-        })
-        .catch(() => { /* noop */ });
+    const retries: ReturnType<typeof setTimeout>[] = [];
+    if (isFirstAttach) {
+      // These retries and the font re-measure below exist to wait out a web
+      // font that may still be loading on this terminal's FIRST open. A
+      // reattach already has confirmed-correct cell metrics, so redoing this
+      // is pure risk: it can race a keystroke or a user's scroll gesture that
+      // lands mid-cascade (see TerminalEntry.settled).
+      retries.push(setTimeout(() => tryFit(true), 60), setTimeout(() => tryFit(true), 240));
+      if (typeof document !== 'undefined' && document.fonts?.ready) {
+        document.fonts.ready
+          .then(() => {
+            // xterm measures the character cell ONCE at open(); if VT323 hadn't
+            // loaded yet, that cached cell is the fallback font's size, so every
+            // fit() proposes the wrong column count and the WebGL glyph atlas is
+            // rastered at the wrong metrics — the banner renders oversized until a
+            // manual resize. Re-applying the font + clearing the texture atlas
+            // forces a re-measure / re-raster with the real font, then we refit.
+            try {
+              const fam = entry.term.options.fontFamily;
+              entry.term.options.fontFamily = fam;
+              entry.term.options.fontSize = fontSizeRef.current;
+              entry.term.clearTextureAtlas?.();
+            } catch { /* noop */ }
+            tryFit(true);
+          })
+          .catch(() => { /* noop */ });
+      }
     }
 
     // The ResizeObserver is the authoritative trigger: it fires when the host

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -47,6 +47,15 @@ export interface TerminalEntry {
   host: HTMLDivElement;
   /** xterm is only `open()`ed once its host is first attached to the document. */
   opened: boolean;
+  /** True once this terminal has been through its first-open settle cascade
+   *  (the delayed refits that wait out web-font loading in PtyTerminalView).
+   *  A REATTACH — switching back to an already-open agent tab — re-parents
+   *  the same host and already has confirmed-correct cell metrics, so it must
+   *  not repeat that cascade: doing so re-opens a texture-atlas-clear/resize
+   *  race against whatever the user does right after switching (a keystroke
+   *  mid-clear paints at the stale cell size; a scroll gesture gets snapped
+   *  back to the bottom by the next delayed refit). */
+  settled: boolean;
   exited: boolean;
   /** Stream subscriptions to tear down on dispose. */
   unsub: Array<() => void>;
@@ -161,6 +170,7 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     fit,
     host,
     opened: false,
+    settled: false,
     exited: false,
     unsub: [],
     recovery: createTerminalRecoveryState(),


### PR DESCRIPTION
## Summary

Fixes #314. Two cosmetic terminal bugs that share a single root cause in the pooled-terminal reattach path.

## Root cause

`PtyTerminalView`'s attach effect runs a "settle cascade" on every mount: a double-`requestAnimationFrame` fit, retries at 60ms and 240ms, and a `document.fonts.ready` re-measure (reapply `fontFamily`/`fontSize`, `clearTextureAtlas`, refit) - each of which also forces `scrollLines(-1)` / `scrollToBottom()` when `scrollToEnd` is true.

Because terminals are pooled (`terminalPool.ts`) and views reparent the same host `div` on every tab switch / fullscreen toggle, this whole cascade re-runs on **every reattach**, even though cell/font metrics were already correct after the terminal's first open:

- **First typed character shifts one column (gap in the first word):** a keystroke landing during the reattach `clearTextureAtlas()` + refit race paints at stale cell metrics. `Ctrl+L` forces a clean repaint (which is why it "fixes" it), and `Enter` is unaffected because the underlying buffer was never wrong - it is purely a paint bug.
- **No usable scrollback:** every reattach yanks scroll to the bottom up to ~4x over a ~240ms window, so a user who scrolls up shortly after switching tabs keeps getting snapped back down - reading as "cannot scroll above the top."

## Fix

- Add `settled: boolean` to `TerminalEntry` (`terminalPool.ts`), initialized `false` on creation.
- In `PtyTerminalView`'s attach effect, latch `isFirstAttach = !entry.settled; entry.settled = true` **before** scheduling async work, and gate the 60ms/240ms retries + `document.fonts.ready` re-measure cascade behind `isFirstAttach`. On reattach the effect keeps only the single double-rAF `fit(scrollToEnd=true)` plus the existing synchronous `scrollToBottom()` - preserving "switching tabs snaps to the latest output" while removing the repeated texture-atlas-clear race and the repeated scroll yank.

## Verification

- `npm run typecheck` (node + web): clean.
- `npm run build` (electron-vite): succeeds.
- Verified by typecheck/build + code reasoning. A live GUI pass on a running build is recommended by a reviewer, as the fix concerns on-screen paint/scroll behavior.
