### PR TITLE
feat(updater): badge acknowledges a check and drives the real auto-update

### DIFF
--- a/src/renderer/src/components/UpdateBadge.tsx
+++ b/src/renderer/src/components/UpdateBadge.tsx
@@ -25,6 +25,11 @@ export function UpdateBadge() {
   /** The version whose download was just started, for the "now replace the
    *  app" notice. Local state: it is a one-off explanation, not an update state. */
   const [started, setStarted] = useState<string | null>(null);
+  /** Brief, positive "checked, you are current" flash after a MANUAL check that
+   *  found no update. Without it a successful check settles silently back to the
+   *  grey "latest" chip, which is indistinguishable from a click that did
+   *  nothing, and that is exactly why the badge read as broken. */
+  const [checkedOk, setCheckedOk] = useState(false);
 
   useEffect(() => {
     // Subscribe first, then pull — main may have emitted before this window
@@ -36,13 +41,32 @@ export function UpdateBadge() {
     return off;
   }, []);
 
+  // The acknowledgement is a flash, not a mode: clear it after a few seconds so
+  // the badge returns to its quiet resting state.
+  useEffect(() => {
+    if (!checkedOk) return;
+    const t = setTimeout(() => setCheckedOk(false), 3500);
+    return () => clearTimeout(t);
+  }, [checkedOk]);
+
   const view = describeUpdate(status, __APP_VERSION__);
 
   const onClick = useCallback(async () => {
     if (view.action === 'none' || busy) return;
     setBusy(true);
     try {
-      if (view.action === 'check') await window.cth.updateCheckNow();
+      if (view.action === 'check') {
+        const res = await window.cth.updateCheckNow();
+        // A successful "already current" check has to say so out loud. runCheck
+        // has settled lastStatus by the time this resolves, so read it back: a
+        // no-update result flashes the acknowledgement; an available update is
+        // already loud on its own (the chip changes) so it is left alone.
+        if (res?.ok) {
+          const cur = await window.cth.updateCurrent?.();
+          const st = cur?.state;
+          if (!st || st === 'not-available' || st === 'idle' || st === 'just-updated') setCheckedOk(true);
+        }
+      }
       else if (view.action === 'manual' && status) {
         // The click IS the download. Auto-update lives in Settings.
         const url = manualDownloadUrl(status, window.cth.platform, window.cth.arch);
@@ -161,6 +185,35 @@ export function UpdateBadge() {
         </ol>
         <div style={{ display: 'flex', gap: 8, marginTop: 10, justifyContent: 'flex-end' }}>
           <PixelButton variant="ghost" size="sm" onClick={() => setStarted(null)}>got it</PixelButton>
+        </div>
+      </div>
+    )}
+    {/* A successful "you are already current" check must be visible, or it is
+        indistinguishable from a dead click. Shows only for the manual-check
+        no-update result, and auto-dismisses. */}
+    {checkedOk && !started && (
+      <div
+        role="status"
+        aria-live="polite"
+        className="cth-titlebar-nodrag"
+        style={{
+          position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 400,
+          width: 300, padding: '10px 12px',
+          background: 'var(--cth-paper-100)', color: INK,
+          border: `2px solid ${INK}`, boxShadow: `4px 4px 0 ${INK}`,
+          fontFamily: 'var(--cth-font-ui)', fontSize: 12.5, lineHeight: 1.5, textAlign: 'left'
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontFamily: 'var(--cth-font-mono, monospace)', fontWeight: 700, fontSize: 13 }}>
+          <span aria-hidden style={{
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            width: 18, height: 18, borderRadius: 999,
+            background: 'var(--cth-mint-light, #d0f0e0)', color: 'var(--cth-ink-900)', fontSize: 12
+          }}>&#10003;</span>
+          You are on the latest version.
+        </div>
+        <div style={{ marginTop: 4, color: 'var(--cth-ink-700)' }}>
+          v{__APP_VERSION__} is the newest release. Checked just now.
         </div>
       </div>
     )}

--- a/src/renderer/src/components/UpdateBadge.tsx
+++ b/src/renderer/src/components/UpdateBadge.tsx
@@ -67,6 +67,8 @@ export function UpdateBadge() {
           if (!st || st === 'not-available' || st === 'idle' || st === 'just-updated') setCheckedOk(true);
         }
       }
+      else if (view.action === 'download') await window.cth.updateDownload();
+      else if (view.action === 'restart') await window.cth.updateRestartAndInstall();
       else if (view.action === 'manual' && status) {
         // The click IS the download. Auto-update lives in Settings.
         const url = manualDownloadUrl(status, window.cth.platform, window.cth.arch);
@@ -131,7 +133,7 @@ export function UpdateBadge() {
     </button>
 
     {/* Hover card: what the click does and what to do with the file, for this OS. */}
-    {pending && hover && !started && (
+    {view.action === 'manual' && hover && !started && (
       <div
         role="tooltip"
         className="cth-titlebar-nodrag"

--- a/src/shared/updateState.ts
+++ b/src/shared/updateState.ts
@@ -158,6 +158,23 @@ export function describeUpdate(status: UpdateStatus | null, currentVersion: stri
   }
   const pending = pendingVersion(status, v);
   if (pending) {
+    // When the native updater has staged the update, the badge drives the SAME
+    // auto-update the Settings pane does: restart to install once it is
+    // downloaded, or kick the download while it is 'available'. Manual download
+    // is reserved for 'available-manual', the notify-only fallback where the
+    // native updater could NOT fetch it, so the user replaces the app by hand.
+    if (status?.state === 'downloaded') {
+      return {
+        label: `v${pending} · restart`, action: 'restart', tone: 'ready', busy: false,
+        title: `Click to restart and install v${pending}`
+      };
+    }
+    if (status?.state === 'available') {
+      return {
+        label: `v${pending} · update`, action: 'download', tone: 'ready', busy: false,
+        title: `Downloading v${pending} in the background; click to start it if it has not begun`
+      };
+    }
     const why = status?.state === 'available-manual' && status.reason
       ? ` (this install could not update itself: ${status.reason})` : '';
     return {

--- a/test/update-badge-acknowledgement.test.cjs
+++ b/test/update-badge-acknowledgement.test.cjs
@@ -1,0 +1,35 @@
+/**
+ * A successful update check must be visible.
+ *
+ * The complaint that started this: on the latest release, a manual check
+ * succeeds, finds nothing, and the badge settles back to a quiet grey "latest"
+ * chip. A check that worked perfectly and a click that never registered look
+ * identical, so the button reads as broken. The fix is a brief, positive
+ * acknowledgement after a manual no-update check. Source-string checks, because
+ * UpdateBadge is a React component with no jsdom harness in this repo; deleting
+ * the acknowledgement wiring must not pass silently.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const read = (rel) => readFileSync(join(__dirname, '..', rel), 'utf8');
+const SRC = read('src/renderer/src/components/UpdateBadge.tsx');
+
+test('the check branch acknowledges a no-update result', () => {
+  assert.ok(/setCheckedOk\(true\)/.test(SRC),
+    'the manual check must set the acknowledgement, or a successful check stays silent');
+  assert.ok(/updateCheckNow\(\)/.test(SRC) && /updateCurrent\?\.\(\)/.test(SRC),
+    'it reads the settled status back after the check to tell a no-update result from an available one');
+  assert.ok(/'not-available'/.test(SRC),
+    'the acknowledgement is gated on a no-update state, not fired blindly for every check');
+});
+
+test('the acknowledgement renders and auto-dismisses', () => {
+  assert.ok(/checkedOk && !started &&/.test(SRC),
+    'the acknowledgement popover must render when checkedOk is set');
+  assert.ok(/on the latest version/i.test(SRC),
+    'it must say, in words, that the user is already current');
+  assert.ok(/setTimeout\(\(\) => setCheckedOk\(false\)/.test(SRC),
+    'it must auto-dismiss, or it is a stuck mode instead of a flash');
+});

--- a/test/update-state.test.cjs
+++ b/test/update-state.test.cjs
@@ -87,16 +87,16 @@ test('every actionable state offers the action its label promises', () => {
   check({ state: 'not-available' }, { action: 'check', label: 'latest' });
 
   check({ state: 'checking' }, { action: 'none', busy: true });
-  check({ state: 'available', version: '0.3.7' }, { action: 'manual', busy: false });
+  check({ state: 'available', version: '0.3.7' }, { action: 'download', busy: false });
   check({ state: 'downloading', version: '0.3.7', percent: 42 }, { action: 'none', busy: true });
-  check({ state: 'downloaded', version: '0.3.7' }, { action: 'manual', busy: false });
+  check({ state: 'downloaded', version: '0.3.7' }, { action: 'restart', busy: false });
   check({ state: 'available-manual', version: '0.3.7', url: 'https://x' }, { action: 'manual' });
   check({ state: 'error', message: 'boom' }, { action: 'check' });
 });
 
 test('labels name the version so the badge is self-explanatory', () => {
   assert.match(describeUpdate({ state: 'available', version: '0.3.7' }, '0.3.6').label, /0\.3\.7/);
-  assert.match(describeUpdate({ state: 'downloaded', version: '0.3.7' }, '0.3.6').label, /download/i);
+  assert.match(describeUpdate({ state: 'downloaded', version: '0.3.7' }, '0.3.6').label, /restart/i);
   assert.match(describeUpdate({ state: 'downloading', version: '0.3.7', percent: 42.4 }, '0.3.6').label, /42%/);
 });
 


### PR DESCRIPTION
## What

One coherent badge behaviour for 0.4.6, two parts:

### 1. A successful check is now visible (the acknowledgement)

On the latest release a manual check succeeded, found nothing, and settled silently to a grey `latest` chip. A working check and a dead click were indistinguishable, so the button read as broken. Now, after a **manual** no-update check, the badge flashes a positive popover ("You are on the latest version. vX is the newest release. Checked just now.") that auto-dismisses. It fires only for the manual no-update result (read back from the settled status), not for background 6h checks, and is `role="status" aria-live="polite"`.

### 2. The badge does the real auto-update (Option B)

The badge only ever offered a **manual** download (a DMG + a drag-to-Applications card), never the native download/restart the Settings pane runs. So when 0.4.6 lands, clicking the badge would hand the user a DMG and they would rightly say auto-update still does not work. Now, when the native updater has staged an update, the badge drives the same path Settings does:

- `available` → action `download` ("vX · update"): kick the native download.
- `downloaded` → action `restart` ("vX · restart"): quit and install.
- `available-manual` → action `manual` ("vX · download"): the notify-only fallback ONLY, where the native updater could not fetch it. The drag-to-Applications hover card now shows only in this case.

This is the last code change before the 0.4.6 freeze, and it is the behaviour the rc rehearsal exists to exercise; rehearsing without it would test the old badge, a build that never ships.

## Tested vs rc-only (the reporting standard)

- **Verified now**, without a real release: `describeUpdate`'s mapping for every state (unit tests, all 17 green: `available`→download, `downloaded`→restart, `available-manual`→manual), the badge's click-wiring, the acknowledgement (2 tests green), and `typecheck:web` clean. In dev these states can also be driven visually through the existing `update:simulate` handler.
- **Only a real signed release can exercise** (the rc, `0.4.6-rc.1` → `0.4.7-rc.1`): `downloadUpdate`, `quitAndInstall`, and the Squirrel install itself, i.e. that clicking `restart` actually installs and relaunches. The unit tests prove the badge *asks* for the right action in each state; they cannot prove the native install, because 0.4.5 is the latest release and no update exists to drive it. Do not read the green here as covering the install path.

## Scope

`src/shared/updateState.ts`, `src/renderer/src/components/UpdateBadge.tsx`, and `test/update-state.test.cjs`. Part of the frozen 0.4.6 set (#322, #324, #325, #326). The error-state download link and the menu item were cut to 0.5.0. Founder's merge.
