### PR TITLE
docs: add a permanent /download fallback page

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -1,0 +1,305 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Download Munder Difflin</title>
+<meta name="description" content="Download or reinstall Munder Difflin for macOS, Windows, and Linux. Always the latest release, straight from GitHub, with checksums to verify it." />
+<link rel="canonical" href="https://munderdiffl.in/download.html" />
+<link rel="icon" type="image/svg+xml" href="./logo.svg" />
+<link rel="icon" type="image/png" sizes="32x32" href="./favicon-32.png" />
+<link rel="icon" type="image/png" sizes="512x512" href="./logo.png" />
+<link rel="apple-touch-icon" href="./apple-touch-icon.png" />
+<meta property="og:title" content="Download Munder Difflin" />
+<meta property="og:description" content="Download or reinstall Munder Difflin for macOS, Windows, and Linux. Always the latest release, with checksums to verify it." />
+<meta property="og:image" content="https://munderdiffl.in/media/og.png" />
+<meta property="og:url" content="https://munderdiffl.in/download.html" />
+<meta property="og:type" content="website" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="theme-color" content="#FFF8E7" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+<script>
+  // theme init, BEFORE first paint. Shares mdf_theme with the landing page.
+  (function () {
+    var t;
+    try { t = localStorage.getItem('mdf_theme'); } catch (e) {}
+    if (t !== 'light' && t !== 'dark') t = 'light';
+    document.documentElement.setAttribute('data-theme', t);
+  })();
+</script>
+<style>
+  /* Tokens mirror docs/index.html design system v2, keep in lockstep. */
+  :root {
+    color-scheme: dark;
+    --bg:        #0A0D14;
+    --bg-2:      #0D111A;
+    --surface:   #121722;
+    --surface-2: #182030;
+    --border:        #232B3A;
+    --border-strong: #303B52;
+    --ink:   #E9EDF5;
+    --muted: #A7B0C0;
+    --faint: #717A8C;
+    --accent:      #FFCA54;
+    --accent-2:    #FFD87A;
+    --accent-ink:  #17150E;
+    --accent-soft: rgba(255,202,84,0.10);
+    --accent-line: rgba(255,202,84,0.38);
+    --accent-fill:       #FFD165;
+    --accent-fill-hover: #FFE08F;
+    --dot: rgba(233,237,245,0.045);
+    --halo: rgba(255,202,84,0.10);
+    --radius: 14px;
+    --radius-sm: 10px;
+    --shadow-soft: 0 16px 40px rgba(0,0,0,0.38);
+    --glow: 0 10px 34px rgba(255,202,84,0.16);
+    --maxw: 1160px;
+    --pad-x: 24px;
+    --font-display: "Space Grotesk", "Inter", sans-serif;
+    --font-body: "Inter", system-ui, -apple-system, sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, monospace;
+  }
+  html[data-theme="light"] {
+    color-scheme: light;
+    --bg:        #F6F8FA;
+    --bg-2:      #EFF2F6;
+    --surface:   #FFFFFF;
+    --surface-2: #F1F4F8;
+    --border:        #E3E8F0;
+    --border-strong: #CDD6E3;
+    --ink:   #131722;
+    --muted: #4A5464;
+    --faint: #7D8798;
+    --accent:      #E5A00D;
+    --accent-2:    #FFC94F;
+    --accent-ink:  #17150E;
+    --accent-soft: rgba(229,160,13,0.12);
+    --accent-line: rgba(212,148,16,0.45);
+    --accent-fill:       #FFC94F;
+    --accent-fill-hover: #FFDC8A;
+    --dot: rgba(19,23,34,0.05);
+    --halo: rgba(229,160,13,0.10);
+    --shadow-soft: 0 14px 36px rgba(19,23,34,0.10);
+    --glow: 0 10px 30px rgba(229,160,13,0.18);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+  body {
+    font-family: var(--font-body);
+    background-color: var(--bg);
+    background-image:
+      radial-gradient(900px 480px at 50% -160px, var(--halo), transparent 65%),
+      radial-gradient(var(--dot) 1px, transparent 1px);
+    background-size: auto, 26px 26px;
+    color: var(--ink);
+    line-height: 1.6;
+    font-size: 16px;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+  }
+  img { max-width: 100%; display: block; }
+  a { color: inherit; }
+  ::selection { background: var(--accent); color: var(--accent-ink); }
+
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 var(--pad-x); }
+  h1, h2, h3 { font-family: var(--font-display); font-weight: 700; line-height: 1.08; letter-spacing: -0.025em; }
+  h1 { font-size: clamp(2.1rem, 5.4vw, 3.4rem); }
+  h2 { font-size: clamp(1.4rem, 3vw, 1.9rem); }
+  .kicker {
+    display: inline-block; font-family: var(--font-mono); font-size: 0.74rem;
+    letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent);
+    border: 1px solid var(--accent-line); border-radius: 999px; padding: 5px 12px;
+    background: var(--accent-soft);
+  }
+  .center { text-align: center; }
+  .muted { color: var(--muted); }
+  .faint { color: var(--faint); }
+
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-body);
+    font-weight: 600; font-size: 0.95rem; text-decoration: none; cursor: pointer;
+    padding: 11px 20px; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);
+    color: var(--ink); background: var(--surface); transition: transform .12s ease, border-color .12s ease, background .12s ease;
+  }
+  .btn:hover { transform: translateY(-1px); border-color: var(--accent-line); }
+  .btn:active { transform: translateY(0); }
+  .btn.primary { background: var(--accent-fill); color: var(--accent-ink); border-color: transparent; box-shadow: var(--glow); }
+  .btn.primary:hover { background: var(--accent-fill-hover); box-shadow: var(--glow), 0 2px 8px rgba(0,0,0,0.25); }
+  .btn.ghost { background: transparent; }
+  .btn.ghost:hover { background: var(--accent-soft); }
+  .btn.lg { font-size: 1.04rem; padding: 14px 26px; }
+  .btn.sm { font-size: 0.87rem; padding: 8px 14px; }
+  .btn-row { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; justify-content: center; }
+
+  /* ------- nav (trimmed copy of the landing nav) ------- */
+  nav { position: sticky; top: 0; z-index: 50; background: color-mix(in srgb, var(--bg) 82%, transparent); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); }
+  .nav-in { max-width: var(--maxw); margin: 0 auto; padding: 12px var(--pad-x); display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+  .brand { display: inline-flex; align-items: center; gap: 10px; text-decoration: none; font-family: var(--font-display); font-weight: 700; letter-spacing: 0.04em; font-size: 0.95rem; }
+  .brand img { width: 34px; height: 34px; border-radius: 8px; }
+  html[data-theme="light"] .lgo-d { display: none; }
+  html:not([data-theme="light"]) .lgo-l { display: none; }
+  .nav-links { display: flex; align-items: center; gap: 10px; }
+  .nav-links .txt { font-size: 0.9rem; font-weight: 500; text-decoration: none; color: var(--muted); padding: 6px 8px; }
+  .nav-links .txt:hover { color: var(--ink); }
+  .theme-toggle {
+    display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px;
+    border: 1px solid var(--border-strong); border-radius: 9px; background: var(--surface);
+    color: var(--muted); cursor: pointer; transition: border-color .12s ease, color .12s ease;
+  }
+  .theme-toggle:hover { border-color: var(--accent-line); color: var(--ink); }
+  .theme-toggle svg { width: 17px; height: 17px; }
+  html[data-theme="light"] .theme-toggle .ic-sun { display: none; }
+  html:not([data-theme="light"]) .theme-toggle .ic-moon { display: none; }
+
+  /* ------- page ------- */
+  header.dl { padding: 64px 0 20px; text-align: center; }
+  header.dl h1 { margin: 16px 0 0; }
+  header.dl .lead { max-width: 680px; margin: 18px auto 0; color: var(--muted); font-size: 1.06rem; }
+
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin: 40px 0 0; }
+  @media (max-width: 820px) { .grid { grid-template-columns: 1fr; } }
+  .card {
+    background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 26px 22px; display: flex; flex-direction: column; gap: 12px; box-shadow: var(--shadow-soft);
+  }
+  .card .os { font-family: var(--font-display); font-weight: 700; font-size: 1.2rem; }
+  .card .req { font-size: 0.85rem; color: var(--faint); }
+  .card .file { font-family: var(--font-mono); font-size: 0.8rem; color: var(--muted); background: var(--surface-2); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; word-break: break-all; }
+  .card .btn { justify-content: center; margin-top: auto; }
+
+  .panel {
+    background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 24px 22px; margin: 22px 0 0;
+  }
+  .panel h2 { font-size: 1.15rem; }
+  .panel p { color: var(--muted); margin-top: 8px; }
+  .panel a { color: var(--accent); text-decoration: none; }
+  .panel a:hover { text-decoration: underline; }
+  pre.code {
+    font-family: var(--font-mono); font-size: 0.82rem; background: var(--bg-2); color: var(--ink);
+    border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; margin-top: 12px;
+    overflow-x: auto; line-height: 1.7;
+  }
+  .note { max-width: 760px; margin: 40px auto 0; text-align: center; color: var(--faint); font-size: 0.9rem; line-height: 1.7; }
+  section.dl { padding: 8px 0 60px; }
+
+  footer { border-top: 1px solid var(--border); background: var(--bg); padding: 34px 0 42px; margin-top: 30px; }
+  .foot-in { max-width: var(--maxw); margin: 0 auto; padding: 0 var(--pad-x); display: flex; flex-wrap: wrap; gap: 14px 26px; justify-content: space-between; align-items: center; font-size: 0.85rem; color: var(--faint); }
+  .foot-links { display: flex; flex-wrap: wrap; gap: 4px 18px; }
+  .foot-links a { text-decoration: none; color: var(--muted); }
+  .foot-links a:hover { color: var(--ink); }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="/">
+      <img class="lgo-d" src="./logo.png" alt="Munder Difflin logo" width="34" height="34" />
+      <img class="lgo-l" src="./logo-light.png" alt="Munder Difflin logo" width="34" height="34" />
+      <span>MUNDER&nbsp;DIFFLIN</span>
+    </a>
+    <div class="nav-links">
+      <a class="txt" href="/#pricing">Pricing</a>
+      <a class="txt" href="/blog/">Blog</a>
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle day / night theme"><svg class="ic-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="4.6"/><path d="M12 2.2v2.4M12 19.4v2.4M2.2 12h2.4M19.4 12h2.4M4.9 4.9l1.7 1.7M17.4 17.4l1.7 1.7M19.1 4.9l-1.7 1.7M6.6 17.4l-1.7 1.7"/></svg><svg class="ic-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.6 14.8A8.8 8.8 0 0 1 9.2 3.4a8.8 8.8 0 1 0 11.4 11.4Z"/></svg></button>
+    </div>
+  </div>
+</nav>
+
+<header class="dl">
+  <div class="wrap">
+    <span class="kicker">Download</span>
+    <h1>Get Munder Difflin</h1>
+    <p class="lead">Install it fresh, move it to a new machine, or reinstall if an update will
+    not go through. Every button here goes straight to the newest release on GitHub, so this
+    page is always current.</p>
+  </div>
+</header>
+
+<section class="dl">
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <span class="os">macOS</span>
+        <span class="req">Apple Silicon and Intel, one universal build. Signed and notarized by Apple.</span>
+        <span class="file">Munder-Difflin-&lt;version&gt;-mac-universal.dmg</span>
+        <a class="btn primary" href="https://github.com/chaitanyagiri/munder-difflin/releases/latest">Download for macOS</a>
+      </div>
+      <div class="card">
+        <span class="os">Windows</span>
+        <span class="req">Windows 10 and 11, 64-bit. Use the setup installer; a portable exe is also on the release.</span>
+        <span class="file">Munder-Difflin-&lt;version&gt;-win-x64-setup.exe</span>
+        <a class="btn primary" href="https://github.com/chaitanyagiri/munder-difflin/releases/latest">Download for Windows</a>
+      </div>
+      <div class="card">
+        <span class="os">Linux</span>
+        <span class="req">Any modern 64-bit distribution. Mark it executable, then run it.</span>
+        <span class="file">Munder-Difflin-&lt;version&gt;-linux-x86_64.AppImage</span>
+        <a class="btn primary" href="https://github.com/chaitanyagiri/munder-difflin/releases/latest">Download for Linux</a>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Verify your download (optional)</h2>
+      <p>Every release ships a checksum file. If you want to confirm the installer arrived intact,
+      download <a href="https://github.com/chaitanyagiri/munder-difflin/releases/latest/download/SHA256SUMS.txt">SHA256SUMS.txt</a>
+      from the same release, then compare it against the file you got.</p>
+      <pre class="code"># macOS and Linux
+shasum -a 256 Munder-Difflin-*.dmg      # or the .AppImage / .exe you downloaded
+
+# Windows (PowerShell)
+Get-FileHash .\Munder-Difflin-*-win-x64-setup.exe -Algorithm SHA256</pre>
+      <p>The value it prints should match the line for that file inside SHA256SUMS.txt.</p>
+    </div>
+
+    <div class="panel">
+      <h2>Already installed?</h2>
+      <p>The app checks for updates on its own and offers a restart to install them. Use this page
+      if an update will not install, if you want to reinstall cleanly, or if you are setting up a
+      second machine. You can always see every build, with its notes, on the
+      <a href="https://github.com/chaitanyagiri/munder-difflin/releases">releases page</a>.</p>
+    </div>
+
+    <p class="note">Munder Difflin is free and open source. Downloads are hosted on GitHub, straight
+    from the release that built them. No account, no gate.</p>
+
+    <div class="btn-row" style="margin-top:28px">
+      <a class="btn ghost" href="/">Back to home</a>
+      <a class="btn ghost" href="https://github.com/chaitanyagiri/munder-difflin/releases">All releases</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="foot-in">
+    <span>© 2026 Munder Difflin, free &amp; open source</span>
+    <div class="foot-links">
+      <a href="/">Home</a>
+      <a href="https://github.com/chaitanyagiri/munder-difflin" target="_blank" rel="noopener">GitHub</a>
+      <a href="/blog/">Blog</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/terms.html">Terms</a>
+      <a href="/privacy.html">Privacy</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // theme toggle, shares mdf_theme with the landing page
+  (function () {
+    var btn = document.getElementById('themeToggle');
+    if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+      var next = cur === 'light' ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', next);
+      try { localStorage.setItem('mdf_theme', next); } catch (e) {}
+    });
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

A permanent `/download.html` fallback page: a stable, always-current place to install or reinstall Munder Difflin for macOS, Windows, and Linux, **independent of the in-app updater**.

This is the highest-leverage item in the updater work because it is the one recovery path that does not depend on the app updating itself. Every other fix ships *through* the updater we are trying to repair; this one does not, so it works even for a client whose auto-update is stuck.

## How it stays "always correct" with no per-release edits

- Every platform button points at **`releases/latest`** (the release page), not a version-stamped asset URL. Installer filenames carry the version (`...-0.4.5-mac-universal.dmg`), so a direct latest-download link to them would 404 the moment 0.4.6 ships. Pointing at `releases/latest` never goes stale.
- The verify link uses **`releases/latest/download/SHA256SUMS.txt`** — that asset name has no version in it, so this URL is both permanent and always the current release's checksums.
- No version number is hard-coded anywhere on the page.

## Contents

- macOS (universal, signed + notarized), Windows (x64 setup), Linux (x86_64 AppImage), each with the exact filename to pick and a button to the latest release.
- An optional "Verify your download" panel with the `shasum` / `Get-FileHash` commands.
- An "Already installed?" panel explaining the app self-updates and when to use this page instead.

## Scope / safety

- New file only: `docs/download.html`. Nothing else changed — no pricing, no wall data, no `index.html`.
- Reuses the site's existing design tokens, nav, footer, and theme toggle (mirrors `wall.html`). No red, no dashes, tags balanced.
- Not yet linked from the landing nav — its primary use is as a stable URL to hand out (Discord, the app's update-error state, new-machine setup). Say the word if you also want it in the top nav; that is a one-line change to `index.html`.

## ⚠️ Do not merge or deploy without the founder

This is a live public page. Opened for review. Making it live is a merge + Pages deploy, which I am leaving to you / the founder rather than doing unilaterally.
