### PR TITLE
fix: reset usage when a PTY exits

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -448,6 +448,8 @@ function teardownPty(id: string): void {
     try { workerWake.forget(agentId, id); } catch { /* best-effort */ }
     // Drop breaker state so a dead agent can't leak/zombie a tripped level.
     try { breaker.forget(agentId); } catch { /* best-effort */ }
+    // A replacement using this id needs a new usage counter, not the dead PTY's.
+    try { telemetry.forgetAgent(agentId); } catch { /* best-effort */ }
     // W1 — kill this agent's proxy-bridge sidecar (qwen), if any, so a dead
     // PTY never leaves an orphan loopback listener. No-op for non-proxy agents.
     try { hive.stopProxyBridge(agentId); } catch (e) { console.error('[hive] stopProxyBridge failed:', e); }

--- a/src/main/telemetry.ts
+++ b/src/main/telemetry.ts
@@ -206,6 +206,25 @@ export class TelemetryCollector {
     return () => this.apiErrorSubs.delete(cb);
   }
 
+  /** Drop an agent's live usage so a respawn starts with a fresh counter.
+   *  Clears the in-memory accumulation only — the on-disk cost ledger and the
+   *  transcript fallback are untouched, so lifetime spending still reports. The
+   *  span ring goes too: it is keyed by agent id, so a replacement would
+   *  otherwise inherit the dead agent's tool waterfall.
+   *
+   *  Known edge: metrics are delivered asynchronously, so a batch already in
+   *  flight when the PTY dies can land after this call and recreate the dead
+   *  session's entries. The window is milliseconds and the next teardown
+   *  clears it, so it is left unguarded rather than carrying a tombstone. */
+  forgetAgent(agentId: string): void {
+    const sessionIds = this.agentSessions.get(agentId);
+    if (sessionIds) {
+      for (const sessionId of sessionIds) this.sessions.delete(sessionId);
+    }
+    this.agentSessions.delete(agentId);
+    this.spans.delete(agentId);
+  }
+
   /** Recent tool spans for the per-agent waterfall (#7B.2), oldest→newest. */
   getSpans(agentId: string): ToolSpan[] {
     return this.spans.get(agentId)?.slice() ?? [];

--- a/test/telemetry-forget-agent.test.cjs
+++ b/test/telemetry-forget-agent.test.cjs
@@ -1,0 +1,108 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { TelemetryCollector } = loadTs('src/main/telemetry.ts');
+
+function tokenBatch(agentId, sessionId, output) {
+  return {
+    resourceMetrics: [{
+      resource: { attributes: [{ key: 'agent.id', value: { stringValue: agentId } }] },
+      scopeMetrics: [{
+        metrics: [{
+          name: 'claude_code.token.usage',
+          sum: {
+            dataPoints: [{
+              asInt: String(output),
+              attributes: [
+                { key: 'session.id', value: { stringValue: sessionId } },
+                { key: 'type', value: { stringValue: 'output' } },
+                { key: 'model', value: { stringValue: 'claude-sonnet-5' } }
+              ]
+            }]
+          }
+        }]
+      }]
+    }]
+  };
+}
+
+async function postMetrics(endpoint, body) {
+  const response = await fetch(`${endpoint}/v1/metrics`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  assert.equal(response.status, 200);
+  await response.text();
+}
+
+test('forgetAgent resets usage before the same agent id is respawned', async (t) => {
+  const telemetry = new TelemetryCollector({ host: '127.0.0.1', port: 0 });
+  await telemetry.start();
+  t.after(() => telemetry.stop());
+  const endpoint = telemetry.endpoint();
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'dead-session', 900));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 900);
+
+  telemetry.forgetAgent('agent-1');
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'respawn-session', 10));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 10);
+});
+
+test('forgetAgent drops the dead session so its total cannot resurrect', async (t) => {
+  const telemetry = new TelemetryCollector({ host: '127.0.0.1', port: 0 });
+  await telemetry.start();
+  t.after(() => telemetry.stop());
+  const endpoint = telemetry.endpoint();
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'dead-session', 900));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 900);
+
+  telemetry.forgetAgent('agent-1');
+
+  // A late or duplicate sample for the SAME session id must accumulate from
+  // zero, not re-attach the forgotten 900. Deleting only agentSessions and
+  // leaving the sessions entry behind would let the dead total resurrect the
+  // moment any further metric arrives for that session — reinstating the very
+  // inherited usage this reset exists to clear.
+  await postMetrics(endpoint, tokenBatch('agent-1', 'dead-session', 10));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 10);
+});
+
+test('forgetAgent keeps usage for other agents', async (t) => {
+  const telemetry = new TelemetryCollector({ host: '127.0.0.1', port: 0 });
+  await telemetry.start();
+  t.after(() => telemetry.stop());
+  const endpoint = telemetry.endpoint();
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'session-1', 500));
+  await postMetrics(endpoint, tokenBatch('agent-2', 'session-2', 700));
+
+  telemetry.forgetAgent('agent-1');
+
+  assert.equal(telemetry.getAgentUsage('agent-1'), null);
+  assert.equal(telemetry.getAgentUsage('agent-2').output, 700);
+});
+
+test('teardown resets telemetry when it forgets breaker state', () => {
+  const indexPath = require('node:path').join(__dirname, '..', 'src', 'main', 'index.ts');
+  const rawSource = require('node:fs').readFileSync(indexPath, 'utf8');
+  const activeSource = rawSource
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+  // Bounded to the teardown block: an unbounded slice would also match the call
+  // if it were moved into any later function in the file.
+  const start = activeSource.indexOf('breaker.forget(agentId)');
+  const end = activeSource.indexOf('hive.stopProxyBridge(agentId)', start);
+  assert.ok(start !== -1 && end > start, 'teardown block not found in index.ts');
+  const afterBreakerReset = activeSource.slice(start, end);
+
+  assert.match(afterBreakerReset, /telemetry\.forgetAgent\(agentId\)/);
+});


### PR DESCRIPTION
## What & why

Tearing down a PTY forgets the agent's circuit-breaker state, but leaves its telemetry sessions in place. Live usage is summed across *every* retained session for an agent id, so a replacement agent that reuses that id starts with its dead predecessor's tokens already counted against it.

A per-agent **token cap can trip on spend that belongs to a session that no longer exists**, throttling or stopping a brand-new agent for something it never did.

This forgets the agent's live telemetry sessions alongside the breaker state. Only the in-memory live accumulation is cleared — the on-disk cost ledger and the transcript fallback are untouched, so lifetime spending is still reported.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
<img width="922" height="262" alt="CleanShot 2026-08-25 at 11 06 10@2x" src="https://github.com/user-attachments/assets/80540b04-9aa5-447b-a8b6-1c894677940b" />

Post 900 output tokens for a session, let the PTY die, then post 10 for a new session under the **same agent id**. The replacement inherits the dead session's spend:

```
not ok 1 - forgetAgent resets usage before the same agent id is respawned
  expected: 10
  actual: 910
  operator: 'strictEqual'
not ok 2 - forgetAgent keeps usage for other agents
```

### After
<img width="926" height="266" alt="CleanShot 2026-08-25 at 11 07 18@2x" src="https://github.com/user-attachments/assets/2d706ef8-e46e-48dc-8732-12cacdb47703" />


The same scenario with the reset in place — the replacement reports only its own usage, and other agents' counters are left alone:

```
# tests 555
# pass 555
# fail 0
```

```
$ npm run typecheck
0 errors

$ npm run build
build_exit=0
```

## Known limitations

Two edges are deliberately left unguarded:

**A metrics batch already in flight when the PTY dies can land after the reset** and recreate the dead session's entries, so one replacement may briefly see the pre-fix behaviour. The window is milliseconds and the next teardown clears it; carrying a tombstone to close it seemed disproportionate to the risk.

**A resumed session keeps its session id**, so until fresh live telemetry arrives its usage is served from the transcript fallback at the session's full historical spend, then drops to post-restart-only once live data lands. That spend is genuinely that session's, and live-over-fallback precedence is the existing contract, so this is arguably correct rather than a defect — but it is visible.

## How I tested it

- OS: macOS (darwin 25.6.0), Munder Difflin 0.4.5
- Steps:
  1. Reproduced against the real `TelemetryCollector`: posted 900 output tokens for a dead session and 10 for a respawn session under one agent id, and read back `output: 910`.
  2. Ran `npm run test:focused` on a branch cut from `main`: 555/555 (baseline on `main` is 552; this adds 3).
  3. Replaced the `forgetAgent` body with a no-op and re-ran — 2 tests fail, including the `10` vs `910` assertion above.
  4. Commented out the call site and re-ran — the wiring test fails, confirming it pins the call rather than matching its own comment text.
  5. `npm run typecheck` — 0 errors. `npm run build` — succeeds.

Scope was checked explicitly: `forgetAgent` runs only inside the `if (agentId)` branch of `teardownPty`, which is the single funnel for every teardown path (natural exit, explicit kill, and the reap/lifecycle sweep), and it clears only the dying agent's entries — a test pins that other agents' usage survives.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.

