### PR TITLE
fix(codex): use the verified Codex default

### DIFF
--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -99,7 +99,7 @@ Return EXACTLY this shape (omit optional fields you don't need; keep the spec st
 }
 
 Rules:
-- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
+- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5.6-sol, "Gemini 3.1 Pro (High)").
 - Do NOT include shell commands or any flags beyond these fields.
 - Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
 

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -187,7 +187,11 @@ export const CODEX_MODELS: ModelOption[] = [
   { id: undefined, label: 'CLI default' },
   { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
   { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
-  { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' }
+  { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+  { id: 'gpt-5.5', label: 'GPT-5.5' },
+  { id: 'gpt-5.4', label: 'GPT-5.4' },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+  { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' }
 ];
 
 /** Models offered when an agent runs on the Antigravity CLI (`agy`). agy's

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -226,9 +226,10 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     canReceiveInbox: true,
     initialPromptFlag: undefined,
     positionalInitialPrompt: true,
-    // Codex's long-context coding model for the orchestrator role. // TODO-verify
-    // the exact codex CLI model id (couldn't install the codex CLI to confirm).
-    recommendedOrchestratorModel: 'gpt-5-codex',
+    // `model/list` verified under ChatGPT login on 2026-08-25 reports this as
+    // Codex's default. Keep this in lockstep with CODEX_MODELS in
+    // renderer/src/store/config.ts.
+    recommendedOrchestratorModel: 'gpt-5.6-sol',
     // Codex resumes via a SUBCOMMAND, not a flag: `codex resume [OPTIONS]
     // [SESSION_ID]`. A `--resume <id>` flag does not exist, which is why restarts
     // used to silently start a brand-new session instead of continuing.

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -87,7 +87,16 @@ test('model picker options stay provider-specific', () => {
   );
   assert.deepEqual(
     modelsForProvider('codex').map((model) => model.id),
-    [undefined, 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']
+    [
+      undefined,
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex-spark'
+    ]
   );
   assert.deepEqual(
     modelsForProvider('grok').map((model) => model.id),
@@ -120,6 +129,17 @@ test('Command Center model choices round-trip provider and model', () => {
     { provider: 'kimi', model: undefined }
   );
   assert.equal(decodeProviderModel('unknown:model'), null);
+});
+
+test('codex recommends the verified ChatGPT default', () => {
+  const recommended = providerPreset('codex').recommendedOrchestratorModel;
+  const codexIds = modelsForProvider('codex').map((model) => model.id);
+
+  assert.equal(recommended, 'gpt-5.6-sol');
+  assert.ok(
+    codexIds.includes(recommended),
+    `codex recommends ${recommended}, which its picker does not offer`
+  );
 });
 
 test('God only sees providers that can drain hive inbox messages', () => {


### PR DESCRIPTION
## What & why

The Codex preset recommends `gpt-5-codex`, but a fresh `model/list` probe under ChatGPT login does not offer that slug. The CLI supports legacy-model access, so list absence alone does not establish rejection; separately, the recorded ChatGPT-login first-message error rejects `gpt-5-codex`. A new orchestrator can therefore fail after launch.

This updates the preset to `gpt-5.6-sol`, the same probe's default, and refreshes the curated picker and add-agent example to its observed catalog. The regression test independently pins the recommendation and verifies that the picker offers it, so a future catalog change is visible in tests rather than silently leaving a stale default.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before
<img width="1868" height="928" alt="CleanShot 2026-08-25 at 15 53 58@2x" src="https://github.com/user-attachments/assets/a840d5c7-4cb2-461c-be5c-7d104f1890f6" />

The preset and add-agent example use `gpt-5-codex`. It is not offered by the fresh ChatGPT-login `model/list` output, and the recorded first-message error rejects it under that login.

### After
<img width="1856" height="922" alt="CleanShot 2026-08-25 at 15 54 51@2x" src="https://github.com/user-attachments/assets/00c400a9-2f00-4fdd-88a6-e35ce4e9b60f" />

The preset, picker, and example use the observed default `gpt-5.6-sol`; the picker now includes the complete observed catalog.

## How I tested it

- Ran the zero-spend `model/list` probe under ChatGPT login on 2026-08-25.
- `npm run typecheck`
- `npm run test:focused` (553 passing)
- `npm run build`

## Known limitations

The catalog result is scoped to a ChatGPT login on 2026-08-25. Codex's model catalog is provider-controlled and can include legacy models outside the picker; refresh `model/list` before changing these curated recommendations.
