### PR TITLE
fix(ci): scope PR evidence to visible sections

### DIFF
--- a/.github/workflows/pr-evidence.yml
+++ b/.github/workflows/pr-evidence.yml
@@ -75,7 +75,9 @@ jobs:
             // Comments are the template's own instructions to the author. Left
             // unfilled they are invisible to a reader, so they must be invisible
             // to this check too — otherwise the empty template would pass.
-            const visible = body.replace(/<!--[\s\S]*?-->/g, '');
+            const visible = body
+              .replace(/<!--[\s\S]*?-->/g, '')
+              .replace(/^(```|~~~)[\s\S]*?^\1\s*$/gm, '');
 
             // ── Before and after, separately ─────────────────────────────────
             // Two assets in one blob is not the same as a before and an after.
@@ -84,7 +86,7 @@ jobs:
             // right place to count for it.
             const section = (name) => {
               const re = new RegExp(
-                `^#{1,6}\\s*${name}\\b[^\\n]*\\n([\\s\\S]*?)(?=\\n#{1,6}\\s|$)`,
+                `^#{1,6}\\s*${name}\\b[^\\n]*\\n([\\s\\S]*?)(?=^#{1,6}\\s|(?![\\s\\S]))`,
                 'im'
               );
               return (visible.match(re) || [, ''])[1];


### PR DESCRIPTION
## What & why

A pull request that follows this repository's own template is rejected by the evidence check.

`PULL_REQUEST_TEMPLATE.md` puts an instructional comment and a blank line under `### Before` and `### After`. The check strips comments before matching, which leaves the blank line, and the section regex ends its lazy capture at `$`, which under the `m` flag matches the first line end it reaches.

In practice the check only reads the single line directly beneath each heading.

Two corrections. Terminate the capture at the next heading line start or at true end of input, so an immediately adjacent heading ends a section at width zero and an empty heading cannot be satisfied by the media under a later one. And strip fenced code blocks alongside HTML comments: test output pasted under a heading otherwise ends the section at its first `#` line and hides an image below it, and Markdown that looks like media inside a fence otherwise counts as evidence though it never renders.

Evidence still has to sit under its own heading, a section stops where the next one starts, and a heading with nothing under it still fails.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] Build / CI

## Evidence

The check's own section extraction, run over a body in the shape the template produces — heading, instructional comment, blank line, then the image — alongside the cases that must keep failing.

### Before
<img width="1480" height="418" alt="CleanShot 2026-08-25 at 15 02 28@2x" src="https://github.com/user-attachments/assets/4ee61719-48a4-462f-a540-2f43d7135de2" />

Both sections come back empty, so a description that follows the template is reported as having no evidence.

### After
<img width="1252" height="404" alt="CleanShot 2026-08-25 at 15 03 04@2x" src="https://github.com/user-attachments/assets/8bf4d83c-ed2e-45a0-a94d-a527f9d420e9" />

The same body is read correctly, while an empty heading beside an adjacent one, media in a later section, and media inside a code fence are all still refused.

## How I tested it

- OS: macOS
- Ran the workflow's extraction over the template shape, a heading immediately followed by another heading with the media under the second, media present only in a later section, media inside a fenced block, test output fenced above a real image, a section ending at end of input, and a heading with nothing under it. Only the template shape and the fenced-output-plus-image case are accepted; the rest are refused.
- `npm run typecheck`, `npm run test:focused` (552/552), `npm run build`.

