### PR TITLE
fix(pi): copy models.json and models-store.json to .pi-agent directory

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -2170,12 +2170,16 @@ export class HiveManager {
       // Pi ignores it). Kept minimal and hive-authored.
       const manifest = { name: 'munder-hive-bridge', version: '0.3.1', main: 'extensions/hive-bridge.js', auto: true };
       writeFileSync(join(home, 'extensions.json'), JSON.stringify(manifest, null, 2), 'utf8');
-      // we need to copy models.json and models-store.json from the user's ~/.pi to the per-agent dir so Pi can load its models
+
       const userPiDir = join(homedir(), '.pi', 'agent');
-      const userModelsPath = join(userPiDir, 'models.json');
-      writeFileSync(join(home, 'models.json'), existsSync(userModelsPath) ? readFileSync(userModelsPath, 'utf8') : '{}', 'utf8');
-      const modelsStorePath = join(userPiDir, 'models-store.json');
-      writeFileSync(join(home, 'models-store.json'), existsSync(modelsStorePath) ? readFileSync(modelsStorePath, 'utf8') : '{}', 'utf8');
+      for (const fileName of ['models.json', 'models-store.json'] as const) {
+        try {
+          const data = readFileSync(join(userPiDir, fileName), 'utf8');
+          writeFileSync(join(home, fileName), data, 'utf8');
+        } catch (e) {
+          if ((e as NodeJS.ErrnoException).code !== 'ENOENT') console.error(`[hive] installPiHooks copy ${fileName} failed:`, e);
+        }
+      }
     } catch (e) { console.error('[hive] installPiHooks failed:', e); }
     return home;
   }

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -2170,6 +2170,12 @@ export class HiveManager {
       // Pi ignores it). Kept minimal and hive-authored.
       const manifest = { name: 'munder-hive-bridge', version: '0.3.1', main: 'extensions/hive-bridge.js', auto: true };
       writeFileSync(join(home, 'extensions.json'), JSON.stringify(manifest, null, 2), 'utf8');
+      // we need to copy models.json and models-store.json from the user's ~/.pi to the per-agent dir so Pi can load its models
+      const userPiDir = join(homedir(), '.pi', 'agent');
+      const userModelsPath = join(userPiDir, 'models.json');
+      writeFileSync(join(home, 'models.json'), existsSync(userModelsPath) ? readFileSync(userModelsPath, 'utf8') : '{}', 'utf8');
+      const modelsStorePath = join(userPiDir, 'models-store.json');
+      writeFileSync(join(home, 'models-store.json'), existsSync(modelsStorePath) ? readFileSync(modelsStorePath, 'utf8') : '{}', 'utf8');
     } catch (e) { console.error('[hive] installPiHooks failed:', e); }
     return home;
   }

--- a/test/hive-pi-models.test.cjs
+++ b/test/hive-pi-models.test.cjs
@@ -13,117 +13,79 @@ function tmpHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'md-hive-pi-models-'));
 }
 
+async function setupPi(t, { get, id }) {
+  const hiveHome = tmpHome();
+  const fakeHome = tmpHome();
+  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
+
+  const realHome = process.env.HOME;
+  const realProfile = process.env.USERPROFILE;
+  process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
+  t.after(() => {
+    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
+    if (realProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = realProfile;
+  });
+  assert.equal(os.homedir(), fakeHome, 'home redirect failed — aborting before touching the real home');
+
+  if (get) {
+    const dir = path.join(fakeHome, '.pi', 'agent');
+    fs.mkdirSync(dir, { recursive: true });
+    for (const [file, data] of Object.entries(get)) {
+      fs.writeFileSync(path.join(dir, file), JSON.stringify(data), 'utf8');
+    }
+  }
+
+  const hive = new HiveManager(() => hiveHome);
+  const injection = await hive.ensureAgent({ id, name: 'Pi Agent', provider: 'pi', cwd: hiveHome });
+  return injection.env.PI_CODING_AGENT_DIR;
+}
+
+function assertFiles(piAgentDir, want) {
+  for (const [file, w] of Object.entries(want)) {
+    const p = path.join(piAgentDir, file);
+    assert.equal(fs.existsSync(p), w.exists, `${file} ${w.exists ? 'should exist' : 'should not be created'}`);
+    if (w.exists) assert.deepEqual(JSON.parse(fs.readFileSync(p, 'utf8')), w.data, `${file} content should match source`);
+  }
+}
+
 test('installPiHooks copies models.json from ~/.pi/agent when it exists', async (t) => {
-  const hiveHome = tmpHome();
-  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+  const get = {
+    'models.json': { default: 'anthropic/claude-sonnet-4-5', custom: { 'openai/gpt-4o': {} } },
+    'models-store.json': { version: 2, models: [{ id: 'm1', name: 'test' }] },
+  };
+  const want = {
+    'models.json': { exists: true, data: get['models.json'] },
+    'models-store.json': { exists: true, data: get['models-store.json'] },
+  };
 
-  const fakeHome = tmpHome();
-  t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
-
-  const realHome = process.env.HOME;
-  process.env.HOME = fakeHome;
-  t.after(() => { if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome; });
-
-  const userPiAgentDir = path.join(fakeHome, '.pi', 'agent');
-  fs.mkdirSync(userPiAgentDir, { recursive: true });
-  const modelsData = { default: 'anthropic/claude-sonnet-4-5', custom: { 'openai/gpt-4o': {} } };
-  fs.writeFileSync(path.join(userPiAgentDir, 'models.json'), JSON.stringify(modelsData), 'utf8');
-  const storeData = { version: 2, models: [{ id: 'm1', name: 'test' }] };
-  fs.writeFileSync(path.join(userPiAgentDir, 'models-store.json'), JSON.stringify(storeData), 'utf8');
-
-  const hive = new HiveManager(() => hiveHome);
-  const injection = await hive.ensureAgent({
-    id: 'pi-1',
-    name: 'Pi Agent',
-    provider: 'pi',
-    cwd: hiveHome
-  });
-
-  const piAgentDir = injection.env.PI_CODING_AGENT_DIR;
+  const piAgentDir = await setupPi(t, { get, id: 'pi-1' });
   assert.ok(piAgentDir, 'PI_CODING_AGENT_DIR should be set');
-  assert.equal(fs.existsSync(path.join(piAgentDir, 'models.json')), true, 'models.json should exist');
-  assert.equal(fs.existsSync(path.join(piAgentDir, 'models-store.json')), true, 'models-store.json should exist');
-  assert.deepEqual(
-    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models.json'), 'utf8')),
-    modelsData,
-    'models.json content should match source'
-  );
-  assert.deepEqual(
-    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models-store.json'), 'utf8')),
-    storeData,
-    'models-store.json content should match source'
-  );
+  assertFiles(piAgentDir, want);
 });
 
-test('installPiHooks writes empty {} when ~/.pi/agent models files do not exist', async (t) => {
-  const hiveHome = tmpHome();
-  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+test('installPiHooks does not create models files when source is missing (lets Pi fall back to its defaults)', async (t) => {
+  const get = null;
+  // absent means "no user override" — must not write {} which Pi reads as "zero models"
+  const want = {
+    'models.json': { exists: false },
+    'models-store.json': { exists: false },
+  };
 
-  const fakeHome = tmpHome();
-  t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
-
-  const realHome = process.env.HOME;
-  process.env.HOME = fakeHome;
-  t.after(() => { if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome; });
-
-  const hive = new HiveManager(() => hiveHome);
-  const injection = await hive.ensureAgent({
-    id: 'pi-2',
-    name: 'Pi Agent',
-    provider: 'pi',
-    cwd: hiveHome
-  });
-
-  const piAgentDir = injection.env.PI_CODING_AGENT_DIR;
+  const piAgentDir = await setupPi(t, { get, id: 'pi-2' });
   assert.ok(piAgentDir, 'PI_CODING_AGENT_DIR should be set');
-  assert.equal(fs.existsSync(path.join(piAgentDir, 'models.json')), true, 'models.json should exist even when source is missing');
-  assert.equal(fs.existsSync(path.join(piAgentDir, 'models-store.json')), true, 'models-store.json should exist even when source is missing');
-  assert.deepEqual(
-    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models.json'), 'utf8')),
-    {},
-    'models.json should default to empty object'
-  );
-  assert.deepEqual(
-    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models-store.json'), 'utf8')),
-    {},
-    'models-store.json should default to empty object'
-  );
+  assertFiles(piAgentDir, want);
 });
 
-test('installPiHooks copies models.json even when models-store.json is missing', async (t) => {
-  const hiveHome = tmpHome();
-  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+test('installPiHooks copies models.json but skips missing models-store.json', async (t) => {
+  const get = { 'models.json': { default: 'openai/gpt-4o' } };
+  const want = {
+    'models.json': { exists: true, data: get['models.json'] },
+    'models-store.json': { exists: false },
+  };
 
-  const fakeHome = tmpHome();
-  t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
-
-  const realHome = process.env.HOME;
-  process.env.HOME = fakeHome;
-  t.after(() => { if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome; });
-
-  const userPiAgentDir = path.join(fakeHome, '.pi', 'agent');
-  fs.mkdirSync(userPiAgentDir, { recursive: true });
-  const modelsData = { default: 'openai/gpt-4o' };
-  fs.writeFileSync(path.join(userPiAgentDir, 'models.json'), JSON.stringify(modelsData), 'utf8');
-
-  const hive = new HiveManager(() => hiveHome);
-  const injection = await hive.ensureAgent({
-    id: 'pi-3',
-    name: 'Pi Agent',
-    provider: 'pi',
-    cwd: hiveHome
-  });
-
-  const piAgentDir = injection.env.PI_CODING_AGENT_DIR;
+  const piAgentDir = await setupPi(t, { get, id: 'pi-3' });
   assert.ok(piAgentDir, 'PI_CODING_AGENT_DIR should be set');
-  assert.deepEqual(
-    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models.json'), 'utf8')),
-    modelsData,
-    'models.json should be copied from source'
-  );
-  assert.deepEqual(
-    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models-store.json'), 'utf8')),
-    {},
-    'models-store.json should default to empty object when source is missing'
-  );
+  assertFiles(piAgentDir, want);
 });

--- a/test/hive-pi-models.test.cjs
+++ b/test/hive-pi-models.test.cjs
@@ -1,0 +1,129 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-hive-pi-models-'));
+}
+
+test('installPiHooks copies models.json from ~/.pi/agent when it exists', async (t) => {
+  const hiveHome = tmpHome();
+  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+
+  const fakeHome = tmpHome();
+  t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
+
+  const realHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+  t.after(() => { if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome; });
+
+  const userPiAgentDir = path.join(fakeHome, '.pi', 'agent');
+  fs.mkdirSync(userPiAgentDir, { recursive: true });
+  const modelsData = { default: 'anthropic/claude-sonnet-4-5', custom: { 'openai/gpt-4o': {} } };
+  fs.writeFileSync(path.join(userPiAgentDir, 'models.json'), JSON.stringify(modelsData), 'utf8');
+  const storeData = { version: 2, models: [{ id: 'm1', name: 'test' }] };
+  fs.writeFileSync(path.join(userPiAgentDir, 'models-store.json'), JSON.stringify(storeData), 'utf8');
+
+  const hive = new HiveManager(() => hiveHome);
+  const injection = await hive.ensureAgent({
+    id: 'pi-1',
+    name: 'Pi Agent',
+    provider: 'pi',
+    cwd: hiveHome
+  });
+
+  const piAgentDir = injection.env.PI_CODING_AGENT_DIR;
+  assert.ok(piAgentDir, 'PI_CODING_AGENT_DIR should be set');
+  assert.equal(fs.existsSync(path.join(piAgentDir, 'models.json')), true, 'models.json should exist');
+  assert.equal(fs.existsSync(path.join(piAgentDir, 'models-store.json')), true, 'models-store.json should exist');
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models.json'), 'utf8')),
+    modelsData,
+    'models.json content should match source'
+  );
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models-store.json'), 'utf8')),
+    storeData,
+    'models-store.json content should match source'
+  );
+});
+
+test('installPiHooks writes empty {} when ~/.pi/agent models files do not exist', async (t) => {
+  const hiveHome = tmpHome();
+  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+
+  const fakeHome = tmpHome();
+  t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
+
+  const realHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+  t.after(() => { if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome; });
+
+  const hive = new HiveManager(() => hiveHome);
+  const injection = await hive.ensureAgent({
+    id: 'pi-2',
+    name: 'Pi Agent',
+    provider: 'pi',
+    cwd: hiveHome
+  });
+
+  const piAgentDir = injection.env.PI_CODING_AGENT_DIR;
+  assert.ok(piAgentDir, 'PI_CODING_AGENT_DIR should be set');
+  assert.equal(fs.existsSync(path.join(piAgentDir, 'models.json')), true, 'models.json should exist even when source is missing');
+  assert.equal(fs.existsSync(path.join(piAgentDir, 'models-store.json')), true, 'models-store.json should exist even when source is missing');
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models.json'), 'utf8')),
+    {},
+    'models.json should default to empty object'
+  );
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models-store.json'), 'utf8')),
+    {},
+    'models-store.json should default to empty object'
+  );
+});
+
+test('installPiHooks copies models.json even when models-store.json is missing', async (t) => {
+  const hiveHome = tmpHome();
+  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+
+  const fakeHome = tmpHome();
+  t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
+
+  const realHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+  t.after(() => { if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome; });
+
+  const userPiAgentDir = path.join(fakeHome, '.pi', 'agent');
+  fs.mkdirSync(userPiAgentDir, { recursive: true });
+  const modelsData = { default: 'openai/gpt-4o' };
+  fs.writeFileSync(path.join(userPiAgentDir, 'models.json'), JSON.stringify(modelsData), 'utf8');
+
+  const hive = new HiveManager(() => hiveHome);
+  const injection = await hive.ensureAgent({
+    id: 'pi-3',
+    name: 'Pi Agent',
+    provider: 'pi',
+    cwd: hiveHome
+  });
+
+  const piAgentDir = injection.env.PI_CODING_AGENT_DIR;
+  assert.ok(piAgentDir, 'PI_CODING_AGENT_DIR should be set');
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models.json'), 'utf8')),
+    modelsData,
+    'models.json should be copied from source'
+  );
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(path.join(piAgentDir, 'models-store.json'), 'utf8')),
+    {},
+    'models-store.json should default to empty object when source is missing'
+  );
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Munder Difflin.

     Read this line before you go further: a PR without a BEFORE and an AFTER
     is not reviewable and will not be merged. The `PR evidence` check runs the
     moment you open this and will tell you if it is missing. Keep the `Before`
     and `After` headings below exactly as they are — the check reads them. -->

## What & why

I use pi with local models and wanted to test munder difflin, however I noticed that in the agent directories my custom config with my models was missing and I could not use them, see the attached gif that it does not see any models.
With the two json files we bring the user's desired config into the agent's directory so that the models work.
<!-- What changed, and why it needed to. Two or three sentences beats a
     bullet list of file names — we can read the diff, we cannot read your
     reasoning. If this fixes an issue, link it: Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence
The agents using pi can now use the locally configured models, evidence is the absence of the warning.
<!-- REQUIRED. Drag images or a screen recording directly under each heading —
     GitHub uploads them inline. Both headings must have something under them.

     No visible UI? You still owe evidence. Record the failing behaviour and
     then the same steps passing: a terminal capture, a log diff, a test that
     goes from red to green. "It has no UI" is not an exemption.

     Truly nothing observable, like a CI tweak or a typo? Say so in
     "What & why" and ask a maintainer for the `no-visual-change` label. -->

### Before
https://github.com/user-attachments/assets/87bfaad0-2482-408d-8b4c-a2d8a9eb6d60

Note the warning that no models are available.
### After
https://github.com/user-attachments/assets/a00472d6-21a7-434e-bc0a-4a27975b7af1

The warning is gone.
<!-- The same view or the same steps, with your change applied.
     Same window size, same theme, same data — a reviewer should be able to
     flip between the two and see only what you changed. -->

## How I tested it

<!-- The actual steps you ran, on which OS. Not "tested locally". -->

- OS: macOS 26.6.2 (25G83)
- Steps:
  - use pi with locally configured models (I use https://github.com/drumih/turbo-fieldfare )
  - create a new agent with pi and default config
  - observe that the newly spaned agent can now use the models which it could not see before the change.

## Discord (optional)

<!-- For the `employee of the month` role in our Discord when this merges.
     Join first so we can find you: https://discord.gg/SEDzP5ZPk5 -->

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.
