### PR TITLE
fix(updater): bound the update check with a timeout (unbounded await)

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -243,6 +243,30 @@ function fallbackCheck(reason: string | undefined, force = false): void {
   } catch { /* never let the fallback take the app down */ }
 }
 
+/** electron-updater's checkForUpdates has no timeout of its own. If the feed
+ *  request opens but never responds (a stalled connection, a captive portal, a
+ *  half-open socket after the machine sleeps), the promise never settles, so
+ *  runCheck never leaves 'checking', the badge spins forever, and nothing is
+ *  logged. And electron-updater caches its in-flight check promise, so once one
+ *  check hangs, every later check returns that same hung promise. A hard cap is
+ *  what guarantees the check always reaches a terminal state, and it is why a
+ *  wedged updater shows a definite error on every tick instead of a permanent
+ *  spinner. Generous, because the feed payload (a few-hundred-byte YAML) is
+ *  tiny, so anything past this is hung, not merely slow. */
+const CHECK_TIMEOUT_MS = 30_000;
+
+/** Reject after `ms` if `p` has not settled; clears the timer either way so a
+ *  slow-but-successful check leaves no dangling handle. */
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s`)), ms);
+    p.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); }
+    );
+  });
+}
+
 /**
  * One check. Native first; on failure, report the real error AND degrade to the
  * notify-only poll for THIS check only — the next tick tries native again, so a
@@ -251,8 +275,14 @@ function fallbackCheck(reason: string | undefined, force = false): void {
 async function runCheck(): Promise<{ ok: boolean; error?: string }> {
   emit({ state: 'checking' });
   try {
-    const autoUpdater = await loadAutoUpdater();
-    const result = await autoUpdater.checkForUpdates();
+    // Hard-capped so a stalled feed request cannot leave the badge on 'checking'
+    // forever (see withTimeout above); a timeout falls through to the catch,
+    // which logs it, shows an error state, and runs the notify-only fallback.
+    const result = await withTimeout(
+      loadAutoUpdater().then((autoUpdater) => autoUpdater.checkForUpdates()),
+      CHECK_TIMEOUT_MS,
+      'update check'
+    );
     if (!result || !isNewer(result.updateInfo.version, app.getVersion())) {
       emit({ state: 'not-available' });
     }

--- a/test/update-check-timeout.test.cjs
+++ b/test/update-check-timeout.test.cjs
@@ -1,0 +1,49 @@
+/**
+ * The native update check must be hard-capped.
+ *
+ * The bug it prevents: electron-updater's checkForUpdates has no timeout of its
+ * own, and it caches its in-flight check promise. If one check's feed request
+ * stalls (opens but never responds), the promise never settles, runCheck never
+ * leaves 'checking', and every LATER check returns the same hung promise. The
+ * badge then spins on 'checking' forever with nothing logged, which is worse
+ * than an error: it looks like the app is working when it is not. A hard cap in
+ * runCheck is the only thing that forces a terminal state.
+ *
+ * Source-string checks, because updater.ts imports electron and cannot be loaded
+ * in a plain test; deleting the cap must not pass silently.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const read = (rel) => readFileSync(join(__dirname, '..', rel), 'utf8');
+
+test('runCheck wraps the native check in a timeout, not a bare await', () => {
+  const src = read('src/main/updater.ts');
+  const runCheck = src.slice(src.indexOf('async function runCheck'), src.indexOf('async function runCheck') + 900);
+  assert.ok(/withTimeout\(/.test(runCheck),
+    'runCheck must wrap the native check in withTimeout; a bare '
+    + 'await autoUpdater.checkForUpdates() can hang forever and freeze the badge');
+  assert.ok(/CHECK_TIMEOUT_MS/.test(runCheck),
+    'the wrap must use the timeout constant, not an unbounded await');
+  assert.ok(!/const result = await autoUpdater\.checkForUpdates\(\);/.test(runCheck),
+    'the un-capped await must be gone, or the timeout is dead code beside it');
+});
+
+test('the timeout constant is finite, positive, and sane', () => {
+  const src = read('src/main/updater.ts');
+  const m = src.match(/const CHECK_TIMEOUT_MS = ([0-9_]+);/);
+  assert.ok(m, 'CHECK_TIMEOUT_MS must be defined');
+  const ms = Number(m[1].replace(/_/g, ''));
+  assert.ok(Number.isFinite(ms) && ms > 0 && ms <= 120000,
+    'the cap must be finite and sane (0 < ms <= 120s), or it is not really a cap');
+});
+
+test('withTimeout arms a rejecting timer and clears it on settle', () => {
+  const src = read('src/main/updater.ts');
+  const wt = src.slice(src.indexOf('function withTimeout'), src.indexOf('function withTimeout') + 500);
+  assert.ok(/setTimeout\(/.test(wt) && /reject\(/.test(wt),
+    'withTimeout must arm a timer that rejects, or a hung check is never cut off');
+  assert.ok(/clearTimeout\(/.test(wt),
+    'it must clear the timer on settle, or a slow-but-successful check leaks a handle');
+});


### PR DESCRIPTION
## What

Bounds an **unbounded await** in `runCheck`: it awaits electron-updater's `checkForUpdates()` with no timeout. If the feed request opens but never responds (a stalled connection, a captive portal, a half-open socket after sleep), that promise never settles, so `runCheck` never leaves the `checking` state it emitted.

## Claim discipline (important)

This is a **missing bound**, not a proven repair of an observed outage. The screenshot that first motivated it (a badge reading `checking…`) was a mid-check capture pointing at the badge's *location*, not a hang, that premise was retracted by the founder. **No wedged client has been witnessed.** An unbounded await on a network call is a defect whether or not it has fired for anyone yet, which is why this stands on its own merit and belongs in 0.4.6. But nothing here is claimed as "fixes the founder's bug."

## Why a hang would be worse than a spinner

While the badge reads `checking`, `describeUpdate` returns `action: 'none', busy: true`, and `UpdateBadge` sets `disabled={!interactive}` from that, so the button is genuinely disabled during a check. A hang would therefore park the badge in **spin-forever plus disabled-forever**: the one manual recovery affordance is locked out exactly when it is needed. And electron-updater caches its in-flight check promise, so once one check hangs, every later 6h tick returns that same hung promise. This cap bounds both: the disabled window can never exceed the timeout.

## Fix

`runCheck` races the load+check against `CHECK_TIMEOUT_MS` (30s; the feed is a few-hundred-byte YAML, so past that it is hung, not slow). A timeout rejects into the **existing** catch, which logs it, shows an error state, and runs the notify-only fallback poll. So the badge always reaches a terminal state and re-enables, and the failure is finally visible in the log.

## Release-planning consequence (for the customer notice)

With this in a **0.4.6** client, a wedged check times out at 30s and the error path reaches the fallback, which polls `releases/latest` directly (bypassing electron-updater's cached promise), so it still *notifies* about 0.5.0. But a **0.4.5** client wedged today does not have this code, so its fallback is never reached and 0.4.6 cannot auto-reach it, recovery for those is quit-and-reopen or the `/download` page. (This whole path is unwitnessed; it is a latent-defect guard, not a report of a live outage.)

## Tests

`test/update-check-timeout.test.cjs` (3 assertions, green): the check is wrapped in `withTimeout` with the constant, the constant is finite/sane, and `withTimeout` arms a rejecting timer and clears it on settle. `typecheck:node` clean. Source-string style, matching the existing updater tests.

## Scope

One concern: `src/main/updater.ts` runCheck + a helper, plus its test. Part of the 0.4.6 set; not for merge on its own timeline, founder's call.
