### PR TITLE
fix: release the WebGL context when a terminal's renderer is torn down

### DIFF
--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -586,6 +586,30 @@ function leaseWebglRenderer(entry: TerminalEntry): void {
   }
 }
 
+/** Find the live WebGL2 context an addon renderer is drawing into, so teardown
+ *  can explicitly release it. @xterm/addon-webgl's dispose() tears down its
+ *  renderer and removes its canvases but never calls loseContext(), so the
+ *  underlying context lingers past the addon that owned it (xterm/xterm.js#6068).
+ *  On a floor where agents are switched repeatedly, each switch disposes one
+ *  renderer and leases another, so these orphan contexts pile up until Chromium
+ *  hits its live-context cap (~16) and evicts an older one — often the office
+ *  floor's own context — blacking out a terminal or the scene. Losing the context
+ *  ourselves frees it immediately instead of waiting on GC.
+ *
+ *  Scoped to THIS terminal's element and matched by an active webgl2 context, so
+ *  it can never touch another terminal's or the scene's context. Returns null when
+ *  no live webgl2 canvas is present (the DOM renderer is in use, or it is gone). */
+function webglContextOf(term: Terminal): WebGL2RenderingContext | null {
+  const el = term.element;
+  if (!el) return null;
+  for (const canvas of Array.from(el.querySelectorAll('canvas'))) {
+    let gl: WebGL2RenderingContext | null = null;
+    try { gl = canvas.getContext('webgl2'); } catch { gl = null; }
+    if (gl && !gl.isContextLost()) return gl;
+  }
+  return null;
+}
+
 /** Release the WebGL lease so an off-screen terminal isn't holding a GPU context
  *  that an on-screen one needs. xterm falls back to the DOM renderer, which is
  *  fine for a terminal nobody is looking at; the next attach takes a fresh
@@ -594,7 +618,11 @@ function releaseWebglRenderer(entry: TerminalEntry): void {
   const webgl = entry.webgl;
   if (!webgl) return;
   entry.webgl = undefined;
+  // Capture the context BEFORE dispose (dispose may detach the canvas), then
+  // release it explicitly — dispose() alone leaks it (see webglContextOf).
+  const gl = webglContextOf(entry.term);
   try { webgl.dispose(); } catch { /* noop */ }
+  try { gl?.getExtension('WEBGL_lose_context')?.loseContext(); } catch { /* noop */ }
   // The DOM renderer that takes over inherits xterm's cached cell metrics, which
   // may be stale by the time this terminal is shown again.
   entry.needsRendererRepaint = true;
@@ -739,7 +767,11 @@ export function disposeTerminal(ptyId: string): void {
   const entry = pool.get(ptyId);
   if (!entry) return;
   entry.unsub.forEach((u) => { try { u(); } catch { /* noop */ } });
+  // Release the GPU context the webgl addon leaves behind; dispose() alone leaks
+  // it (see webglContextOf). Captured before dispose in case it detaches the canvas.
+  const gl = webglContextOf(entry.term);
   try { entry.webgl?.dispose(); } catch { /* noop */ }
+  try { gl?.getExtension('WEBGL_lose_context')?.loseContext(); } catch { /* noop */ }
   try { entry.term.dispose(); } catch { /* noop */ }
   entry.host.remove();
   pool.delete(ptyId);


### PR DESCRIPTION
## What & why

Switching between agent terminals slowly kills the office floor's rendering. Each switch tears down one terminal's WebGL renderer and leases another, but `@xterm/addon-webgl`'s `dispose()` never releases the underlying WebGL2 context (xtermjs/xterm.js#6068, still present in the latest stable). The orphaned contexts accumulate — measured climbing ~2 per switch — until Chromium's live-context cap (32) is reached and the browser starts evicting the oldest context, which on a busy floor is the scene's own context: the floor goes black.

The fix releases the context ourselves at both teardown sites in `terminalPool.ts`: capture the terminal's `webgl2` context before `dispose()`, then call `getExtension('WEBGL_lose_context').loseContext()` after. The lookup is scoped to that terminal's own canvases, and the call is guarded and idempotent — a no-op when the canvas, extension, or live context is absent.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

Instrumented probe (real `@xterm/xterm` + `@xterm/addon-webgl` in Electron, tracking every `webgl2` context) running 30 lease/dispose cycles — the exact per-switch churn the app performs.

### Before
<img width="1332" height="276" alt="CleanShot 2026-08-25 at 17 12 38@2x" src="https://github.com/user-attachments/assets/7b49bc75-779d-4742-9a7c-2579e31c71e8" />


Live contexts climb 3, 5, 7, … 31 and plateau at 32 — Chromium's cap, where eviction of the oldest context begins.

### After
<img width="1526" height="604" alt="CleanShot 2026-08-25 at 17 13 10@2x" src="https://github.com/user-attachments/assets/643af7a6-8eaa-41d1-a6aa-6d9d6e91e262" />

Live contexts stay at 0 across all 30 cycles; nothing accumulates and the cap is never approached.

## How I tested it

- OS: macOS
- Reproduction probe: hidden Electron with remote debugging, instrumented `HTMLCanvasElement.getContext`, 30 renderer lease/dispose cycles; unpatched curve climbs to the 32-context cap, patched curve stays flat at zero.
- `npm run typecheck` (clean), production build (fix present in bundle), `npm run test:focused` (552/552 — renderer GPU behavior is covered by the probe, which the node suite cannot exercise).
