### PR TITLE
fix: refresh MCP defaults after toggling

### DIFF
--- a/src/renderer/src/components/McpDefaultsSettings.tsx
+++ b/src/renderer/src/components/McpDefaultsSettings.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { HarnessConfig } from '@/store/config';
 import { MCP_CATALOG, type McpTier } from '@shared/mcpCatalog';
+import { applyToggle, resolveEnabledFor } from './mcpToggleLogic';
 
 export interface McpDefaultsSettingsProps {
   config: HarnessConfig;
@@ -28,16 +29,34 @@ const labelStyle: React.CSSProperties = {
 
 export function McpDefaultsSettings({ config }: McpDefaultsSettingsProps) {
   const [note, setNote] = useState('');
+  // Seeded from the prop, then replaced by the persisted config after each
+  // toggle. Rendering from the prop alone keeps showing the stale value.
+  const [mcpDefaults, setMcpDefaults] = useState(config.mcpDefaults ?? {});
 
-  const enabledFor = (id: string): boolean =>
-    config.mcpDefaults?.[id]?.enabled ?? MCP_CATALOG.find((e) => e.id === id)?.defaultEnabled ?? false;
+  // …and re-seeded from disk on every MOUNT. The prop alone is not enough:
+  // SettingsModal renders this panel only while the Connections section is
+  // open, and its `config` is App's, loaded once at start-up and never
+  // refreshed after a save (see the re-seed note in SettingsModal). So
+  // switching sections and coming back remounts against a config object that
+  // still says the grant never happened. A consent control has to read the
+  // persisted value, not remember a stale prop.
+  useEffect(() => {
+    let alive = true;
+    window.cth.getConfig()
+      .then((c) => { if (alive) setMcpDefaults((c as HarnessConfig).mcpDefaults ?? {}); })
+      .catch(() => { /* keep the prop-seeded value */ });
+    return () => { alive = false; };
+  }, []);
+
+  const enabledFor = (id: string): boolean => resolveEnabledFor(mcpDefaults, id);
 
   const toggle = async (id: string) => {
     const next = !enabledFor(id);
     try {
-      await window.cth.updateConfig({
-        mcpDefaults: { ...(config.mcpDefaults ?? {}), [id]: { enabled: next } }
-      });
+      setMcpDefaults(await applyToggle(id, next, mcpDefaults, {
+        updateConfig: window.cth.updateConfig,
+        getConfig: window.cth.getConfig
+      }));
       setNote(`${id}: ${next ? 'enabled' : 'disabled'}`);
       setTimeout(() => setNote(''), 1800);
     } catch {

--- a/src/renderer/src/components/mcpToggleLogic.ts
+++ b/src/renderer/src/components/mcpToggleLogic.ts
@@ -1,0 +1,32 @@
+import type { HarnessConfig } from '@/store/config';
+import { MCP_CATALOG } from '@shared/mcpCatalog';
+
+export function resolveEnabledFor(
+  mcpDefaults: HarnessConfig['mcpDefaults'],
+  id: string,
+  catalog = MCP_CATALOG
+): boolean {
+  return mcpDefaults?.[id]?.enabled ?? catalog.find((e) => e.id === id)?.defaultEnabled ?? false;
+}
+
+interface ApplyToggleDeps {
+  updateConfig: (patch: Partial<HarnessConfig>) => Promise<unknown>;
+  getConfig: () => Promise<{ mcpDefaults?: Record<string, { enabled: boolean }> }>;
+}
+
+/**
+ * Persist the toggle, then RE-READ what actually landed and return that.
+ *
+ * The returned config is the value the component renders, so a stale prop does
+ * not survive a save or a settings-panel remount.
+ */
+export async function applyToggle(
+  id: string,
+  next: boolean,
+  currentDefaults: HarnessConfig['mcpDefaults'],
+  deps: ApplyToggleDeps
+): Promise<Record<string, { enabled: boolean }>> {
+  await deps.updateConfig({ mcpDefaults: { ...(currentDefaults ?? {}), [id]: { enabled: next } } });
+  const fresh = await deps.getConfig();
+  return fresh.mcpDefaults ?? {};
+}

--- a/test/load-ts.cjs
+++ b/test/load-ts.cjs
@@ -10,7 +10,7 @@ function resolveTs(fromDir, request) {
   const base = request.startsWith('@shared/')
     ? path.resolve(__dirname, '..', 'src/shared', request.slice('@shared/'.length))
     : path.resolve(fromDir, request);
-  for (const candidate of [base, `${base}.ts`, path.join(base, 'index.ts')]) {
+  for (const candidate of [base, `${base}.ts`, `${base}.tsx`, path.join(base, 'index.ts')]) {
     if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
   }
   return null;
@@ -29,7 +29,13 @@ function loadFile(filename) {
       // builtin (`import path from 'node:path'`) compiles to `path_1.default`,
       // which is undefined at run time — the module loads fine and then explodes
       // on first use. Test harness only; no shipped code compiles through here.
-      esModuleInterop: true
+      esModuleInterop: true,
+      // .tsx files need a JSX emit or transpileModule chokes on the first `<`.
+      // The AUTOMATIC runtime is deliberate: classic emit needs `React` in
+      // scope, and these components do not need a React default import.
+      // A test can therefore stub `react/jsx-runtime` and get a plain element
+      // tree without pulling in react-dom.
+      ...(filename.endsWith('.tsx') ? { jsx: ts.JsxEmit.ReactJSX } : {})
     },
     fileName: filename,
     reportDiagnostics: true

--- a/test/mcp-toggle-component.test.cjs
+++ b/test/mcp-toggle-component.test.cjs
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * Component coverage for the stale configuration prop regression.
+ *
+ * test/mcp-toggle-state.test.cjs covers the two functions that were extracted
+ * out of McpDefaultsSettings. It does not cover McpDefaultsSettings. Comment
+ * out the `setMcpDefaults(await applyToggle(...))` line and every one of those
+ * tests stays green while the stale-prop bug returns in full. So these tests
+ * mount the real component, click the real button, and read the real rendered
+ * label.
+ *
+ * The control under test is a consent control. `github-token` is tier `secret`
+ * with defaultEnabled:false — it is only ever on because a human turned it on.
+ * The component must render the persisted value after a toggle and remount.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+// MUST come before loadTs of any component — it seeds require.cache for react.
+const { mount, flatten, text } = require('./render-hooks.cjs');
+const loadTs = require('./load-ts.cjs');
+
+const { McpDefaultsSettings } = loadTs('src/renderer/src/components/McpDefaultsSettings.tsx');
+
+// The id under test, written out literally. NOT imported from the catalog: a
+// test that asks the implementation which id to check cannot notice the id
+// changing, and this one must always name an upstream catalog entry.
+const GITHUB_TOKEN = 'github-token';
+
+/** The label the toggle button renders for a catalog id: 'on' | 'off'. */
+function buttonLabel(tree, id) {
+  const hit = flatten(tree).find((e) => e.key === id && e.node.type === 'button');
+  assert.ok(hit, `no toggle button rendered for "${id}"`);
+  return text(hit.node).join('');
+}
+
+/** Click the toggle button for a catalog id, exactly as a user would. */
+function click(tree, id) {
+  const hit = flatten(tree).find((e) => e.key === id && e.node.type === 'button');
+  assert.ok(hit, `no toggle button rendered for "${id}"`);
+  assert.equal(typeof hit.node.props.onClick, 'function', 'the button must be clickable');
+  hit.node.props.onClick();
+}
+
+/**
+ * Stand in for the preload bridge. `disk` is the real subject: updateConfig
+ * writes into it and getConfig reads back out of it.
+ */
+function fakeBridge({ disk = {} } = {}) {
+  const calls = { updateConfig: [], getConfig: 0 };
+  const state = { mcpDefaults: { ...disk } };
+  global.window = {
+    cth: {
+      updateConfig: async (patch) => {
+        calls.updateConfig.push(patch);
+        state.mcpDefaults = { ...patch.mcpDefaults };
+        return {};
+      },
+      getConfig: async () => { calls.getConfig += 1; return { mcpDefaults: { ...state.mcpDefaults } }; }
+    }
+  };
+  return { calls, state };
+}
+
+/** Let the click's async chain settle. */
+const settle = () => new Promise((r) => setImmediate(r));
+
+test.afterEach(() => { delete global.window; });
+
+// ── 1. the component renders from the resolver, not from nothing ─────────────
+
+test('an unset consent-tier server renders off', () => {
+  fakeBridge();
+  const inst = mount(McpDefaultsSettings, { config: { mcpDefaults: {} } });
+  assert.equal(buttonLabel(inst.tree, GITHUB_TOKEN), 'off',
+    'github-token is secret tier, defaultEnabled:false — unset must read as NOT granted');
+});
+
+test('a stored grant renders on', () => {
+  fakeBridge();
+  const inst = mount(McpDefaultsSettings, { config: { mcpDefaults: { [GITHUB_TOKEN]: { enabled: true } } } });
+  assert.equal(buttonLabel(inst.tree, GITHUB_TOKEN), 'on');
+});
+
+// ── 2. the wiring — this is what the extracted-function tests cannot see ─────
+
+test('clicking the toggle writes the merged map and re-renders from the disk read', async () => {
+  const { calls } = fakeBridge({ disk: { 'other-server': { enabled: true } } });
+  const inst = mount(McpDefaultsSettings, {
+    config: { mcpDefaults: { 'other-server': { enabled: true } } }
+  });
+  assert.equal(buttonLabel(inst.tree, GITHUB_TOKEN), 'off');
+
+  click(inst.tree, GITHUB_TOKEN);
+  await settle();
+
+  assert.equal(calls.updateConfig.length, 1, 'the click must reach updateConfig');
+  assert.deepEqual(calls.updateConfig[0].mcpDefaults, {
+    'other-server': { enabled: true },
+    [GITHUB_TOKEN]: { enabled: true }
+  }, 'the patch replaces mcpDefaults wholesale, so it must carry the other entries');
+  assert.ok(calls.getConfig >= 1, 'the component must RE-READ after writing, not trust the write');
+
+  assert.equal(buttonLabel(inst.render(), GITHUB_TOKEN), 'on',
+    'the rendered label must follow the persisted config read');
+  assert.ok(text(inst.render()).join('').includes(`${GITHUB_TOKEN}: enabled`),
+    'the confirmation note must name what was granted');
+});
+
+test('a failed write leaves the label alone and says so', async () => {
+  // A disk that never accepts the write, and never claims it did.
+  global.window = {
+    cth: {
+      updateConfig: async () => { throw new Error('EACCES'); },
+      getConfig: async () => ({ mcpDefaults: {} })
+    }
+  };
+  const inst = mount(McpDefaultsSettings, { config: { mcpDefaults: {} } });
+  click(inst.tree, GITHUB_TOKEN);
+  await settle();
+  assert.equal(buttonLabel(inst.render(), GITHUB_TOKEN), 'off',
+    'a throw must never leave the control claiming the grant went through');
+  assert.ok(text(inst.render()).join('').includes('could not save'));
+});
+
+// ── 3. the stale-prop bug, on REMOUNT ──────────────────────────────────────────
+
+test('the granted state survives closing and reopening the panel', async () => {
+  // SettingsModal renders <McpDefaultsSettings config={config} /> only while
+  // activeSection === 'Connections', and SettingsModal's own `config` prop is
+  // App's, which App loads once at start-up and never refreshes after a save.
+  // So switching settings sections and back is a real REMOUNT against a config
+  // object that still says the grant never happened.
+  const stale = { mcpDefaults: { [GITHUB_TOKEN]: { enabled: false } } };
+  const { state } = fakeBridge({ disk: { [GITHUB_TOKEN]: { enabled: false } } });
+
+  const first = mount(McpDefaultsSettings, { config: stale });
+  click(first.tree, GITHUB_TOKEN);
+  await settle();
+  assert.equal(buttonLabel(first.render(), GITHUB_TOKEN), 'on');
+  assert.equal(state.mcpDefaults[GITHUB_TOKEN].enabled, true, 'the grant is on disk');
+
+  // …user switches to another settings section and comes back. Same stale prop.
+  const second = mount(McpDefaultsSettings, { config: stale });
+  await settle();
+  assert.equal(buttonLabel(second.render(), GITHUB_TOKEN), 'on',
+    'seeding from the prop alone re-runs the original stale-prop bug: '
+    + 'the write landed, and the control shows off');
+});

--- a/test/mcp-toggle-state.test.cjs
+++ b/test/mcp-toggle-state.test.cjs
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * MCP toggle state helpers.
+ *
+ * applyToggle writes the requested map, then returns the persisted map used by
+ * the component. resolveEnabledFor supplies catalog defaults for omitted ids.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { applyToggle, resolveEnabledFor } = loadTs('src/renderer/src/components/mcpToggleLogic.ts');
+
+const { MCP_CATALOG } = loadTs('src/shared/mcpCatalog.ts');
+const GITHUB_TOKEN_ID = 'github-token';
+
+// ── applyToggle — the state-transition path ──────────────────────────────────
+
+test('applyToggle returns mcpDefaults from getConfig when the write succeeds', async () => {
+  const deps = {
+    updateConfig: async () => ({}),
+    getConfig: async () => ({ mcpDefaults: { [GITHUB_TOKEN_ID]: { enabled: true } } })
+  };
+  const result = await applyToggle(GITHUB_TOKEN_ID, true, {}, deps);
+  assert.deepEqual(result[GITHUB_TOKEN_ID], { enabled: true });
+});
+
+test('applyToggle merges the id change into currentDefaults when calling updateConfig', async () => {
+  const captured = [];
+  const deps = {
+    updateConfig: async (patch) => { captured.push(patch); return {}; },
+    getConfig: async () => ({ mcpDefaults: { [GITHUB_TOKEN_ID]: { enabled: true } } })
+  };
+  const currentDefaults = { 'some-other-server': { enabled: true } };
+  await applyToggle(GITHUB_TOKEN_ID, true, currentDefaults, deps);
+  assert.equal(captured.length, 1);
+  assert.deepEqual(captured[0].mcpDefaults, {
+    'some-other-server': { enabled: true },
+    [GITHUB_TOKEN_ID]: { enabled: true }
+  });
+});
+
+// ── resolveEnabledFor — catalog fallback path ────────────────────────────────
+
+test('resolveEnabledFor falls back to the catalog defaultEnabled for an unset id', () => {
+  const entry = MCP_CATALOG.find((e) => e.id === GITHUB_TOKEN_ID);
+  assert.ok(entry, `${GITHUB_TOKEN_ID} must exist in the catalog`);
+  const result = resolveEnabledFor({}, GITHUB_TOKEN_ID);
+  assert.equal(result, entry.defaultEnabled ?? false);
+});
+
+test('resolveEnabledFor returns false for a completely unknown id', () => {
+  assert.equal(resolveEnabledFor({}, 'not-a-real-server'), false);
+});
+
+test('resolveEnabledFor respects explicit false even when catalog default is true', () => {
+  // Fixture catalog: one entry with defaultEnabled:true
+  const fixtureCatalog = [{ id: GITHUB_TOKEN_ID, defaultEnabled: true, tier: 'safe-readonly', label: 'x', description: '' }];
+  const overrides = { [GITHUB_TOKEN_ID]: { enabled: false } };
+  assert.equal(resolveEnabledFor(overrides, GITHUB_TOKEN_ID, fixtureCatalog), false,
+    'explicit human opt-out must beat the catalog default');
+});
+
+test('resolveEnabledFor uses the injected catalog, not a shared constant', () => {
+  // This test uses a FIXTURE catalog with a custom id — never in the real catalog.
+  // If resolveEnabledFor shared the catalog constant with the test, this id would
+  // not be found and the fallback (false) would mask a wrong catalog lookup.
+  const fixtureCatalog = [{ id: 'fixture-server', defaultEnabled: true, tier: 'safe-readonly', label: 'x', description: '' }];
+  assert.equal(resolveEnabledFor({}, 'fixture-server', fixtureCatalog), true,
+    'catalog param drives the defaultEnabled fallback');
+  assert.equal(resolveEnabledFor({}, 'fixture-server'), false,
+    'real catalog has no fixture-server, so fallback is false — confirms injection works');
+});

--- a/test/render-hooks.cjs
+++ b/test/render-hooks.cjs
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * A ~60-line React host for node:test — enough to MOUNT a real component and
+ * drive it, without jsdom or react-dom.
+ *
+ * Why this exists: a pure-function test proves nothing about the component
+ * wiring — it stays green when the component stops calling the function.
+ * Grepping the source for the call site is not a test either; it goes green on
+ * a call that is present but wired to the wrong state. So we run the actual
+ * component function, with the actual JSX, and assert on what it renders.
+ *
+ * It works by seeding `require.cache` for `react` and `react/jsx-runtime`
+ * (the same trick test/harness-home-tilde.test.cjs uses for `electron`), so it
+ * MUST be required before any component module is loaded.
+ *
+ * Deliberately NOT a React reimplementation: no reconciler, no batching, no
+ * concurrent anything. `render()` is synchronous and re-runs the component with
+ * the current hook slots — call it after an interaction to see the next frame.
+ */
+
+let HOST = null;
+
+const seed = (spec, exports) => {
+  const f = require.resolve(spec);
+  require.cache[f] = { id: f, filename: f, loaded: true, exports };
+};
+
+seed('react', {
+  useState: (init) => HOST.useState(init),
+  useEffect: (fn, deps) => HOST.useEffect(fn, deps),
+  useRef: (init) => HOST.useRef(init),
+  useMemo: (fn) => fn(),
+  useCallback: (fn) => fn
+});
+
+const jsx = (type, props, key) => ({ type, props: props ?? {}, key: key ?? null });
+seed('react/jsx-runtime', { jsx, jsxs: jsx, Fragment: Symbol.for('react.fragment') });
+
+/** Mount `Component` with `props`. Each call gets its own hook slots — mounting
+ *  twice is a genuine REMOUNT, which is how the settings panel behaves when the
+ *  user switches sections. */
+function mount(Component, props) {
+  const slots = [];
+  let idx = 0;
+  let effects = [];
+  let tree = null;
+  const host = {
+    useState(init) {
+      const i = idx++;
+      if (!(i in slots)) slots[i] = typeof init === 'function' ? init() : init;
+      return [slots[i], (v) => { slots[i] = typeof v === 'function' ? v(slots[i]) : v; }];
+    },
+    useEffect(fn) { effects.push(fn); },
+    useRef(init) {
+      const i = idx++;
+      if (!(i in slots)) slots[i] = { current: init };
+      return slots[i];
+    }
+  };
+  const render = () => {
+    HOST = host;
+    idx = 0;
+    effects = [];
+    try { tree = Component(props); } finally { HOST = null; }
+    return tree;
+  };
+  render();
+  // Mount effects run once, after the first render — deps are ignored because
+  // nothing here re-renders on its own.
+  const cleanups = effects.map((fn) => fn());
+  return { render, get tree() { return tree; }, cleanups };
+}
+
+/** Every element in the tree, each paired with the nearest ancestor that
+ *  carried a `key` — which is how a row is identified back to its catalog id. */
+function flatten(node, key = null, out = []) {
+  if (node == null || typeof node !== 'object') return out;
+  if (Array.isArray(node)) {
+    for (const n of node) flatten(n, key, out);
+    return out;
+  }
+  const own = node.key ?? key;
+  out.push({ node, key: own });
+  const children = node.props && node.props.children;
+  if (children !== undefined) flatten(children, own, out);
+  return out;
+}
+
+/** All rendered text, flattened — for asserting on notices and labels. */
+function text(node, out = []) {
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') { out.push(String(node)); return out; }
+  if (Array.isArray(node)) { for (const n of node) text(n, out); return out; }
+  if (typeof node === 'object' && node.props) text(node.props.children, out);
+  return out;
+}
+
+module.exports = { mount, flatten, text };


### PR DESCRIPTION
## What & why

Enabling an MCP server writes the grant to disk, but the toggle keeps rendering the value the app was launched with. 

The toggle's on/off state reads `config.mcpDefaults[id].enabled` from the `HarnessConfig` prop, which is loaded once at start-up and never refreshed. The green status line is local state, set after the write resolves to the value that was *requested*, never to a read-back. So the status line reports the attempt and the control reports start-up.

This reads the persisted configuration on mount and again after each write, so the control renders what the configuration says actually landed. A failed read keeps the prop-seeded value rather than guessing, and a failed write leaves the control showing the unchanged grant.

This holds regardless of whether config props are ever broadcast-refreshed (as #286 proposes): a consent control should render the persisted grant read back from disk, not a prop that may or may not have been refreshed. The two changes compose as defense in depth.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
<img width="1288" height="1576" alt="CleanShot 2026-08-25 at 16 27 55@2x" src="https://github.com/user-attachments/assets/a1d1d37b-b2c5-4bb6-9bcc-e99fac8edcdf" />

Enable an MCP server in Connections. The green status line reports it as enabled while the toggle stays **off**, in the same view, at the same moment. Leaving Settings and returning still shows **off**, though the on-disk configuration is correct throughout.

### After
<img width="1316" height="1358" alt="CleanShot 2026-08-25 at 16 29 09@2x" src="https://github.com/user-attachments/assets/60d86eac-cc86-4431-b76b-2999bae4b7ae" />

The toggle flips at the same moment the status line appears, and re-entering the section shows the state read back from disk rather than the start-up snapshot.

## Known limitations

The control reflects what the configuration file contains after the write. It does not verify that a server subsequently starts, or that a granted tool is reachable.
