### PR TITLE
fix(updater): guard restart re-entry and report a failed quit

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -71,7 +71,7 @@ let lastStatus: UpdateStatus | null = null;
  * left to tell), or the user cancels and `abortPendingRestart()` settles it and
  * the handler reports the truth.
  */
-let pendingRestart: (() => void) | null = null;
+let pendingRestart: ((outcome: { ok: boolean; error?: string }) => void) | null = null;
 
 /**
  * The user backed out of the quit that a restart-to-install asked for.
@@ -85,7 +85,24 @@ export function abortPendingRestart(): void {
   const resolve = pendingRestart;
   pendingRestart = null;
   logLine('quitAndInstall cancelled by the user at the quit warning');
-  resolve();
+  resolve({ ok: false, error: 'cancelled' });
+}
+
+/**
+ * A restart-to-install that the native updater REFUSED (Squirrel emits "The
+ * command is disabled and cannot be executed" rather than throwing) reports
+ * through the autoUpdater error event, not the handler's try/catch. Without
+ * this, the handler's `await` would hang forever, the button would spin, the
+ * user would click again, and the repeated quitAndInstall is exactly what keeps
+ * Squirrel wedged. Settling here reports the failure back so the UI shows it and
+ * stops the user re-clicking. Safe when nothing is pending (an ordinary check
+ * error is not our business).
+ */
+function failPendingRestart(error: string): void {
+  if (!pendingRestart) return;
+  const resolve = pendingRestart;
+  pendingRestart = null;
+  resolve({ ok: false, error });
 }
 
 /** Append-only breadcrumb trail in userData. The whole point of this file's
@@ -321,18 +338,22 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
 
   // IPC surface is registered unconditionally so the renderer can always call it.
   ipcMain.handle('update:restartAndInstall', async () => {
+    // Re-entry guard: a restart is already in flight. Firing quitAndInstall a
+    // second time hits a native command Squirrel has already disabled and it
+    // throws "The command is disabled and cannot be executed", the recurring
+    // wedge behind the six-clicks-to-install reports. Refuse the duplicate and
+    // let the caller wait on the one already running instead of starting another.
+    if (pendingRestart) return { ok: false, error: 'a restart is already in progress' };
     try {
       const autoUpdater = await loadAutoUpdater();
       logLine('quitAndInstall requested by the user');
-      // A restart already in flight is superseded rather than left dangling, so
-      // its caller is released instead of waiting on a resolve that never comes.
-      abortPendingRestart();
-      const cancelled = new Promise<void>((resolve) => { pendingRestart = resolve; });
+      const cancelled = new Promise<{ ok: boolean; error?: string }>((resolve) => { pendingRestart = resolve; });
       autoUpdater.quitAndInstall();
-      // Settles ONLY if the quit was called off. If the app is really going, the
-      // process exits here and the renderer's promise dies with the window.
-      await cancelled;
-      return { ok: false, error: 'cancelled' };
+      // Settles ONLY if the quit was called off (abortPendingRestart) or the
+      // native updater reported it failed (failPendingRestart, from the error
+      // event). If the app is really going, the process exits here and the
+      // renderer's promise dies with the window.
+      return await cancelled;
     } catch (e) {
       pendingRestart = null;
       const error = errText(e);
@@ -464,6 +485,11 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
         const message = errText(err);
         logLine(`native updater error: ${message}`);
         emit({ state: 'error', message });
+        // A restart-to-install that failed reports here, not as a throw. Settle
+        // the pending restart (no-op if none) so the handler stops awaiting and
+        // the UI shows the error instead of spinning, and so the user does not
+        // click again, which is the repeated quitAndInstall that wedges Squirrel.
+        failPendingRestart(message);
         // Notify-only for THIS failure; the next tick still tries native.
         fallbackCheck(message);
       });

--- a/test/restart-cancel.test.cjs
+++ b/test/restart-cancel.test.cjs
@@ -53,3 +53,28 @@ test('the renderer restores its notice when the restart reports a cancel', () =>
     'a cancelled restart has to put the notice back AND clear busy — clearing one '
     + 'without the other leaves either a dead button or no way to retry');
 });
+
+test('a re-entry guard refuses a duplicate restart instead of firing quitAndInstall twice', () => {
+  const src = read('src/main/updater.ts');
+  const handler = src.slice(src.indexOf("ipcMain.handle('update:restartAndInstall'"));
+  const body = handler.slice(0, handler.indexOf('\n  });'));
+  assert.ok(/if \(pendingRestart\) return/.test(body),
+    'a second restart-to-install while one is pending must be refused; firing '
+    + 'quitAndInstall again hits the native command Squirrel has already disabled '
+    + '("The command is disabled and cannot be executed"), the recurring install wedge');
+  assert.ok(!body.includes('abortPendingRestart()'),
+    'the handler must NOT abort-and-refire a pending restart, that abort-then-new '
+    + 'quitAndInstall WAS the double fire; the guard replaces it');
+});
+
+test('a failed quit settles the pending restart so the button stops spinning', () => {
+  const src = read('src/main/updater.ts');
+  assert.ok(/function failPendingRestart\(error: string\): void/.test(src),
+    'a restart the native updater refuses reports via the error event, not a throw; '
+    + 'without a way to settle the pending restart the handler awaits forever');
+  const onErrorIdx = src.indexOf("autoUpdater.on('error'");
+  const settleIdx = src.indexOf('failPendingRestart(message)');
+  assert.ok(onErrorIdx !== -1 && settleIdx > onErrorIdx && settleIdx - onErrorIdx < 900,
+    'the autoUpdater error handler is where a failed quit surfaces, so it must settle '
+    + 'the pending restart there (failPendingRestart), or the handler hangs');
+});


### PR DESCRIPTION
## What

Fixes the recurring restart-to-install wedge: `The command is disabled and cannot be executed`, seen **twice** in `updater.log` (13 Aug and 22 Aug), where the 22 Aug case took six restart clicks before one install finally landed. This is the founder-visible "I click restart and nothing happens" symptom.

## Root cause (two, both here)

1. **Re-entry.** The handler aborted any in-flight restart and fired a fresh `quitAndInstall()` on **every** click. The first call starts Squirrel's install/relaunch, which disables further install commands; a second click's `quitAndInstall()` hits that now-disabled command and Squirrel emits `The command is disabled and cannot be executed`. A guard now refuses a duplicate while a restart is already pending.

2. **Silent failure.** `quitAndInstall` reports a refusal through the autoUpdater **error event**, not a throw, so the handler's `await` never settled: the button spun forever with no way back, which is what drove the repeated clicking in the first place. A failed quit now settles the pending restart (`failPendingRestart`) so the renderer reports the error and restores its notice instead of hanging.

## Change

- `pendingRestart` resolver now carries an outcome `{ ok, error }`, so both the cancel path (`abortPendingRestart`) and the new failure path (`failPendingRestart`) report the truth back to the renderer.
- `abortPendingRestart` keeps its exact signature; `index.ts` `app:cancelClose` still calls it unchanged.
- The autoUpdater `error` handler settles a pending restart (no-op when none is pending, so an ordinary background check error is unaffected).

## Tests

- `test/restart-cancel.test.cjs` extended with the re-entry-guard and settle-on-error contracts. **All 5 assertions green.** `typecheck:node` clean.
- The existing three assertions (await-an-outcome, cancel wiring, renderer restore) still pass unchanged.

## Scope

- One concern only: the restart path. `src/main/updater.ts` + its test. No renderer change (the existing `if (!res.ok)` restore in UpdateToast already recovers now that the handler actually returns on failure).
- The **native menu item** and the **error-state download link** (the other two GO items) are deliberately separate follow-up PRs, per single-concern hygiene.

## Not for merge yet

Part of the 0.4.6 updater set. Opened for review; merge/release is the founder's call.
