### PR TITLE
Upstream/model catalog json

### DIFF
--- a/.github/workflows/pr-evidence.yml
+++ b/.github/workflows/pr-evidence.yml
@@ -75,7 +75,9 @@ jobs:
             // Comments are the template's own instructions to the author. Left
             // unfilled they are invisible to a reader, so they must be invisible
             // to this check too — otherwise the empty template would pass.
-            const visible = body.replace(/<!--[\s\S]*?-->/g, '');
+            const visible = body
+              .replace(/<!--[\s\S]*?-->/g, '')
+              .replace(/^(```|~~~)[\s\S]*?^\1\s*$/gm, '');
 
             // ── Before and after, separately ─────────────────────────────────
             // Two assets in one blob is not the same as a before and an after.
@@ -84,7 +86,7 @@ jobs:
             // right place to count for it.
             const section = (name) => {
               const re = new RegExp(
-                `^#{1,6}\\s*${name}\\b[^\\n]*\\n([\\s\\S]*?)(?=\\n#{1,6}\\s|$)`,
+                `^#{1,6}\\s*${name}\\b[^\\n]*\\n([\\s\\S]*?)(?=^#{1,6}\\s|(?![\\s\\S]))`,
                 'im'
               );
               return (visible.match(re) || [, ''])[1];

--- a/docs/superpowers/plans/2026-08-25-pluggable-memory.md
+++ b/docs/superpowers/plans/2026-08-25-pluggable-memory.md
@@ -1,0 +1,264 @@
+# Pluggable Memory Backends Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the semantic memory layer configurable behind a `MemoryBackend` interface, with MemPalace (default, behavior-identical) and Hindsight (HTTP) adapters and a backend-neutral `hive-memory` shim for agents.
+
+**Architecture:** `MemoryManager` keeps the backend-neutral machinery (mine cadence, mtime skips, serialization, status caching) and delegates backend verbs to the active adapter. MemPalaceAdapter is today's code moved verbatim; HindsightAdapter is a small HTTP client against a Hindsight server. Agents call a spawn-written `hive/bin/hive-memory` script routed by env.
+
+**Tech Stack:** TypeScript (Electron main), node:test (`.test.cjs` files, run via `npm run test:focused`), plain `node:http` for the Hindsight stub server in tests, `fetch` (Node ≥18 global) for the adapter.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-pluggable-memory-design.md` — read it first; every decision below is argued there.
+
+## Global Constraints
+
+- Branch: `feat/pluggable-memory` (fork-only; NEVER opened against upstream).
+- Commit 1 must not touch any test file — the untouched suite passing IS its proof.
+- MemPalace behavior must stay byte-identical through the whole plan (same CLI args, same env, same quarantine/backoff, same log lines).
+- No buffering/queueing of memories anywhere: `memory.md` is the durable store.
+- Shim failure mode: backend unreachable → print exactly one line and `exit 0`.
+- All new claims in comments must be dated and scoped (house rule; see spec's Hindsight section).
+- Tests must assert EFFECTS, not proxies; expect both removal- and substitution-mutation review in QA.
+- Run before every commit: `npm run typecheck && npm run test:focused` (baseline 553 passing on this branch's base).
+
+---
+
+### Task 1: Pure extraction — `MemoryBackend` interface + `MemPalaceAdapter` (Commit 1)
+
+**Files:**
+- Create: `src/main/memoryBackend.ts`
+- Create: `src/main/memPalaceAdapter.ts`
+- Modify: `src/main/memory.ts` (shrinks to the neutral manager)
+- Test: NONE — commit 1 may not touch tests.
+
+**Interfaces:**
+- Consumes: existing `palaceReap.ts` exports (`quarantineDirsToReap`, `quarantineStampMs`, `nextMineDelayMs`), `procKill.ensureKilled`.
+- Produces (later tasks rely on these exact names):
+
+```ts
+// src/main/memoryBackend.ts
+export type BackendId = 'mempalace' | 'hindsight';
+export interface BackendStatus {
+  backend: BackendId;
+  available: boolean;   // CLI on PATH / server answered /health recently
+  enabled: boolean;
+  active: boolean;
+  initialized: boolean; // palace dir exists / bank exists
+  location: string | null; // palace path / `${url} · ${bank}`
+  model: string | null;    // embedding model (mempalace) / null (hindsight)
+  bin: string | null;      // CLI path (mempalace) / null (hindsight)
+}
+export interface MineResult { ok: boolean; backoffAdviceMs?: number }
+export interface TextResult { ok: boolean; output: string; error?: string }
+export interface MemoryBackend {
+  readonly id: BackendId;
+  available(): boolean;                 // sync, cached — matches today's bin() caching
+  init(): void;                         // arm anything needed pre-mine (mempalace: boot reap)
+  mineAgent(agentDir: string, agentId: string): Promise<MineResult>;
+  search(q: string, opts: { agentId?: string; results?: number }): Promise<TextResult>;
+  wakeUp(agentId?: string): Promise<TextResult>;
+  status(enabled: boolean, home: string | null): BackendStatus;
+  agentEnv(): Record<string, string>;   // injected into agent spawns
+  resetCaches(): void;                  // today's resetBinCache
+}
+```
+
+- [ ] **Step 1: Create `memoryBackend.ts`** with exactly the block above (plus a file-top comment pointing at the spec).
+
+- [ ] **Step 2: Create `MemPalaceAdapter` by MOVING code out of `memory.ts`.** Move-map (source lines refer to current `src/main/memory.ts`):
+  - `MINE_IGNORE_LINES` + `ensureMineIgnore` (22–46) → adapter (keep the hive.ts sync-comment verbatim; `test/mine-ignore-sync.test.cjs` greps both copies — the adapter file must keep the literal array so that test stays green; if it asserts the file path `memory.ts`, STOP: that means the sync test names files, and you must check what it matches before moving — do this check FIRST).
+  - `EmbeddingModel`, `mempalaceDevice`, `MEMPALACE_DEVICE` (48, 81–111) → adapter, re-export `EmbeddingModel` and `mempalaceDevice` from `memory.ts` (`export { ... } from './memPalaceAdapter'`) so existing imports/tests resolve unchanged.
+  - `bin()`, `resetBinCache()` (139–177) → adapter (`resetCaches()`).
+  - `env()`/`childEnv()` (198–215) → adapter `agentEnv()`/private `childEnv()`; palace path comes via a `getPalacePath: () => string | null` constructor callback.
+  - `reapPalace()` (334–360) → adapter; expose as `init()` (boot sweep) and fold the post-mine call into `mineAgent`'s return: `mineAgent` runs today's `mineAgent` (362–392) then `reapPalace()`, returning `{ ok, backoffAdviceMs: nextMineDelayMs(...) }` computed with the SAME constants (`MINE_INTERVAL_MS`, `MINE_BACKOFF_MAX_MS` move to the adapter; the manager just applies advice).
+    NOTE an intentional, behavior-preserving nuance: today `reapPalace()` runs once per PASS (after all agents), not per agent. Preserve that: give the adapter a `postMinePass(): { backoffAdviceMs: number }` method instead of folding into `mineAgent`, and have the manager call it after each pass. Adjust the interface: add `postMinePass?(): { backoffAdviceMs: number }` (optional; hindsight omits it).
+  - `runCli`, `search`, `wakeUp` (400–446) → adapter; `wing` param becomes `agentId`.
+- `memory.ts` keeps: `MemorySettings`, `MemoryStatus` (unchanged shape, now derived from `BackendStatus` for compat), the mine loop (`start/stop/refresh/startMineLoop/mineNow`, mtime `lastMined` map, `mining` flag, `mineDelayMs`), constructing the adapter, and delegating `search/wakeUp/env/status/resetBinCache` to it. `status()` keeps returning today's `MemoryStatus` shape so `index.ts:3454/3483` and the renderer are untouched in this commit.
+
+- [ ] **Step 3: Typecheck** — `npm run typecheck`, expect clean.
+
+- [ ] **Step 4: Full suite untouched** — `npm run test:focused`. Expected: 553/553 pass with ZERO test-file edits. If any test fails, the extraction changed behavior — fix the extraction, never the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/memoryBackend.ts src/main/memPalaceAdapter.ts src/main/memory.ts
+git commit -m "refactor(memory): extract MemoryBackend interface and MemPalaceAdapter
+
+Pure extraction. MemoryManager keeps the backend-neutral mine loop,
+mtime tracking, and single-writer serialization; every mempalace-
+specific behavior (bin discovery, env + device pin, quarantine backoff,
+palace reaping, CLI search/wake-up) moves verbatim into the adapter.
+No behavior change: the untouched test suite is the proof."
+```
+
+### Task 2: The `hive-memory` shim + prompt text (Commit 2)
+
+**Files:**
+- Create: `resources/hive-memory.cjs` (the shim source, shipped like hive-node's payload — find how `hive/bin/hive-node` gets written at spawn: `grep -rn "hive-node" src/main/hive.ts` and mirror that mechanism exactly)
+- Modify: `src/main/hive.ts` (write `hive/bin/hive-memory` beside hive-node at spawn; swap prompt text at ~1302 and ~2524)
+- Modify: `src/main/index.ts:2673` region only if needed to add `HIVE_MEMORY_BACKEND` to spawn env (preferred: include it in the adapter's `agentEnv()` — mempalace adds `HIVE_MEMORY_BACKEND=mempalace`, hindsight `=hindsight`)
+- Test: `test/hive-memory-shim.test.cjs`
+
+**Interfaces:**
+- Consumes: `agentEnv()` from Task 1 (now also carrying `HIVE_MEMORY_BACKEND`).
+- Produces: `hive/bin/hive-memory` CLI: `hive-memory search "<q>" [--results N]`, `hive-memory wake-up`. Exit 0 always except usage errors (exit 2 with usage on stderr).
+
+- [ ] **Step 1: Write the failing test** (`test/hive-memory-shim.test.cjs`):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const SHIM = require.resolve('../resources/hive-memory.cjs');
+
+test('unknown backend prints the unavailable line and exits 0', () => {
+  const out = execFileSync(process.execPath, [SHIM, 'search', 'anything'], {
+    env: { ...process.env, HIVE_MEMORY_BACKEND: 'nonexistent' }, encoding: 'utf8'
+  });
+  assert.match(out, /memory recall unavailable — continue without it/);
+});
+
+test('hindsight backend renders recall hits as plain text', () => {
+  // stub server started in-test on 127.0.0.1:0; see implementation step for the handler
+  const http = require('node:http');
+  const srv = http.createServer((req, res) => {
+    if (req.method === 'POST' && /\/memories\/recall$/.test(req.url)) {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ results: [{ text: 'the fact', score: 0.91, metadata: { agent: 'pam' } }] }));
+    } else { res.statusCode = 404; res.end('{}'); }
+  });
+  return new Promise((resolve) => srv.listen(0, '127.0.0.1', () => {
+    const out = execFileSync(process.execPath, [SHIM, 'search', 'fact'], {
+      env: { ...process.env, HIVE_MEMORY_BACKEND: 'hindsight',
+             HINDSIGHT_URL: `http://127.0.0.1:${srv.address().port}`, HINDSIGHT_BANK: 'b1' },
+      encoding: 'utf8'
+    });
+    assert.match(out, /the fact/);
+    assert.match(out, /0\.91/);
+    srv.close(); resolve();
+  }));
+});
+
+test('mempalace backend execs the mempalace CLI with passthrough args', () => {
+  // PATH is prefixed with a temp dir containing a fake `mempalace` that echoes its argv
+  const { mkdtempSync, writeFileSync, chmodSync } = require('node:fs');
+  const { join } = require('node:path');
+  const dir = mkdtempSync(join(require('node:os').tmpdir(), 'shimtest-'));
+  const fake = join(dir, 'mempalace');
+  writeFileSync(fake, '#!/bin/sh\necho FAKE-MEMPALACE "$@"\n'); chmodSync(fake, 0o755);
+  const out = execFileSync(process.execPath, [SHIM, 'search', 'q1', '--results', '3'], {
+    env: { ...process.env, HIVE_MEMORY_BACKEND: 'mempalace', PATH: `${dir}:${process.env.PATH}` },
+    encoding: 'utf8'
+  });
+  assert.match(out, /FAKE-MEMPALACE search q1 --results 3/);
+});
+```
+
+- [ ] **Step 2: Run it** — `node --test test/hive-memory-shim.test.cjs`. Expected: FAIL (`Cannot find module '../resources/hive-memory.cjs'`).
+
+- [ ] **Step 3: Write the shim** (`resources/hive-memory.cjs`). Requirements, all load-bearing:
+  - argv: `search <query> [--results N]` | `wake-up`. Anything else → usage on stderr, exit 2.
+  - `HIVE_MEMORY_BACKEND=mempalace` → `spawnSync('mempalace', [verb, ...args])` inheriting stdio (verb `wake-up` maps to `wake-up`; `search q --results N` passes through unchanged, `--wing` from `HIVE_MEMORY_AGENT` if set). If spawn fails (ENOENT) → the unavailable line, exit 0.
+  - `HIVE_MEMORY_BACKEND=hindsight` → `fetch(`${HINDSIGHT_URL}/v1/default/banks/${HINDSIGHT_BANK}/memories/recall`, { method:'POST', body: JSON.stringify({ query, top_k: N }) })` with a 10s AbortController timeout; render each hit as `— <text>  (score <score>, <agent>)`; wake-up = recall with `query: 'recent important context'`, `top_k: 8`, filtered to `HIVE_MEMORY_AGENT` when set. Any network/HTTP error → the unavailable line, exit 0. (Verify the pilot's exact recall request/response field names against `~/code/hindsight-pilot/openapi.json` and `retain-bridge.py` BEFORE coding; adjust `top_k`/`results` names to what the API actually takes and mirror them in the Task 3 adapter.)
+  - Anything else / unset → unavailable line, exit 0.
+  - The unavailable line is EXACTLY: `memory recall unavailable — continue without it`
+- [ ] **Step 4: Run the test** — expected: 3/3 PASS.
+- [ ] **Step 5: Wire spawn + prompts.** In `hive.ts`: write `hive/bin/hive-memory` beside `hive-node` (same writer, mode 0755, content from `resources/hive-memory.cjs`). Replace the two prompt blocks (hive.ts:1302 and ~2524) so they name ONLY `hive-memory search "<query>"` and `hive-memory wake-up`. Keep the sentence structure; drop every `mempalace` mention. Then `grep -rn mempalace src/main/hive.ts` — expected: only the MINE_IGNORE sync comment remains (see Task 1 note).
+- [ ] **Step 6: Verify + commit**
+
+```bash
+npm run typecheck && npm run test:focused && node --test test/hive-memory-shim.test.cjs
+git add resources/hive-memory.cjs src/main/hive.ts src/main/index.ts src/main/memPalaceAdapter.ts test/hive-memory-shim.test.cjs
+git commit -m "feat(memory): backend-neutral hive-memory shim; prompts stop naming mempalace"
+```
+
+### Task 3: `HindsightAdapter` (first half of Commit 3)
+
+**Files:**
+- Create: `src/main/hindsightAdapter.ts`
+- Test: `test/hindsight-adapter.test.cjs` (loads TS via the existing `test/load-ts.cjs` helper — read how `test/` loads other main-process TS first and copy that pattern)
+
+**Interfaces:**
+- Consumes: `MemoryBackend`, `MineResult`, `TextResult`, `BackendStatus` from Task 1.
+- Produces: `class HindsightAdapter implements MemoryBackend` with constructor `(cfg: () => { url: string; bank: string }, getHome: () => string | null)`.
+
+- [ ] **Step 1: Write failing tests** — stub `node:http` server (pattern from Task 2), asserting EFFECTS:
+
+```js
+// shapes it must pin:
+// 1) mineAgent posts to /v1/default/banks/<bank>/memories with items[] and
+//    DETERMINISTIC ids: same file content -> same document id (run twice, capture both bodies, deepEqual).
+// 2) mineAgent returns { ok: true } on 200 and { ok: false } on ECONNREFUSED (server closed) — no throw.
+// 3) search posts to .../memories/recall and returns rendered text containing hit text + score.
+// 4) wakeUp returns ok:true with text when the server answers, and ok:false with error when down.
+// 5) available() flips false when /health stops answering (cache TTL <= 30s).
+// 6) agentEnv() === { HIVE_MEMORY_BACKEND: 'hindsight', HINDSIGHT_URL: cfg.url, HINDSIGHT_BANK: cfg.bank }.
+```
+
+Write each as a real `node:test` case against the stub; capture request bodies in the stub and assert on them (`assert.deepEqual(seen.path, '/v1/default/banks/b1/memories')` etc.).
+- [ ] **Step 2: Run to fail** — module not found.
+- [ ] **Step 3: Implement.** Mine = read `<agentDir>/memory.md`, split into sections on `^## ` headings, one item per section: `{ id: sha256(agentId + heading + body).slice(0,32), text: body, metadata: { agent: agentId, source: 'memory.md', heading } }`, POST with `async:false` (verify field name against openapi.json). Timeout: reuse the manager's mine timeout by racing an AbortController at 10 min. `search`/`wakeUp` per the shim's Task 3 shapes (same rendering helper — put `renderRecall(results): string` in the adapter and have the shim duplicate it deliberately: the shim is a standalone script and must not import app code; note this duplication in a comment on both sides). No `postMinePass` (mempalace-only). `init()` = ensure bank exists (GET bank stats; on 404 POST create if the API supports it — otherwise document that the bank must pre-exist and make `available()` false with a status detail when missing).
+- [ ] **Step 4: Run tests green.** `node --test test/hindsight-adapter.test.cjs`.
+- [ ] **Step 5: NO commit yet** — Commit 3 lands after Task 5.
+
+### Task 4: Config, migration, backend selection (second half of Commit 3)
+
+**Files:**
+- Modify: `src/main/config.ts` (find `MemorySettings` persistence — grep `memory` in it), `src/main/memory.ts` (adapter selection), `src/main/index.ts:304` (constructor args if they change)
+- Test: `test/memory-config-migration.test.cjs`
+
+**Interfaces:**
+- Produces: `MemorySettings` becomes `{ enabled: boolean; backend: 'mempalace'|'hindsight'; mempalace: { model: EmbeddingModel }; hindsight: { url: string; bank: string } }` with `migrateMemorySettings(old: unknown): MemorySettings` exported from `config.ts`.
+
+- [ ] **Step 1: Failing tests** for migration, three cases:
+
+```js
+// {enabled:true, model:'minilm'}            -> {enabled:true, backend:'mempalace', mempalace:{model:'minilm'}, hindsight:{url:'http://127.0.0.1:8888', bank:'hive-memory'}}
+// already-new shape                          -> returned unchanged (idempotent)
+// undefined/garbage                          -> safe defaults (enabled:false, backend:'mempalace')
+```
+
+- [ ] **Step 2: Fail, implement `migrateMemorySettings`, pass.** Call it at the single point config is loaded (find where the config file is read and parsed; migration runs there, and the migrated shape is what gets persisted on next save).
+- [ ] **Step 3: Backend selection in `MemoryManager`:** construct the adapter from `settings.backend` once at start; `refresh()` re-reads the setting and swaps the adapter if it changed (drop `lastMined` so the new backend re-mines everything — this implements the spec's "switch = re-mine from scratch"). Write a test: manager with backend swapped via settings stub re-mines an agent it had already mined (assert the stub adapter's `mineAgent` called again after swap).
+- [ ] **Step 4: Suite green; no commit yet.**
+
+### Task 5: Setup/Onboarding UI (completes Commit 3)
+
+**Files:**
+- Modify: `src/renderer/src/components/SetupPanel.tsx` and `OnboardingWizard.tsx` (find the existing memory section: `grep -n mempalace src/renderer/src/components/SetupPanel.tsx`)
+- Test: extend `test/` only if a renderer test harness already exists for these panels (`grep -rl SetupPanel test/`); otherwise UI is covered by the evidence script + typecheck (state this in the commit body honestly).
+
+**Interfaces:**
+- Consumes: the `hive:memoryStatus` IPC (now returning `MemoryStatus` derived from `BackendStatus` — extend the payload with `backend: BackendId` and `location`), a new `hive:memoryTestConnection` IPC handler added in `index.ts` near :3483: `(url, bank) => hindsight /health + bank stats` returning `{ ok, detail }`.
+
+- [ ] **Step 1:** Add the IPC handler in `index.ts` (main): try `fetch(url + '/health')` then `fetch(url + '/v1/default/banks/' + bank + '/stats')`, 5s timeout, return `{ ok, detail: '<n> memories' | error text }`. Never throws.
+- [ ] **Step 2:** UI: radio/select for backend; mempalace shows today's fields unchanged; hindsight shows url + bank inputs and a "Test connection" button calling the IPC and rendering `detail` — result comes from the IPC READ-BACK, never local state (spec: the C-02 rule). Status chip renders from `hive:memoryStatus` polling exactly as today, plus the backend label. Match the file's existing component and styling idioms — copy a neighboring field's markup rather than inventing structure.
+- [ ] **Step 3:** `npm run typecheck && npm run build` green.
+- [ ] **Step 4: Commit 3**
+
+```bash
+git add src/main/hindsightAdapter.ts src/main/config.ts src/main/memory.ts src/main/index.ts \
+        src/renderer/src/components/SetupPanel.tsx src/renderer/src/components/OnboardingWizard.tsx \
+        test/hindsight-adapter.test.cjs test/memory-config-migration.test.cjs
+git commit -m "feat(memory): Hindsight backend — adapter, config migration, backend picker"
+```
+
+### Task 6: Conformance suite + live evidence script (Commit 4)
+
+**Files:**
+- Create: `test/memory-backend-conformance.test.cjs`
+- Create: `hive/evidence/c21-memory-backend-evidence.sh` (NOT committed to the repo — it lives in the hive; the repo gets only the conformance test)
+
+**Interfaces:** consumes both adapters + a fake-CLI dir (Task 2's pattern) and stub server (Task 3's pattern).
+
+- [ ] **Step 1: Conformance test** — one parametrized spec run over `[mempalaceAdapterUnderFakeCli, hindsightAdapterUnderStub]` asserting the CONTRACT: `mineAgent` ok:true on healthy backend and ok:false (no throw) on broken one; `search` returns `TextResult` with non-empty output for a seeded hit; `wakeUp` same; `agentEnv()` contains `HIVE_MEMORY_BACKEND` = adapter id; `status(...)` has `backend` = id and never throws with home=null. Each assertion runs against BOTH adapters via `for (const make of cases) test(...)`.
+- [ ] **Step 2: Green**, then **Commit 4** (`test: memory backend conformance suite`).
+- [ ] **Step 3: Evidence script** (house format, hive/evidence/): `before` mode = current released behavior label optional — this feature has no "bug", so the script has modes `mempalace` and `hindsight`: each prints TREE/REF/STEPS, then against the LIVE pilot (hindsight mode; `HINDSIGHT_URL=http://localhost:8888`, throwaway bank `c21-evidence-<user>-<pid>`): mine a real fixture memory.md, recall it back, wake-up, print EXPECTED/ACTUAL/VERDICT (`BACKEND VERIFIED`), delete the throwaway bank. Run both modes end-to-end yourself before reporting done.
+- [ ] **Step 4:** Report to god with: suite counts, conformance output, both evidence blocks.
+
+## Self-review notes (already applied)
+
+- Spec coverage: interface (T1), adapters (T1/T3), shim+prompts (T2), config+migration+switch-re-mine (T4), UI+test-connection+read-back (T5), degraded mode (T2 exit-0 + T3 ok:false cases + T4 swap), testing+evidence (T6). Graph panel: explicitly v1-hidden — no task, matches spec.
+- The `postMinePass` nuance in T1 amends the spec's `backoffAdviceMs`-on-`mineAgent` sketch to preserve per-PASS reaping; the interface in T1 is the authoritative shape.
+- Field-name uncertainty (recall `top_k` vs `results`, retain `async`) is called out in T2/T3 with the instruction to verify against the pilot's openapi.json before coding — do not skip it.

--- a/docs/superpowers/plans/2026-08-25-pluggable-memory.md
+++ b/docs/superpowers/plans/2026-08-25-pluggable-memory.md
@@ -19,7 +19,7 @@
 - Shim failure mode: backend unreachable → print exactly one line and `exit 0`.
 - All new claims in comments must be dated and scoped (house rule; see spec's Hindsight section).
 - Tests must assert EFFECTS, not proxies; expect both removal- and substitution-mutation review in QA.
-- Run before every commit: `npm run typecheck && npm run test:focused` (baseline 553 passing on this branch's base).
+- Run before every commit: `npm run typecheck && npm run test:focused` (baseline 552 passing at this branch's base — always trust the branch-base count you measure over this number).
 
 ---
 

--- a/docs/superpowers/specs/2026-08-25-pluggable-memory-design.md
+++ b/docs/superpowers/specs/2026-08-25-pluggable-memory-design.md
@@ -1,0 +1,98 @@
+# Pluggable memory backends — design
+
+**Date:** 2026-08-25 · **Status:** approved section-by-section by Aaron; this file is the consolidated spec.
+**Delivery:** long-lived branch `feat/pluggable-memory` on the fork. May never be upstreamed; it is our working copy either way. Shaped so upstream could adopt it (clean seam, no fork-only dependencies in the interface).
+
+## Problem
+
+Semantic memory is hardwired to MemPalace. `MemoryManager` (`src/main/memory.ts`) shells to the `mempalace` CLI for everything; `palaceReap.ts` is MemPalace-specific disk care; the agent prompt text names `mempalace search` literally (`hive.ts`). Users with an existing memory system cannot bring it. First supported alternative: **Hindsight** (HTTP server; Aaron's store). Obsidian was considered and dropped — a markdown vault is a different kind of thing, not a memory backend.
+
+## Decisions (locked with Aaron)
+
+1. **Full replacement, substrate kept.** The active backend is both where new memories are indexed and what agents search. Per-agent `memory.md` remains the write substrate and the durable source of truth; it is mined/synced into the active backend.
+2. **Agents reach memory through a harness-owned shim** — `hive-memory search "<q>"` / `hive-memory wake-up`. Prompts never name a backend. Adding a backend touches zero prompt text.
+3. **Scope: MemPalace (default) + Hindsight.** No third backend in v1.
+4. **Approach: extracted TypeScript interface with in-process adapters** (over shim-only and out-of-process contracts).
+
+## Architecture
+
+### The interface (`src/main/memoryBackend.ts`)
+
+```ts
+interface MemoryBackend {
+  readonly id: 'mempalace' | 'hindsight';
+  available(): Promise<boolean>;        // CLI on PATH / server answers /health
+  init(): Promise<void>;                // palace init / ensure bank exists
+  mineAgent(agentDir: string, agentId: string): Promise<{ ok: boolean; backoffAdviceMs?: number }>;
+  search(q: string, opts: { agentId?: string; results?: number }): Promise<{ ok: boolean; output: string; error?: string }>;
+  wakeUp(agentId?: string): Promise<{ ok: boolean; output: string; error?: string }>;
+  status(): BackendStatus;              // one shape for the renderer, backend-labelled
+  agentEnv(): Record<string, string>;   // env spawned agents inherit (shim routing)
+}
+```
+
+`MemoryManager` keeps everything backend-neutral, behavior unchanged: the 10-minute mine cadence, mtime skip-unchanged tracking, single-writer serialization, start/stop, status caching. It delegates the verbs above to the active adapter.
+
+### MemPalaceAdapter
+
+Today's code moved, behavior byte-identical: bin discovery (including, per upstream #217's shape, a bundled-binary fallback in the resolution order — bin resolution is adapter-internal so #217 slots in whether or not it merges), `MEMPALACE_*` env plus the macOS CPU device pin, quarantine detection surfaced as `backoffAdviceMs`, and `palaceReap`. Quarantine/reap machinery exists **only** in this adapter.
+
+### HindsightAdapter
+
+Small HTTP client against a Hindsight server (verified against the live pilot and its OpenAPI):
+
+- **One bank per hive** (config; default derived from harness home). Search is bank-wide for cross-agent recall parity with the palace.
+- `mineAgent` → `POST /v1/default/banks/{bank}/memories` with `items[]` — the pilot's `retain-bridge.py` semantics ported to TS: deterministic per-file document ids so re-retain is idempotent; MemoryManager's mtime tracking supplies the delta. Retain is LLM-backed and slow: posts run `async:false` under the existing per-mine timeout.
+- `search` → `POST …/memories/recall`. `wakeUp` → recall top-N scoped by agent-id metadata — cheap, no LLM. Hindsight's `reflect` is deliberately unused in v1 (cost, latency); noted as future work.
+- HTTP failure = plain retry next cycle. No quarantine-style machinery.
+- `agentEnv`: `HINDSIGHT_URL`, `HINDSIGHT_BANK`.
+
+## Config and migration
+
+```jsonc
+memory: {
+  enabled: boolean,
+  backend: 'mempalace' | 'hindsight',
+  mempalace: { model: 'minilm' | 'embeddinggemma' },
+  hindsight: { url: string, bank: string }
+}
+```
+
+Existing configs `{enabled, model}` auto-migrate to `backend: 'mempalace'` with the model preserved — no behavior change on upgrade.
+
+## UI
+
+Setup/Onboarding gain a backend picker with per-backend fields; Hindsight gets url + bank + a **Test connection** button (`/health` + bank stats, shows counts). One status chip driven by the unified `BackendStatus` for either backend — **status always comes from a read-back, never optimistic local state** (the C-02 lesson). The memory graph panel stays MemPalace-only in v1 and is hidden for Hindsight; Hindsight's `/banks/{bank}/graph` endpoint is a noted fast-follow.
+
+## The shim
+
+`hive/bin/hive-memory` — a small node script written at agent spawn beside `hive-node`. Verbs: `search "<q>" [--results N]`, `wake-up`. Routing reads `HIVE_MEMORY_BACKEND` plus the adapter's `agentEnv`, all injected at spawn:
+
+- mempalace → exec the `mempalace` CLI; output unchanged from today.
+- hindsight → `POST` recall; render plain readable text (title, snippet, score). Agents never see JSON or curl.
+- Backend unreachable → print one line ("memory recall unavailable — continue without it") and **exit 0**. An agent's task never dies because memory is down.
+
+Hive protocol prompt blocks stop naming mempalace and say only `hive-memory search` / `hive-memory wake-up`. Already-running agents keep working (with backend=mempalace the old commands still function); new text applies from next spawn.
+
+## Degraded mode
+
+- **Backend unavailable:** status chip says so (read-back); the mine loop idles with a cheap availability recheck each cadence; the shim prints its one-liner. Formalizes what mempalace-missing does today.
+- **No buffering or queueing anywhere.** `memory.md` is the durable store; the next successful mine picks up current file state, so nothing is lost.
+- **Switching backends mid-hive:** allowed and cheap — the new backend re-mines every `memory.md` from scratch. Index contents are not migrated in v1; anything condensed out of `memory.md` history is not re-mined. Documented limitation; acceptable because the substrate is the source of truth.
+- `enabled: false` — markdown memory keeps working; everything else off (unchanged).
+
+## Testing and rollout
+
+Branch `feat/pluggable-memory`, four commits:
+
+1. **Pure extraction** — interface + MemPalaceAdapter. Proof: the existing suite passes **untouched**; no test edits allowed in this commit.
+2. **Shim + prompt text.** Shim e2e: spawn the real script per backend env; assert output and exit codes, including unavailable→0.
+3. **HindsightAdapter + config + UI.** Unit tests against a stub HTTP server asserting request shapes (bank path, `items[]`, deterministic idempotent ids) and text rendering; house mutation rules (removal AND substitution). Plus an adapter **conformance suite**: one spec run against both adapters (mocked CLI / stub server) pinning the `MemoryBackend` contract — asserting effects, not proxies.
+4. **Evidence** — a script in the house evidence format run against the live pilot: mine a real `memory.md` into a throwaway bank, search it back, wake-up returns text. That output is the PR evidence; this is the ship gate.
+
+## Known limitations / future work
+
+- Backend switch does not migrate index contents (re-mine covers it; condensed-away history is lost to the index).
+- Hindsight `reflect` and the `/graph` panel: fast-follows, not v1.
+- `listModels()`-style optional per-adapter capabilities (from the C-20 discussion) are out of scope here.
+- API-key-mode and multi-tenant Hindsight (`/v1/{tenant}/…` beyond `default`) unexamined; pilot uses the `default` tenant.

--- a/resources/hive-memory.cjs
+++ b/resources/hive-memory.cjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const unavailable = () => console.log('memory recall unavailable — continue without it');
+const usage = () => console.error('usage: hive-memory search <query> [--results N] | wake-up');
+const [verb, ...args] = process.argv.slice(2);
+if (!((verb === 'search' && args[0]) || (verb === 'wake-up' && args.length === 0))) { usage(); process.exit(2); }
+
+const backend = process.env.HIVE_MEMORY_BACKEND;
+if (backend === 'mempalace') {
+  const forwarded = [...args];
+  if (process.env.HIVE_MEMORY_AGENT) forwarded.push('--wing', process.env.HIVE_MEMORY_AGENT);
+  const result = spawnSync('mempalace', [verb, ...forwarded], { stdio: 'inherit' });
+  if (result.error) unavailable();
+  process.exitCode = result.error ? 0 : (result.status ?? 0);
+  process.exit(process.exitCode);
+}
+
+if (backend !== 'hindsight' || !process.env.HINDSIGHT_URL || !process.env.HINDSIGHT_BANK) { unavailable(); process.exit(0); }
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), 10_000);
+const query = verb === 'wake-up' ? 'recent important context' : args[0];
+const results = verb === 'wake-up' ? 8 : Number(args[args.indexOf('--results') + 1] || 5);
+const tags = process.env.HIVE_MEMORY_AGENT ? [`owner:${process.env.HIVE_MEMORY_AGENT}`] : undefined;
+fetch(`${process.env.HINDSIGHT_URL}/v1/default/banks/${process.env.HINDSIGHT_BANK}/memories/recall`, {
+  method: 'POST', headers: { 'content-type': 'application/json' }, signal: controller.signal,
+  body: JSON.stringify({ query, max_tokens: Math.max(1, results) * 512, ...(tags ? { tags } : {}) })
+}).then(async (response) => {
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const body = await response.json();
+  for (const hit of body.results || []) console.log(`— ${hit.text || ''}${hit.score == null ? '' : `  (score ${hit.score})`}`);
+}).catch(unavailable).finally(() => clearTimeout(timer));

--- a/resources/hive-memory.cjs
+++ b/resources/hive-memory.cjs
@@ -29,5 +29,10 @@ fetch(`${process.env.HINDSIGHT_URL}/v1/default/banks/${process.env.HINDSIGHT_BAN
 }).then(async (response) => {
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const body = await response.json();
-  for (const hit of body.results || []) console.log(`— ${hit.text || ''}${hit.score == null ? '' : `  (score ${hit.score})`}`);
+  for (const hit of body.results || []) {
+    // Recall ranks each result with a `scores` object; `final` is the value the
+    // ordering is based on. Older/simpler responses carry a flat `score` instead.
+    const score = hit.scores?.final ?? hit.score;
+    console.log(`— ${hit.text || ''}${score == null ? '' : `  (score ${score})`}`);
+  }
 }).catch(unavailable).finally(() => clearTimeout(timer));

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -11,6 +11,7 @@ import {
 } from '../shared/agentProvider';
 import { defaultMcpDefaults } from '../shared/mcpCatalog';
 import { MAX_AGENT_TOKEN_CAP } from '../shared/tokenCaps';
+import type { MemorySettings } from './memoryBackend';
 import { expandTilde, normalizeHiveHome } from './fs';
 import type { IntegrationRecord } from '../shared/integrations';
 import {
@@ -219,6 +220,13 @@ export interface HarnessConfig {
   semanticMemory: boolean;
   /** Embedding model for the palace: lightweight 'minilm' or multilingual 'embeddinggemma'. */
   embeddingModel: 'minilm' | 'embeddinggemma';
+  /** Which engine backs semantic memory: the local MemPalace CLI or a Hindsight
+   *  server over HTTP. Absent = 'mempalace', the only backend that existed before. */
+  memoryBackend?: 'mempalace' | 'hindsight';
+  /** Base URL of the Hindsight server, used only when memoryBackend is 'hindsight'. */
+  hindsightUrl?: string;
+  /** Which bank on that server holds the hive's memories. */
+  hindsightBank?: string;
   /** Recurring auto-dispatch missions handled by the scheduler. */
   missions?: ScheduledMission[];
   /** One-time guard: has the built-in hourly ops standup been seeded into an
@@ -581,6 +589,50 @@ function migrateTriggersV1(cfg: HarnessConfig): HarnessConfig {
     // migration retries on the next launch rather than on every single read.
     return cfg;
   }
+}
+
+/** Where a Hindsight server is expected when none has been configured. */
+export const DEFAULT_HINDSIGHT_URL = 'http://127.0.0.1:8888';
+export const DEFAULT_HINDSIGHT_BANK = 'hive-memory';
+
+/**
+ * Fold whatever is persisted into the backend-aware `MemorySettings` shape.
+ *
+ * Memory settings have never been stored as one object — they are flat keys on
+ * the config (`semanticMemory`, `embeddingModel`, and now `memoryBackend` and
+ * the Hindsight endpoint). So this is a read-time normaliser rather than a
+ * rewrite-on-disk migration: the flat keys stay the persisted form and adding a
+ * backend does not invalidate a config written by an older build.
+ *
+ * It accepts the already-normalised shape too and returns it unchanged, so it
+ * is safe to apply more than once, and it accepts anything at all — a corrupt
+ * config must still boot the app, with memory simply off.
+ */
+export function migrateMemorySettings(old: unknown): MemorySettings {
+  const src: Record<string, unknown> =
+    old && typeof old === 'object' && !Array.isArray(old) ? (old as Record<string, unknown>) : {};
+  const nested = (key: string): Record<string, unknown> => {
+    const value = src[key];
+    return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+  };
+  const text = (...candidates: unknown[]): string | null => {
+    for (const c of candidates) if (typeof c === 'string' && c.trim()) return c.trim();
+    return null;
+  };
+  const enabled = src.enabled ?? src.semanticMemory;
+  const model = nested('mempalace').model ?? src.model ?? src.embeddingModel;
+  const backend = src.backend ?? src.memoryBackend;
+  return {
+    // Absent means "nothing was ever configured", which is not consent to run.
+    // A stored `true`/`false` is honoured either way.
+    enabled: enabled === undefined ? false : enabled !== false,
+    backend: backend === 'hindsight' ? 'hindsight' : 'mempalace',
+    mempalace: { model: model === 'embeddinggemma' ? 'embeddinggemma' : 'minilm' },
+    hindsight: {
+      url: text(nested('hindsight').url, src.hindsightUrl) ?? DEFAULT_HINDSIGHT_URL,
+      bank: text(nested('hindsight').bank, src.hindsightBank) ?? DEFAULT_HINDSIGHT_BANK
+    }
+  };
 }
 
 export function readConfig(): HarnessConfig {

--- a/src/main/fs.ts
+++ b/src/main/fs.ts
@@ -1,22 +1,146 @@
-import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
-import { isAbsolute, join, normalize, relative, resolve } from 'node:path';
+import { readdir, lstat, open, realpath, stat } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { basename, dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { imageMimeForPath } from '../shared/imageTypes';
 
 /**
- * Confines `path` inside `root` to prevent path-traversal escapes.
- * Returns the resolved absolute path on success, or null on violation.
+ * Lexical containment — pure string math, no filesystem access.
  *
- * Exported so other main-process modules (e.g. git.ts) validate caller-supplied
- * relative paths against a workspace root with the SAME guard — there is exactly
- * one path-escape policy in the app and it lives here.
+ * PRIVATE on purpose. On its own this is NOT a containment guarantee: `resolve`,
+ * `normalize` and `relative` know nothing about symlinks, while the `readFile` /
+ * `writeFile` / `readdir` that runs afterwards is resolved by the kernel, which
+ * follows them. `safeResolve` is the guard every consumer must use.
  */
-export function safeJoin(root: string, rel: string): string | null {
+function lexicalJoin(root: string, rel: string): { absRoot: string; absPath: string } | null {
   const absRoot = resolve(root);
   const absPath = isAbsolute(rel) ? normalize(rel) : resolve(absRoot, rel);
   const rel2 = relative(absRoot, absPath);
   if (rel2.startsWith('..') || isAbsolute(rel2)) return null;
-  return absPath;
+  return { absRoot, absPath };
+}
+
+/**
+ * Canonicalize `absPath` and re-check containment against the canonical root.
+ *
+ * `realpath` throws ENOENT for a path that does not exist yet — which is normal
+ * for a write that creates a file — so the deepest EXISTING ancestor is
+ * canonicalized and the not-yet-existing tail is re-attached to it. That keeps
+ * "create a new file in a real workspace directory" working while still pinning
+ * every existing component to where it actually lives on disk.
+ */
+async function canonicalize(realRoot: string, absPath: string): Promise<string | null> {
+  let probe = absPath;
+  const tail: string[] = [];
+  for (;;) {
+    try {
+      const real = await realpath(probe);
+      const full = tail.length ? resolve(real, ...tail) : real;
+      const r = relative(realRoot, full);
+      if (r.startsWith('..') || isAbsolute(r)) return null;
+      return full;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') return null;
+      const parent = dirname(probe);
+      if (parent === probe) return null;      // walked past the filesystem root
+      tail.unshift(basename(probe));
+      probe = parent;
+    }
+  }
+}
+
+/**
+ * True if any component of `absPath` below `realRoot` is a symlink.
+ *
+ * Runs on the CANONICALIZED path, so every link that `realpath` could resolve is
+ * already gone by the time it walks — which is exactly why an in-workspace link
+ * to an existing in-workspace target is followed rather than refused.
+ *
+ * What is left for it to catch is the DANGLING link, and that is load-bearing: a
+ * link whose target does not exist yet makes `realpath` throw ENOENT, so
+ * canonicalization treats it as a to-be-created name and lets it through. A write
+ * then follows the link and creates the file at its EXTERNAL target. An `lstat`
+ * walk sees the link itself and refuses it regardless of where it points.
+ */
+async function hasSymlinkComponent(realRoot: string, absPath: string): Promise<boolean> {
+  let cur = realRoot;
+  for (const part of relative(realRoot, absPath).split(sep).filter(Boolean)) {
+    cur = resolve(cur, part);
+    try {
+      if ((await lstat(cur)).isSymbolicLink()) return true;
+    } catch (e) {
+      // Nothing there yet — the rest of the path cannot exist either, so there is
+      // no link left to find. Anything else is unreadable metadata: fail closed.
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Confines `rel` inside `root` and returns the CANONICAL absolute path, or null
+ * on violation.
+ *
+ * Exported so other main-process modules (e.g. git.ts) validate caller-supplied
+ * relative paths against a workspace root with the SAME guard — there is exactly
+ * one path-escape policy in the app and it lives here.
+ *
+ * Async because containment cannot be decided without touching the filesystem.
+ *
+ * The boundary is the WORKSPACE, not "no symlinks at all". A link whose target
+ * exists and is itself inside the workspace is followed, and what comes back is
+ * the canonical path of that target — it reaches nothing the caller could not
+ * already reach by its real name, and refusing it would make an ordinary
+ * `node_modules` or monorepo checkout unbrowsable. What is refused is a link that
+ * leaves the workspace, and a DANGLING link, whose target does not exist yet and
+ * so cannot be proven to land inside it.
+ */
+export async function safeResolve(root: string, rel: string): Promise<string | null> {
+  const lex = lexicalJoin(root, rel);
+  if (!lex) return null;
+  let realRoot: string;
+  try {
+    realRoot = await realpath(lex.absRoot);
+  } catch {
+    return null;
+  }
+  const abs = await canonicalize(realRoot, lex.absPath);
+  if (!abs) return null;
+  if (await hasSymlinkComponent(realRoot, abs)) return null;
+  return abs;
+}
+
+/**
+ * Open-time guards, so containment does not depend on the path still meaning the
+ * same thing between the check above and the open below.
+ *
+ * O_NOFOLLOW makes the kernel refuse the final component if it is a symlink;
+ * O_NONBLOCK keeps a FIFO from parking the open (and with it the IPC call and the
+ * renderer's loading state) forever. Both are POSIX-only — on Windows they are
+ * undefined and OR in as 0, which is why the `lstat` walk above is a check in its
+ * own right and not merely a pre-filter.
+ */
+const READ_FLAGS = constants.O_RDONLY | (constants.O_NOFOLLOW | 0) | (constants.O_NONBLOCK | 0);
+const WRITE_FLAGS =
+  constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW | 0);
+
+/**
+ * Open a path that `safeResolve` has ALREADY cleared, for reading.
+ *
+ * Exported, and the only way any main-process module opens a confined path,
+ * because clearing a path and reading it are two separate resolutions: the guard
+ * inspects the path, and then the kernel looks it up again at open time. Whatever
+ * replaces the final component in between is what the read actually gets, so the
+ * open has to refuse it on its own — a caller that reaches for a plain `readFile`
+ * after `safeResolve` has no final-component protection at all.
+ *
+ * Callers still have to check `fstat` THROUGH the returned handle (not `stat` on
+ * the path, which resolves it a third time) before trusting what they opened.
+ */
+export function openForRead(abs: string): Promise<FileHandle> {
+  return open(abs, READ_FLAGS);
 }
 
 export interface DirEntry {
@@ -29,7 +153,7 @@ export interface DirEntry {
 export async function listDir(root: string, rel: string): Promise<{
   ok: true; entries: DirEntry[]; path: string;
 } | { ok: false; error: string }> {
-  const abs = safeJoin(root, rel);
+  const abs = await safeResolve(root, rel);
   if (!abs) return { ok: false, error: 'path escapes root' };
   try {
     const names = await readdir(abs);
@@ -56,19 +180,24 @@ const MAX_READ_BYTES = 2 * 1024 * 1024; // 2 MB
 export async function readFileText(root: string, rel: string): Promise<{
   ok: true; content: string; path: string; size: number;
 } | { ok: false; error: string }> {
-  const abs = safeJoin(root, rel);
+  const abs = await safeResolve(root, rel);
   if (!abs) return { ok: false, error: 'path escapes root' };
+  let fh;
   try {
-    const s = await stat(abs);
+    fh = await openForRead(abs);
+    const s = await fh.stat();
+    if (!s.isFile()) return { ok: false, error: 'not a regular file' };
     if (s.size > MAX_READ_BYTES) {
       return { ok: false, error: `file too large (${(s.size / 1024 / 1024).toFixed(1)} MB)` };
     }
-    const buf = await readFile(abs);
+    const buf = await fh.readFile();
     // Reject obvious binary files based on null-byte sniff
     if (buf.includes(0)) return { ok: false, error: 'binary file (not displayable)' };
     return { ok: true, content: buf.toString('utf8'), path: abs, size: s.size };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  } finally {
+    await fh?.close().catch(() => {});
   }
 }
 
@@ -83,7 +212,7 @@ export async function readFileText(root: string, rel: string): Promise<{
 const MAX_BINARY_READ_BYTES = 10 * 1024 * 1024; // 10 MB
 
 /**
- * Read a file as raw BYTES, confined to `root` by the same `safeJoin` guard as
+ * Read a file as raw BYTES, confined to `root` by the same `safeResolve` guard as
  * every other fs entry point here.
  *
  * Exists because the text path deliberately refuses binary content (the
@@ -102,10 +231,12 @@ const MAX_BINARY_READ_BYTES = 10 * 1024 * 1024; // 10 MB
 export async function readFileBinary(root: string, rel: string, maxBytes = MAX_BINARY_READ_BYTES): Promise<{
   ok: true; bytes: Uint8Array<ArrayBuffer>; mime: string; path: string; size: number;
 } | { ok: false; error: string }> {
-  const abs = safeJoin(root, rel);
+  const abs = await safeResolve(root, rel);
   if (!abs) return { ok: false, error: 'path escapes root' };
+  let fh;
   try {
-    const s = await stat(abs);
+    fh = await openForRead(abs);
+    const s = await fh.stat();
     // Directories and FIFOs are the trap here: readFile on a directory throws
     // (fine) but on a FIFO it BLOCKS forever with no size to check against, which
     // would hang the IPC call and, with it, the renderer's loading state.
@@ -113,7 +244,7 @@ export async function readFileBinary(root: string, rel: string, maxBytes = MAX_B
     if (s.size > maxBytes) {
       return { ok: false, error: `file too large (${(s.size / 1024 / 1024).toFixed(1)} MB)` };
     }
-    const buf = await readFile(abs);
+    const buf = await fh.readFile();
     if (buf.byteLength > maxBytes) {
       // The file grew between stat and read. Rare, but the cap is a memory
       // guarantee for the renderer, not an advisory.
@@ -136,19 +267,25 @@ export async function readFileBinary(root: string, rel: string, maxBytes = MAX_B
     };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  } finally {
+    await fh?.close().catch(() => {});
   }
 }
 
 export async function writeFileText(root: string, rel: string, content: string): Promise<{
   ok: true; path: string;
 } | { ok: false; error: string }> {
-  const abs = safeJoin(root, rel);
+  const abs = await safeResolve(root, rel);
   if (!abs) return { ok: false, error: 'path escapes root' };
+  let fh;
   try {
-    await writeFile(abs, content, 'utf8');
+    fh = await open(abs, WRITE_FLAGS, 0o666);
+    await fh.writeFile(content, 'utf8');
     return { ok: true, path: abs };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  } finally {
+    await fh?.close().catch(() => {});
   }
 }
 

--- a/src/main/git.ts
+++ b/src/main/git.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process';
-import { readFile, stat } from 'node:fs/promises';
-import { safeJoin } from './fs';
+import { openForRead, safeResolve } from './fs';
 
 /** Run git in `cwd` with `args`. Returns stdout text or an error. */
 function runGit(cwd: string, args: string[], timeoutMs = 8000): Promise<{
@@ -170,7 +169,7 @@ export interface GitDiff {
 export async function getDiff(
   cwd: string, relPath: string
 ): Promise<GitDiff | { ok: false; error: string }> {
-  const abs = safeJoin(cwd, relPath);
+  const abs = await safeResolve(cwd, relPath);
   if (!abs) return { ok: false, error: 'path escapes repository root' };
 
   // HEAD side: `git show HEAD:<path>` — errors (untracked / new file) → no head version.
@@ -179,21 +178,33 @@ export async function getDiff(
   const show = await runGit(cwd, ['show', `HEAD:${relPath}`]);
   if (show.ok) { head = show.stdout; headExists = true; }
 
-  // Working side: read the on-disk file. ENOENT → deleted from the working tree.
+  // Working side: read the on-disk file through the same guarded open as the file
+  // IPC, so the final component is re-checked by the kernel at open time rather
+  // than trusted from the `safeResolve` above. ENOENT (or a refused open) →
+  // nothing diffable in the working tree.
   let working = '';
   let workingExists = false;
   let workingBinary = false;
+  let fh;
   try {
-    const s = await stat(abs);
+    fh = await openForRead(abs);
+    // Stat THROUGH the handle: it describes what is actually open, where a second
+    // `stat` on the path would resolve it again. A directory has no diffable
+    // content, and a FIFO would park the read — and the IPC call behind it —
+    // forever.
+    const s = await fh.stat();
+    if (!s.isFile()) throw new Error('not a regular file');
     if (s.size > MAX_DIFF_BYTES) {
       return { ok: false, error: `file too large to diff (${(s.size / 1048576).toFixed(1)} MB)` };
     }
-    const buf = await readFile(abs);
+    const buf = await fh.readFile();
     workingExists = true;
     if (buf.includes(0)) workingBinary = true;
     else working = buf.toString('utf8');
   } catch {
     workingExists = false;
+  } finally {
+    await fh?.close().catch(() => {});
   }
 
   const isBinary = workingBinary || head.includes('\0');
@@ -412,7 +423,7 @@ export async function getFileAtRev(cwd: string, rev: string, relPath: string): P
   { ok: true; exists: boolean; isBinary: boolean; content: string } | { ok: false; error: string }
 > {
   if (!isSafeRev(rev)) return { ok: false, error: 'invalid revision' };
-  if (!safeJoin(cwd, relPath)) return { ok: false, error: 'path escapes repository root' };
+  if (!(await safeResolve(cwd, relPath))) return { ok: false, error: 'path escapes repository root' };
   const size = await runGit(cwd, ['cat-file', '-s', `${rev}:${relPath}`]);
   if (!size.ok) return { ok: true, exists: false, isBinary: false, content: '' };
   if ((parseInt(size.stdout.trim(), 10) || 0) > MAX_SHOW_BYTES) {

--- a/src/main/hindsightAdapter.ts
+++ b/src/main/hindsightAdapter.ts
@@ -1,0 +1,302 @@
+/** Hindsight HTTP memory backend; see docs/superpowers/specs/2026-08-25-pluggable-memory-design.md.
+ *
+ * Every request shape below was taken from the server's own OpenAPI document
+ * (verified 2026-08-25) rather than guessed:
+ *   - retain is POST .../memories with `{ items: [{ content, metadata, tags,
+ *     document_id }], async }` — the item field is `content`, not `text`;
+ *   - recall is POST .../memories/recall with `{ query, max_tokens, tags }` —
+ *     there is no `top_k`; the result budget is expressed in tokens;
+ *   - a recalled hit carries `scores.final`, not a flat `score`;
+ *   - there is no POST for creating a bank — PUT .../banks/<id> upserts one.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { BackendStatus, MemoryBackend, MineResult, TextResult } from './memoryBackend';
+
+/** How long a /health answer is trusted before the next call re-probes. */
+const HEALTH_TTL_MS = 30_000;
+/** Matches the mempalace adapter's mine timeout, so a wedged server cannot
+ *  stall the mine loop for longer than a local miner would. */
+const MINE_TIMEOUT_MS = 10 * 60_000;
+const RECALL_TIMEOUT_MS = 120_000;
+const PROBE_TIMEOUT_MS = 5_000;
+/** Recall budgets in tokens, so a caller's "N results" becomes a token
+ *  allowance. 512 is a generous ceiling for one mined memory.md section. */
+const TOKENS_PER_RESULT = 512;
+const WAKE_UP_QUERY = 'recent important context';
+const WAKE_UP_RESULTS = 8;
+
+interface RecallHit {
+  text?: string;
+  score?: number;
+  scores?: { final?: number };
+}
+
+/**
+ * Render recall hits as the plain text an agent sees.
+ *
+ * DELIBERATELY DUPLICATED in `resources/hive-memory.cjs`. That shim is copied
+ * onto disk and run by agent processes standing alone outside the app bundle,
+ * so it cannot import this module. Change one, change the other — the shim's
+ * test pins the exact output format.
+ */
+export function renderRecall(results: RecallHit[]): string {
+  return results
+    .map((hit) => {
+      const score = hit.scores?.final ?? hit.score;
+      return `— ${hit.text ?? ''}${score == null ? '' : `  (score ${score})`}`;
+    })
+    .join('\n');
+}
+
+/** Split a memory.md into one retainable item per `## ` section. */
+export function memorySections(markdown: string): { heading: string; body: string }[] {
+  const sections: { heading: string; body: string }[] = [];
+  let current: { heading: string; body: string[] } | null = null;
+  for (const line of markdown.split('\n')) {
+    const heading = /^## +(.*)$/.exec(line);
+    if (heading) {
+      if (current) sections.push({ heading: current.heading, body: current.body.join('\n').trim() });
+      current = { heading: heading[1].trim(), body: [] };
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  if (current) sections.push({ heading: current.heading, body: current.body.join('\n').trim() });
+  return sections.filter((s) => s.body.length > 0);
+}
+
+export class HindsightAdapter implements MemoryBackend {
+  readonly id = 'hindsight' as const;
+  /** `available()` can only answer after /health has been asked, and asking is
+   *  part of being armed — so the manager must not wait for availability. */
+  readonly probesAsync = true;
+  private healthy = false;
+  private healthCheckedAt = -Infinity;
+  private inFlightProbe: Promise<boolean> | null = null;
+  private bankReady = false;
+
+  constructor(
+    private cfg: () => { url: string; bank: string },
+    private getHome: () => string | null,
+    private now: () => number = Date.now
+  ) {}
+
+  private base(): string {
+    const { url, bank } = this.cfg();
+    return `${url.replace(/\/+$/, '')}/v1/default/banks/${encodeURIComponent(bank)}`;
+  }
+
+  private async request(
+    path: string,
+    init: { method: string; body?: unknown; timeoutMs: number }
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), init.timeoutMs);
+    timer.unref?.();
+    try {
+      return await fetch(path, {
+        method: init.method,
+        signal: controller.signal,
+        ...(init.body === undefined
+          ? {}
+          : { headers: { 'content-type': 'application/json' }, body: JSON.stringify(init.body) })
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Ask /health now and refresh the cache. Safe to call concurrently. */
+  probeHealth(): Promise<boolean> {
+    if (this.inFlightProbe) return this.inFlightProbe;
+    const { url } = this.cfg();
+    this.inFlightProbe = (async () => {
+      let ok = false;
+      try {
+        ok = (await this.request(`${url.replace(/\/+$/, '')}/health`, { method: 'GET', timeoutMs: PROBE_TIMEOUT_MS })).ok;
+      } catch {
+        ok = false;
+      }
+      this.healthy = ok;
+      this.healthCheckedAt = this.now();
+      if (!ok) this.bankReady = false;
+      this.inFlightProbe = null;
+      return ok;
+    })();
+    return this.inFlightProbe;
+  }
+
+  /** Sync, cached — the interface's contract. A stale cache is refreshed in the
+   *  background so the next caller sees the newer answer. */
+  available(): boolean {
+    if (this.now() - this.healthCheckedAt >= HEALTH_TTL_MS) void this.probeHealth();
+    return this.healthy;
+  }
+
+  resetCaches(): void {
+    this.healthy = false;
+    this.healthCheckedAt = -Infinity;
+    this.bankReady = false;
+  }
+
+  init(): void {
+    void this.ready();
+  }
+
+  /** The awaitable half of `init()`: confirm the server is up and the bank
+   *  exists, creating it when the server has never heard of it. */
+  async ready(): Promise<boolean> {
+    if (!(await this.probeHealth())) return false;
+    try {
+      const stats = await this.request(`${this.base()}/stats`, { method: 'GET', timeoutMs: PROBE_TIMEOUT_MS });
+      if (stats.ok) {
+        this.bankReady = true;
+        return true;
+      }
+      if (stats.status !== 404) return false;
+      // No POST /banks exists — PUT on the bank id is the create/update verb.
+      const created = await this.request(this.base(), {
+        method: 'PUT',
+        body: { name: this.cfg().bank },
+        timeoutMs: PROBE_TIMEOUT_MS
+      });
+      this.bankReady = created.ok;
+      return created.ok;
+    } catch {
+      this.bankReady = false;
+      return false;
+    }
+  }
+
+  async mineAgent(agentDir: string, agentId: string): Promise<MineResult> {
+    const path = join(agentDir, 'memory.md');
+    if (!existsSync(path)) return { ok: false };
+    let markdown: string;
+    try {
+      markdown = readFileSync(path, 'utf8');
+    } catch {
+      return { ok: false };
+    }
+    const items = memorySections(markdown).map(({ heading, body }) => ({
+      // Stable across passes so re-mining an unchanged section updates the same
+      // document instead of stacking a duplicate copy of it in the bank.
+      document_id: createHash('sha256').update(`${agentId}\n${heading}\n${body}`).digest('hex').slice(0, 32),
+      content: body,
+      // Metadata values must be strings — the API rejects anything else.
+      metadata: { agent: agentId, source: 'memory.md', heading },
+      tags: [`owner:${agentId}`]
+    }));
+    if (!items.length) return { ok: true };
+    try {
+      const res = await this.request(`${this.base()}/memories`, {
+        method: 'POST',
+        body: { items, async: false },
+        timeoutMs: MINE_TIMEOUT_MS
+      });
+      if (!res.ok) {
+        console.error(`[memory] hindsight mine ${agentId} failed: HTTP ${res.status}`);
+        return { ok: false };
+      }
+      return { ok: true };
+    } catch (error) {
+      console.error(`[memory] hindsight mine ${agentId} failed: ${error instanceof Error ? error.message : String(error)}`);
+      return { ok: false };
+    }
+  }
+
+  private async recall(query: string, resultCount: number, agentId?: string): Promise<TextResult> {
+    try {
+      const res = await this.request(`${this.base()}/memories/recall`, {
+        method: 'POST',
+        body: {
+          query,
+          max_tokens: Math.max(1, resultCount) * TOKENS_PER_RESULT,
+          ...(agentId ? { tags: [`owner:${agentId}`] } : {})
+        },
+        timeoutMs: RECALL_TIMEOUT_MS
+      });
+      if (!res.ok) return { ok: false, output: '', error: `HTTP ${res.status}` };
+      const body = (await res.json()) as { results?: RecallHit[] };
+      return { ok: true, output: renderRecall(body.results ?? []) };
+    } catch (error) {
+      return { ok: false, output: '', error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  search(query: string, opts: { agentId?: string; results?: number } = {}): Promise<TextResult> {
+    return this.recall(query, opts.results ?? 5, opts.agentId);
+  }
+
+  wakeUp(agentId?: string): Promise<TextResult> {
+    return this.recall(WAKE_UP_QUERY, WAKE_UP_RESULTS, agentId);
+  }
+
+  status(enabled: boolean, home: string | null): BackendStatus {
+    const { url, bank } = this.cfg();
+    const available = this.available();
+    return {
+      backend: this.id,
+      available,
+      enabled,
+      active: available && enabled && home !== null,
+      initialized: this.bankReady,
+      location: `${url} · ${bank}`,
+      // A remote server owns its own embedding model; there is nothing local to name.
+      model: null,
+      bin: null
+    };
+  }
+
+  agentEnv(): Record<string, string> {
+    const { url, bank } = this.cfg();
+    return { HIVE_MEMORY_BACKEND: 'hindsight', HINDSIGHT_URL: url, HINDSIGHT_BANK: bank };
+  }
+}
+
+/**
+ * Probe a Hindsight endpoint the user has typed but not committed to, and
+ * describe what was found there.
+ *
+ * Returns the url and bank it actually reached alongside the verdict: the
+ * settings panel renders this object rather than its own inputs, so a stale
+ * "connected" can never be shown next to an address that has since been edited.
+ * Never throws — an unreachable server is an answer, not a failure.
+ */
+export async function testHindsightConnection(
+  url: string,
+  bank: string
+): Promise<{ ok: boolean; detail: string; url: string; bank: string }> {
+  const base = url.trim().replace(/\/+$/, '');
+  const bankId = bank.trim();
+  if (!base) return { ok: false, detail: 'Enter the server address first.', url: base, bank: bankId };
+  if (!bankId) return { ok: false, detail: 'Enter a bank name first.', url: base, bank: bankId };
+
+  const get = async (path: string): Promise<Response> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    timer.unref?.();
+    try {
+      return await fetch(path, { method: 'GET', signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  try {
+    const health = await get(`${base}/health`);
+    if (!health.ok) return { ok: false, detail: `Server answered HTTP ${health.status}.`, url: base, bank: bankId };
+    const stats = await get(`${base}/v1/default/banks/${encodeURIComponent(bankId)}/stats`);
+    if (stats.status === 404) {
+      return { ok: false, detail: `Server is up, but there is no bank named "${bankId}" yet.`, url: base, bank: bankId };
+    }
+    if (!stats.ok) return { ok: false, detail: `Bank check returned HTTP ${stats.status}.`, url: base, bank: bankId };
+    const body = (await stats.json()) as { total_nodes?: number };
+    const count = typeof body.total_nodes === 'number' ? body.total_nodes : 0;
+    return { ok: true, detail: `Connected — ${count} ${count === 1 ? 'memory' : 'memories'} in "${bankId}".`, url: base, bank: bankId };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { ok: false, detail: `Couldn't reach ${base} — ${reason}`, url: base, bank: bankId };
+  }
+}

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -696,7 +696,9 @@ export class HiveManager {
       AGENT_ID: meta.id,
       AGENT_NAME: meta.name,
       HIVE_ROOT: root,
-      AGENT_DIR: dir
+      AGENT_DIR: dir,
+      // Scopes the hive-memory shim's recalls to this agent's own memories.
+      HIVE_MEMORY_AGENT: meta.id
     };
     // The bundled-node launcher, so an agent can run the hive's .cjs helpers (KG
     // CLI, Slack reply helper) even when `node` is not on its PATH. Invoking the

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -20,7 +20,8 @@
  */
 import {
   existsSync, mkdirSync, readFileSync, writeFileSync, renameSync,
-  readdirSync, statSync, rmSync, appendFileSync, symlinkSync, copyFileSync, chmodSync
+  readdirSync, statSync, rmSync, appendFileSync, symlinkSync, copyFileSync, chmodSync,
+  realpathSync
 } from 'node:fs';
 import { join, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
@@ -41,6 +42,7 @@ import { selectBroadcastTargets } from '../shared/broadcast';
 import { preferredAgentRole } from '../shared/agentRole';
 import { mergeTaskLedger } from '../shared/taskLedger';
 import { expandTilde } from './fs';
+import { codexTrustEntry } from '../shared/codexTrust';
 
 /** The subset of HarnessConfig the hive consumes for the default-MCP merge.
  *  Kept as a local shape so hive.ts never imports the foundation-owned config
@@ -751,7 +753,7 @@ export class HiveManager {
           if (desc.kind === 'hooks') {
             if (desc.shim === 'agy') this.installAgyHooks();
             else if (desc.shim === 'codex') {
-              env.CODEX_HOME = this.installCodexHooks(dir);
+              env.CODEX_HOME = this.installCodexHooks(dir, meta.cwd);
               // Codex refuses to run hooks from a config dir without persisted
               // "hook trust" (normally an interactive gate). Our hooks.json is
               // hive-authored inside an isolated CODEX_HOME, so we bypass that gate
@@ -1872,7 +1874,7 @@ export class HiveManager {
    *  untouched. The user's ~/.codex/auth.json is linked in and their config.toml is
    *  copied + extended (login + model/provider/trust settings still apply).
    *  Returns the CODEX_HOME path for the caller to put in the worker's env. */
-  private installCodexHooks(dir: string): string {
+  private installCodexHooks(dir: string, cwd: string): string {
     const home = join(dir, '.codex');
     try {
       mkdirSync(home, { recursive: true });
@@ -1934,6 +1936,22 @@ export class HiveManager {
           config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = '${this.nodeRunUnquoted(shim)}'\ntimeout = 30\n`;
         }
       }
+      // Directory trust. A fresh config dir has never answered Codex's "do you
+      // trust this directory?" prompt, so an agent launched into one stops on it
+      // before its first turn and, with nobody at the keyboard, never resumes.
+      // Pressing Yes persists exactly the table below, and pre-seeding it is the
+      // ONLY suppression there is — no flag or env skips the prompt (in
+      // particular `--dangerously-bypass-approvals-and-sandbox` governs command
+      // approval, not trust) and a `-c projects…` override is not persisted, so
+      // it does not read as an answer. Trust the FINAL working directory: by the
+      // time this runs, isolation has resolved, so `cwd` is the agent's git
+      // worktree when one was created and the original repo when it fell back —
+      // one path, always the one the CLI will actually open in. Canonical
+      // (realpath) spelling, because Codex resolves the directory before looking
+      // it up and `/tmp/x` would never match its `/private/tmp/x`.
+      let trusted = cwd;
+      try { trusted = realpathSync(cwd); } catch { /* not on disk yet — best spelling we have */ }
+      config += codexTrustEntry(trusted);
       writeFileSync(join(home, 'config.toml'), config, 'utf8');
     } catch (e) { console.error('[hive] installCodexHooks failed:', e); }
     return home;

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -419,6 +419,17 @@ export class HiveManager {
     }
   }
 
+  private writeMemoryShim(): void {
+    const root = this.root();
+    if (!root) return;
+    try {
+      const source = join(__dirname, '../../resources/hive-memory.cjs');
+      const target = join(root, 'bin', process.platform === 'win32' ? 'hive-memory.cjs' : 'hive-memory');
+      writeFileSync(target, readFileSync(source, 'utf8'), 'utf8');
+      if (process.platform !== 'win32') chmodSync(target, 0o755);
+    } catch (e) { console.error('[hive] writeMemoryShim failed:', e); }
+  }
+
   /** The launcher path if it is actually on disk, else null (→ callers fall back
    *  to bare `node`, i.e. exactly the pre-fix behavior — never worse than before). */
   private nodeLauncher(): string | null {
@@ -561,6 +572,7 @@ export class HiveManager {
     // The bundled-node launcher every shim above is invoked through — MUST be
     // written before any hook installer runs (they probe for it).
     this.writeNodeLauncher();
+    this.writeMemoryShim();
     // …and the PATH-visible `node` fallback for the agent's OWN subprocesses.
     this.writeRuntimeShims();
 
@@ -1296,10 +1308,7 @@ export class HiveManager {
     const ctxLine = 'LIVE CONTEXT: each agent row in the LIVE ROSTER carries a `ctx NN%` tag — its live context-window occupancy. Treat it as the real headroom signal when routing: prefer an agent with a LOW `ctx` for a big task; treat a HIGH `ctx` (near 100%) as busy rather than idle, even if the cumulative token count looks modest.';
 
     const memoryLine = semanticMemory
-      // The palace location is named, not spelled as `$MEMPALACE_PALACE_PATH`:
-      // `mempalace` reads that env var itself, and the POSIX `$` form was noise
-      // (or an empty expansion) for a Windows agent that tried to use it literally.
-      ? 'Semantic memory: the whole hive shares a searchable MemPalace at the path in your MEMPALACE_PALACE_PATH environment variable. To recall relevant past knowledge across the team, run `mempalace search "<query>"`; run `mempalace wake-up` at the start of a task for a memory digest. Your notes in memory.md are mined into the palace automatically — write durable facts there.'
+      ? 'Semantic memory: the whole hive shares searchable semantic memory. To recall relevant past knowledge across the team, run `hive-memory search "<query>"`; run `hive-memory wake-up` at the start of a task for a memory digest. Your notes in memory.md are indexed automatically — write durable facts there.'
       : '';
     // Enterprise Knowledge Graph (opt-in). Volatile-free: the bundled-node launcher
     // and the KG CLI are both fixed absolute paths for an install, so baking them
@@ -2513,15 +2522,14 @@ request is NOT failed or deleted, it waits in \`spawn-requests/\` and runs if th
 If a request of yours has sat there without moving, that is why, and it is a decision to raise with the
 human rather than retry. Route work to an agent already on the floor first either way.
 
-## Semantic memory (optional — when \`mempalace\` is installed)
-When \`MEMPALACE_PALACE_PATH\` is set in your environment, the hive shares a
-searchable MemPalace and you have the \`mempalace\` CLI:
-- \`mempalace search "<query>"\` — recall relevant past knowledge across the whole
+## Semantic memory (optional)
+The hive shares searchable semantic memory through the \`hive-memory\` command:
+- \`hive-memory search "<query>"\` — recall relevant past knowledge across the whole
   team by meaning (not just keywords). Add \`--wing <agent-id>\` to scope to one
   agent, \`--results N\` to widen.
-- \`mempalace wake-up\` — a short digest of what matters, good at the start of a task.
+- \`hive-memory wake-up\` — a short digest of what matters, good at the start of a task.
 
-Your \`memory.md\` is mined into the palace automatically, so the durable facts you
+Your \`memory.md\` is indexed automatically, so the durable facts you
 write there become searchable by every agent. You don't run \`mine\` yourself.
 `;
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,7 @@ import {
   addWorktree, removeWorktree, worktreeHasUnintegratedWork, worktreeIsGcSafe,
   getLogGraph, getCommitFiles, getFileAtRev, compareRefs, listWorktrees, checkoutRef
 } from './git';
+import { linkWorktreeDeps, unlinkWorktreeDeps } from './worktreeDeps';
 import { HiveManager, type AgentMeta, type HiveMessage, type HiveTask } from './hive';
 import { HookServer } from './hooks';
 import { CircuitBreaker, type BreakerInput } from './breaker';
@@ -512,6 +513,8 @@ function informGod(subject: string, body: string, slack?: { channel: string; thr
  *  (fail-safe — never auto-discard possibly-valuable work). */
 async function finalizeWorkerWorktree(wtPath: string, origCwd: string, worker: WorkerRec): Promise<void> {
   try {
+    const deps = await unlinkWorktreeDeps(origCwd, wtPath);
+    if (!deps.ok) console.error('[worktree] dependency unlink failed:', deps.error);
     const work = await worktreeHasUnintegratedWork(wtPath, worker.baseBranch);
     if (work.keep) {
       console.warn(`[worker] PRESERVING worktree with unintegrated work: ${wtPath} (${work.detail})`);
@@ -2622,6 +2625,8 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
           opts.cwd = wtPath;
           worktreePaths.set(opts.id, wtPath);
           worktreeOrigins.set(opts.id, origCwd);
+          const deps = await linkWorktreeDeps(origCwd, wtPath);
+          if (!deps.ok) console.error('[worktree] dependency link failed:', deps.error);
         } else {
           console.error('[worktree] addWorktree failed:', wt.error);
         }
@@ -4639,6 +4644,8 @@ async function gcPreservedWorktrees(): Promise<void> {
         continue;
       }
       // (b) Still on disk → reclaim ONLY when provably integrated + clean.
+      const deps = await unlinkWorktreeDeps(e.origCwd, e.wtPath);
+      if (!deps.ok) { console.error('[worker gc] dependency unlink failed (keeping):', deps.error); continue; }
       let safe: { gc: boolean; detail: string };
       try { safe = await worktreeIsGcSafe(e.wtPath, e.baseBranch); }
       catch (err) { console.error('[worker gc] gc-safe check threw (keeping):', err); continue; }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,8 @@ import { initAutoUpdater, abortPendingRestart } from './updater';
 import { RealtimeFloorWatcher } from './realtimeFloorWatcher';
 import {
   readConfig, writeConfig, setAgentTokenCap, resetConfig, ensureHarnessHome, ensureClaudePermissionsAccepted,
-  modelForRole, OPS_STANDUP_MISSION, HEARTBEAT_MISSION, COMPACT_MAINTENANCE_MISSION, type HarnessConfig, type ScheduledMission
+  modelForRole, OPS_STANDUP_MISSION, HEARTBEAT_MISSION, COMPACT_MAINTENANCE_MISSION, migrateMemorySettings,
+  type HarnessConfig, type ScheduledMission
 } from './config';
 import { listDir, readFileText, readFileBinary, writeFileText, statAbs, expandTilde } from './fs';
 import { normalizeWeekly, weeklyDelayMs } from '../shared/weeklySchedule';
@@ -29,6 +30,7 @@ import { HookServer } from './hooks';
 import { CircuitBreaker, type BreakerInput } from './breaker';
 import type { UsageProvider } from './usage';
 import { MemoryManager } from './memory';
+import { testHindsightConnection } from './hindsightAdapter';
 import { KnowledgeManager } from './knowledge';
 import { MemoryReflector, type ReflectSettings } from './reflect';
 import { PersistStore } from './db';
@@ -303,7 +305,7 @@ const hookServer = new HookServer(
 );
 const memory = new MemoryManager(
   () => readConfig().harnessHome,
-  () => { const c = readConfig(); return { enabled: c.semanticMemory !== false, model: c.embeddingModel ?? 'minilm' }; }
+  () => migrateMemorySettings(readConfig())
 );
 // Enterprise Knowledge Graph — file-backed store + agent CLI (default OFF).
 const knowledge = new KnowledgeManager();
@@ -3488,6 +3490,12 @@ ipcMain.handle('hive:searchMemory', (_evt, query: unknown, wing: unknown) => {
 ipcMain.handle('hive:memoryWakeUp', (_evt, wing: unknown) =>
   memory.wakeUp(typeof wing === 'string' ? wing : undefined));
 ipcMain.handle('hive:mineNow', () => { memory.mineNow(); return { ok: true }; });
+// Probe a Hindsight server the user has typed in but not committed to. The
+// panel renders what THIS returns, so the answer has to describe the endpoint
+// it actually reached — echoing the url and bank back stops the UI reporting a
+// success for one server next to an address the user has since edited.
+ipcMain.handle('hive:memoryTestConnection', (_evt, url: unknown, bank: unknown) =>
+  testHindsightConnection(typeof url === 'string' ? url : '', typeof bank === 'string' ? bank : ''));
 // Condense memory.md on demand: an explicit id condenses that one agent (skips
 // the size trigger — a "condense now" button); no id runs a full threshold scan.
 ipcMain.handle('memory:reflectNow', (_evt, id: unknown) =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -448,6 +448,8 @@ function teardownPty(id: string): void {
     try { workerWake.forget(agentId, id); } catch { /* best-effort */ }
     // Drop breaker state so a dead agent can't leak/zombie a tripped level.
     try { breaker.forget(agentId); } catch { /* best-effort */ }
+    // A replacement using this id needs a new usage counter, not the dead PTY's.
+    try { telemetry.forgetAgent(agentId); } catch { /* best-effort */ }
     // W1 — kill this agent's proxy-bridge sidecar (qwen), if any, so a dead
     // PTY never leaves an orphan loopback listener. No-op for non-proxy agents.
     try { hive.stopProxyBridge(agentId); } catch (e) { console.error('[hive] stopProxyBridge failed:', e); }

--- a/src/main/memPalaceAdapter.ts
+++ b/src/main/memPalaceAdapter.ts
@@ -69,6 +69,9 @@ export class MemPalaceAdapter implements MemoryBackend {
     const palace = this.getPalacePath();
     if (!palace || !this.available()) return {};
     return {
+      // How the standalone hive-memory shim learns which backend to talk to.
+      // Without it the shim has no backend and degrades to its unavailable line.
+      HIVE_MEMORY_BACKEND: this.id,
       MEMPALACE_PALACE_PATH: palace,
       MEMPALACE_EMBEDDING_MODEL: this.getModel(),
       ...(MEMPALACE_DEVICE ? { MEMPALACE_EMBEDDING_DEVICE: MEMPALACE_DEVICE } : {})

--- a/src/main/memPalaceAdapter.ts
+++ b/src/main/memPalaceAdapter.ts
@@ -1,0 +1,164 @@
+import { existsSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { ensureKilled } from './procKill';
+import { quarantineDirsToReap, quarantineStampMs, nextMineDelayMs } from './palaceReap';
+import type { BackendStatus, MemoryBackend, MineResult, TextResult } from './memoryBackend';
+
+export type EmbeddingModel = 'minilm' | 'embeddinggemma';
+const MINE_INTERVAL_MS = 600_000;
+const MINE_BACKOFF_MAX_MS = 1_800_000;
+const MINE_TIMEOUT_MS = 10 * 60_000;
+
+export function mempalaceDevice(platform: NodeJS.Platform, envOverride: string | undefined): string | undefined {
+  if (envOverride) return undefined;
+  return platform === 'darwin' ? 'cpu' : undefined;
+}
+
+const MEMPALACE_DEVICE = mempalaceDevice(process.platform, process.env.MEMPALACE_EMBEDDING_DEVICE);
+
+export class MemPalaceAdapter implements MemoryBackend {
+  readonly id = 'mempalace' as const;
+  private binCache: string | null | undefined;
+  private lastQuarantineTs = 0;
+  private mineDelayMs = MINE_INTERVAL_MS;
+
+  constructor(
+    private getPalacePath: () => string | null,
+    private getModel: () => EmbeddingModel
+  ) {}
+
+  bin(): string | null {
+    if (this.binCache !== undefined) return this.binCache;
+    let found: string | null = null;
+    const isWin = process.platform === 'win32';
+    try {
+      if (isWin) {
+        const res = spawnSync('where', ['mempalace'], { encoding: 'utf8', timeout: 3000 });
+        const p = res.stdout.trim().split(/\r?\n/)[0]?.trim();
+        if (p && existsSync(p)) found = p;
+      } else {
+        const res = spawnSync(process.env.SHELL ?? '/bin/zsh', ['-ilc', 'which mempalace'], { encoding: 'utf8', timeout: 3000 });
+        const p = res.stdout.trim().split('\n').pop();
+        if (p && existsSync(p)) found = p;
+      }
+    } catch { /* fall through */ }
+    if (!found) {
+      const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+      const candidates = isWin
+        ? [join(home, '.local', 'bin', 'mempalace.exe'), join(process.env.LOCALAPPDATA ?? '', 'Programs', 'Python', 'Scripts', 'mempalace.exe')]
+        : [`${home}/.local/bin/mempalace`, '/opt/homebrew/bin/mempalace', '/usr/local/bin/mempalace'];
+      for (const candidate of candidates) if (candidate && existsSync(candidate)) { found = candidate; break; }
+    }
+    this.binCache = found;
+    return found;
+  }
+
+  available(): boolean { return this.bin() !== null; }
+  resetCaches(): void { this.binCache = undefined; }
+  private childEnv(): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      MEMPALACE_PALACE_PATH: this.getPalacePath() ?? '',
+      MEMPALACE_EMBEDDING_MODEL: this.getModel(),
+      ...(MEMPALACE_DEVICE ? { MEMPALACE_EMBEDDING_DEVICE: MEMPALACE_DEVICE } : {})
+    };
+  }
+
+  agentEnv(): Record<string, string> {
+    const palace = this.getPalacePath();
+    if (!palace || !this.available()) return {};
+    return {
+      MEMPALACE_PALACE_PATH: palace,
+      MEMPALACE_EMBEDDING_MODEL: this.getModel(),
+      ...(MEMPALACE_DEVICE ? { MEMPALACE_EMBEDDING_DEVICE: MEMPALACE_DEVICE } : {})
+    };
+  }
+
+  status(enabled: boolean, home: string | null): BackendStatus {
+    const palace = this.getPalacePath();
+    const available = this.available();
+    return { backend: this.id, available, enabled, active: available && enabled && home !== null,
+      initialized: !!palace && existsSync(palace), location: palace, model: this.getModel(), bin: this.bin() };
+  }
+
+  init(): void { this.reapPalace(); }
+
+  async mineAgent(agentDir: string, id: string): Promise<MineResult> {
+    return new Promise((resolve) => {
+      const bin = this.bin();
+      if (!bin) { resolve({ ok: false }); return; }
+      const proc = spawn(bin, ['mine', agentDir, '--wing', id, '--agent', id], { env: this.childEnv(), stdio: ['ignore', 'ignore', 'pipe'] });
+      let err = '';
+      proc.stderr?.on('data', (data) => { err += data.toString(); });
+      const timer = setTimeout(() => {
+        console.error(`[memory] mine ${id} timed out after ${MINE_TIMEOUT_MS / 60000}min — killing`);
+        try { proc.kill('SIGTERM'); } catch { /* gone */ }
+        ensureKilled(proc.pid);
+      }, MINE_TIMEOUT_MS);
+      timer.unref?.();
+      proc.on('close', (code) => {
+        clearTimeout(timer);
+        if (code !== 0) console.error(`[memory] mine ${id} exited ${code}: ${err.slice(-300)}`);
+        resolve({ ok: code === 0 });
+      });
+      proc.on('error', () => { clearTimeout(timer); resolve({ ok: false }); });
+    });
+  }
+
+  postMinePass(): { backoffAdviceMs: number } {
+    const quarantined = this.reapPalace();
+    this.mineDelayMs = nextMineDelayMs(this.mineDelayMs, MINE_INTERVAL_MS, MINE_BACKOFF_MAX_MS, quarantined);
+    return { backoffAdviceMs: this.mineDelayMs };
+  }
+
+  private reapPalace(): boolean {
+    const palace = this.getPalacePath();
+    if (!palace || !existsSync(palace)) return false;
+    let names: string[];
+    try { names = readdirSync(palace); } catch { return false; }
+    let newest = 0;
+    for (const name of names) { const stamp = quarantineStampMs(name); if (stamp !== null && stamp > newest) newest = stamp; }
+    const fresh = this.lastQuarantineTs > 0 && newest > this.lastQuarantineTs;
+    if (newest > this.lastQuarantineTs) this.lastQuarantineTs = newest;
+    const doomed = quarantineDirsToReap(names.map((name) => ({ name })), Date.now());
+    let removed = 0;
+    for (const name of doomed) {
+      try { rmSync(join(palace, name), { recursive: true, force: true }); removed += 1; }
+      catch { /* locked, gone, or not ours — leave it and try again next pass */ }
+    }
+    if (removed) console.log(`[memory] reaped ${removed} quarantined palace segment(s)`);
+    return fresh;
+  }
+
+  private runCli(args: string[], label: string): Promise<TextResult> {
+    return new Promise((resolve) => {
+      const bin = this.bin();
+      if (!bin) { resolve({ ok: false, output: '', error: 'semantic memory not active' }); return; }
+      let proc: ReturnType<typeof spawn>;
+      try { proc = spawn(bin, args, { env: this.childEnv(), stdio: ['ignore', 'pipe', 'pipe'] }); }
+      catch (error) { resolve({ ok: false, output: '', error: error instanceof Error ? error.message : String(error) }); return; }
+      let out = '', err = '', settled = false;
+      const settle = (result: TextResult): void => { if (!settled) { settled = true; clearTimeout(timer); resolve(result); } };
+      proc.stdout?.setEncoding('utf8'); proc.stderr?.setEncoding('utf8');
+      proc.stdout?.on('data', (data: string) => { out += data; });
+      proc.stderr?.on('data', (data: string) => { err += data; });
+      const timer = setTimeout(() => { try { proc.kill('SIGTERM'); } catch { /* gone */ } ensureKilled(proc.pid); settle({ ok: false, output: out, error: `${label} timed out` }); }, 120_000);
+      timer.unref?.();
+      proc.on('close', (code) => code !== 0 ? settle({ ok: false, output: out, error: (err || `${label} failed`).trim() }) : settle({ ok: true, output: out }));
+      proc.on('error', (error) => settle({ ok: false, output: '', error: error.message }));
+    });
+  }
+
+  search(query: string, opts: { agentId?: string; results?: number } = {}): Promise<TextResult> {
+    const args = ['search', query, '--results', String(opts.results ?? 5)];
+    if (opts.agentId) args.push('--wing', opts.agentId);
+    return this.runCli(args, 'search');
+  }
+
+  wakeUp(agentId?: string): Promise<TextResult> {
+    const args = ['wake-up'];
+    if (agentId) args.push('--wing', agentId);
+    return this.runCli(args, 'wake-up');
+  }
+}

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -2,7 +2,9 @@
 import { existsSync, statSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { MemPalaceAdapter } from './memPalaceAdapter';
-import type { MemoryBackend } from './memoryBackend';
+import { HindsightAdapter } from './hindsightAdapter';
+import type { BackendId, MemoryBackend, MemorySettings } from './memoryBackend';
+export type { MemorySettings } from './memoryBackend';
 export { mempalaceDevice, type EmbeddingModel } from './memPalaceAdapter';
 import type { EmbeddingModel } from './memPalaceAdapter';
 
@@ -22,8 +24,7 @@ function ensureMineIgnore(agentDir: string): void {
   try { writeFileSync(path, prefix + missing.join('\n') + '\n', 'utf8'); } catch { /* best-effort */ }
 }
 
-export interface MemorySettings { enabled: boolean; model: EmbeddingModel; }
-export interface MemoryStatus { available: boolean; enabled: boolean; active: boolean; initialized: boolean; palacePath: string | null; model: EmbeddingModel; bin: string | null; }
+export interface MemoryStatus { available: boolean; enabled: boolean; active: boolean; initialized: boolean; palacePath: string | null; backend: BackendId; location: string | null; model: EmbeddingModel; bin: string | null; }
 const MINE_INTERVAL_MS = 600_000;
 
 export class MemoryManager {
@@ -33,28 +34,59 @@ export class MemoryManager {
   private initStarted = false;
   private mining = false;
   private lastMined = new Map<string, number>();
-  private readonly backend: MemoryBackend;
-  constructor(private getHome: () => string | null, private getSettings: () => MemorySettings) {
-    this.backend = new MemPalaceAdapter(() => this.palacePath(), () => this.model());
+  private backend: MemoryBackend;
+  constructor(
+    private getHome: () => string | null,
+    private getSettings: () => MemorySettings,
+    private makeBackend: (id: BackendId) => MemoryBackend = (id) =>
+      id === 'hindsight'
+        ? new HindsightAdapter(() => this.getSettings().hindsight, () => this.getHome())
+        : new MemPalaceAdapter(() => this.palacePath(), () => this.model())
+  ) {
+    this.backend = this.makeBackend(this.getSettings().backend);
   }
   palacePath(): string | null { const home = this.getHome(); return home ? join(home, 'palace') : null; }
-  bin(): string | null { return (this.backend as MemPalaceAdapter).bin(); }
-  available(): boolean { return this.bin() !== null; }
+  bin(): string | null { return this.backend.status(this.enabled(), this.getHome()).bin; }
+  available(): boolean { return this.backend.available(); }
   enabled(): boolean { return this.getSettings().enabled; }
   active(): boolean { return this.available() && this.enabled() && this.getHome() !== null; }
-  model(): EmbeddingModel { return this.getSettings().model === 'embeddinggemma' ? 'embeddinggemma' : 'minilm'; }
+  model(): EmbeddingModel { return this.getSettings().mempalace.model === 'embeddinggemma' ? 'embeddinggemma' : 'minilm'; }
   status(): MemoryStatus {
     const status = this.backend.status(this.enabled(), this.getHome());
-    return { available: this.available(), enabled: status.enabled, active: this.active(), initialized: status.initialized, palacePath: status.location, model: status.model === 'embeddinggemma' ? 'embeddinggemma' : 'minilm', bin: this.bin() };
+    return {
+      available: status.available, enabled: status.enabled, active: status.active, initialized: status.initialized,
+      // A remote backend has no palace directory; `location` is where its
+      // memories actually live, and callers that want a path must not be handed
+      // a server URL dressed up as one.
+      palacePath: status.backend === 'mempalace' ? status.location : null,
+      backend: status.backend, location: status.location,
+      model: status.model === 'embeddinggemma' ? 'embeddinggemma' : 'minilm', bin: status.bin
+    };
   }
   env(): Record<string, string> { return this.active() ? this.backend.agentEnv() : {}; }
   resetBinCache(): void { this.backend.resetCaches(); }
   start(): void {
-    if (!this.active() || this.initStarted || !this.getHome() || !this.palacePath()) return;
+    if (this.initStarted || !this.enabled() || !this.getHome()) return;
+    // A backend that only learns its availability from an async probe cannot be
+    // available yet — arming it IS what starts the probe. A local CLI backend
+    // answers synchronously, so it stays dark until its CLI is really there.
+    if (!this.backend.probesAsync && (!this.active() || !this.palacePath())) return;
     this.initStarted = true; this.backend.init(); this.startMineLoop();
   }
   stop(): void { this.mineStopped = true; if (this.mineTimer) { clearTimeout(this.mineTimer); this.mineTimer = null; } }
-  refresh(): MemoryStatus { this.resetBinCache(); this.start(); return this.status(); }
+  refresh(): MemoryStatus { this.swapBackendIfChanged(); this.resetBinCache(); this.start(); return this.status(); }
+  /** Adopt the backend the settings now name. Switching means starting over:
+   *  the new backend holds none of the old one's memories, so every agent's
+   *  memory.md has to be mined into it from scratch. */
+  private swapBackendIfChanged(): void {
+    const wanted = this.getSettings().backend;
+    if (wanted === this.backend.id) return;
+    if (this.mineTimer) { clearTimeout(this.mineTimer); this.mineTimer = null; }
+    this.backend = this.makeBackend(wanted);
+    this.lastMined.clear();
+    this.initStarted = false;
+    this.mineDelayMs = MINE_INTERVAL_MS;
+  }
   private startMineLoop(): void {
     if (this.mineTimer) return;
     const tick = () => { void this.mineNow().finally(() => { if (this.mineStopped) return; this.mineTimer = setTimeout(tick, this.mineDelayMs); this.mineTimer.unref?.(); }); };

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -1,447 +1,88 @@
-/**
- * MemoryManager — semantic memory for the hive, backed by the MemPalace CLI.
- *
- * CLI-only (no MCP): the harness keeps a single shared palace under harnessHome,
- * points every agent's `MEMPALACE_PALACE_PATH` at it, and mines each agent's
- * `memory.md` into its own wing so the whole team can recall by meaning via
- * `mempalace search` / `mempalace wake-up`. Degrades silently to no-op when the
- * `mempalace` CLI isn't installed — the markdown memory still works.
- *
- *   init    : mempalace init <home> --yes --no-llm        (heuristics-only, no LLM)
- *   store   : mempalace mine <agentDir> --wing <id> --agent <id>
- *   recall  : mempalace search "<q>" --results N   /   mempalace wake-up
- *
- * Runs in the Electron main process.
- */
-import { existsSync, statSync, readdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+/** Backend-neutral semantic-memory scheduler. */
+import { existsSync, statSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { spawn, spawnSync } from 'node:child_process';
-import { ensureKilled } from './procKill';
-import { quarantineDirsToReap, quarantineStampMs, nextMineDelayMs } from './palaceReap';
+import { MemPalaceAdapter } from './memPalaceAdapter';
+import type { MemoryBackend } from './memoryBackend';
+export { mempalaceDevice, type EmbeddingModel } from './memPalaceAdapter';
+import type { EmbeddingModel } from './memPalaceAdapter';
 
-/** Non-memory files `mempalace mine` must not ingest: the Claude Code hooks
- *  config (a large JSON blob that swamps the wake-up digest), the cursor, raw
- *  inbox/outbox message JSON, and a Codex worker's private CODEX_HOME. `mempalace
- *  mine` honors .gitignore, so we drop one in each agent dir rather than touch the
- *  mine command.
- *
- *  MUST STAY IN SYNC with MINE_IGNORE_LINES in hive.ts — that copy is written when
- *  an agent spawns, this one on every mine cycle, and only this one reaches agents
- *  that are not currently running. See hive.ts for why `.codex/` matters beyond
- *  mempalace: it is also what stopped the hive's git repo from versioning every
- *  Codex transcript and sqlite log into a 7.5GB history. */
+/** MUST STAY IN SYNC with MINE_IGNORE_LINES in hive.ts — that copy is written when
+ * an agent spawns, this one on every mine cycle, and only this one reaches agents
+ * that are not currently running. See hive.ts for why `.codex/` matters beyond
+ * mempalace: it is also what stopped the hive's git repo from versioning every
+ * Codex transcript and sqlite log into a 7.5GB history. */
 const MINE_IGNORE_LINES = ['settings.json', 'cursor.json', 'inbox/', 'outbox/', '.codex/'];
-
-/** Idempotently ensure `<agentDir>/.gitignore` excludes the non-memory files.
- *  Writes only the missing lines (append-only) so it's safe to call every cycle. */
 function ensureMineIgnore(agentDir: string): void {
-  const path = join(agentDir, '.gitignore');
-  let existing = '';
+  const path = join(agentDir, '.gitignore'); let existing = '';
   try { if (existsSync(path)) existing = readFileSync(path, 'utf8'); } catch { return; }
-  const have = new Set(existing.split('\n').map((l) => l.trim()));
-  const missing = MINE_IGNORE_LINES.filter((l) => !have.has(l));
-  if (missing.length === 0) return; // already covered — don't rewrite every cycle
+  const have = new Set(existing.split('\n').map((line) => line.trim()));
+  const missing = MINE_IGNORE_LINES.filter((line) => !have.has(line));
+  if (!missing.length) return;
   const prefix = existing && !existing.endsWith('\n') ? existing + '\n' : existing;
   try { writeFileSync(path, prefix + missing.join('\n') + '\n', 'utf8'); } catch { /* best-effort */ }
 }
 
-export type EmbeddingModel = 'minilm' | 'embeddinggemma';
-
-export interface MemorySettings {
-  enabled: boolean;
-  model: EmbeddingModel;
-}
-
-export interface MemoryStatus {
-  available: boolean;        // mempalace CLI found on PATH
-  enabled: boolean;          // user setting
-  active: boolean;           // available && enabled && have a home
-  initialized: boolean;      // palace directory exists
-  palacePath: string | null;
-  model: EmbeddingModel;
-  bin: string | null;
-}
-
-// Re-mine changed memories every 10 min, up from 3.
-//
-// Every `mempalace mine` opens the palace, and every open runs MemPalace's
-// quarantine gate — which on a palace stuck in the rename loop means another
-// full-size copy of the segment left on disk. The gate is not ours to fix, but
-// how often we invoke it is. Mining is already skipped for agents whose
-// memory.md has not changed, so this only affects an agent editing its notes
-// repeatedly: its changes are batched into one mine instead of three. A memory
-// written now is searchable within ten minutes rather than three, which no one
-// is waiting on. `reapPalace` handles the copies that still get made.
+export interface MemorySettings { enabled: boolean; model: EmbeddingModel; }
+export interface MemoryStatus { available: boolean; enabled: boolean; active: boolean; initialized: boolean; palacePath: string | null; model: EmbeddingModel; bin: string | null; }
 const MINE_INTERVAL_MS = 600_000;
-// Ceiling for the quarantine backoff below. Low on purpose: a memory is not
-// searchable until it has been mined, and the reaper already handles the disk,
-// so there is nothing here worth making recall half an hour stale for.
-const MINE_BACKOFF_MAX_MS = 1_800_000;
-const MINE_TIMEOUT_MS = 10 * 60_000; // hard cap per mine (first run downloads the embedding model)
-/** mempalace's device "auto" picks the CoreML execution provider on Apple
- *  Silicon, and CoreML runs the quantized embeddinggemma ONNX graph partially
- *  (330/1647 nodes) with fp16 partitions that overflow → EVERY vector comes
- *  back NaN and chroma rejects every upsert ("Embeddings must not contain NaN
- *  or Infinity values"), so no memory ever gets indexed. Reproduced + verified
- *  2026-08-16: same input is NaN under CoreMLExecutionProvider and clean under
- *  CPU. Pin cpu for BOTH the mine loop and the agents' own `mempalace search`
- *  (a query embedded to NaN breaks recall the same way).
- *
- *  Scope, deliberately macOS-WIDE rather than per-model: the pin costs the
- *  other model nothing. minilm rides chromadb's ONNXMiniLM_L6_V2, whose model
- *  build UNCONDITIONALLY removes CoreMLExecutionProvider ("not as well
- *  optimized as CPU" — chromadb's words), so minilm never runs on CoreML with
- *  or without this pin; embeddinggemma (mempalace's own ONNX class, no such
- *  pruning) is the only path that would reach CoreML, and that path is the NaN
- *  bug. Other platforms keep mempalace's own default ("auto").
- *
- *  A user's OWN device choice wins: if MEMPALACE_EMBEDDING_DEVICE is already
- *  exported we emit nothing, so the inherited value flows through untouched —
- *  which also leaves a one-command way to reproduce the NaN behaviour
- *  (`MEMPALACE_EMBEDDING_DEVICE=coreml`). Exported as a function of
- *  (platform, envOverride) so every branch is reachable from a test on any
- *  platform — same trick as `buildMissingCliScript`. */
-export function mempalaceDevice(
-  platform: NodeJS.Platform,
-  envOverride: string | undefined
-): string | undefined {
-  if (envOverride) return undefined; // explicit user choice — never override
-  return platform === 'darwin' ? 'cpu' : undefined;
-}
-const MEMPALACE_DEVICE = mempalaceDevice(process.platform, process.env.MEMPALACE_EMBEDDING_DEVICE);
 
 export class MemoryManager {
-  private binCache: string | null | undefined;
   private mineTimer: NodeJS.Timeout | null = null;
   private mineStopped = false;
-  /** Current gap between mine passes. Widens while the palace is quarantining. */
   private mineDelayMs = MINE_INTERVAL_MS;
-  /** Newest quarantine stamp seen so far, so a LATER one means the palace
-   *  quarantined again. A count would be useless: the reaper deletes them. */
-  private lastQuarantineTs = 0;
   private initStarted = false;
-  /** True while a mineNow() pass is in flight — serializes palace writers. */
   private mining = false;
-  /** agentId → memory.md mtimeMs at last successful mine (skip unchanged). */
   private lastMined = new Map<string, number>();
-
-  constructor(
-    private getHome: () => string | null,
-    private getSettings: () => MemorySettings
-  ) {}
-
-  palacePath(): string | null {
-    const h = this.getHome();
-    return h ? join(h, 'palace') : null;
+  private readonly backend: MemoryBackend;
+  constructor(private getHome: () => string | null, private getSettings: () => MemorySettings) {
+    this.backend = new MemPalaceAdapter(() => this.palacePath(), () => this.model());
   }
-
-  /** Resolve the mempalace CLI against the user's PATH + common uv/pip spots. */
-  bin(): string | null {
-    if (this.binCache !== undefined) return this.binCache;
-    let found: string | null = null;
-    const isWin = process.platform === 'win32';
-    // 1) Ask the shell/PATH resolver. Windows has no POSIX shell + uses `where`
-    //    and a `.exe` suffix; everything else goes through the login shell.
-    try {
-      if (isWin) {
-        const res = spawnSync('where', ['mempalace'], { encoding: 'utf8', timeout: 3000 });
-        const p = res.stdout.trim().split(/\r?\n/)[0]?.trim();
-        if (p && existsSync(p)) found = p;
-      } else {
-        const res = spawnSync(process.env.SHELL ?? '/bin/zsh', ['-ilc', 'which mempalace'], {
-          encoding: 'utf8', timeout: 3000
-        });
-        const p = res.stdout.trim().split('\n').pop();
-        if (p && existsSync(p)) found = p;
-      }
-    } catch { /* fall through */ }
-    // 2) Probe common install locations (uv tool / homebrew / pip).
-    if (!found) {
-      const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
-      const candidates = isWin
-        ? [
-            join(home, '.local', 'bin', 'mempalace.exe'),
-            join(process.env.LOCALAPPDATA ?? '', 'Programs', 'Python', 'Scripts', 'mempalace.exe')
-          ]
-        : [
-            `${home}/.local/bin/mempalace`,
-            '/opt/homebrew/bin/mempalace',
-            '/usr/local/bin/mempalace'
-          ];
-      for (const c of candidates) if (c && existsSync(c)) { found = c; break; }
-    }
-    this.binCache = found;
-    return found;
-  }
-  /** Force re-resolution (e.g. after the user installs mempalace). */
-  resetBinCache(): void { this.binCache = undefined; }
-
+  palacePath(): string | null { const home = this.getHome(); return home ? join(home, 'palace') : null; }
+  bin(): string | null { return (this.backend as MemPalaceAdapter).bin(); }
   available(): boolean { return this.bin() !== null; }
   enabled(): boolean { return this.getSettings().enabled; }
   active(): boolean { return this.available() && this.enabled() && this.getHome() !== null; }
   model(): EmbeddingModel { return this.getSettings().model === 'embeddinggemma' ? 'embeddinggemma' : 'minilm'; }
-
   status(): MemoryStatus {
-    const palace = this.palacePath();
-    return {
-      available: this.available(),
-      enabled: this.enabled(),
-      active: this.active(),
-      initialized: !!palace && existsSync(palace),
-      palacePath: palace,
-      model: this.model(),
-      bin: this.bin()
-    };
+    const status = this.backend.status(this.enabled(), this.getHome());
+    return { available: this.available(), enabled: status.enabled, active: this.active(), initialized: status.initialized, palacePath: status.location, model: status.model === 'embeddinggemma' ? 'embeddinggemma' : 'minilm', bin: this.bin() };
   }
-
-  /** Env merged into each agent's spawn so its `mempalace` CLI hits the shared palace. */
-  env(): Record<string, string> {
-    const palace = this.palacePath();
-    if (!this.active() || !palace) return {};
-    return {
-      MEMPALACE_PALACE_PATH: palace,
-      MEMPALACE_EMBEDDING_MODEL: this.model(),
-      ...(MEMPALACE_DEVICE ? { MEMPALACE_EMBEDDING_DEVICE: MEMPALACE_DEVICE } : {})
-    };
-  }
-
-  private childEnv(): NodeJS.ProcessEnv {
-    return {
-      ...process.env,
-      MEMPALACE_PALACE_PATH: this.palacePath() ?? '',
-      MEMPALACE_EMBEDDING_MODEL: this.model(),
-      ...(MEMPALACE_DEVICE ? { MEMPALACE_EMBEDDING_DEVICE: MEMPALACE_DEVICE } : {})
-    };
-  }
-
-  // — lifecycle —
-
-  /** Start the mine loop. `mempalace mine` auto-creates the palace on first run
-   *  (lazily downloading the embedding model, one-time). We deliberately do NOT
-   *  run `mempalace init`: it ends in an interactive "Mine now? [Y/n]" prompt
-   *  that --yes doesn't cover, so a spawned child would hang forever. */
+  env(): Record<string, string> { return this.active() ? this.backend.agentEnv() : {}; }
+  resetBinCache(): void { this.backend.resetCaches(); }
   start(): void {
-    if (!this.active() || this.initStarted) return;
-    if (!this.bin() || !this.getHome() || !this.palacePath()) return;
-    this.initStarted = true;
-    // Sweep once at boot, before the first mine. An app updating into this fix
-    // arrives at a palace that has been accumulating copies for as long as it
-    // has been running — 357 of them here — and waiting for the first agent to
-    // edit its memory.md would leave all of that on disk for an arbitrary
-    // while. This is the pass that makes the existing pile go away by itself.
-    this.reapPalace();
-    this.startMineLoop();
+    if (!this.active() || this.initStarted || !this.getHome() || !this.palacePath()) return;
+    this.initStarted = true; this.backend.init(); this.startMineLoop();
   }
-
-  stop(): void {
-    this.mineStopped = true;
-    if (this.mineTimer) { clearTimeout(this.mineTimer); this.mineTimer = null; }
-  }
-
-  /**
-   * Re-resolve the CLI, arm the mine loop if it is only now possible, and report.
-   *
-   * `start()` runs once at boot and bails when mempalace isn't on PATH yet. If the
-   * user installs it AFTER that — the common case, since the settings panel is
-   * where they find out they need it — nothing re-invoked `start()`, so the mine
-   * loop never ran. The palace is created by the first `mempalace mine`, so it
-   * never appeared either, and `initialized` (existsSync(palace)) stayed false
-   * while `available` flipped true: the status pill read "On — getting ready…"
-   * forever and only an app restart cleared it.
-   *
-   * The status poll is the one thing that reliably notices the install, so it is
-   * where the re-arm belongs. `start()` is idempotent (initStarted), so repeated
-   * polls never start a second loop — and it still deliberately does NOT run
-   * `mempalace init`, which ends in an interactive "Mine now? [Y/n]" that `--yes`
-   * doesn't cover and that hangs a spawned child.
-   */
-  refresh(): MemoryStatus {
-    this.resetBinCache();
-    this.start();
-    return this.status();
-  }
-
-  /** Self-scheduling rather than `setInterval`, so the gap can widen when the
-   *  palace is quarantining and snap back the moment it stops. */
+  stop(): void { this.mineStopped = true; if (this.mineTimer) { clearTimeout(this.mineTimer); this.mineTimer = null; } }
+  refresh(): MemoryStatus { this.resetBinCache(); this.start(); return this.status(); }
   private startMineLoop(): void {
     if (this.mineTimer) return;
-    const tick = () => {
-      void this.mineNow().finally(() => {
-        if (this.mineStopped) return;
-        this.mineTimer = setTimeout(tick, this.mineDelayMs);
-        this.mineTimer.unref?.();
-      });
-    };
-    // Armed synchronously. `mineTimer` is the "is the loop running" signal that
-    // `refresh()` reports on right after `start()`, and setting it only once the
-    // first mine resolves would report the loop as dead for a whole pass —
-    // which is exactly the re-arm-after-install case that has its own test.
-    this.mineTimer = setTimeout(tick, 0);
-    this.mineTimer.unref?.();
+    const tick = () => { void this.mineNow().finally(() => { if (this.mineStopped) return; this.mineTimer = setTimeout(tick, this.mineDelayMs); this.mineTimer.unref?.(); }); };
+    this.mineTimer = setTimeout(tick, 0); this.mineTimer.unref?.();
   }
-
-  // — mining (store) —
-
-  /** Mine every agent whose memory changed since last time, one at a time.
-   *  The palace permits a single writer, so mines MUST be serialized — firing
-   *  them concurrently makes all but one fail with "held by another writer".
-   *  `mining` guards against a slow pass overlapping the next interval tick. */
   async mineNow(): Promise<void> {
-    const home = this.getHome();
-    const bin = this.bin();
-    if (!this.active() || !home || !bin) return;
-    if (this.mining) return; // a previous pass is still running — let it finish
-    const agentsDir = join(home, 'hive', 'agents');
-    if (!existsSync(agentsDir)) return;
-    let ids: string[];
-    try { ids = readdirSync(agentsDir); } catch { return; }
+    const home = this.getHome(); if (!this.active() || !home || this.mining) return;
+    const agentsDir = join(home, 'hive', 'agents'); if (!existsSync(agentsDir)) return;
+    let ids: string[]; try { ids = readdirSync(agentsDir); } catch { return; }
     this.mining = true;
     try {
       for (const id of ids) {
-        const agentDir = join(agentsDir, id);
-        const mem = join(agentDir, 'memory.md');
-        if (!existsSync(mem)) continue;
-        let mtime = 0;
-        try { mtime = statSync(mem).mtimeMs; } catch { continue; }
-        if (this.lastMined.get(id) === mtime) continue; // unchanged — skip the model load
-        this.lastMined.set(id, mtime);
-        await this.mineAgent(agentDir, id); // one writer at a time
+        const agentDir = join(agentsDir, id), memory = join(agentDir, 'memory.md');
+        if (!existsSync(memory)) continue;
+        let mtime: number; try { mtime = statSync(memory).mtimeMs; } catch { continue; }
+        if (this.lastMined.get(id) === mtime) continue;
+        this.lastMined.set(id, mtime); ensureMineIgnore(agentDir);
+        if (!(await this.backend.mineAgent(agentDir, id)).ok) this.lastMined.delete(id);
       }
-    } finally {
-      this.mining = false;
-    }
-    // Every pass above may have left another copy behind, and whether it did
-    // decides how long we wait before the next one.
-    const quarantined = this.reapPalace();
-    this.mineDelayMs = nextMineDelayMs(
-      this.mineDelayMs, MINE_INTERVAL_MS, MINE_BACKOFF_MAX_MS, quarantined
-    );
+    } finally { this.mining = false; }
+    const postMine = this.backend.postMinePass?.(); if (postMine) this.mineDelayMs = postMine.backoffAdviceMs;
   }
-
-  /**
-   * Delete quarantined segment copies MemPalace renamed aside and never removed.
-   *
-   * Safe to delete: the rename is precisely what takes them OUT of the palace's
-   * live set, and Chroma has already rebuilt by the time we see one. They are
-   * diagnostic residue. `quarantineDirsToReap` keeps the newest couple so there
-   * is still something to look at, and refuses to touch anything recent enough
-   * to still be mid-recovery.
-   *
-   * Best-effort throughout. A palace we cannot read, or a directory we cannot
-   * remove, must never take down the mine loop — this is disk hygiene, not a
-   * correctness path.
-   */
-  private reapPalace(): boolean {
-    const palace = this.palacePath();
-    if (!palace || !existsSync(palace)) return false;
-    let names: string[];
-    try { names = readdirSync(palace); } catch { return false; }
-
-    let newest = 0;
-    for (const name of names) {
-      const ts = quarantineStampMs(name);
-      if (ts !== null && ts > newest) newest = ts;
-    }
-    // The boot sweep runs before the first mine precisely so it can seed this:
-    // otherwise a palace that arrives with a backlog would read as "just
-    // quarantined" and back the loop off before it has mined anything.
-    const fresh = this.lastQuarantineTs > 0 && newest > this.lastQuarantineTs;
-    if (newest > this.lastQuarantineTs) this.lastQuarantineTs = newest;
-
-    const doomed = quarantineDirsToReap(names.map((name) => ({ name })), Date.now());
-    if (!doomed.length) return fresh;
-    let removed = 0;
-    for (const name of doomed) {
-      try { rmSync(join(palace, name), { recursive: true, force: true }); removed += 1; }
-      catch { /* locked, gone, or not ours — leave it and try again next pass */ }
-    }
-    if (removed) console.log(`[memory] reaped ${removed} quarantined palace segment(s)`);
-    return fresh;
+  search(query: string, opts: { wing?: string; results?: number } = {}) {
+    if (!this.active()) return Promise.resolve({ ok: false, output: '', error: 'semantic memory not active' });
+    return this.backend.search(query, { agentId: opts.wing, results: opts.results });
   }
-
-  private mineAgent(agentDir: string, id: string): Promise<void> {
-    return new Promise((resolve) => {
-      const bin = this.bin();
-      if (!bin) { resolve(); return; }
-      ensureMineIgnore(agentDir); // keep settings.json / cursor / messages out of the index
-      // stdin closed (mempalace can prompt); mempalace dedups so re-mining is safe.
-      const proc = spawn(bin, ['mine', agentDir, '--wing', id, '--agent', id], {
-        env: this.childEnv(), stdio: ['ignore', 'ignore', 'pipe']
-      });
-      let err = '';
-      proc.stderr?.on('data', (d) => { err += d.toString(); });
-      // Hard ceiling: a wedged mine used to hold its PID forever AND leave
-      // `mining` stuck true, silently stopping all future passes. Generous cap
-      // because the first run may lazily download the embedding model.
-      const timer = setTimeout(() => {
-        console.error(`[memory] mine ${id} timed out after ${MINE_TIMEOUT_MS / 60000}min — killing`);
-        try { proc.kill('SIGTERM'); } catch { /* gone */ }
-        ensureKilled(proc.pid); // SIGKILL sweep if SIGTERM is ignored
-      }, MINE_TIMEOUT_MS);
-      timer.unref?.();
-      proc.on('close', (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          console.error(`[memory] mine ${id} exited ${code}: ${err.slice(-300)}`);
-          this.lastMined.delete(id); // let the next tick retry
-        }
-        resolve();
-      });
-      proc.on('error', () => { clearTimeout(timer); this.lastMined.delete(id); resolve(); });
-    });
-  }
-
-  // — recall (read) —
-
-  /** Run one mempalace read command asynchronously. These used to be spawnSync
-   *  with a 120s timeout — on a cold model load that BLOCKED the Electron main
-   *  process (renderer IPC, timers, every window) for up to two minutes. Same
-   *  contract, but the event loop keeps breathing and a wedged CLI is swept. */
-  private runCli(args: string[], label: string): Promise<{ ok: boolean; output: string; error?: string }> {
-    return new Promise((resolve) => {
-      const bin = this.bin();
-      if (!this.active() || !bin) { resolve({ ok: false, output: '', error: 'semantic memory not active' }); return; }
-      let proc: ReturnType<typeof spawn>;
-      try {
-        proc = spawn(bin, args, { env: this.childEnv(), stdio: ['ignore', 'pipe', 'pipe'] });
-      } catch (e) {
-        resolve({ ok: false, output: '', error: e instanceof Error ? e.message : String(e) });
-        return;
-      }
-      let out = '', err = '';
-      let settled = false;
-      const settle = (r: { ok: boolean; output: string; error?: string }): void => {
-        if (!settled) { settled = true; clearTimeout(timer); resolve(r); }
-      };
-      proc.stdout?.setEncoding('utf8');
-      proc.stderr?.setEncoding('utf8');
-      proc.stdout?.on('data', (d: string) => { out += d; });
-      proc.stderr?.on('data', (d: string) => { err += d; });
-      const timer = setTimeout(() => {
-        try { proc.kill('SIGTERM'); } catch { /* gone */ }
-        ensureKilled(proc.pid);
-        settle({ ok: false, output: out, error: `${label} timed out` });
-      }, 120_000);
-      timer.unref?.();
-      proc.on('close', (code) => {
-        if (code !== 0) settle({ ok: false, output: out, error: (err || `${label} failed`).trim() });
-        else settle({ ok: true, output: out });
-      });
-      proc.on('error', (e) => settle({ ok: false, output: '', error: e.message }));
-    });
-  }
-
-  /** Semantic search across the shared palace. Returns the CLI's text output. */
-  search(query: string, opts: { wing?: string; results?: number } = {}): Promise<{ ok: boolean; output: string; error?: string }> {
-    const args = ['search', query, '--results', String(opts.results ?? 5)];
-    if (opts.wing) args.push('--wing', opts.wing);
-    return this.runCli(args, 'search');
-  }
-
-  /** Session-start digest (~600-900 tokens). */
-  wakeUp(wing?: string): Promise<{ ok: boolean; output: string; error?: string }> {
-    const args = ['wake-up'];
-    if (wing) args.push('--wing', wing);
-    return this.runCli(args, 'wake-up');
+  wakeUp(wing?: string) {
+    if (!this.active()) return Promise.resolve({ ok: false, output: '', error: 'semantic memory not active' });
+    return this.backend.wakeUp(wing);
   }
 }

--- a/src/main/memoryBackend.ts
+++ b/src/main/memoryBackend.ts
@@ -1,0 +1,30 @@
+/** Memory backend contract; see docs/superpowers/specs/2026-08-25-pluggable-memory-design.md. */
+
+export type BackendId = 'mempalace' | 'hindsight';
+
+export interface BackendStatus {
+  backend: BackendId;
+  available: boolean;
+  enabled: boolean;
+  active: boolean;
+  initialized: boolean;
+  location: string | null;
+  model: string | null;
+  bin: string | null;
+}
+
+export interface MineResult { ok: boolean; backoffAdviceMs?: number }
+export interface TextResult { ok: boolean; output: string; error?: string }
+
+export interface MemoryBackend {
+  readonly id: BackendId;
+  available(): boolean;
+  init(): void;
+  mineAgent(agentDir: string, agentId: string): Promise<MineResult>;
+  search(q: string, opts: { agentId?: string; results?: number }): Promise<TextResult>;
+  wakeUp(agentId?: string): Promise<TextResult>;
+  status(enabled: boolean, home: string | null): BackendStatus;
+  agentEnv(): Record<string, string>;
+  resetCaches(): void;
+  postMinePass?(): { backoffAdviceMs: number };
+}

--- a/src/main/memoryBackend.ts
+++ b/src/main/memoryBackend.ts
@@ -27,4 +27,16 @@ export interface MemoryBackend {
   agentEnv(): Record<string, string>;
   resetCaches(): void;
   postMinePass?(): { backoffAdviceMs: number };
+  /** True when availability can only be learned from an async probe, so the
+   *  manager must arm the backend before `available()` can ever say yes. A
+   *  local CLI backend leaves this unset: it knows synchronously. */
+  readonly probesAsync?: boolean;
+}
+
+/** The persisted, backend-aware shape of the memory settings. */
+export interface MemorySettings {
+  enabled: boolean;
+  backend: BackendId;
+  mempalace: { model: 'minilm' | 'embeddinggemma' };
+  hindsight: { url: string; bank: string };
 }

--- a/src/main/telemetry.ts
+++ b/src/main/telemetry.ts
@@ -206,6 +206,25 @@ export class TelemetryCollector {
     return () => this.apiErrorSubs.delete(cb);
   }
 
+  /** Drop an agent's live usage so a respawn starts with a fresh counter.
+   *  Clears the in-memory accumulation only — the on-disk cost ledger and the
+   *  transcript fallback are untouched, so lifetime spending still reports. The
+   *  span ring goes too: it is keyed by agent id, so a replacement would
+   *  otherwise inherit the dead agent's tool waterfall.
+   *
+   *  Known edge: metrics are delivered asynchronously, so a batch already in
+   *  flight when the PTY dies can land after this call and recreate the dead
+   *  session's entries. The window is milliseconds and the next teardown
+   *  clears it, so it is left unguarded rather than carrying a tombstone. */
+  forgetAgent(agentId: string): void {
+    const sessionIds = this.agentSessions.get(agentId);
+    if (sessionIds) {
+      for (const sessionId of sessionIds) this.sessions.delete(sessionId);
+    }
+    this.agentSessions.delete(agentId);
+    this.spans.delete(agentId);
+  }
+
   /** Recent tool spans for the per-agent waterfall (#7B.2), oldest→newest. */
   getSpans(agentId: string): ToolSpan[] {
     return this.spans.get(agentId)?.slice() ?? [];

--- a/src/main/worktreeDeps.ts
+++ b/src/main/worktreeDeps.ts
@@ -1,0 +1,55 @@
+import { existsSync } from 'node:fs';
+import { lstat, readlink, realpath, symlink, unlink } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export type DepLink =
+  | { ok: true; skipped: boolean }
+  | { ok: false; error: string };
+
+export type DepUnlink =
+  | { ok: true; removed: boolean }
+  | { ok: false; error: string };
+
+/** Link the base checkout's dependencies into an isolated worktree. */
+export async function linkWorktreeDeps(baseDir: string, worktreeDir: string): Promise<DepLink> {
+  const baseNodeModules = join(baseDir, 'node_modules');
+  const worktreeNodeModules = join(worktreeDir, 'node_modules');
+  if (!existsSync(baseNodeModules)) return { ok: true, skipped: true };
+
+  try {
+    await lstat(worktreeNodeModules);
+    return { ok: true, skipped: true };
+  } catch {
+    // node_modules does not exist in this worktree yet.
+  }
+
+  try {
+    await symlink(baseNodeModules, worktreeNodeModules, process.platform === 'win32' ? 'junction' : null);
+    return { ok: true, skipped: false };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  }
+}
+
+/** Remove the dependency link before testing whether a worktree is dirty. */
+export async function unlinkWorktreeDeps(baseDir: string, worktreeDir: string): Promise<DepUnlink> {
+  const baseNodeModules = join(baseDir, 'node_modules');
+  const worktreeNodeModules = join(worktreeDir, 'node_modules');
+
+  try {
+    const stat = await lstat(worktreeNodeModules);
+    if (!stat.isSymbolicLink()) return { ok: true, removed: false };
+    const linkTarget = await readlink(worktreeNodeModules);
+    const [baseTarget, worktreeTarget] = await Promise.all([
+      realpath(baseNodeModules),
+      realpath(resolve(worktreeDir, linkTarget))
+    ]);
+    if (baseTarget !== worktreeTarget) return { ok: true, removed: false };
+    await unlink(worktreeNodeModules);
+    return { ok: true, removed: true };
+  } catch (error) {
+    const code = error instanceof Error && 'code' in error ? error.code : undefined;
+    if (code === 'ENOENT') return { ok: true, removed: false };
+    return { ok: false, error: String(error) };
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -274,6 +274,9 @@ export interface HarnessConfig {
   mcpDefaults?: { [id: string]: { enabled: boolean } };
   semanticMemory: boolean;
   embeddingModel: 'minilm' | 'embeddinggemma';
+  memoryBackend?: 'mempalace' | 'hindsight';
+  hindsightUrl?: string;
+  hindsightBank?: string;
   missions?: ScheduledMission[];
   opsStandupSeeded?: boolean;
   heartbeatSeeded?: boolean;
@@ -334,9 +337,23 @@ export interface MemoryStatus {
   enabled: boolean;
   active: boolean;
   initialized: boolean;
+  /** The palace directory — null for a backend that keeps memories on a server. */
   palacePath: string | null;
+  /** Which engine is answering: the local CLI or a Hindsight server. */
+  backend: 'mempalace' | 'hindsight';
+  /** Where those memories live, in whatever form the backend has: a palace path
+   *  or a `<url> · <bank>` pair. */
+  location: string | null;
   model: 'minilm' | 'embeddinggemma';
   bin: string | null;
+}
+
+/** What a Hindsight endpoint probe found, echoing back what it reached. */
+export interface MemoryConnectionTest {
+  ok: boolean;
+  detail: string;
+  url: string;
+  bank: string;
 }
 
 /** Enterprise Knowledge Graph — corpus status, one document, and a search hit. */
@@ -771,6 +788,10 @@ const api = {
 
   // ─── Semantic memory (MemPalace CLI) ─────────────────────────────────────
   memoryStatus: (): Promise<MemoryStatus> => ipcRenderer.invoke('hive:memoryStatus'),
+  /** Probe a Hindsight server before committing to it. The panel must render
+   *  what this resolves to, not what is in its own inputs. */
+  memoryTestConnection: (url: string, bank: string): Promise<MemoryConnectionTest> =>
+    ipcRenderer.invoke('hive:memoryTestConnection', url, bank),
   /** Which external tools (uv, mempalace, git, each agent engine) are actually
    *  present on this machine, with a platform-resolved install command each. */
   toolsStatus: (): Promise<ToolStatus[]> => ipcRenderer.invoke('tools:status'),

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -99,7 +99,7 @@ Return EXACTLY this shape (omit optional fields you don't need; keep the spec st
 }
 
 Rules:
-- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
+- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5.6-sol, "Gemini 3.1 Pro (High)").
 - Do NOT include shell commands or any flags beyond these fields.
 - Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
 

--- a/src/renderer/src/components/McpDefaultsSettings.tsx
+++ b/src/renderer/src/components/McpDefaultsSettings.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { HarnessConfig } from '@/store/config';
 import { MCP_CATALOG, type McpTier } from '@shared/mcpCatalog';
+import { applyToggle, resolveEnabledFor } from './mcpToggleLogic';
 
 export interface McpDefaultsSettingsProps {
   config: HarnessConfig;
@@ -28,16 +29,34 @@ const labelStyle: React.CSSProperties = {
 
 export function McpDefaultsSettings({ config }: McpDefaultsSettingsProps) {
   const [note, setNote] = useState('');
+  // Seeded from the prop, then replaced by the persisted config after each
+  // toggle. Rendering from the prop alone keeps showing the stale value.
+  const [mcpDefaults, setMcpDefaults] = useState(config.mcpDefaults ?? {});
 
-  const enabledFor = (id: string): boolean =>
-    config.mcpDefaults?.[id]?.enabled ?? MCP_CATALOG.find((e) => e.id === id)?.defaultEnabled ?? false;
+  // …and re-seeded from disk on every MOUNT. The prop alone is not enough:
+  // SettingsModal renders this panel only while the Connections section is
+  // open, and its `config` is App's, loaded once at start-up and never
+  // refreshed after a save (see the re-seed note in SettingsModal). So
+  // switching sections and coming back remounts against a config object that
+  // still says the grant never happened. A consent control has to read the
+  // persisted value, not remember a stale prop.
+  useEffect(() => {
+    let alive = true;
+    window.cth.getConfig()
+      .then((c) => { if (alive) setMcpDefaults((c as HarnessConfig).mcpDefaults ?? {}); })
+      .catch(() => { /* keep the prop-seeded value */ });
+    return () => { alive = false; };
+  }, []);
+
+  const enabledFor = (id: string): boolean => resolveEnabledFor(mcpDefaults, id);
 
   const toggle = async (id: string) => {
     const next = !enabledFor(id);
     try {
-      await window.cth.updateConfig({
-        mcpDefaults: { ...(config.mcpDefaults ?? {}), [id]: { enabled: next } }
-      });
+      setMcpDefaults(await applyToggle(id, next, mcpDefaults, {
+        updateConfig: window.cth.updateConfig,
+        getConfig: window.cth.getConfig
+      }));
       setNote(`${id}: ${next ? 'enabled' : 'disabled'}`);
       setTimeout(() => setNote(''), 1800);
     } catch {

--- a/src/renderer/src/components/MemoryPanel.tsx
+++ b/src/renderer/src/components/MemoryPanel.tsx
@@ -8,11 +8,24 @@ interface MemoryStatus {
   active: boolean;
   initialized: boolean;
   palacePath: string | null;
+  backend: BackendId;
+  location: string | null;
   model: 'minilm' | 'embeddinggemma';
   bin: string | null;
 }
 
+/** What the endpoint probe reported, exactly as main returned it. */
+interface ConnectionTest { ok: boolean; detail: string; url: string; bank: string }
+
 type ModelId = 'minilm' | 'embeddinggemma';
+type BackendId = 'mempalace' | 'hindsight';
+
+// Named by what the user gets, not by the product behind it — the codename is
+// the sub-line, the same way the model choice below reads.
+const BACKENDS: { id: BackendId; title: string; detail: string }[] = [
+  { id: 'mempalace', title: 'On this machine', detail: 'MemPalace · nothing leaves the laptop' },
+  { id: 'hindsight', title: 'On a server',     detail: 'Hindsight · shared across machines' },
+];
 
 // Plain-language framing of each model — lead with the benefit the user actually
 // chooses between, not the model's codename.
@@ -32,11 +45,45 @@ export function MemoryPanel() {
   const [query, setQuery] = useState('');
   const [result, setResult] = useState<string>('');
   const [busy, setBusy] = useState(false);
+  const [url, setUrl] = useState('');
+  const [bank, setBank] = useState('');
+  const [testing, setTesting] = useState(false);
+  // ONLY ever assigned from a resolved memoryTestConnection response. The panel
+  // must not claim a connection it merely attempted, so nothing here is derived
+  // from the inputs above — including the address the verdict is shown against.
+  const [tested, setTested] = useState<ConnectionTest | null>(null);
 
   const refreshStatus = async () => {
     try { setStatus(await window.cth.memoryStatus()); } catch { /* ignore */ }
   };
-  useEffect(() => { refreshStatus(); }, []);
+  const loadEndpoint = async () => {
+    try {
+      const cfg = await window.cth.getConfig();
+      setUrl(cfg.hindsightUrl ?? '');
+      setBank(cfg.hindsightBank ?? '');
+    } catch { /* ignore */ }
+  };
+  useEffect(() => { refreshStatus(); loadEndpoint(); }, []);
+
+  const setBackend = async (backend: BackendId) => {
+    setTested(null); // a verdict about one backend says nothing about the other
+    await window.cth.updateConfig({ memoryBackend: backend });
+    await refreshStatus();
+  };
+  const saveEndpoint = async () => {
+    await window.cth.updateConfig({ hindsightUrl: url.trim(), hindsightBank: bank.trim() });
+    await refreshStatus();
+  };
+  const testConnection = async () => {
+    setTesting(true);
+    setTested(null);
+    try {
+      await saveEndpoint();
+      setTested(await window.cth.memoryTestConnection(url.trim(), bank.trim()));
+    } finally {
+      setTesting(false);
+    }
+  };
 
   const setModel = async (model: ModelId) => {
     await window.cth.updateConfig({ embeddingModel: model });
@@ -63,6 +110,7 @@ export function MemoryPanel() {
   const pill = active ? `🧠 memory · ${status?.model}` : '🧠 memory';
 
   // One clear state line: is memory working, off, or not set up?
+  const onServer = status?.backend === 'hindsight';
   const state: { dot: string; label: string } = !status?.available
     ? { dot: 'var(--cth-coral)', label: 'Not set up' }
     : !status.enabled
@@ -72,6 +120,7 @@ export function MemoryPanel() {
         : { dot: 'var(--cth-lemon)', label: 'On · getting ready…' };
 
   const canSearch = !!status?.available && !!status?.enabled;
+  const testDot = tested ? (tested.ok ? 'var(--cth-mint)' : 'var(--cth-coral)') : 'var(--cth-ink-300)';
 
   return (
     <div style={{ position: 'absolute', bottom: 12, left: 12, width: open ? 380 : 'auto', zIndex: 40 }}>
@@ -118,8 +167,97 @@ export function MemoryPanel() {
               )}
             </div>
 
+            {/* Where memories are kept. Everything below keys off this choice. */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span style={{ fontSize: 11, color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-display)', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                Where memories are kept
+              </span>
+              <div style={{ display: 'flex', gap: 8 }}>
+                {BACKENDS.map((b) => {
+                  const sel = (status?.backend ?? 'mempalace') === b.id;
+                  return (
+                    <button
+                      key={b.id}
+                      onClick={() => setBackend(b.id)}
+                      style={{
+                        flex: 1, textAlign: 'left', cursor: 'pointer', border: 'none',
+                        padding: '7px 9px 6px',
+                        background: sel ? 'var(--cth-lemon-light)' : 'var(--cth-cream-100)',
+                        boxShadow: sel ? 'inset 0 0 0 1.5px var(--cth-ink-500)' : 'inset 0 0 0 1px var(--cth-ink-300)',
+                        fontFamily: 'var(--cth-font-ui)'
+                      }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: 'var(--cth-ink-900)' }}>
+                        <span style={{
+                          width: 8, height: 8, flexShrink: 0,
+                          background: sel ? 'var(--cth-ink-900)' : 'transparent',
+                          boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)'
+                        }} />
+                        {b.title}
+                      </div>
+                      <div style={{ fontSize: 11, color: 'var(--cth-ink-500)', marginTop: 3 }}>{b.detail}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Server address. Switching backends re-mines every agent's notes
+                into the new one, so this is a real move, not a view toggle. */}
+            {onServer && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <span style={{ fontSize: 11, color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-display)', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                  Server
+                </span>
+                <input
+                  value={url}
+                  onChange={(e) => { setUrl(e.target.value); setTested(null); }}
+                  onBlur={saveEndpoint}
+                  placeholder="http://127.0.0.1:8888"
+                  style={{
+                    padding: '6px 8px 4px', background: 'var(--cth-paper-100)', border: 'none',
+                    boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
+                    fontFamily: 'var(--cth-font-mono)', fontSize: 12, color: 'var(--cth-ink-900)', outline: 'none'
+                  }}
+                />
+                <input
+                  value={bank}
+                  onChange={(e) => { setBank(e.target.value); setTested(null); }}
+                  onBlur={saveEndpoint}
+                  placeholder="hive-memory"
+                  style={{
+                    padding: '6px 8px 4px', background: 'var(--cth-paper-100)', border: 'none',
+                    boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
+                    fontFamily: 'var(--cth-font-mono)', fontSize: 12, color: 'var(--cth-ink-900)', outline: 'none'
+                  }}
+                />
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <PixelButton variant="secondary" size="sm" onClick={testConnection} disabled={testing}>
+                    {testing ? 'Testing…' : 'Test connection'}
+                  </PixelButton>
+                </div>
+                {/* Rendered straight off the probe's answer — its `url`, not the
+                    input's, so an edited address can't inherit an old verdict. */}
+                {tested && (
+                  <div style={{
+                    display: 'flex', gap: 7, alignItems: 'flex-start',
+                    fontSize: 12, lineHeight: 1.5, color: 'var(--cth-ink-700)',
+                    background: 'var(--cth-cream-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)', padding: 8
+                  }}>
+                    <span style={{ width: 9, height: 9, marginTop: 3, flexShrink: 0, background: testDot, boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)' }} />
+                    <span>
+                      {tested.detail}
+                      <div style={{ marginTop: 3, color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-mono)', fontSize: 11, wordBreak: 'break-all' }}>
+                        {tested.url || '(no address)'} · {tested.bank || '(no bank)'}
+                      </div>
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* Not installed: show full self-sufficient setup so any machine can follow it. */}
-            {!status?.available && (
+            {!onServer && !status?.available && (
               <div style={{
                 fontSize: 12, color: 'var(--cth-ink-700)', lineHeight: 1.6,
                 background: 'var(--cth-cream-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)', padding: 10
@@ -154,8 +292,9 @@ export function MemoryPanel() {
               </div>
             )}
 
-            {/* Model: a benefit-framed choice, not a codename dump. */}
-            {status?.available && (
+            {/* Model: a benefit-framed choice, not a codename dump. Local only —
+                a server owns its own embeddings. */}
+            {!onServer && status?.available && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
                 <span style={{ fontSize: 11, color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-display)', textTransform: 'uppercase', letterSpacing: 0.5 }}>
                   Search language

--- a/src/renderer/src/components/mcpToggleLogic.ts
+++ b/src/renderer/src/components/mcpToggleLogic.ts
@@ -1,0 +1,32 @@
+import type { HarnessConfig } from '@/store/config';
+import { MCP_CATALOG } from '@shared/mcpCatalog';
+
+export function resolveEnabledFor(
+  mcpDefaults: HarnessConfig['mcpDefaults'],
+  id: string,
+  catalog = MCP_CATALOG
+): boolean {
+  return mcpDefaults?.[id]?.enabled ?? catalog.find((e) => e.id === id)?.defaultEnabled ?? false;
+}
+
+interface ApplyToggleDeps {
+  updateConfig: (patch: Partial<HarnessConfig>) => Promise<unknown>;
+  getConfig: () => Promise<{ mcpDefaults?: Record<string, { enabled: boolean }> }>;
+}
+
+/**
+ * Persist the toggle, then RE-READ what actually landed and return that.
+ *
+ * The returned config is the value the component renders, so a stale prop does
+ * not survive a save or a settings-panel remount.
+ */
+export async function applyToggle(
+  id: string,
+  next: boolean,
+  currentDefaults: HarnessConfig['mcpDefaults'],
+  deps: ApplyToggleDeps
+): Promise<Record<string, { enabled: boolean }>> {
+  await deps.updateConfig({ mcpDefaults: { ...(currentDefaults ?? {}), [id]: { enabled: next } } });
+  const fresh = await deps.getConfig();
+  return fresh.mcpDefaults ?? {};
+}

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -586,6 +586,30 @@ function leaseWebglRenderer(entry: TerminalEntry): void {
   }
 }
 
+/** Find the live WebGL2 context an addon renderer is drawing into, so teardown
+ *  can explicitly release it. @xterm/addon-webgl's dispose() tears down its
+ *  renderer and removes its canvases but never calls loseContext(), so the
+ *  underlying context lingers past the addon that owned it (xterm/xterm.js#6068).
+ *  On a floor where agents are switched repeatedly, each switch disposes one
+ *  renderer and leases another, so these orphan contexts pile up until Chromium
+ *  hits its live-context cap (~16) and evicts an older one — often the office
+ *  floor's own context — blacking out a terminal or the scene. Losing the context
+ *  ourselves frees it immediately instead of waiting on GC.
+ *
+ *  Scoped to THIS terminal's element and matched by an active webgl2 context, so
+ *  it can never touch another terminal's or the scene's context. Returns null when
+ *  no live webgl2 canvas is present (the DOM renderer is in use, or it is gone). */
+function webglContextOf(term: Terminal): WebGL2RenderingContext | null {
+  const el = term.element;
+  if (!el) return null;
+  for (const canvas of Array.from(el.querySelectorAll('canvas'))) {
+    let gl: WebGL2RenderingContext | null = null;
+    try { gl = canvas.getContext('webgl2'); } catch { gl = null; }
+    if (gl && !gl.isContextLost()) return gl;
+  }
+  return null;
+}
+
 /** Release the WebGL lease so an off-screen terminal isn't holding a GPU context
  *  that an on-screen one needs. xterm falls back to the DOM renderer, which is
  *  fine for a terminal nobody is looking at; the next attach takes a fresh
@@ -594,7 +618,11 @@ function releaseWebglRenderer(entry: TerminalEntry): void {
   const webgl = entry.webgl;
   if (!webgl) return;
   entry.webgl = undefined;
+  // Capture the context BEFORE dispose (dispose may detach the canvas), then
+  // release it explicitly — dispose() alone leaks it (see webglContextOf).
+  const gl = webglContextOf(entry.term);
   try { webgl.dispose(); } catch { /* noop */ }
+  try { gl?.getExtension('WEBGL_lose_context')?.loseContext(); } catch { /* noop */ }
   // The DOM renderer that takes over inherits xterm's cached cell metrics, which
   // may be stale by the time this terminal is shown again.
   entry.needsRendererRepaint = true;
@@ -739,7 +767,11 @@ export function disposeTerminal(ptyId: string): void {
   const entry = pool.get(ptyId);
   if (!entry) return;
   entry.unsub.forEach((u) => { try { u(); } catch { /* noop */ } });
+  // Release the GPU context the webgl addon leaves behind; dispose() alone leaks
+  // it (see webglContextOf). Captured before dispose in case it detaches the canvas.
+  const gl = webglContextOf(entry.term);
   try { entry.webgl?.dispose(); } catch { /* noop */ }
+  try { gl?.getExtension('WEBGL_lose_context')?.loseContext(); } catch { /* noop */ }
   try { entry.term.dispose(); } catch { /* noop */ }
   entry.host.remove();
   pool.delete(ptyId);

--- a/src/renderer/src/markdown/mdLinks.ts
+++ b/src/renderer/src/markdown/mdLinks.ts
@@ -13,7 +13,7 @@ import { isImagePath } from '@shared/imageTypes';
  *  Note that `..` can only ever pop segments that this function itself pushed —
  *  once `parts` is empty a `..` is dropped — so the result is always a path
  *  UNDER the workspace root, never a sibling of it. That is a convenience, not
- *  the security boundary: the real containment check is `safeJoin` in the main
+ *  the security boundary: the real containment check is `safeResolve` in the main
  *  process, which every read goes through. */
 export function resolveRel(baseRel: string | undefined, href: string): string {
   const baseDir = (baseRel ?? '').split('/').slice(0, -1);

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -77,6 +77,9 @@ export interface HarnessConfig {
   mcpDefaults?: { [id: string]: { enabled: boolean } };
   semanticMemory: boolean;
   embeddingModel: 'minilm' | 'embeddinggemma';
+  memoryBackend?: 'mempalace' | 'hindsight';
+  hindsightUrl?: string;
+  hindsightBank?: string;
   missions?: ScheduledMission[];
   opsStandupSeeded?: boolean;
   heartbeatSeeded?: boolean;

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -187,7 +187,11 @@ export const CODEX_MODELS: ModelOption[] = [
   { id: undefined, label: 'CLI default' },
   { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
   { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
-  { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' }
+  { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+  { id: 'gpt-5.5', label: 'GPT-5.5' },
+  { id: 'gpt-5.4', label: 'GPT-5.4' },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+  { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' }
 ];
 
 /** Models offered when an agent runs on the Antigravity CLI (`agy`). agy's

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -12,6 +12,8 @@ import type {
   OrgTriggerConfig,
   WebhookTrigger
 } from '@shared/triggers';
+import { isNewer } from '@shared/updateState';
+import modelCatalog from '@shared/modelCatalog.json';
 
 export {
   AGENT_PROVIDER_PRESETS,
@@ -160,178 +162,118 @@ export interface ModelOption {
   label: string;
 }
 
-/** The models offered in the "add agent" picker and the per-agent selector.
- *  `[1m]` selects the 1M-token context window variant. */
-// Deliberately has NO "pass no --model flag" entry. Every option here names a
-// real model, because the whole reason to open this picker is to know which
-// model an agent is on — and a no-flag option resolves to whatever Claude Code
-// happens to choose, which the UI cannot show and the user cannot predict. The
-// harness default is marked ` · default` instead, and it names a real model.
-export const AGENT_MODELS: ModelOption[] = [
-  { id: 'claude-fable-5', label: 'Fable 5' },
-  { id: 'claude-opus-5', label: 'Opus 5 · 1M' },
-  { id: 'claude-opus-4-8', label: 'Opus 4.8' },
-  { id: 'claude-opus-4-8[1m]', label: 'Opus 4.8 · 1M' },
-  { id: 'claude-sonnet-5', label: 'Sonnet 5' },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { id: ASSISTANT_MODEL, label: 'Sonnet 4.6 · 1M' },
-  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' }
-];
+/** One row of the model catalog. `minAppVersion` / `maxAppVersion` are INCLUSIVE
+ *  app-version bounds: the model is offered while the running build sits inside
+ *  them, and null (or an absent key) means unbounded in that direction. That is
+ *  what lets a release introduce or retire a model without a code change. */
+interface CatalogModel {
+  /** absent = use the CLI default (no --model flag) */
+  id?: string;
+  label: string;
+  minAppVersion?: string | null;
+  maxAppVersion?: string | null;
+}
 
-/** Current OpenAI models offered by Codex for coding agents. The command field
- *  stays editable and `codex --model <id>` is the source of truth. */
-export const CODEX_MODELS: ModelOption[] = [
-  // No `--model` flag at all — whatever the CLI itself defaults to. NOT the
-  // harness's `config.defaultModel`; the pickers mark that one separately, and
-  // labelling both "default" is what made the two impossible to tell apart.
-  { id: undefined, label: 'CLI default' },
-  { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
-  { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
-  { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' }
-];
+interface ModelCatalog {
+  version: number;
+  providers: Record<string, CatalogModel[]>;
+}
 
-/** Models offered when an agent runs on the Antigravity CLI (`agy`). agy's
- *  `--model` takes the DISPLAY-NAME LABEL exactly as `agy models` prints it
- *  (verified: agy logs `Propagating selected model override … label="…"`), not a
- *  slug — so these ids ARE the labels (spaces/parens included; buildSpawnCommand
- *  quotes them and the command tokenizer keeps them whole). The command field
- *  stays editable; `agy models` is the source of truth for the live list. */
-export const ANTIGRAVITY_MODELS: ModelOption[] = [
-  // No `--model` flag at all — whatever the CLI itself defaults to. NOT the
-  // harness's `config.defaultModel`; the pickers mark that one separately, and
-  // labelling both "default" is what made the two impossible to tell apart.
-  { id: undefined, label: 'CLI default' },
-  { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro · High' },
-  { id: 'Gemini 3.1 Pro (Low)', label: 'Gemini 3.1 Pro · Low' },
-  { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash · High' },
-  { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash · Med' },
-  { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash · Low' },
-  { id: 'Claude Sonnet 4.6 (Thinking)', label: 'Claude Sonnet 4.6' },
-  { id: 'Claude Opus 4.6 (Thinking)', label: 'Claude Opus 4.6' },
-  { id: 'GPT-OSS 120B (Medium)', label: 'GPT-OSS 120B' }
-];
+/** The model presets every provider picker offers.
+ *
+ *  These were a dozen hardcoded `ModelOption[]` arrays in this file, so shipping
+ *  a model — one string — meant editing, type-checking and rebuilding renderer
+ *  source. They now live in src/shared/modelCatalog.json, imported at BUILD time
+ *  (no fs, no network, offline-safe) and filtered per running version, so adding
+ *  a model is a one-line JSON edit and a model can name the releases it belongs
+ *  to instead of appearing in builds whose CLI never shipped it.
+ *
+ *  What the arrays used to say — kept, because it explains why the entries look
+ *  the way they do:
+ *
+ *  - claude: `[1m]` selects the 1M-token context-window variant. The list
+ *    deliberately has NO "pass no --model flag" entry: every option names a real
+ *    model, because the whole reason to open this picker is to know which model
+ *    an agent is on, and a no-flag option resolves to whatever Claude Code
+ *    happens to choose — which the UI cannot show and the user cannot predict.
+ *    The harness default is marked ` · default` instead, and it names a real model.
+ *  - The leading `CLI default` entry several providers carry means no `--model`
+ *    flag at all — whatever the CLI itself defaults to. That is NOT the harness's
+ *    `config.defaultModel`; the pickers mark that one separately, and labelling
+ *    both "default" is what made the two impossible to tell apart.
+ *  - codex: current OpenAI models offered by Codex. The command field stays
+ *    editable and `codex --model <id>` is the source of truth.
+ *  - antigravity: agy's `--model` takes the DISPLAY-NAME LABEL exactly as
+ *    `agy models` prints it (verified: agy logs `Propagating selected model
+ *    override … label="…"`), not a slug — so these ids ARE labels, spaces and
+ *    parens included; buildSpawnCommand quotes them and the command tokenizer
+ *    keeps them whole. `agy models` is the source of truth for the live list.
+ *  - gemini: stable aliases accepted by the official Google Gemini CLI. They
+ *    follow the CLI instead of pinning preview model ids that drift.
+ *  - qwen: qwen-code (`qwen`), the proxy-bridge CLI driving an OpenAI-compatible
+ *    endpoint. Starting suggestions only. // TODO-verify the live list.
+ *  - opencode: `--model` takes a `provider/model` slug; curated BYOK suggestions
+ *    (`opencode models` / models.dev is the source of truth). `CLI default` is the
+ *    PRESELECTED entry, because a BYOK slug the user holds no key for fails
+ *    silently — see the recommendedOrchestratorModel note in agentProvider.ts.
+ *    // TODO-verify exact live slugs (they drift).
+ *  - crush: `--model` takes a `provider/model-id` slug; free-text editable (Crush
+ *    accepts arbitrary slugs). The local pick is an OpenAI-wire slug so traffic
+ *    routes through the proxy (the harness overrides the `openai` provider's
+ *    base_url → loopback → your configured Crush base-URL); an `ollama/*` slug
+ *    would bypass the proxy. // TODO-verify exact live ids.
+ *  - pi: `--model` takes a `provider/model` slug (thinking via a `:high` suffix).
+ *    Curated BYOK suggestions; free-text editable. // TODO-verify exact live slugs.
+ *  - copilot: `--model` takes a plain model id ('auto' lets Copilot pick); curated
+ *    suggestions, editable command field. // TODO-verify exact live ids (the
+ *    /model picker is the source of truth; they drift).
+ *  - cursor: ids match `cursor-agent models` / `--model` (Cursor account catalog).
+ *    Luna is the cheap, high-context default for Michael; the rest are curated
+ *    quick-picks and the command field stays editable for any live slug.
+ *  - grok: the models reported by the installed Grok CLI (`grok models`).
+ *  - kimi: managed Kimi Code aliases accepted by `kimi --model <alias>`.
+ *  - custom: no presets at all; the command field is the whole interface.
+ */
+const CATALOG: ModelCatalog = modelCatalog;
 
-/** Stable model aliases accepted by the official Google Gemini CLI. The aliases
- *  intentionally follow the CLI instead of pinning preview model ids that drift. */
-export const GEMINI_MODELS: ModelOption[] = [
-  { id: undefined, label: 'CLI default' },
-  { id: 'auto', label: 'Auto' },
-  { id: 'pro', label: 'Pro' },
-  { id: 'flash', label: 'Flash' },
-  { id: 'flash-lite', label: 'Flash Lite' }
-];
+declare const __APP_VERSION__: string | undefined;
 
-/** Models offered when an agent runs on qwen-code (`qwen`), the proxy-bridge CLI
- *  driving an OpenAI-compatible endpoint. Starting suggestions only (editable
- *  command field). // TODO-verify the live list (`qwen` model ids). */
-export const QWEN_MODELS: ModelOption[] = [
-  { id: undefined, label: 'default' },
-  { id: 'qwen3-coder-plus', label: 'Qwen3 Coder Plus' },
-  { id: 'qwen3-coder', label: 'Qwen3 Coder' },
-  { id: 'qwen-max', label: 'Qwen Max' }
-];
+/** The version of the running build. electron-vite replaces `__APP_VERSION__`
+ *  with package.json's version at build time — the same value the update badge
+ *  shows — so the renderer knows it synchronously, with no round trip to main.
+ *  Outside a build (unit tests) the define is absent and there is no version to
+ *  compare against; see the fail-open note on `offeredAtVersion`. */
+export function runningAppVersion(): string {
+  return typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '';
+}
 
-/** Models offered when an agent runs on OpenCode (`opencode`). OpenCode's `--model`
- *  takes a `provider/model` slug; these are curated BYOK suggestions (the command
- *  field stays editable; `opencode models` / models.dev is the source of truth).
- *  // TODO-verify exact live slugs (humanQA — they drift). */
-export const OPENCODE_MODELS: ModelOption[] = [
-  // "CLI default", not "default" — the distinction ANTIGRAVITY_MODELS already
-  // draws: pass NO --model and run whatever OpenCode itself is configured and
-  // authenticated for. That is not the harness's own default model, and calling
-  // both "default" is what made the two impossible to tell apart. This is now the
-  // PRESELECTED entry for OpenCode, because a BYOK slug the user holds no key for
-  // fails silently — see the recommendedOrchestratorModel note in agentProvider.ts.
-  { id: undefined, label: 'CLI default' },
-  { id: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (Anthropic)' },
-  { id: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5 (Anthropic)' },
-  { id: 'openai/gpt-5', label: 'GPT-5 (OpenAI)' },
-  { id: 'openai/gpt-5-mini', label: 'GPT-5 mini (OpenAI)' },
-  { id: 'openrouter/anthropic/claude-sonnet-4.5', label: 'Claude Sonnet 4.5 (OpenRouter)' },
-  { id: 'google/gemini-2.5-pro', label: 'Gemini 2.5 Pro (Google)' },
-  { id: 'local/llama3', label: 'Local · OpenAI-compatible (set base-URL)' }
-];
+/** Whether a catalog entry belongs in a picker on this build. Both bounds are
+ *  inclusive of the release they name. Anything unparseable — an absent bound, a
+ *  malformed one, an unknown app version — is ignored rather than hiding the
+ *  model: a picker that silently loses every model is far worse than one that
+ *  offers a model this build's CLI cannot run (the command field is editable and
+ *  the CLI reports the bad slug). */
+function offeredAtVersion(model: CatalogModel, appVersion: string): boolean {
+  if (model.minAppVersion && isNewer(model.minAppVersion, appVersion)) return false;
+  if (model.maxAppVersion && isNewer(appVersion, model.maxAppVersion)) return false;
+  return true;
+}
 
-/** Models offered when an agent runs on Crush (`crush`). Crush's `--model` takes a
- *  `provider/model-id` slug; free-text editable (Crush accepts arbitrary slugs).
- *  // TODO-verify exact live ids (humanQA). */
-export const CRUSH_MODELS: ModelOption[] = [
-  { id: undefined, label: 'Crush default (config)' },
-  { id: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (Anthropic)' },
-  { id: 'anthropic/claude-opus-4-1', label: 'Claude Opus (Anthropic)' },
-  { id: 'openai/gpt-4o', label: 'GPT-4o (OpenAI)' },
-  { id: 'openai/o3', label: 'o3 (OpenAI)' },
-  { id: 'gemini/gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-  { id: 'openrouter/auto', label: 'OpenRouter (auto)' },
-  // OpenAI-wire local slug so traffic routes through the proxy (the harness overrides
-  // the `openai` provider's base_url → loopback → your configured Crush base-URL).
-  // An `ollama/*` slug would bypass the proxy (Dwight verify-crush NIT-2).
-  { id: 'openai/local', label: 'Local · OpenAI-compatible (set base-URL)' }
-];
-
-/** Models offered when an agent runs on Pi (`pi`). Pi's `--model` takes a
- *  `provider/model` slug (thinking via a `:high` suffix). Curated BYOK suggestions;
- *  free-text editable. // TODO-verify exact live slugs (humanQA). */
-export const PI_MODELS: ModelOption[] = [
-  { id: undefined, label: 'default' },
-  { id: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (Anthropic)' },
-  { id: 'anthropic/claude-opus-4-1', label: 'Claude Opus (Anthropic)' },
-  { id: 'openai/gpt-5', label: 'GPT-5 (OpenAI)' },
-  { id: 'google/gemini-2.5-pro', label: 'Gemini 2.5 Pro (Google)' },
-  { id: 'groq/llama-3.3-70b', label: 'Llama 3.3 70B (Groq)' },
-  { id: 'local/llama3', label: 'Local · OpenAI-compatible (set base-URL)' }
-];
-
-/** Models offered when an agent runs on GitHub Copilot (`copilot`). Copilot's
- *  `--model` takes a plain model id ('auto' lets Copilot pick); these are curated
- *  suggestions and the command field stays editable. // TODO-verify exact live ids
- *  (the /model picker is the source of truth; they drift). */
-export const COPILOT_MODELS: ModelOption[] = [
-  { id: undefined, label: 'default (Claude Sonnet 4.5)' },
-  { id: 'auto', label: 'Auto (Copilot picks)' },
-  { id: 'claude-sonnet-4.5', label: 'Claude Sonnet 4.5' },
-  { id: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
-  { id: 'gpt-5.4', label: 'GPT-5.4' },
-  { id: 'gpt-5', label: 'GPT-5' }
-];
-
-/** Models offered when an agent runs on Cursor Agent CLI (`cursor-agent`). Ids match
- *  `cursor-agent models` / `--model` (Cursor account catalog). Luna is the cheap,
- *  high-context default for Michael; other entries are curated quick-picks —
- *  the command field stays editable for any live slug. */
-export const CURSOR_MODELS: ModelOption[] = [
-  { id: undefined, label: 'CLI default (auto)' },
-  { id: 'auto', label: 'Auto' },
-  { id: 'gpt-5.6-luna-high', label: 'GPT-5.6 Luna 1M High (cheap)' },
-  { id: 'gpt-5.6-sol-medium', label: 'GPT-5.6 Sol 1M' },
-  { id: 'gpt-5.6-sol-high', label: 'GPT-5.6 Sol 1M High' },
-  { id: 'composer-2.5', label: 'Composer 2.5' },
-  { id: 'composer-2.5-fast', label: 'Composer 2.5 Fast' },
-  { id: 'gpt-5.2', label: 'GPT-5.2' },
-  { id: 'claude-opus-4-8-high', label: 'Opus 4.8 1M' },
-  { id: 'claude-sonnet-5-thinking-high', label: 'Sonnet 5 1M Thinking' }
-];
-
-/** Models reported by the installed Grok CLI (`grok models`). */
-export const GROK_MODELS: ModelOption[] = [
-  // No `--model` flag at all — whatever the CLI itself defaults to. NOT the
-  // harness's `config.defaultModel`; the pickers mark that one separately, and
-  // labelling both "default" is what made the two impossible to tell apart.
-  { id: undefined, label: 'CLI default' },
-  { id: 'grok-4.6', label: 'Grok 4.6' },
-  { id: 'grok-4.5', label: 'Grok 4.5' }
-];
-
-/** Managed Kimi Code aliases accepted by `kimi --model <alias>`. */
-export const KIMI_MODELS: ModelOption[] = [
-  // No `--model` flag at all — whatever the CLI itself defaults to. NOT the
-  // harness's `config.defaultModel`; the pickers mark that one separately, and
-  // labelling both "default" is what made the two impossible to tell apart.
-  { id: undefined, label: 'CLI default' },
-  { id: 'kimi-code/k3', label: 'Kimi K3' },
-  { id: 'kimi-code/kimi-for-coding', label: 'Kimi K2.7 Code' },
-  { id: 'kimi-code/kimi-for-coding-highspeed', label: 'Kimi K2.7 · HighSpeed' }
-];
+/** The model preset list for a provider's picker, as of a given app version.
+ *  `providers` is injectable so the version filter can be exercised against
+ *  bounded entries — the shipped catalog is deliberately all-unbounded. */
+export function modelsForProviderAtVersion(
+  provider: AgentProvider,
+  appVersion: string,
+  providers: Record<string, CatalogModel[]> = CATALOG.providers
+): ModelOption[] {
+  // An unknown provider falls back to the Claude list, as the hardcoded dispatch
+  // did. 'custom' is a real key holding an empty list, not a missing one.
+  const entries = providers[provider] ?? providers.claude ?? [];
+  return entries
+    .filter((model) => offeredAtVersion(model, appVersion))
+    .map((model) => (model.id === undefined ? { label: model.label } : { id: model.id, label: model.label }));
+}
 
 // tokenizeCommand moved to src/shared/commandLine.ts so main's spawn-request
 // path splits command lines with the SAME rules as the renderer's spawn flows
@@ -339,22 +281,13 @@ export const KIMI_MODELS: ModelOption[] = [
 // importers keep their path.
 export { tokenizeCommand } from '@shared/commandLine';
 
-/** The model preset list for a given provider's picker. */
+/** The model preset list for a given provider's picker, on this build. */
 export function modelsForProvider(provider: AgentProvider): ModelOption[] {
-  if (provider === 'codex') return CODEX_MODELS;
-  if (provider === 'grok') return GROK_MODELS;
-  if (provider === 'kimi') return KIMI_MODELS;
-  if (provider === 'gemini') return GEMINI_MODELS;
-  if (provider === 'antigravity') return ANTIGRAVITY_MODELS;
-  if (provider === 'qwen') return QWEN_MODELS;
-  if (provider === 'opencode') return OPENCODE_MODELS;
-  if (provider === 'crush') return CRUSH_MODELS;
-  if (provider === 'pi') return PI_MODELS;
-  if (provider === 'copilot') return COPILOT_MODELS;
-  if (provider === 'cursor') return CURSOR_MODELS;
-  if (provider === 'custom') return [];
-  return AGENT_MODELS;
+  return modelsForProviderAtVersion(provider, runningAppVersion());
 }
+
+/** The Claude presets, for the surfaces that only ever offer Claude models. */
+export const AGENT_MODELS: ModelOption[] = modelsForProvider('claude');
 
 /** Providers shown in the Command Center's cross-provider model picker.
  *  God must remain on a provider with a working inbox drain; otherwise switching

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -226,9 +226,10 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     canReceiveInbox: true,
     initialPromptFlag: undefined,
     positionalInitialPrompt: true,
-    // Codex's long-context coding model for the orchestrator role. // TODO-verify
-    // the exact codex CLI model id (couldn't install the codex CLI to confirm).
-    recommendedOrchestratorModel: 'gpt-5-codex',
+    // `model/list` verified under ChatGPT login on 2026-08-25 reports this as
+    // Codex's default. Keep this in lockstep with CODEX_MODELS in
+    // renderer/src/store/config.ts.
+    recommendedOrchestratorModel: 'gpt-5.6-sol',
     // Codex resumes via a SUBCOMMAND, not a flag: `codex resume [OPTIONS]
     // [SESSION_ID]`. A `--resume <id>` flag does not exist, which is why restarts
     // used to silently start a brand-new session instead of continuing.

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -382,8 +382,8 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     // Sonnet 4.5 — the picker said one model, the agent ran another, and nothing
     // flagged the divergence. Undefined means buildSpawnCommand emits no
     // `--model` at all, so OpenCode uses the model the user actually configured;
-    // every BYOK slug in OPENCODE_MODELS stays one click away for whoever has
-    // the key.
+    // every BYOK slug in the OpenCode model catalog stays one click away for
+    // whoever has the key.
     recommendedOrchestratorModel: undefined,
     // Capturing the TUI session id for resume is unverified; spawn fresh on respawn
     // (protocol re-injected as the initial prompt), matching codex.

--- a/src/shared/codexTrust.ts
+++ b/src/shared/codexTrust.ts
@@ -1,0 +1,42 @@
+/** Codex gates every working directory behind an interactive "do you trust this
+ *  directory?" prompt, and the answer is persisted per config home as a
+ *  `[projects."<dir>"]` table with `trust_level = "trusted"`. An agent that gets
+ *  its own isolated CODEX_HOME therefore starts with a virgin config and hits
+ *  that prompt on its first turn — with nobody at the keyboard it simply stalls.
+ *
+ *  Pre-seeding the same table is the only way out: no flag or environment
+ *  variable skips the prompt (notably NOT
+ *  `--dangerously-bypass-approvals-and-sandbox`, which governs command approval,
+ *  not directory trust), and a `-c projects…` override is not persisted so it
+ *  does not count as an answer either. */
+
+/** Render a string as a TOML basic string, quotes included.
+ *
+ *  A directory name may legally contain a quote or a backslash on POSIX, and
+ *  interpolating one straight into `[projects."…"]` produces a config file Codex
+ *  cannot parse — which is worse than the prompt it was meant to remove. */
+export function tomlBasicString(value: string): string {
+  let out = '"';
+  for (const ch of value) {
+    const code = ch.codePointAt(0) as number;
+    if (ch === '"') out += '\\"';
+    else if (ch === '\\') out += '\\\\';
+    else if (ch === '\b') out += '\\b';
+    else if (ch === '\t') out += '\\t';
+    else if (ch === '\n') out += '\\n';
+    else if (ch === '\f') out += '\\f';
+    else if (ch === '\r') out += '\\r';
+    else if (code < 0x20 || code === 0x7f) out += `\\u${code.toString(16).padStart(4, '0')}`;
+    else out += ch;
+  }
+  return `${out}"`;
+}
+
+/** The config.toml fragment that marks `dir` as already trusted.
+ *
+ *  `dir` must be canonical (realpath-resolved): Codex resolves the directory
+ *  before looking it up, so an entry keyed by an unresolved spelling — `/tmp/x`
+ *  where the kernel says `/private/tmp/x` — never matches and the prompt returns. */
+export function codexTrustEntry(dir: string): string {
+  return `\n[projects.${tomlBasicString(dir)}]\ntrust_level = "trusted"\n`;
+}

--- a/src/shared/modelCatalog.json
+++ b/src/shared/modelCatalog.json
@@ -1,0 +1,106 @@
+{
+  "version": 1,
+  "providers": {
+    "claude": [
+      { "id": "claude-fable-5", "label": "Fable 5", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-opus-5", "label": "Opus 5 · 1M", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-opus-4-8", "label": "Opus 4.8", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-opus-4-8[1m]", "label": "Opus 4.8 · 1M", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-sonnet-5", "label": "Sonnet 5", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-sonnet-4-6", "label": "Sonnet 4.6", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-sonnet-4-6[1m]", "label": "Sonnet 4.6 · 1M", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "codex": [
+      { "label": "CLI default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.6-sol", "label": "GPT-5.6 Sol", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.6-terra", "label": "GPT-5.6 Terra", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.6-luna", "label": "GPT-5.6 Luna", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "grok": [
+      { "label": "CLI default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "grok-4.6", "label": "Grok 4.6", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "grok-4.5", "label": "Grok 4.5", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "kimi": [
+      { "label": "CLI default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "kimi-code/k3", "label": "Kimi K3", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "kimi-code/kimi-for-coding", "label": "Kimi K2.7 Code", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "kimi-code/kimi-for-coding-highspeed", "label": "Kimi K2.7 · HighSpeed", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "gemini": [
+      { "label": "CLI default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "auto", "label": "Auto", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "pro", "label": "Pro", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "flash", "label": "Flash", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "flash-lite", "label": "Flash Lite", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "antigravity": [
+      { "label": "CLI default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "Gemini 3.1 Pro (High)", "label": "Gemini 3.1 Pro · High", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "Gemini 3.1 Pro (Low)", "label": "Gemini 3.1 Pro · Low", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "Gemini 3.5 Flash (High)", "label": "Gemini 3.5 Flash · High", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "Gemini 3.5 Flash (Medium)", "label": "Gemini 3.5 Flash · Med", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "Gemini 3.5 Flash (Low)", "label": "Gemini 3.5 Flash · Low", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "Claude Sonnet 4.6 (Thinking)", "label": "Claude Sonnet 4.6", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "Claude Opus 4.6 (Thinking)", "label": "Claude Opus 4.6", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "GPT-OSS 120B (Medium)", "label": "GPT-OSS 120B", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "qwen": [
+      { "label": "default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "qwen3-coder-plus", "label": "Qwen3 Coder Plus", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "qwen3-coder", "label": "Qwen3 Coder", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "qwen-max", "label": "Qwen Max", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "opencode": [
+      { "label": "CLI default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "anthropic/claude-sonnet-4-5", "label": "Claude Sonnet 4.5 (Anthropic)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "anthropic/claude-haiku-4-5", "label": "Claude Haiku 4.5 (Anthropic)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openai/gpt-5", "label": "GPT-5 (OpenAI)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openai/gpt-5-mini", "label": "GPT-5 mini (OpenAI)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openrouter/anthropic/claude-sonnet-4.5", "label": "Claude Sonnet 4.5 (OpenRouter)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "google/gemini-2.5-pro", "label": "Gemini 2.5 Pro (Google)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "local/llama3", "label": "Local · OpenAI-compatible (set base-URL)", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "crush": [
+      { "label": "Crush default (config)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "anthropic/claude-sonnet-4-5", "label": "Claude Sonnet 4.5 (Anthropic)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "anthropic/claude-opus-4-1", "label": "Claude Opus (Anthropic)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openai/gpt-4o", "label": "GPT-4o (OpenAI)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openai/o3", "label": "o3 (OpenAI)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gemini/gemini-2.5-pro", "label": "Gemini 2.5 Pro", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openrouter/auto", "label": "OpenRouter (auto)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openai/local", "label": "Local · OpenAI-compatible (set base-URL)", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "pi": [
+      { "label": "default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "anthropic/claude-sonnet-4-5", "label": "Claude Sonnet 4.5 (Anthropic)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "anthropic/claude-opus-4-1", "label": "Claude Opus (Anthropic)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "openai/gpt-5", "label": "GPT-5 (OpenAI)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "google/gemini-2.5-pro", "label": "Gemini 2.5 Pro (Google)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "groq/llama-3.3-70b", "label": "Llama 3.3 70B (Groq)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "local/llama3", "label": "Local · OpenAI-compatible (set base-URL)", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "copilot": [
+      { "label": "default (Claude Sonnet 4.5)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "auto", "label": "Auto (Copilot picks)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-sonnet-4.5", "label": "Claude Sonnet 4.5", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-sonnet-4", "label": "Claude Sonnet 4", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.4", "label": "GPT-5.4", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5", "label": "GPT-5", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "cursor": [
+      { "label": "CLI default (auto)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "auto", "label": "Auto", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.6-luna-high", "label": "GPT-5.6 Luna 1M High (cheap)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.6-sol-medium", "label": "GPT-5.6 Sol 1M", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.6-sol-high", "label": "GPT-5.6 Sol 1M High", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "composer-2.5", "label": "Composer 2.5", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "composer-2.5-fast", "label": "Composer 2.5 Fast", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "gpt-5.2", "label": "GPT-5.2", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-opus-4-8-high", "label": "Opus 4.8 1M", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "claude-sonnet-5-thinking-high", "label": "Sonnet 5 1M Thinking", "minAppVersion": null, "maxAppVersion": null }
+    ],
+    "custom": []
+  }
+}

--- a/test/codex-directory-trust.test.cjs
+++ b/test/codex-directory-trust.test.cjs
@@ -1,0 +1,97 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager } = loadTs('src/main/hive.ts');
+const { codexRemoteAliasPath } = loadTs('src/shared/codexRemote.ts');
+
+/** A per-agent CODEX_HOME starts life as a virgin config dir, so Codex asks
+ *  "do you trust this directory?" on the first turn and a headless agent sits
+ *  on the prompt forever. Pressing Yes persists exactly this table, and
+ *  pre-seeding it suppresses the prompt (verified on Codex 0.149.1 — no flag or
+ *  env does; `--dangerously-bypass-approvals-and-sandbox` does not). */
+function trustTable(cwd) {
+  return `[projects."${cwd}"]\ntrust_level = "trusted"`;
+}
+
+/** A hive home plus a `$HOME` whose `~/.codex/config.toml` is under our control:
+ *  installCodexHooks seeds the generated config from the user's, so the test has
+ *  to own that file to say anything about what survives. */
+function sandbox(t, userConfig) {
+  const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'md-codex-trust-')));
+  const fakeHome = path.join(home, 'user-home');
+  fs.mkdirSync(path.join(fakeHome, '.codex'), { recursive: true });
+  if (userConfig !== undefined) {
+    fs.writeFileSync(path.join(fakeHome, '.codex', 'config.toml'), userConfig, 'utf8');
+  }
+  const realHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+  t.after(() => {
+    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+  return home;
+}
+
+async function prepCodexAgent(home, id, cwd) {
+  const hive = new HiveManager(() => home);
+  const injection = await hive.ensureAgent({ id, name: id, provider: 'codex', cwd });
+  const codexHome = injection.env.CODEX_HOME;
+  assert.ok(codexHome, 'a codex spawn must get an isolated CODEX_HOME');
+  return { codexHome, config: fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8') };
+}
+
+test('codex spawn prep trusts the agent\'s final working directory', async (t) => {
+  const home = sandbox(t);
+  // Codex canonicalizes the directory it prompts about, so the entry has to be
+  // stored realpath-resolved or it simply does not match and the prompt returns.
+  const repo = path.join(home, 'repo');
+  const via = path.join(home, 'symlinked-repo');
+  fs.mkdirSync(repo, { recursive: true });
+  fs.symlinkSync(repo, via, 'dir');
+
+  const { config } = await prepCodexAgent(home, 'codex-trust-1', via);
+  assert.ok(config.includes(trustTable(repo)), `no trust entry for ${repo} in:\n${config}`);
+});
+
+test('a working directory needing TOML escaping is escaped, not interpolated', async (t) => {
+  const home = sandbox(t);
+  const repo = path.join(home, 'we"ird\\repo');
+  fs.mkdirSync(repo, { recursive: true });
+
+  const { config } = await prepCodexAgent(home, 'codex-trust-2', repo);
+  const escaped = `${home}/we\\"ird\\\\repo`;
+  assert.ok(config.includes(trustTable(escaped)), `path was not TOML-escaped in:\n${config}`);
+});
+
+test('the user\'s own codex settings survive the trust entry', async (t) => {
+  const home = sandbox(t, 'model = "gpt-5-codex"\n');
+  const repo = path.join(home, 'repo');
+  fs.mkdirSync(repo, { recursive: true });
+
+  const { config } = await prepCodexAgent(home, 'codex-trust-3', repo);
+  assert.ok(config.includes('model = "gpt-5-codex"'), `user setting was lost:\n${config}`);
+  assert.ok(config.includes(trustTable(repo)), `no trust entry for ${repo} in:\n${config}`);
+});
+
+test('the short home alias used for remote control sees the trust entry', async (t) => {
+  const home = sandbox(t);
+  const repo = path.join(home, 'repo');
+  fs.mkdirSync(repo, { recursive: true });
+
+  const { codexHome } = await prepCodexAgent(home, 'codex-trust-4', repo);
+  // Remote control runs the CLI against a short symlinked spelling of the same
+  // home (macOS caps a Unix socket path at 104 bytes). Built here under the test
+  // root rather than the production CODEX_REMOTE_ALIAS_ROOT so the test owns it.
+  const alias = codexRemoteAliasPath(codexHome, 'codex-trust-4', path.join(home, 'alias'));
+  fs.mkdirSync(path.dirname(alias), { recursive: true });
+  fs.symlinkSync(codexHome, alias, 'dir');
+
+  const config = fs.readFileSync(path.join(alias, 'config.toml'), 'utf8');
+  assert.ok(config.includes(trustTable(repo)), `no trust entry for ${repo} in:\n${config}`);
+});

--- a/test/fs-path-containment.test.cjs
+++ b/test/fs-path-containment.test.cjs
@@ -1,0 +1,217 @@
+'use strict';
+
+/**
+ * The workspace root is the confinement boundary for the file IPC: the renderer
+ * may only reach files INSIDE the selected workspace.
+ *
+ * A purely lexical containment check cannot enforce that. `resolve`/`normalize`/
+ * `relative` are string math — they know nothing about symlinks — while the
+ * `readFile`/`writeFile`/`readdir` that runs afterwards is resolved by the
+ * kernel, which DOES follow them. So a symlink planted inside the workspace
+ * (agent-generated content and cloned repos both routinely contain them) reads
+ * as an in-root relative name to the guard and as an external file to the sink.
+ *
+ * These tests pin the boundary against that: every escape below must be refused
+ * by the shared guard, on every consumer of it, while ordinary in-workspace
+ * reads and writes keep working.
+ *
+ * The boundary is the workspace, not "no symlinks at all" — a link to a target
+ * that is itself inside the workspace is followed — so the legitimate case is
+ * pinned here too, in both directions.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { readFileText, readFileBinary, writeFileText, listDir } = loadTs('src/main/fs.ts');
+const { getDiff } = loadTs('src/main/git.ts');
+
+const SECRET = 'external-secret-contents\n';
+
+/**
+ * A throwaway workspace with an `outside` sibling standing in for the rest of
+ * the user's filesystem. Every symlink here points at that sibling — no test
+ * touches a real file outside its own temp dir.
+ */
+function makeWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'path-containment-'));
+  const root = path.join(dir, 'workspace');
+  const outside = path.join(dir, 'outside');
+  fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+  fs.mkdirSync(path.join(outside, 'dir'), { recursive: true });
+
+  fs.writeFileSync(path.join(outside, 'secret.txt'), SECRET);
+  fs.writeFileSync(path.join(outside, 'secret.bin'), Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]));
+  fs.writeFileSync(path.join(outside, 'dir', 'deep.txt'), SECRET);
+  fs.writeFileSync(path.join(outside, 'overwrite-me.txt'), 'original\n');
+
+  // Ordinary, legitimate workspace content.
+  fs.writeFileSync(path.join(root, 'real.txt'), 'in-workspace\n');
+  fs.writeFileSync(path.join(root, 'docs', 'shot.bin'), Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x02]));
+
+  // (a) final-component symlinks to external targets
+  fs.symlinkSync(path.join(outside, 'secret.txt'), path.join(root, 'innocent.txt'));
+  fs.symlinkSync(path.join(outside, 'secret.bin'), path.join(root, 'innocent.bin'));
+  fs.symlinkSync(path.join(outside, 'overwrite-me.txt'), path.join(root, 'notes.txt'));
+  // (b) an intermediate directory symlink — the escape is a path COMPONENT
+  fs.symlinkSync(path.join(outside, 'dir'), path.join(root, 'sub'));
+  // (c) a DANGLING final symlink: its target does not exist yet, so a write
+  //     through it CREATES the external file.
+  fs.symlinkSync(path.join(outside, 'newly-created.txt'), path.join(root, 'dangling.txt'));
+  // (d) links that stay INSIDE the workspace and point at something that exists.
+  //     These are the legitimate case — node_modules and monorepo checkouts are
+  //     full of them — and they must keep working.
+  fs.symlinkSync(path.join(root, 'real.txt'), path.join(root, 'alias.txt'));
+  fs.symlinkSync(path.join(root, 'docs'), path.join(root, 'docs-link'));
+
+  return { dir, root, outside };
+}
+
+function withWorkspace(fn) {
+  const ws = makeWorkspace();
+  return Promise.resolve(fn(ws)).finally(() => fs.rmSync(ws.dir, { recursive: true, force: true }));
+}
+
+// ─── reads ──────────────────────────────────────────────────────────────────
+
+test('a final-component symlink cannot be read as text', () => withWorkspace(async ({ root }) => {
+  const res = await readFileText(root, 'innocent.txt');
+  assert.equal(res.ok, false, 'a symlink out of the workspace must not be readable');
+  assert.equal(res.content, undefined);
+}));
+
+test('a final-component symlink cannot be read as bytes', () => withWorkspace(async ({ root }) => {
+  const res = await readFileBinary(root, 'innocent.bin');
+  assert.equal(res.ok, false, 'the binary reader shares the boundary and must refuse too');
+}));
+
+test('an intermediate directory symlink cannot be read through', () => withWorkspace(async ({ root }) => {
+  const res = await readFileText(root, 'sub/deep.txt');
+  assert.equal(res.ok, false, 'the escape can be any component, not just the last one');
+}));
+
+// ─── writes ─────────────────────────────────────────────────────────────────
+
+test('a final-component symlink cannot be written through', () => withWorkspace(async ({ root, outside }) => {
+  const target = path.join(outside, 'overwrite-me.txt');
+  const before = fs.readFileSync(target, 'utf8');
+  const res = await writeFileText(root, 'notes.txt', 'clobbered\n');
+  assert.equal(res.ok, false, 'writing through a symlink must be refused');
+  assert.equal(fs.readFileSync(target, 'utf8'), before, 'the external file must be untouched');
+}));
+
+test('a dangling symlink cannot be used to create a file outside the workspace', () =>
+  withWorkspace(async ({ root, outside }) => {
+    // The link target does not exist, so `realpath` cannot see where this leads —
+    // canonicalization alone would let the write through and CREATE the external
+    // file. Only an lstat walk (and an O_NOFOLLOW open) catches this one.
+    const res = await writeFileText(root, 'dangling.txt', 'created outside\n');
+    assert.equal(res.ok, false, 'a dangling symlink is still a symlink');
+    assert.equal(
+      fs.existsSync(path.join(outside, 'newly-created.txt')), false,
+      'no file may be created outside the workspace'
+    );
+  }));
+
+// ─── the other consumers of the same guard ──────────────────────────────────
+
+test('listDir cannot list a directory outside the workspace', () => withWorkspace(async ({ root }) => {
+  const res = await listDir(root, 'sub');
+  assert.equal(res.ok, false, 'the directory listing shares the boundary');
+}));
+
+test('the git diff path check refuses a symlink escape', () => withWorkspace(async ({ root }) => {
+  const res = await getDiff(root, 'innocent.txt');
+  assert.equal(res.ok, false, 'git path operations validate against the same boundary');
+  assert.equal(res.working, undefined, 'the external file contents must never be returned');
+}));
+
+// ─── and ordinary workspace use still works ─────────────────────────────────
+
+test('ordinary in-workspace reads and writes still succeed', () => withWorkspace(async ({ root }) => {
+  const text = await readFileText(root, 'real.txt');
+  assert.equal(text.ok, true, text.ok ? '' : text.error);
+  assert.equal(text.content, 'in-workspace\n');
+
+  const bin = await readFileBinary(root, 'docs/shot.bin');
+  assert.equal(bin.ok, true, bin.ok ? '' : bin.error);
+  assert.equal(bin.size, 6);
+
+  const created = await writeFileText(root, 'docs/new.txt', 'hello\n');
+  assert.equal(created.ok, true, created.ok ? '' : created.error);
+  assert.equal(fs.readFileSync(path.join(root, 'docs', 'new.txt'), 'utf8'), 'hello\n');
+
+  const overwritten = await writeFileText(root, 'real.txt', 'replaced\n');
+  assert.equal(overwritten.ok, true, overwritten.ok ? '' : overwritten.error);
+  assert.equal(fs.readFileSync(path.join(root, 'real.txt'), 'utf8'), 'replaced\n');
+
+  const listed = await listDir(root, 'docs');
+  assert.equal(listed.ok, true, listed.ok ? '' : listed.error);
+  assert.ok(listed.entries.some((e) => e.name === 'shot.bin'));
+}));
+
+test('an in-workspace symlink to an in-workspace target is followed, not refused', () =>
+  withWorkspace(async ({ root }) => {
+    // The boundary is the workspace, not "no symlinks at all": a link whose
+    // target is itself inside the workspace reaches nothing the caller could not
+    // already reach by its real name. Refusing it would make an ordinary
+    // node_modules or monorepo checkout unbrowsable for no security gain. This
+    // pins that so the policy cannot be flipped by accident.
+    const viaLink = await readFileText(root, 'alias.txt');
+    assert.equal(viaLink.ok, true, viaLink.ok ? '' : viaLink.error);
+    assert.equal(viaLink.content, 'in-workspace\n');
+    assert.equal(
+      viaLink.path, path.join(fs.realpathSync(root), 'real.txt'),
+      'the link resolves to the canonical path of its target, not to the link'
+    );
+
+    const listed = await listDir(root, 'docs-link');
+    assert.equal(listed.ok, true, listed.ok ? '' : listed.error);
+    assert.ok(listed.entries.some((e) => e.name === 'shot.bin'), 'a directory link lists its target');
+  }));
+
+test('the git diff read refuses a final component swapped for a symlink mid-call', {
+  skip: process.platform === 'win32' ? 'needs a POSIX shell shim and symlinks' : false
+}, () => withWorkspace(async ({ root, outside, dir }) => {
+  // Validating a path and then reading it are two separate resolutions, and the
+  // kernel redoes the lookup at open time. `getDiff` runs `git show HEAD:<path>`
+  // between the two, so shadowing `git` with a script that plants the symlink
+  // puts an attacker in exactly that window — deterministically, rather than
+  // hoping to win a race. The read must refuse what it is handed, not trust that
+  // the earlier check still holds.
+  const target = path.join(root, 'real.txt');
+  const binDir = path.join(dir, 'bin');
+  fs.mkdirSync(binDir);
+  const shim = path.join(binDir, 'git');
+  fs.writeFileSync(
+    shim,
+    `#!/bin/sh\nrm -f '${target}'\nln -s '${path.join(outside, 'secret.txt')}' '${target}'\nexit 1\n`
+  );
+  fs.chmodSync(shim, 0o755);
+
+  const savedPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+  let res;
+  try {
+    res = await getDiff(root, 'real.txt');
+  } finally {
+    process.env.PATH = savedPath;
+  }
+
+  assert.equal(fs.lstatSync(target).isSymbolicLink(), true, 'the shim must have run inside the window');
+  assert.equal(res.ok, true, res.ok ? '' : res.error);
+  assert.equal(res.workingExists, false, 'a symlink is not the regular file the guard cleared');
+  assert.equal(res.working, '', 'the external file contents must never reach the renderer');
+}));
+
+test('lexical traversal out of the root is still rejected', () => withWorkspace(async ({ root, dir }) => {
+  for (const rel of ['../outside/secret.txt', 'docs/../../outside/secret.txt', path.join(dir, 'outside', 'secret.txt')]) {
+    const res = await readFileText(root, rel);
+    assert.equal(res.ok, false, `${rel} must not be readable`);
+    assert.equal(res.error, 'path escapes root');
+  }
+}));

--- a/test/hindsight-adapter.test.cjs
+++ b/test/hindsight-adapter.test.cjs
@@ -1,0 +1,239 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { HindsightAdapter } = loadTs('src/main/hindsightAdapter.ts');
+
+/** A stub Hindsight server that records every request it is handed. */
+async function stub(t, routes = {}) {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => { raw += chunk; });
+    req.on('end', () => {
+      const entry = { method: req.method, url: req.url, body: raw ? JSON.parse(raw) : null };
+      seen.push(entry);
+      const key = `${req.method} ${req.url.split('?')[0]}`;
+      const route = routes[key];
+      if (!route) { res.statusCode = 404; res.end('{}'); return; }
+      const reply = typeof route === 'function' ? route(entry) : route;
+      res.statusCode = reply.status ?? 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(reply.json ?? {}));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const url = `http://127.0.0.1:${server.address().port}`;
+  return { url, seen, server, close: () => new Promise((resolve) => server.close(resolve)) };
+}
+
+function agentDirWith(body) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hindsight-adapter-'));
+  fs.writeFileSync(path.join(dir, 'memory.md'), body, 'utf8');
+  return dir;
+}
+
+const MEMORY_MD = '# Memory\n\n## The first thing\n\nBudgets are set quarterly.\n\n## The second thing\n\nSales sits on floor two.\n';
+
+const make = (url, bank = 'b1', home = '/tmp/home', now) =>
+  new HindsightAdapter(() => ({ url, bank }), () => home, now);
+
+test('mining posts each memory section to the bank', async (t) => {
+  const s = await stub(t, { 'POST /v1/default/banks/b1/memories': { json: { success: true, items_count: 2 } } });
+  const result = await make(s.url).mineAgent(agentDirWith(MEMORY_MD), 'pam');
+
+  assert.equal(result.ok, true);
+  assert.equal(s.seen.length, 1);
+  assert.equal(s.seen[0].url, '/v1/default/banks/b1/memories');
+  assert.equal(s.seen[0].body.async, false);
+  assert.equal(s.seen[0].body.items.length, 2);
+  assert.match(s.seen[0].body.items[0].content, /Budgets are set quarterly/);
+  assert.equal(s.seen[0].body.items[0].metadata.agent, 'pam');
+  assert.equal(s.seen[0].body.items[0].metadata.heading, 'The first thing');
+  assert.deepEqual(s.seen[0].body.items[0].tags, ['owner:pam']);
+});
+
+test('mining the same memory twice sends the same document ids', async (t) => {
+  const s = await stub(t, { 'POST /v1/default/banks/b1/memories': { json: { success: true } } });
+  const adapter = make(s.url);
+  await adapter.mineAgent(agentDirWith(MEMORY_MD), 'pam');
+  await adapter.mineAgent(agentDirWith(MEMORY_MD), 'pam');
+
+  assert.deepEqual(s.seen[0].body, s.seen[1].body);
+  const ids = s.seen[0].body.items.map((i) => i.document_id);
+  assert.equal(new Set(ids).size, 2, 'distinct sections need distinct ids');
+  for (const id of ids) assert.match(id, /^[0-9a-f]{32}$/);
+});
+
+test('mining a different agent id produces different document ids', async (t) => {
+  const s = await stub(t, { 'POST /v1/default/banks/b1/memories': { json: { success: true } } });
+  const adapter = make(s.url);
+  await adapter.mineAgent(agentDirWith(MEMORY_MD), 'pam');
+  await adapter.mineAgent(agentDirWith(MEMORY_MD), 'jim');
+
+  assert.notDeepEqual(
+    s.seen[0].body.items.map((i) => i.document_id),
+    s.seen[1].body.items.map((i) => i.document_id)
+  );
+});
+
+test('mining reports failure instead of throwing when the server is gone', async (t) => {
+  const s = await stub(t, {});
+  await s.close();
+  const result = await make(s.url).mineAgent(agentDirWith(MEMORY_MD), 'pam');
+  assert.deepEqual(result, { ok: false });
+});
+
+test('mining reports failure when the server rejects the write', async (t) => {
+  const s = await stub(t, { 'POST /v1/default/banks/b1/memories': { status: 500, json: { detail: 'nope' } } });
+  const result = await make(s.url).mineAgent(agentDirWith(MEMORY_MD), 'pam');
+  assert.equal(result.ok, false);
+});
+
+test('search recalls from the bank and renders text with its score', async (t) => {
+  const s = await stub(t, {
+    'POST /v1/default/banks/b1/memories/recall': {
+      json: { results: [{ text: 'Budgets are set quarterly.', scores: { final: 0.91 } }] }
+    }
+  });
+  const result = await make(s.url).search('budget', { agentId: 'pam', results: 3 });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.output, '— Budgets are set quarterly.  (score 0.91)');
+  assert.equal(s.seen[0].url, '/v1/default/banks/b1/memories/recall');
+  assert.equal(s.seen[0].body.query, 'budget');
+  assert.deepEqual(s.seen[0].body.tags, ['owner:pam']);
+  assert.equal(typeof s.seen[0].body.max_tokens, 'number');
+  assert.equal('top_k' in s.seen[0].body, false, 'recall has no top_k; the budget is max_tokens');
+});
+
+test('wake-up recalls recent context and reports failure when the server is down', async (t) => {
+  const s = await stub(t, {
+    'POST /v1/default/banks/b1/memories/recall': { json: { results: [{ text: 'Sales sits on floor two.', scores: { final: 0.5 } }] } }
+  });
+  const adapter = make(s.url);
+  const up = await adapter.wakeUp('pam');
+  assert.equal(up.ok, true);
+  assert.match(up.output, /Sales sits on floor two\./);
+  assert.equal(typeof s.seen[0].body.query, 'string');
+  assert.ok(s.seen[0].body.query.length > 0);
+
+  await s.close();
+  const down = await adapter.wakeUp('pam');
+  assert.equal(down.ok, false);
+  assert.equal(down.output, '');
+  assert.ok(down.error);
+});
+
+test('availability follows the health endpoint once the cache expires', async (t) => {
+  let clock = 1_000_000;
+  const s = await stub(t, { 'GET /health': { json: { status: 'ok' } } });
+  const adapter = make(s.url, 'b1', '/tmp/home', () => clock);
+
+  assert.equal(await adapter.probeHealth(), true);
+  assert.equal(adapter.available(), true);
+
+  await s.close();
+  assert.equal(adapter.available(), true, 'still cached');
+
+  clock += 31_000;
+  adapter.available();
+  assert.equal(await adapter.probeHealth(), false);
+  assert.equal(adapter.available(), false);
+});
+
+test('agent env names the backend and its endpoint', async (t) => {
+  const s = await stub(t, {});
+  assert.deepEqual(make(s.url, 'b1').agentEnv(), {
+    HIVE_MEMORY_BACKEND: 'hindsight',
+    HINDSIGHT_URL: s.url,
+    HINDSIGHT_BANK: 'b1'
+  });
+});
+
+test('status reports the backend and the bank it points at, even with no home', async (t) => {
+  const s = await stub(t, {});
+  const status = make(s.url, 'b1').status(true, null);
+  assert.equal(status.backend, 'hindsight');
+  assert.equal(status.enabled, true);
+  assert.equal(status.active, false, 'no home means not active');
+  assert.match(status.location, /b1/);
+  assert.equal(status.model, null);
+  assert.equal(status.bin, null);
+});
+
+test('init creates the bank when the server has never heard of it', async (t) => {
+  let created = false;
+  const s = await stub(t, {
+    'GET /health': { json: {} },
+    'GET /v1/default/banks/b1/stats': () => (created ? { json: { bank_id: 'b1', total_nodes: 1 } } : { status: 404, json: {} }),
+    'PUT /v1/default/banks/b1': () => { created = true; return { json: { bank_id: 'b1', name: 'b1' } }; }
+  });
+  const adapter = make(s.url, 'b1');
+  await adapter.ready();
+
+  assert.ok(s.seen.some((r) => r.method === 'PUT' && r.url === '/v1/default/banks/b1'));
+  assert.equal(adapter.status(true, '/tmp/home').initialized, true);
+});
+
+test('init does not recreate a bank that already exists', async (t) => {
+  const s = await stub(t, {
+    'GET /health': { json: {} },
+    'GET /v1/default/banks/b1/stats': { json: { bank_id: 'b1', total_nodes: 7 } }
+  });
+  const adapter = make(s.url, 'b1');
+  await adapter.ready();
+
+  assert.equal(s.seen.filter((r) => r.method === 'PUT').length, 0);
+  assert.equal(adapter.status(true, '/tmp/home').initialized, true);
+});
+
+test('the mempalace-only post-mine pass is absent', async (t) => {
+  const s = await stub(t, {});
+  assert.equal(make(s.url).postMinePass, undefined);
+});
+
+// ─── Test-connection probe (what the settings panel's button calls) ──────────
+
+const { testHindsightConnection } = loadTs('src/main/hindsightAdapter.ts');
+
+test('a reachable bank reports how much it is holding', async (t) => {
+  const s = await stub(t, {
+    'GET /health': { json: { status: 'ok' } },
+    'GET /v1/default/banks/b1/stats': { json: { bank_id: 'b1', total_nodes: 42 } }
+  });
+  const result = await testHindsightConnection(s.url, 'b1');
+  assert.equal(result.ok, true);
+  assert.match(result.detail, /42/);
+  assert.equal(result.url, s.url, 'the answer names the endpoint it actually reached');
+  assert.equal(result.bank, 'b1');
+});
+
+test('a server that is up but has no such bank is reported as not ready', async (t) => {
+  const s = await stub(t, { 'GET /health': { json: {} } });
+  const result = await testHindsightConnection(s.url, 'nope');
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /nope/);
+});
+
+test('an unreachable server is reported, not thrown', async (t) => {
+  const s = await stub(t, {});
+  await s.close();
+  const result = await testHindsightConnection(s.url, 'b1');
+  assert.equal(result.ok, false);
+  assert.ok(result.detail.length > 0);
+});
+
+test('an empty address is refused without a network call', async () => {
+  for (const [url, bank] of [['', 'b1'], ['http://x', ''], ['   ', '   ']]) {
+    const result = await testHindsightConnection(url, bank);
+    assert.equal(result.ok, false, `for ${JSON.stringify([url, bank])}`);
+    assert.match(result.detail, /address|bank/i);
+  }
+});

--- a/test/hive-memory-shim-env.test.cjs
+++ b/test/hive-memory-shim-env.test.cjs
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * The `hive-memory` shim is a standalone script: it learns which backend to
+ * talk to, and on whose behalf, entirely from its environment. If nothing sets
+ * those variables the shim takes its "no backend" path and every agent's
+ * `hive-memory search` prints the unavailable line, however healthy the backend
+ * actually is. These tests pin the two ends of that wire.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const loadTs = require('./load-ts.cjs');
+
+const { MemPalaceAdapter } = loadTs('src/main/memPalaceAdapter.ts');
+const { HindsightAdapter } = loadTs('src/main/hindsightAdapter.ts');
+const { HiveManager } = loadTs('src/main/hive.ts');
+const SHIM = require.resolve('../resources/hive-memory.cjs');
+
+test('every backend tells a spawned agent which one it is', () => {
+  const mempalace = new MemPalaceAdapter(() => '/tmp/palace', () => 'minilm');
+  mempalace.bin = () => '/fake/bin/mempalace'; // the real one probes this machine's PATH
+  assert.equal(mempalace.agentEnv().HIVE_MEMORY_BACKEND, 'mempalace');
+
+  const hindsight = new HindsightAdapter(() => ({ url: 'http://x', bank: 'b1' }), () => '/tmp/home');
+  assert.equal(hindsight.agentEnv().HIVE_MEMORY_BACKEND, 'hindsight');
+});
+
+test('the name each backend reports is one the shim actually recognises', () => {
+  // A backend id the shim does not know is indistinguishable from none at all.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shim-env-'));
+  const fake = path.join(dir, 'mempalace');
+  fs.writeFileSync(fake, '#!/bin/sh\necho REACHED "$@"\n');
+  fs.chmodSync(fake, 0o755);
+
+  const mempalace = new MemPalaceAdapter(() => '/tmp/palace', () => 'minilm');
+  mempalace.bin = () => fake;
+  const out = execFileSync(process.execPath, [SHIM, 'search', 'q'], {
+    env: { ...process.env, ...mempalace.agentEnv(), PATH: `${dir}:${process.env.PATH}` },
+    encoding: 'utf8'
+  });
+  assert.match(out, /REACHED search q/);
+  assert.doesNotMatch(out, /unavailable/);
+});
+
+test('a spawned agent is told which agent the shim is recalling for', async (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'shim-env-hive-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  const injected = await hive.ensureAgent({ id: 'pam', name: 'Pam', provider: 'claude', cwd: home }, {});
+
+  assert.equal(injected.env.HIVE_MEMORY_AGENT, 'pam');
+});

--- a/test/hive-memory-shim.test.cjs
+++ b/test/hive-memory-shim.test.cjs
@@ -1,0 +1,73 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFile, execFileSync } = require('node:child_process');
+const http = require('node:http');
+const net = require('node:net');
+const SHIM = require.resolve('../resources/hive-memory.cjs');
+
+const runShim = (env, args = ['search', 'anything']) => new Promise((resolve, reject) => {
+  execFile(process.execPath, [SHIM, ...args], { env: { ...process.env, ...env }, encoding: 'utf8' }, (error, stdout, stderr) => {
+    if (error) reject(Object.assign(error, { stdout, stderr }));
+    else resolve(stdout);
+  });
+});
+
+test('unknown memory backend degrades without failing the agent', () => {
+  const out = execFileSync(process.execPath, [SHIM, 'search', 'anything'], { env: { ...process.env, HIVE_MEMORY_BACKEND: 'missing' }, encoding: 'utf8' });
+  assert.match(out, /memory recall unavailable — continue without it/);
+});
+
+test('mempalace search passes its arguments through', () => {
+  const fs = require('node:fs'); const os = require('node:os'); const path = require('node:path');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hive-memory-'));
+  const fake = path.join(dir, 'mempalace'); fs.writeFileSync(fake, '#!/bin/sh\necho "$@"\n'); fs.chmodSync(fake, 0o755);
+  const out = execFileSync(process.execPath, [SHIM, 'search', 'q', '--results', '3'], { env: { ...process.env, HIVE_MEMORY_BACKEND: 'mempalace', PATH: `${dir}:${process.env.PATH}` }, encoding: 'utf8' });
+  assert.match(out, /search q --results 3/);
+});
+
+test('hindsight search renders recalled text and score', async (t) => {
+  let request;
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/v1/default/banks/test-bank/memories/recall') {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      request = JSON.parse(body);
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ results: [{ text: 'A useful memory', score: 0.91 }] }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+  const { port } = server.address();
+
+  const out = await runShim({
+    HIVE_MEMORY_BACKEND: 'hindsight',
+    HINDSIGHT_URL: `http://127.0.0.1:${port}`,
+    HINDSIGHT_BANK: 'test-bank'
+  }, ['search', 'budget']);
+
+  assert.equal(request.query, 'budget');
+  assert.match(out, /A useful memory/);
+  assert.match(out, /\(score 0\.91\)/);
+});
+
+test('unreachable hindsight degrades to the one-line fallback', async () => {
+  const probe = net.createServer();
+  await new Promise((resolve) => probe.listen(0, '127.0.0.1', resolve));
+  const { port } = probe.address();
+  await new Promise((resolve) => probe.close(resolve));
+
+  const out = await runShim({
+    HIVE_MEMORY_BACKEND: 'hindsight',
+    HINDSIGHT_URL: `http://127.0.0.1:${port}`,
+    HINDSIGHT_BANK: 'test-bank'
+  });
+
+  assert.equal(out, 'memory recall unavailable — continue without it\n');
+});

--- a/test/hive-memory-shim.test.cjs
+++ b/test/hive-memory-shim.test.cjs
@@ -71,3 +71,31 @@ test('unreachable hindsight degrades to the one-line fallback', async () => {
 
   assert.equal(out, 'memory recall unavailable — continue without it\n');
 });
+
+// The recall response carries per-result scores in a `scores` object whose
+// `final` member is the ranked value; a flat `score` is not part of the shape.
+test('hindsight search renders the final score from the scores object', async (t) => {
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/v1/default/banks/test-bank/memories/recall') {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    req.resume();
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ results: [{ text: 'A useful memory', scores: { final: 0.91, semantic: 0.42 } }] }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+  const { port } = server.address();
+
+  const out = await runShim({
+    HIVE_MEMORY_BACKEND: 'hindsight',
+    HINDSIGHT_URL: `http://127.0.0.1:${port}`,
+    HINDSIGHT_BANK: 'test-bank'
+  }, ['search', 'budget']);
+
+  assert.match(out, /A useful memory {2}\(score 0\.91\)/);
+});

--- a/test/ide-image.test.cjs
+++ b/test/ide-image.test.cjs
@@ -117,7 +117,7 @@ test('non-image sources are refused even when local', () => {
 });
 
 test('`..` can never climb above the workspace root textually', () => {
-  // Not the security boundary (safeJoin is), but it must not even try.
+  // Not the security boundary (safeResolve is), but it must not even try.
   assert.equal(resolveRel('a/b/c.md', '../../../../../etc/passwd'), 'etc/passwd');
   assert.equal(resolveLocalImageRel('a/b.md', '../../../../x.png'), 'x.png');
 });
@@ -172,7 +172,7 @@ test('path traversal out of the root is rejected', async () => {
       assert.equal(res.ok, false, `${rel} must not be readable`);
       assert.equal(res.error, 'path escapes root');
     }
-    // …while an absolute path INSIDE the root is still fine (safeJoin's rule).
+    // …while an absolute path INSIDE the root is still fine (safeResolve's rule).
     const inside = await readFileBinary(root, path.join(root, 'docs', 'shot.png'));
     assert.equal(inside.ok, true);
   } finally {

--- a/test/load-ts.cjs
+++ b/test/load-ts.cjs
@@ -19,6 +19,14 @@ function resolveTs(fromDir, request) {
 function loadFile(filename) {
   const cached = cache.get(filename);
   if (cached) return cached.exports;
+  // A `.json` import is data, not TypeScript. The bundler parses it (the app
+  // compiles with resolveJsonModule); handing it to transpileModule instead
+  // fails output generation outright, so parse it the same way here.
+  if (filename.endsWith('.json')) {
+    const json = { exports: JSON.parse(fs.readFileSync(filename, 'utf8')) };
+    cache.set(filename, json);
+    return json.exports;
+  }
   const source = fs.readFileSync(filename, 'utf8');
   const output = ts.transpileModule(source, {
     compilerOptions: {

--- a/test/load-ts.cjs
+++ b/test/load-ts.cjs
@@ -10,7 +10,7 @@ function resolveTs(fromDir, request) {
   const base = request.startsWith('@shared/')
     ? path.resolve(__dirname, '..', 'src/shared', request.slice('@shared/'.length))
     : path.resolve(fromDir, request);
-  for (const candidate of [base, `${base}.ts`, path.join(base, 'index.ts')]) {
+  for (const candidate of [base, `${base}.ts`, `${base}.tsx`, path.join(base, 'index.ts')]) {
     if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
   }
   return null;
@@ -29,7 +29,13 @@ function loadFile(filename) {
       // builtin (`import path from 'node:path'`) compiles to `path_1.default`,
       // which is undefined at run time — the module loads fine and then explodes
       // on first use. Test harness only; no shipped code compiles through here.
-      esModuleInterop: true
+      esModuleInterop: true,
+      // .tsx files need a JSX emit or transpileModule chokes on the first `<`.
+      // The AUTOMATIC runtime is deliberate: classic emit needs `React` in
+      // scope, and these components do not need a React default import.
+      // A test can therefore stub `react/jsx-runtime` and get a plain element
+      // tree without pulling in react-dom.
+      ...(filename.endsWith('.tsx') ? { jsx: ts.JsxEmit.ReactJSX } : {})
     },
     fileName: filename,
     reportDiagnostics: true

--- a/test/mcp-toggle-component.test.cjs
+++ b/test/mcp-toggle-component.test.cjs
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * Component coverage for the stale configuration prop regression.
+ *
+ * test/mcp-toggle-state.test.cjs covers the two functions that were extracted
+ * out of McpDefaultsSettings. It does not cover McpDefaultsSettings. Comment
+ * out the `setMcpDefaults(await applyToggle(...))` line and every one of those
+ * tests stays green while the stale-prop bug returns in full. So these tests
+ * mount the real component, click the real button, and read the real rendered
+ * label.
+ *
+ * The control under test is a consent control. `github-token` is tier `secret`
+ * with defaultEnabled:false — it is only ever on because a human turned it on.
+ * The component must render the persisted value after a toggle and remount.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+// MUST come before loadTs of any component — it seeds require.cache for react.
+const { mount, flatten, text } = require('./render-hooks.cjs');
+const loadTs = require('./load-ts.cjs');
+
+const { McpDefaultsSettings } = loadTs('src/renderer/src/components/McpDefaultsSettings.tsx');
+
+// The id under test, written out literally. NOT imported from the catalog: a
+// test that asks the implementation which id to check cannot notice the id
+// changing, and this one must always name an upstream catalog entry.
+const GITHUB_TOKEN = 'github-token';
+
+/** The label the toggle button renders for a catalog id: 'on' | 'off'. */
+function buttonLabel(tree, id) {
+  const hit = flatten(tree).find((e) => e.key === id && e.node.type === 'button');
+  assert.ok(hit, `no toggle button rendered for "${id}"`);
+  return text(hit.node).join('');
+}
+
+/** Click the toggle button for a catalog id, exactly as a user would. */
+function click(tree, id) {
+  const hit = flatten(tree).find((e) => e.key === id && e.node.type === 'button');
+  assert.ok(hit, `no toggle button rendered for "${id}"`);
+  assert.equal(typeof hit.node.props.onClick, 'function', 'the button must be clickable');
+  hit.node.props.onClick();
+}
+
+/**
+ * Stand in for the preload bridge. `disk` is the real subject: updateConfig
+ * writes into it and getConfig reads back out of it.
+ */
+function fakeBridge({ disk = {} } = {}) {
+  const calls = { updateConfig: [], getConfig: 0 };
+  const state = { mcpDefaults: { ...disk } };
+  global.window = {
+    cth: {
+      updateConfig: async (patch) => {
+        calls.updateConfig.push(patch);
+        state.mcpDefaults = { ...patch.mcpDefaults };
+        return {};
+      },
+      getConfig: async () => { calls.getConfig += 1; return { mcpDefaults: { ...state.mcpDefaults } }; }
+    }
+  };
+  return { calls, state };
+}
+
+/** Let the click's async chain settle. */
+const settle = () => new Promise((r) => setImmediate(r));
+
+test.afterEach(() => { delete global.window; });
+
+// ── 1. the component renders from the resolver, not from nothing ─────────────
+
+test('an unset consent-tier server renders off', () => {
+  fakeBridge();
+  const inst = mount(McpDefaultsSettings, { config: { mcpDefaults: {} } });
+  assert.equal(buttonLabel(inst.tree, GITHUB_TOKEN), 'off',
+    'github-token is secret tier, defaultEnabled:false — unset must read as NOT granted');
+});
+
+test('a stored grant renders on', () => {
+  fakeBridge();
+  const inst = mount(McpDefaultsSettings, { config: { mcpDefaults: { [GITHUB_TOKEN]: { enabled: true } } } });
+  assert.equal(buttonLabel(inst.tree, GITHUB_TOKEN), 'on');
+});
+
+// ── 2. the wiring — this is what the extracted-function tests cannot see ─────
+
+test('clicking the toggle writes the merged map and re-renders from the disk read', async () => {
+  const { calls } = fakeBridge({ disk: { 'other-server': { enabled: true } } });
+  const inst = mount(McpDefaultsSettings, {
+    config: { mcpDefaults: { 'other-server': { enabled: true } } }
+  });
+  assert.equal(buttonLabel(inst.tree, GITHUB_TOKEN), 'off');
+
+  click(inst.tree, GITHUB_TOKEN);
+  await settle();
+
+  assert.equal(calls.updateConfig.length, 1, 'the click must reach updateConfig');
+  assert.deepEqual(calls.updateConfig[0].mcpDefaults, {
+    'other-server': { enabled: true },
+    [GITHUB_TOKEN]: { enabled: true }
+  }, 'the patch replaces mcpDefaults wholesale, so it must carry the other entries');
+  assert.ok(calls.getConfig >= 1, 'the component must RE-READ after writing, not trust the write');
+
+  assert.equal(buttonLabel(inst.render(), GITHUB_TOKEN), 'on',
+    'the rendered label must follow the persisted config read');
+  assert.ok(text(inst.render()).join('').includes(`${GITHUB_TOKEN}: enabled`),
+    'the confirmation note must name what was granted');
+});
+
+test('a failed write leaves the label alone and says so', async () => {
+  // A disk that never accepts the write, and never claims it did.
+  global.window = {
+    cth: {
+      updateConfig: async () => { throw new Error('EACCES'); },
+      getConfig: async () => ({ mcpDefaults: {} })
+    }
+  };
+  const inst = mount(McpDefaultsSettings, { config: { mcpDefaults: {} } });
+  click(inst.tree, GITHUB_TOKEN);
+  await settle();
+  assert.equal(buttonLabel(inst.render(), GITHUB_TOKEN), 'off',
+    'a throw must never leave the control claiming the grant went through');
+  assert.ok(text(inst.render()).join('').includes('could not save'));
+});
+
+// ── 3. the stale-prop bug, on REMOUNT ──────────────────────────────────────────
+
+test('the granted state survives closing and reopening the panel', async () => {
+  // SettingsModal renders <McpDefaultsSettings config={config} /> only while
+  // activeSection === 'Connections', and SettingsModal's own `config` prop is
+  // App's, which App loads once at start-up and never refreshes after a save.
+  // So switching settings sections and back is a real REMOUNT against a config
+  // object that still says the grant never happened.
+  const stale = { mcpDefaults: { [GITHUB_TOKEN]: { enabled: false } } };
+  const { state } = fakeBridge({ disk: { [GITHUB_TOKEN]: { enabled: false } } });
+
+  const first = mount(McpDefaultsSettings, { config: stale });
+  click(first.tree, GITHUB_TOKEN);
+  await settle();
+  assert.equal(buttonLabel(first.render(), GITHUB_TOKEN), 'on');
+  assert.equal(state.mcpDefaults[GITHUB_TOKEN].enabled, true, 'the grant is on disk');
+
+  // …user switches to another settings section and comes back. Same stale prop.
+  const second = mount(McpDefaultsSettings, { config: stale });
+  await settle();
+  assert.equal(buttonLabel(second.render(), GITHUB_TOKEN), 'on',
+    'seeding from the prop alone re-runs the original stale-prop bug: '
+    + 'the write landed, and the control shows off');
+});

--- a/test/mcp-toggle-state.test.cjs
+++ b/test/mcp-toggle-state.test.cjs
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * MCP toggle state helpers.
+ *
+ * applyToggle writes the requested map, then returns the persisted map used by
+ * the component. resolveEnabledFor supplies catalog defaults for omitted ids.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { applyToggle, resolveEnabledFor } = loadTs('src/renderer/src/components/mcpToggleLogic.ts');
+
+const { MCP_CATALOG } = loadTs('src/shared/mcpCatalog.ts');
+const GITHUB_TOKEN_ID = 'github-token';
+
+// ── applyToggle — the state-transition path ──────────────────────────────────
+
+test('applyToggle returns mcpDefaults from getConfig when the write succeeds', async () => {
+  const deps = {
+    updateConfig: async () => ({}),
+    getConfig: async () => ({ mcpDefaults: { [GITHUB_TOKEN_ID]: { enabled: true } } })
+  };
+  const result = await applyToggle(GITHUB_TOKEN_ID, true, {}, deps);
+  assert.deepEqual(result[GITHUB_TOKEN_ID], { enabled: true });
+});
+
+test('applyToggle merges the id change into currentDefaults when calling updateConfig', async () => {
+  const captured = [];
+  const deps = {
+    updateConfig: async (patch) => { captured.push(patch); return {}; },
+    getConfig: async () => ({ mcpDefaults: { [GITHUB_TOKEN_ID]: { enabled: true } } })
+  };
+  const currentDefaults = { 'some-other-server': { enabled: true } };
+  await applyToggle(GITHUB_TOKEN_ID, true, currentDefaults, deps);
+  assert.equal(captured.length, 1);
+  assert.deepEqual(captured[0].mcpDefaults, {
+    'some-other-server': { enabled: true },
+    [GITHUB_TOKEN_ID]: { enabled: true }
+  });
+});
+
+// ── resolveEnabledFor — catalog fallback path ────────────────────────────────
+
+test('resolveEnabledFor falls back to the catalog defaultEnabled for an unset id', () => {
+  const entry = MCP_CATALOG.find((e) => e.id === GITHUB_TOKEN_ID);
+  assert.ok(entry, `${GITHUB_TOKEN_ID} must exist in the catalog`);
+  const result = resolveEnabledFor({}, GITHUB_TOKEN_ID);
+  assert.equal(result, entry.defaultEnabled ?? false);
+});
+
+test('resolveEnabledFor returns false for a completely unknown id', () => {
+  assert.equal(resolveEnabledFor({}, 'not-a-real-server'), false);
+});
+
+test('resolveEnabledFor respects explicit false even when catalog default is true', () => {
+  // Fixture catalog: one entry with defaultEnabled:true
+  const fixtureCatalog = [{ id: GITHUB_TOKEN_ID, defaultEnabled: true, tier: 'safe-readonly', label: 'x', description: '' }];
+  const overrides = { [GITHUB_TOKEN_ID]: { enabled: false } };
+  assert.equal(resolveEnabledFor(overrides, GITHUB_TOKEN_ID, fixtureCatalog), false,
+    'explicit human opt-out must beat the catalog default');
+});
+
+test('resolveEnabledFor uses the injected catalog, not a shared constant', () => {
+  // This test uses a FIXTURE catalog with a custom id — never in the real catalog.
+  // If resolveEnabledFor shared the catalog constant with the test, this id would
+  // not be found and the fallback (false) would mask a wrong catalog lookup.
+  const fixtureCatalog = [{ id: 'fixture-server', defaultEnabled: true, tier: 'safe-readonly', label: 'x', description: '' }];
+  assert.equal(resolveEnabledFor({}, 'fixture-server', fixtureCatalog), true,
+    'catalog param drives the defaultEnabled fallback');
+  assert.equal(resolveEnabledFor({}, 'fixture-server'), false,
+    'real catalog has no fixture-server, so fallback is false — confirms injection works');
+});

--- a/test/memory-backend-conformance.test.cjs
+++ b/test/memory-backend-conformance.test.cjs
@@ -1,0 +1,139 @@
+'use strict';
+
+/**
+ * One contract, run against every backend.
+ *
+ * The manager treats backends interchangeably, so anything it relies on has to
+ * hold for all of them — including the awkward parts: a broken backend reports
+ * failure rather than throwing (a throw would abort the whole mine pass and
+ * take the other agents down with it), and status() answers even with no hive
+ * home, because the settings panel polls it before one is chosen.
+ *
+ * Each case supplies a backend that is healthy and one that is broken, so the
+ * degraded path is exercised the same way for both.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+const loadTs = require('./load-ts.cjs');
+
+const { MemPalaceAdapter } = loadTs('src/main/memPalaceAdapter.ts');
+const { HindsightAdapter } = loadTs('src/main/hindsightAdapter.ts');
+
+const HIT = 'Sales sits on floor two.';
+
+function agentDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conformance-'));
+  fs.writeFileSync(path.join(dir, 'memory.md'), `## A fact\n\n${HIT}\n`, 'utf8');
+  return dir;
+}
+
+/** A stand-in `mempalace` executable: succeeds, and prints a hit when asked. */
+function fakeCli(t, { broken } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conformance-cli-'));
+  const bin = path.join(dir, 'mempalace');
+  fs.writeFileSync(bin, broken
+    ? '#!/bin/sh\necho "backend is down" >&2\nexit 1\n'
+    : `#!/bin/sh\ncase "$1" in mine) : ;; *) echo "${HIT}" ;; esac\nexit 0\n`);
+  fs.chmodSync(bin, 0o755);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return bin;
+}
+
+async function hindsightStub(t, { broken } = {}) {
+  const server = http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json');
+      if (/\/memories\/recall$/.test(req.url)) {
+        res.end(JSON.stringify({ results: [{ text: HIT, scores: { final: 0.77 } }] }));
+      } else {
+        res.end(JSON.stringify({ success: true, bank_id: 'b1', total_nodes: 1 }));
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const url = `http://127.0.0.1:${server.address().port}`;
+  if (broken) await new Promise((resolve) => server.close(resolve));
+  else t.after(() => new Promise((resolve) => server.close(resolve)));
+  return url;
+}
+
+const CASES = [
+  {
+    id: 'mempalace',
+    make: async (t, opts = {}) => {
+      const palace = fs.mkdtempSync(path.join(os.tmpdir(), 'conformance-palace-'));
+      t.after(() => fs.rmSync(palace, { recursive: true, force: true }));
+      const adapter = new MemPalaceAdapter(() => palace, () => 'minilm');
+      const bin = fakeCli(t, opts);
+      adapter.bin = () => bin; // the real one probes this machine's PATH
+      return adapter;
+    }
+  },
+  {
+    id: 'hindsight',
+    make: async (t, opts = {}) => {
+      const url = await hindsightStub(t, opts);
+      const adapter = new HindsightAdapter(() => ({ url, bank: 'b1' }), () => '/tmp/home');
+      await adapter.probeHealth();
+      return adapter;
+    }
+  }
+];
+
+for (const { id, make } of CASES) {
+  test(`${id}: a healthy backend accepts a mined memory`, async (t) => {
+    assert.deepEqual(await (await make(t)).mineAgent(agentDir(), 'pam'), { ok: true });
+  });
+
+  test(`${id}: a broken backend reports failure instead of throwing`, async (t) => {
+    const adapter = await make(t, { broken: true });
+    const result = await adapter.mineAgent(agentDir(), 'pam');
+    assert.equal(result.ok, false, 'a mine pass must survive one bad backend');
+  });
+
+  test(`${id}: search returns the seeded hit as text`, async (t) => {
+    const result = await (await make(t)).search('floor', { agentId: 'pam', results: 3 });
+    assert.equal(result.ok, true);
+    assert.match(result.output, /floor two/);
+  });
+
+  test(`${id}: wake-up returns text`, async (t) => {
+    const result = await (await make(t)).wakeUp('pam');
+    assert.equal(result.ok, true);
+    assert.match(result.output, /floor two/);
+  });
+
+  test(`${id}: a broken backend answers a search without throwing`, async (t) => {
+    const adapter = await make(t, { broken: true });
+    const result = await adapter.search('floor', { agentId: 'pam' });
+    assert.equal(result.ok, false);
+    assert.equal(result.output, '');
+    assert.ok(result.error, 'a failure has to say something about itself');
+  });
+
+  test(`${id}: the spawn environment names this backend`, async (t) => {
+    assert.equal((await make(t)).agentEnv().HIVE_MEMORY_BACKEND, id);
+  });
+
+  test(`${id}: status answers before a hive home exists`, async (t) => {
+    const adapter = await make(t);
+    const status = adapter.status(true, null);
+    assert.equal(status.backend, id);
+    assert.equal(status.enabled, true);
+    assert.equal(status.active, false, 'no home means nothing to mine');
+    assert.equal(typeof status.available, 'boolean');
+    assert.equal(typeof status.initialized, 'boolean');
+  });
+
+  test(`${id}: init does not throw against a broken backend`, async (t) => {
+    const adapter = await make(t, { broken: true });
+    adapter.init();
+    assert.equal(adapter.status(true, null).active, false);
+  });
+}

--- a/test/memory-config-migration.test.cjs
+++ b/test/memory-config-migration.test.cjs
@@ -1,0 +1,150 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { migrateMemorySettings, DEFAULT_HINDSIGHT_URL, DEFAULT_HINDSIGHT_BANK } = loadTs('src/main/config.ts');
+const { MemoryManager } = loadTs('src/main/memory.ts');
+
+test('the pre-backend settings become a mempalace configuration', () => {
+  assert.deepEqual(migrateMemorySettings({ semanticMemory: true, embeddingModel: 'embeddinggemma' }), {
+    enabled: true,
+    backend: 'mempalace',
+    mempalace: { model: 'embeddinggemma' },
+    hindsight: { url: DEFAULT_HINDSIGHT_URL, bank: DEFAULT_HINDSIGHT_BANK }
+  });
+});
+
+test('an off switch survives the migration', () => {
+  assert.equal(migrateMemorySettings({ semanticMemory: false, embeddingModel: 'minilm' }).enabled, false);
+});
+
+test('migrating an already-migrated shape changes nothing', () => {
+  const migrated = migrateMemorySettings({ semanticMemory: true, embeddingModel: 'minilm' });
+  assert.deepEqual(migrateMemorySettings(migrated), migrated);
+
+  const hindsight = {
+    enabled: true,
+    backend: 'hindsight',
+    mempalace: { model: 'minilm' },
+    hindsight: { url: 'http://memories.example:9000', bank: 'floor-two' }
+  };
+  assert.deepEqual(migrateMemorySettings(hindsight), hindsight);
+});
+
+test('garbage migrates to a safe, disabled default', () => {
+  for (const junk of [undefined, null, 'nonsense', 42, []]) {
+    assert.deepEqual(migrateMemorySettings(junk), {
+      enabled: false,
+      backend: 'mempalace',
+      mempalace: { model: 'minilm' },
+      hindsight: { url: DEFAULT_HINDSIGHT_URL, bank: DEFAULT_HINDSIGHT_BANK }
+    }, `for ${JSON.stringify(junk)}`);
+  }
+});
+
+test('an unrecognised backend name falls back to the local one', () => {
+  assert.equal(migrateMemorySettings({ semanticMemory: true, memoryBackend: 'telepathy' }).backend, 'mempalace');
+});
+
+test('a blank server address falls back to the default endpoint', () => {
+  const migrated = migrateMemorySettings({ semanticMemory: true, memoryBackend: 'hindsight', hindsightUrl: '   ', hindsightBank: '' });
+  assert.equal(migrated.backend, 'hindsight');
+  assert.equal(migrated.hindsight.url, DEFAULT_HINDSIGHT_URL);
+  assert.equal(migrated.hindsight.bank, DEFAULT_HINDSIGHT_BANK);
+});
+
+// ─── Backend selection and the swap ─────────────────────────────────────────
+
+/** A MemoryBackend that records what the manager asked it to do. */
+function stubBackend(id) {
+  return {
+    id,
+    mined: [],
+    available: () => true,
+    probesAsync: true,
+    init() {},
+    async mineAgent(_dir, agentId) { this.mined.push(agentId); return { ok: true }; },
+    async search() { return { ok: true, output: '' }; },
+    async wakeUp() { return { ok: true, output: '' }; },
+    status: (enabled, home) => ({
+      backend: id, available: true, enabled, active: enabled && home !== null,
+      initialized: true, location: id, model: null, bin: null
+    }),
+    agentEnv: () => ({ HIVE_MEMORY_BACKEND: id }),
+    resetCaches() {}
+  };
+}
+
+function hiveWithAgent(agentId) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-swap-'));
+  const dir = path.join(home, 'hive', 'agents', agentId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'memory.md'), '## A fact\n\nSales sits on floor two.\n', 'utf8');
+  return home;
+}
+
+test('switching backend re-mines memories the previous backend had already taken', async () => {
+  const home = hiveWithAgent('pam');
+  const settings = migrateMemorySettings({ semanticMemory: true, memoryBackend: 'mempalace' });
+  const backends = { mempalace: stubBackend('mempalace'), hindsight: stubBackend('hindsight') };
+
+  const manager = new MemoryManager(() => home, () => settings, (id) => backends[id]);
+  manager.refresh();
+  await manager.mineNow();
+  assert.deepEqual(backends.mempalace.mined, ['pam']);
+
+  // Unchanged memory.md: the same backend must NOT mine it a second time.
+  await manager.mineNow();
+  assert.deepEqual(backends.mempalace.mined, ['pam'], 'unchanged memory is skipped');
+
+  settings.backend = 'hindsight';
+  manager.refresh();
+  await manager.mineNow();
+
+  assert.deepEqual(backends.hindsight.mined, ['pam'], 'the new backend starts from scratch');
+  assert.deepEqual(backends.mempalace.mined, ['pam'], 'the old backend is not asked again');
+});
+
+test('the manager routes searches to whichever backend the settings name', async () => {
+  const home = hiveWithAgent('jim');
+  const settings = migrateMemorySettings({ semanticMemory: true, memoryBackend: 'hindsight' });
+  const backends = { mempalace: stubBackend('mempalace'), hindsight: stubBackend('hindsight') };
+  const manager = new MemoryManager(() => home, () => settings, (id) => backends[id]);
+
+  assert.equal(manager.status().backend, 'hindsight');
+  assert.deepEqual(manager.env(), { HIVE_MEMORY_BACKEND: 'hindsight' });
+});
+
+test('with no factory supplied the manager builds the real adapter each setting names', () => {
+  const home = hiveWithAgent('dwight');
+  for (const backend of ['mempalace', 'hindsight']) {
+    const settings = migrateMemorySettings({ semanticMemory: true, memoryBackend: backend });
+    assert.equal(new MemoryManager(() => home, () => settings).status().backend, backend);
+  }
+});
+
+test('a server backend arms its mine loop before the first health answer', async (t) => {
+  // Availability for a remote backend is only knowable after a probe, and the
+  // probe is part of arming it. Gating start() on availability the way a local
+  // CLI is gated would mean it never starts and so never becomes available.
+  const http = require('node:http');
+  const server = http.createServer((req, res) => { req.resume(); res.end('{}'); });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const home = hiveWithAgent('creed');
+  const settings = migrateMemorySettings({
+    semanticMemory: true, memoryBackend: 'hindsight',
+    hindsightUrl: `http://127.0.0.1:${server.address().port}`, hindsightBank: 'b1'
+  });
+  const manager = new MemoryManager(() => home, () => settings);
+  t.after(() => manager.stop());
+
+  assert.equal(manager.available(), false, 'nothing has been probed yet');
+  manager.refresh();
+  assert.notEqual(manager.mineTimer, null, 'the loop must be armed anyway');
+});

--- a/test/memory-rearm.test.cjs
+++ b/test/memory-rearm.test.cjs
@@ -23,13 +23,25 @@ const path = require('node:path');
 const loadTs = require('./load-ts.cjs');
 
 const { MemoryManager } = loadTs('src/main/memory.ts');
+const { MemPalaceAdapter } = loadTs('src/main/memPalaceAdapter.ts');
 
 /** A manager over an empty temp home whose CLI resolution we control. */
 function managerWithCli(t, opts = {}) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-memory-'));
   const state = { bin: opts.bin ?? null, enabled: opts.enabled !== false };
-  const memory = new MemoryManager(() => home, () => ({ enabled: state.enabled, model: 'minilm' }));
-  memory.bin = () => state.bin; // the real one shells out to `which mempalace`
+  const settings = {
+    enabled: state.enabled, backend: 'mempalace',
+    mempalace: { model: 'minilm' }, hindsight: { url: 'http://127.0.0.1:8888', bank: 'hive-memory' }
+  };
+  const memory = new MemoryManager(
+    () => home,
+    () => ({ ...settings, enabled: state.enabled }),
+    () => {
+      const adapter = new MemPalaceAdapter(() => path.join(home, 'palace'), () => 'minilm');
+      adapter.bin = () => state.bin; // the real one shells out to `which mempalace`
+      return adapter;
+    }
+  );
   t.after(() => { memory.stop(); fs.rmSync(home, { recursive: true, force: true }); });
   return { memory, state, home };
 }

--- a/test/model-catalog.test.cjs
+++ b/test/model-catalog.test.cjs
@@ -1,0 +1,194 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+const catalog = require('../src/shared/modelCatalog.json');
+
+const {
+  ASSISTANT_MODEL,
+  modelsForProvider,
+  modelsForProviderAtVersion,
+  runningAppVersion
+} = loadTs('src/renderer/src/store/config.ts');
+
+/** Every model the pickers offered while the lists were hardcoded TypeScript
+ *  arrays, as `[id, label]` pairs — the providers whose full list no other test
+ *  pins (provider-config.test.cjs pins codex/grok/kimi/gemini/custom). Moving
+ *  the lists into JSON must not change one byte of what a user sees, and these
+ *  literals are the only record of what shipped before the move. */
+const SHIPPED = {
+  claude: [
+    ["claude-fable-5", "Fable 5"],
+    ["claude-opus-5", "Opus 5 · 1M"],
+    ["claude-opus-4-8", "Opus 4.8"],
+    ["claude-opus-4-8[1m]", "Opus 4.8 · 1M"],
+    ["claude-sonnet-5", "Sonnet 5"],
+    ["claude-sonnet-4-6", "Sonnet 4.6"],
+    ["claude-sonnet-4-6[1m]", "Sonnet 4.6 · 1M"],
+    ["claude-haiku-4-5-20251001", "Haiku 4.5"]
+  ],
+  antigravity: [
+    [undefined, "CLI default"],
+    ["Gemini 3.1 Pro (High)", "Gemini 3.1 Pro · High"],
+    ["Gemini 3.1 Pro (Low)", "Gemini 3.1 Pro · Low"],
+    ["Gemini 3.5 Flash (High)", "Gemini 3.5 Flash · High"],
+    ["Gemini 3.5 Flash (Medium)", "Gemini 3.5 Flash · Med"],
+    ["Gemini 3.5 Flash (Low)", "Gemini 3.5 Flash · Low"],
+    ["Claude Sonnet 4.6 (Thinking)", "Claude Sonnet 4.6"],
+    ["Claude Opus 4.6 (Thinking)", "Claude Opus 4.6"],
+    ["GPT-OSS 120B (Medium)", "GPT-OSS 120B"]
+  ],
+  qwen: [
+    [undefined, "default"],
+    ["qwen3-coder-plus", "Qwen3 Coder Plus"],
+    ["qwen3-coder", "Qwen3 Coder"],
+    ["qwen-max", "Qwen Max"]
+  ],
+  opencode: [
+    [undefined, "CLI default"],
+    ["anthropic/claude-sonnet-4-5", "Claude Sonnet 4.5 (Anthropic)"],
+    ["anthropic/claude-haiku-4-5", "Claude Haiku 4.5 (Anthropic)"],
+    ["openai/gpt-5", "GPT-5 (OpenAI)"],
+    ["openai/gpt-5-mini", "GPT-5 mini (OpenAI)"],
+    ["openrouter/anthropic/claude-sonnet-4.5", "Claude Sonnet 4.5 (OpenRouter)"],
+    ["google/gemini-2.5-pro", "Gemini 2.5 Pro (Google)"],
+    ["local/llama3", "Local · OpenAI-compatible (set base-URL)"]
+  ],
+  crush: [
+    [undefined, "Crush default (config)"],
+    ["anthropic/claude-sonnet-4-5", "Claude Sonnet 4.5 (Anthropic)"],
+    ["anthropic/claude-opus-4-1", "Claude Opus (Anthropic)"],
+    ["openai/gpt-4o", "GPT-4o (OpenAI)"],
+    ["openai/o3", "o3 (OpenAI)"],
+    ["gemini/gemini-2.5-pro", "Gemini 2.5 Pro"],
+    ["openrouter/auto", "OpenRouter (auto)"],
+    ["openai/local", "Local · OpenAI-compatible (set base-URL)"]
+  ],
+  pi: [
+    [undefined, "default"],
+    ["anthropic/claude-sonnet-4-5", "Claude Sonnet 4.5 (Anthropic)"],
+    ["anthropic/claude-opus-4-1", "Claude Opus (Anthropic)"],
+    ["openai/gpt-5", "GPT-5 (OpenAI)"],
+    ["google/gemini-2.5-pro", "Gemini 2.5 Pro (Google)"],
+    ["groq/llama-3.3-70b", "Llama 3.3 70B (Groq)"],
+    ["local/llama3", "Local · OpenAI-compatible (set base-URL)"]
+  ],
+  copilot: [
+    [undefined, "default (Claude Sonnet 4.5)"],
+    ["auto", "Auto (Copilot picks)"],
+    ["claude-sonnet-4.5", "Claude Sonnet 4.5"],
+    ["claude-sonnet-4", "Claude Sonnet 4"],
+    ["gpt-5.4", "GPT-5.4"],
+    ["gpt-5", "GPT-5"]
+  ],
+  cursor: [
+    [undefined, "CLI default (auto)"],
+    ["auto", "Auto"],
+    ["gpt-5.6-luna-high", "GPT-5.6 Luna 1M High (cheap)"],
+    ["gpt-5.6-sol-medium", "GPT-5.6 Sol 1M"],
+    ["gpt-5.6-sol-high", "GPT-5.6 Sol 1M High"],
+    ["composer-2.5", "Composer 2.5"],
+    ["composer-2.5-fast", "Composer 2.5 Fast"],
+    ["gpt-5.2", "GPT-5.2"],
+    ["claude-opus-4-8-high", "Opus 4.8 1M"],
+    ["claude-sonnet-5-thinking-high", "Sonnet 5 1M Thinking"]
+  ],
+};
+
+/** A stand-in catalog: the real one is deliberately all-unbounded (the port had
+ *  to be behaviour-identical), so the version bounds can only be exercised
+ *  against models invented here. `modelsForProviderAtVersion` takes the provider
+ *  map as its last argument for exactly this reason — the test drives the real
+ *  filter, not a copy of it. */
+const BOUNDED = {
+  claude: [
+    { id: 'unbounded', label: 'Unbounded', minAppVersion: null, maxAppVersion: null },
+    { id: 'no-bound-keys', label: 'No bound keys at all' },
+    { id: 'since-0.5.0', label: 'Ships in a later release', minAppVersion: '0.5.0', maxAppVersion: null },
+    { id: 'since-0.4.5', label: 'Ships in this release', minAppVersion: '0.4.5', maxAppVersion: null },
+    { id: 'until-0.4.4', label: 'Retired one release ago', minAppVersion: null, maxAppVersion: '0.4.4' },
+    { id: 'until-0.4.5', label: 'Retired after this release', minAppVersion: null, maxAppVersion: '0.4.5' },
+    { id: 'window', label: 'Only inside a window', minAppVersion: '0.4.0', maxAppVersion: '0.4.9' }
+  ]
+};
+
+const ids = (models) => models.map((model) => model.id);
+
+test('the pickers offer exactly the models that shipped before the catalog', () => {
+  for (const [provider, expected] of Object.entries(SHIPPED)) {
+    assert.deepEqual(
+      modelsForProvider(provider).map((model) => [model.id, model.label]),
+      expected,
+      provider
+    );
+  }
+});
+
+test('the Claude list still offers the 1M-context assistant model', () => {
+  // The hardcoded array built this entry out of the ASSISTANT_MODEL constant.
+  // The catalog carries the id as a literal, so this is now the only thing
+  // holding the picker entry and the constant together.
+  assert.ok(ids(modelsForProvider('claude')).includes(ASSISTANT_MODEL));
+});
+
+test('the catalog is the schema config.ts expects', () => {
+  assert.equal(catalog.version, 1);
+  assert.deepEqual(
+    Object.keys(catalog.providers).sort(),
+    ['antigravity', 'claude', 'copilot', 'codex', 'crush', 'cursor', 'custom',
+      'gemini', 'grok', 'kimi', 'opencode', 'pi', 'qwen'].sort()
+  );
+});
+
+test('a model is offered only by the app versions its bounds cover', () => {
+  assert.deepEqual(ids(modelsForProviderAtVersion('claude', '0.4.5', BOUNDED)), [
+    'unbounded',
+    'no-bound-keys',
+    'since-0.4.5',
+    'until-0.4.5',
+    'window'
+  ]);
+  assert.deepEqual(ids(modelsForProviderAtVersion('claude', '0.5.0', BOUNDED)), [
+    'unbounded',
+    'no-bound-keys',
+    'since-0.5.0',
+    'since-0.4.5'
+  ]);
+  assert.deepEqual(ids(modelsForProviderAtVersion('claude', '0.3.0', BOUNDED)), [
+    'unbounded',
+    'no-bound-keys',
+    'until-0.4.4',
+    'until-0.4.5'
+  ]);
+});
+
+test('both bounds are inclusive of the release named in them', () => {
+  assert.ok(ids(modelsForProviderAtVersion('claude', '0.4.5', BOUNDED)).includes('since-0.4.5'));
+  assert.ok(ids(modelsForProviderAtVersion('claude', '0.4.5', BOUNDED)).includes('until-0.4.5'));
+  assert.ok(!ids(modelsForProviderAtVersion('claude', '0.4.4', BOUNDED)).includes('since-0.4.5'));
+  assert.ok(!ids(modelsForProviderAtVersion('claude', '0.4.6', BOUNDED)).includes('until-0.4.5'));
+});
+
+test('a version the filter cannot read hides nothing', () => {
+  // A picker that silently loses every model is far worse than one that offers
+  // a model the running build cannot use, so an unreadable version fails open.
+  assert.deepEqual(ids(modelsForProviderAtVersion('claude', '', BOUNDED)), ids(BOUNDED.claude));
+});
+
+test('an unknown provider falls back to the Claude list, custom to nothing', () => {
+  assert.deepEqual(modelsForProvider('not-a-provider'), modelsForProvider('claude'));
+  assert.deepEqual(modelsForProvider('custom'), []);
+});
+
+test('the filter reads the version the app was built with', () => {
+  // electron-vite defines __APP_VERSION__ from package.json at build time; the
+  // renderer already reads it that way for the update badge.
+  globalThis.__APP_VERSION__ = '1.2.3';
+  try {
+    assert.equal(runningAppVersion(), '1.2.3');
+  } finally {
+    delete globalThis.__APP_VERSION__;
+  }
+  assert.equal(runningAppVersion(), '');
+});

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -87,7 +87,16 @@ test('model picker options stay provider-specific', () => {
   );
   assert.deepEqual(
     modelsForProvider('codex').map((model) => model.id),
-    [undefined, 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']
+    [
+      undefined,
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex-spark'
+    ]
   );
   assert.deepEqual(
     modelsForProvider('grok').map((model) => model.id),
@@ -120,6 +129,17 @@ test('Command Center model choices round-trip provider and model', () => {
     { provider: 'kimi', model: undefined }
   );
   assert.equal(decodeProviderModel('unknown:model'), null);
+});
+
+test('codex recommends the verified ChatGPT default', () => {
+  const recommended = providerPreset('codex').recommendedOrchestratorModel;
+  const codexIds = modelsForProvider('codex').map((model) => model.id);
+
+  assert.equal(recommended, 'gpt-5.6-sol');
+  assert.ok(
+    codexIds.includes(recommended),
+    `codex recommends ${recommended}, which its picker does not offer`
+  );
 });
 
 test('God only sees providers that can drain hive inbox messages', () => {

--- a/test/render-hooks.cjs
+++ b/test/render-hooks.cjs
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * A ~60-line React host for node:test — enough to MOUNT a real component and
+ * drive it, without jsdom or react-dom.
+ *
+ * Why this exists: a pure-function test proves nothing about the component
+ * wiring — it stays green when the component stops calling the function.
+ * Grepping the source for the call site is not a test either; it goes green on
+ * a call that is present but wired to the wrong state. So we run the actual
+ * component function, with the actual JSX, and assert on what it renders.
+ *
+ * It works by seeding `require.cache` for `react` and `react/jsx-runtime`
+ * (the same trick test/harness-home-tilde.test.cjs uses for `electron`), so it
+ * MUST be required before any component module is loaded.
+ *
+ * Deliberately NOT a React reimplementation: no reconciler, no batching, no
+ * concurrent anything. `render()` is synchronous and re-runs the component with
+ * the current hook slots — call it after an interaction to see the next frame.
+ */
+
+let HOST = null;
+
+const seed = (spec, exports) => {
+  const f = require.resolve(spec);
+  require.cache[f] = { id: f, filename: f, loaded: true, exports };
+};
+
+seed('react', {
+  useState: (init) => HOST.useState(init),
+  useEffect: (fn, deps) => HOST.useEffect(fn, deps),
+  useRef: (init) => HOST.useRef(init),
+  useMemo: (fn) => fn(),
+  useCallback: (fn) => fn
+});
+
+const jsx = (type, props, key) => ({ type, props: props ?? {}, key: key ?? null });
+seed('react/jsx-runtime', { jsx, jsxs: jsx, Fragment: Symbol.for('react.fragment') });
+
+/** Mount `Component` with `props`. Each call gets its own hook slots — mounting
+ *  twice is a genuine REMOUNT, which is how the settings panel behaves when the
+ *  user switches sections. */
+function mount(Component, props) {
+  const slots = [];
+  let idx = 0;
+  let effects = [];
+  let tree = null;
+  const host = {
+    useState(init) {
+      const i = idx++;
+      if (!(i in slots)) slots[i] = typeof init === 'function' ? init() : init;
+      return [slots[i], (v) => { slots[i] = typeof v === 'function' ? v(slots[i]) : v; }];
+    },
+    useEffect(fn) { effects.push(fn); },
+    useRef(init) {
+      const i = idx++;
+      if (!(i in slots)) slots[i] = { current: init };
+      return slots[i];
+    }
+  };
+  const render = () => {
+    HOST = host;
+    idx = 0;
+    effects = [];
+    try { tree = Component(props); } finally { HOST = null; }
+    return tree;
+  };
+  render();
+  // Mount effects run once, after the first render — deps are ignored because
+  // nothing here re-renders on its own.
+  const cleanups = effects.map((fn) => fn());
+  return { render, get tree() { return tree; }, cleanups };
+}
+
+/** Every element in the tree, each paired with the nearest ancestor that
+ *  carried a `key` — which is how a row is identified back to its catalog id. */
+function flatten(node, key = null, out = []) {
+  if (node == null || typeof node !== 'object') return out;
+  if (Array.isArray(node)) {
+    for (const n of node) flatten(n, key, out);
+    return out;
+  }
+  const own = node.key ?? key;
+  out.push({ node, key: own });
+  const children = node.props && node.props.children;
+  if (children !== undefined) flatten(children, own, out);
+  return out;
+}
+
+/** All rendered text, flattened — for asserting on notices and labels. */
+function text(node, out = []) {
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') { out.push(String(node)); return out; }
+  if (Array.isArray(node)) { for (const n of node) text(n, out); return out; }
+  if (typeof node === 'object' && node.props) text(node.props.children, out);
+  return out;
+}
+
+module.exports = { mount, flatten, text };

--- a/test/telemetry-forget-agent.test.cjs
+++ b/test/telemetry-forget-agent.test.cjs
@@ -1,0 +1,108 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { TelemetryCollector } = loadTs('src/main/telemetry.ts');
+
+function tokenBatch(agentId, sessionId, output) {
+  return {
+    resourceMetrics: [{
+      resource: { attributes: [{ key: 'agent.id', value: { stringValue: agentId } }] },
+      scopeMetrics: [{
+        metrics: [{
+          name: 'claude_code.token.usage',
+          sum: {
+            dataPoints: [{
+              asInt: String(output),
+              attributes: [
+                { key: 'session.id', value: { stringValue: sessionId } },
+                { key: 'type', value: { stringValue: 'output' } },
+                { key: 'model', value: { stringValue: 'claude-sonnet-5' } }
+              ]
+            }]
+          }
+        }]
+      }]
+    }]
+  };
+}
+
+async function postMetrics(endpoint, body) {
+  const response = await fetch(`${endpoint}/v1/metrics`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  assert.equal(response.status, 200);
+  await response.text();
+}
+
+test('forgetAgent resets usage before the same agent id is respawned', async (t) => {
+  const telemetry = new TelemetryCollector({ host: '127.0.0.1', port: 0 });
+  await telemetry.start();
+  t.after(() => telemetry.stop());
+  const endpoint = telemetry.endpoint();
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'dead-session', 900));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 900);
+
+  telemetry.forgetAgent('agent-1');
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'respawn-session', 10));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 10);
+});
+
+test('forgetAgent drops the dead session so its total cannot resurrect', async (t) => {
+  const telemetry = new TelemetryCollector({ host: '127.0.0.1', port: 0 });
+  await telemetry.start();
+  t.after(() => telemetry.stop());
+  const endpoint = telemetry.endpoint();
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'dead-session', 900));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 900);
+
+  telemetry.forgetAgent('agent-1');
+
+  // A late or duplicate sample for the SAME session id must accumulate from
+  // zero, not re-attach the forgotten 900. Deleting only agentSessions and
+  // leaving the sessions entry behind would let the dead total resurrect the
+  // moment any further metric arrives for that session — reinstating the very
+  // inherited usage this reset exists to clear.
+  await postMetrics(endpoint, tokenBatch('agent-1', 'dead-session', 10));
+  assert.equal(telemetry.getAgentUsage('agent-1').output, 10);
+});
+
+test('forgetAgent keeps usage for other agents', async (t) => {
+  const telemetry = new TelemetryCollector({ host: '127.0.0.1', port: 0 });
+  await telemetry.start();
+  t.after(() => telemetry.stop());
+  const endpoint = telemetry.endpoint();
+
+  await postMetrics(endpoint, tokenBatch('agent-1', 'session-1', 500));
+  await postMetrics(endpoint, tokenBatch('agent-2', 'session-2', 700));
+
+  telemetry.forgetAgent('agent-1');
+
+  assert.equal(telemetry.getAgentUsage('agent-1'), null);
+  assert.equal(telemetry.getAgentUsage('agent-2').output, 700);
+});
+
+test('teardown resets telemetry when it forgets breaker state', () => {
+  const indexPath = require('node:path').join(__dirname, '..', 'src', 'main', 'index.ts');
+  const rawSource = require('node:fs').readFileSync(indexPath, 'utf8');
+  const activeSource = rawSource
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+  // Bounded to the teardown block: an unbounded slice would also match the call
+  // if it were moved into any later function in the file.
+  const start = activeSource.indexOf('breaker.forget(agentId)');
+  const end = activeSource.indexOf('hive.stopProxyBridge(agentId)', start);
+  assert.ok(start !== -1 && end > start, 'teardown block not found in index.ts');
+  const afterBreakerReset = activeSource.slice(start, end);
+
+  assert.match(afterBreakerReset, /telemetry\.forgetAgent\(agentId\)/);
+});

--- a/test/worktree-deps.test.cjs
+++ b/test/worktree-deps.test.cjs
@@ -1,0 +1,203 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { linkWorktreeDeps, unlinkWorktreeDeps } = loadTs('src/main/worktreeDeps.ts');
+const { removeWorktree } = loadTs('src/main/git.ts');
+
+const git = (cwd, ...args) => execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+function makeHarness() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-worktree-deps-'));
+  const repo = path.join(home, 'repo');
+  fs.mkdirSync(repo);
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.email', 'test@example.com');
+  git(repo, 'config', 'user.name', 'Test');
+  fs.writeFileSync(path.join(repo, 'README.md'), 'base\n');
+  git(repo, 'add', '-A');
+  git(repo, 'commit', '-q', '-m', 'base');
+  const wtRoot = path.join(home, 'worktrees');
+  fs.mkdirSync(wtRoot);
+  return { repo, wtRoot };
+}
+
+function addWorktree(repo, wtRoot, name) {
+  const wtPath = path.join(wtRoot, name);
+  git(repo, 'worktree', 'add', '-q', wtPath, '-b', `agent/${name}`, 'main');
+  return wtPath;
+}
+
+test('links the base node_modules into an isolated worktree', async () => {
+  const { repo, wtRoot } = makeHarness();
+  const baseNodeModules = path.join(repo, 'node_modules');
+  fs.mkdirSync(baseNodeModules);
+  fs.writeFileSync(path.join(baseNodeModules, 'sentinel.txt'), 'base\n');
+  const wtPath = addWorktree(repo, wtRoot, 'agent-a');
+
+  const result = await linkWorktreeDeps(repo, wtPath);
+
+  assert.deepEqual(result, { ok: true, skipped: false });
+  const worktreeNodeModules = path.join(wtPath, 'node_modules');
+  assert.equal(fs.lstatSync(worktreeNodeModules).isSymbolicLink(), true);
+  assert.equal(fs.readlinkSync(worktreeNodeModules), baseNodeModules);
+  assert.equal(fs.readFileSync(path.join(worktreeNodeModules, 'sentinel.txt'), 'utf8'), 'base\n');
+});
+
+test('skips linking when the base checkout has no node_modules', async () => {
+  const { repo, wtRoot } = makeHarness();
+  const wtPath = addWorktree(repo, wtRoot, 'agent-b');
+
+  const result = await linkWorktreeDeps(repo, wtPath);
+
+  assert.deepEqual(result, { ok: true, skipped: true });
+  assert.throws(() => fs.lstatSync(path.join(wtPath, 'node_modules')), /ENOENT/);
+});
+
+test('does not replace an existing worktree node_modules entry', async () => {
+  const { repo, wtRoot } = makeHarness();
+  fs.mkdirSync(path.join(repo, 'node_modules'));
+  const wtPath = addWorktree(repo, wtRoot, 'agent-c');
+  const worktreeNodeModules = path.join(wtPath, 'node_modules');
+  fs.mkdirSync(worktreeNodeModules);
+  fs.writeFileSync(path.join(worktreeNodeModules, 'own.txt'), 'own\n');
+
+  const result = await linkWorktreeDeps(repo, wtPath);
+
+  assert.deepEqual(result, { ok: true, skipped: true });
+  assert.equal(fs.lstatSync(worktreeNodeModules).isSymbolicLink(), false);
+  assert.equal(fs.readFileSync(path.join(worktreeNodeModules, 'own.txt'), 'utf8'), 'own\n');
+});
+
+test('does not follow the dependency symlink when removing a worktree', async () => {
+  const { repo, wtRoot } = makeHarness();
+  const baseNodeModules = path.join(repo, 'node_modules');
+  fs.mkdirSync(baseNodeModules);
+  const sentinel = path.join(baseNodeModules, 'must-survive.txt');
+  fs.writeFileSync(sentinel, 'still here\n');
+  const wtPath = addWorktree(repo, wtRoot, 'agent-d');
+
+  assert.deepEqual(await linkWorktreeDeps(repo, wtPath), { ok: true, skipped: false });
+  const worktreeNodeModules = path.join(wtPath, 'node_modules');
+  assert.equal(fs.lstatSync(worktreeNodeModules).isSymbolicLink(), true, 'symlink must exist before removal');
+  assert.deepEqual(await removeWorktree(repo, wtPath), { ok: true });
+
+  assert.equal(fs.existsSync(wtPath), false);
+  assert.equal(fs.readFileSync(sentinel, 'utf8'), 'still here\n');
+});
+
+test('leaves a dangling worktree dependency symlink untouched', async () => {
+  const { repo, wtRoot } = makeHarness();
+  fs.mkdirSync(path.join(repo, 'node_modules'));
+  const wtPath = addWorktree(repo, wtRoot, 'agent-e');
+  const worktreeNodeModules = path.join(wtPath, 'node_modules');
+  fs.symlinkSync('/does-not-exist', worktreeNodeModules);
+
+  const result = await linkWorktreeDeps(repo, wtPath);
+
+  assert.deepEqual(result, { ok: true, skipped: true });
+  assert.equal(fs.readlinkSync(worktreeNodeModules), '/does-not-exist');
+});
+
+test('reports a failed link without throwing', async () => {
+  const { repo } = makeHarness();
+  fs.mkdirSync(path.join(repo, 'node_modules'));
+  const notADirectory = path.join(repo, 'not-a-directory');
+  fs.writeFileSync(notADirectory, 'file\n');
+
+  const result = await linkWorktreeDeps(repo, notADirectory);
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /EEXIST|ENOTDIR/);
+});
+
+test('removes only the linked dependencies before checking worktree status', async () => {
+  const { repo, wtRoot } = makeHarness();
+  const baseNodeModules = path.join(repo, 'node_modules');
+  fs.mkdirSync(baseNodeModules);
+  const wtPath = addWorktree(repo, wtRoot, 'agent-f');
+  const worktreeNodeModules = path.join(wtPath, 'node_modules');
+
+  assert.deepEqual(await linkWorktreeDeps(repo, wtPath), { ok: true, skipped: false });
+  assert.notEqual(git(wtPath, 'status', '--porcelain'), '', 'the unignored link makes the worktree dirty');
+
+  assert.deepEqual(await unlinkWorktreeDeps(repo, wtPath), { ok: true, removed: true });
+  assert.throws(() => fs.lstatSync(worktreeNodeModules), /ENOENT/);
+  assert.equal(git(wtPath, 'status', '--porcelain'), '', 'removing the link restores a clean worktree');
+  assert.equal(fs.existsSync(baseNodeModules), true, 'the base dependencies must remain');
+});
+
+test('does not remove a real worktree node_modules directory', async () => {
+  const { repo, wtRoot } = makeHarness();
+  fs.mkdirSync(path.join(repo, 'node_modules'));
+  const wtPath = addWorktree(repo, wtRoot, 'agent-g');
+  const worktreeNodeModules = path.join(wtPath, 'node_modules');
+  fs.mkdirSync(worktreeNodeModules);
+  const sentinel = path.join(worktreeNodeModules, 'must-survive.txt');
+  fs.writeFileSync(sentinel, 'worktree dependencies\n');
+
+  const result = await unlinkWorktreeDeps(repo, wtPath);
+  assert.equal(fs.lstatSync(worktreeNodeModules).isDirectory(), true);
+  assert.equal(fs.readFileSync(sentinel, 'utf8'), 'worktree dependencies\n');
+  assert.deepEqual(result, { ok: true, removed: false });
+});
+
+test('does not remove a worktree node_modules link to another directory', async () => {
+  const { repo, wtRoot } = makeHarness();
+  fs.mkdirSync(path.join(repo, 'node_modules'));
+  const foreignNodeModules = path.join(repo, 'foreign-node-modules');
+  fs.mkdirSync(foreignNodeModules);
+  const sentinel = path.join(foreignNodeModules, 'must-survive.txt');
+  fs.writeFileSync(sentinel, 'foreign dependencies\n');
+  const wtPath = addWorktree(repo, wtRoot, 'agent-h');
+  const worktreeNodeModules = path.join(wtPath, 'node_modules');
+  fs.symlinkSync(foreignNodeModules, worktreeNodeModules);
+
+  const result = await unlinkWorktreeDeps(repo, wtPath);
+  assert.equal(fs.lstatSync(worktreeNodeModules).isSymbolicLink(), true);
+  assert.equal(fs.readlinkSync(worktreeNodeModules), foreignNodeModules);
+  assert.equal(fs.readFileSync(sentinel, 'utf8'), 'foreign dependencies\n');
+  assert.deepEqual(result, { ok: true, removed: false });
+});
+
+test('wires dependency linking into successful isolated worktree creation', () => {
+  const indexSource = fs.readFileSync(path.join(__dirname, '..', 'src/main/index.ts'), 'utf8');
+  const activeSource = indexSource
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+
+  assert.match(activeSource, /from ['"]\.\/worktreeDeps['"]/);
+  const successBranch = activeSource.slice(
+    activeSource.indexOf('if (wt.ok)'),
+    activeSource.indexOf('} else {', activeSource.indexOf('if (wt.ok)'))
+  );
+  assert.match(successBranch, /await linkWorktreeDeps\(origCwd, wtPath\)/);
+});
+
+test('removes linked dependencies before worker retention checks', () => {
+  const indexSource = fs.readFileSync(path.join(__dirname, '..', 'src/main/index.ts'), 'utf8');
+  const activeSource = indexSource
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+
+  const beforeRetention = activeSource.slice(0, activeSource.indexOf('const work = await worktreeHasUnintegratedWork'));
+  assert.match(beforeRetention, /await unlinkWorktreeDeps\(origCwd, wtPath\)/);
+  const beforeGc = activeSource.slice(0, activeSource.indexOf('safe = await worktreeIsGcSafe'));
+  assert.match(beforeGc, /await unlinkWorktreeDeps\(e\.origCwd, e\.wtPath\)/);
+});
+
+test('uses a Windows junction for the directory link', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'src/main/worktreeDeps.ts'), 'utf8');
+
+  assert.match(source, /process\.platform === ['"]win32['"] \? ['"]junction['"] :/);
+});


### PR DESCRIPTION
## What & why

Every provider's model picker was a hardcoded `ModelOption[]` in the renderer store, so
shipping a model — one string — meant editing renderer source, type-checking and
rebuilding. The arrays also could not say *which releases* a model belongs to: a build
whose CLI never shipped a model still offered it, and a retired model stayed in the
picker forever.

The twelve arrays now live in `src/shared/modelCatalog.json`, ported verbatim, each entry
carrying inclusive `minAppVersion` / `maxAppVersion` bounds. Every ported entry has `null`
for both, so this build offers exactly what it offered before — the version fields are the
mechanism, not a behaviour change. The catalog is imported at **build** time (no fs, no
network, offline-safe) and `modelsForProvider` filters it by the running app version, which
electron-vite already inlines into the renderer as `__APP_VERSION__` for the update badge.
Adding a model is now a one-line JSON edit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

No visible UI change: the pickers offer the same models, in the same order, with the same
labels. The evidence is the test suite going red → green, plus proof that the built bundle
really carries the version into the filter.

Reproduce both halves:

```
node --test test/model-catalog.test.cjs                                        # green
git checkout <base> -- src/renderer/src/store/config.ts test/load-ts.cjs
node --test test/model-catalog.test.cjs                                        # red
```

### Before
<img width="1366" height="550" alt="CleanShot 2026-08-26 at 14 58 15@2x" src="https://github.com/user-attachments/assets/8b1bce21-14e8-42b9-be12-8431f0e821c0" />

The catalog-backed API does not exist, so the version-bound assertions fail. The three
tests that *do* pass are the ones pinning today's picker output — they pass against the
hardcoded arrays, which is what makes them a faithful record of what shipped:


### After
<img width="1162" height="406" alt="CleanShot 2026-08-26 at 14 58 46@2x" src="https://github.com/user-attachments/assets/df490eec-ce23-4052-bed1-ac96bf426ce0" />

Same file, same assertions — the picker-output tests still pass (so nothing a user sees
changed), and the version filter now works:

And the production bundle proves the version reaches the filter — esbuild folds the
build-time define straight through, so there is no round trip to main:

```
$ npm run build && grep -n -A3 'function runningAppVersion' out/renderer/assets/index-*.js
40935:function runningAppVersion() {
40936-  return "0.4.5";
40937-}
40938-function offeredAtVersion(model, appVersion) {
```

## How I tested it

- OS: macOS 15 (Darwin 25.6.0), Node 22
- Steps:
  - `npm run typecheck` — 0 errors (node + web).
  - `npm run test:focused` — **560 of 560 pass**; the base commit is 552 of 552, and the
    8 new tests are the whole difference.
  - `npm run build` — succeeds; bundle checked as above.
  - Mutation-checked the new tests: disabling the `minAppVersion` check, dropping the
    `maxAppVersion` check, editing one catalog label, and making the version accessor
    ignore `__APP_VERSION__` each turn the matching test red.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing,
      or fonts. (No UI in this change.)
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`. (No art.)


---

## How the catalog works & how to maintain it

The provider model lists live in `src/shared/modelCatalog.json` and are imported
at build time. `modelsForProvider(provider)` returns that provider's list,
filtered at runtime by the running app version.

There are **two independent "version" concepts** — they do not map to each other:

- **Top-level `"version"`** is the *file schema version*. Nothing reads it today;
  it exists so that if the file's **structure** ever changes, code can branch on
  it. Bump it only when the shape of the JSON changes — never for adding or
  removing a model.
- **Per-model `minAppVersion` / `maxAppVersion`** are the *app-version bounds*
  (inclusive; `null` = unbounded). A model is shown only when the running app
  version falls within its bounds. Every model currently ships `null`/`null`, so
  the picker is identical to the previous hardcoded lists.

### Add a new model

Add an entry under the provider in `modelCatalog.json`:

```json
{ "id": "gpt-6-nova", "label": "GPT-6 Nova", "minAppVersion": null, "maxAppVersion": null }
```

If the model only works from a future release, set `minAppVersion` to that
release (e.g. `"0.5.0"`) so users on older builds — whose CLI can't run it —
don't see it. Otherwise leave both bounds `null`.

### Retire an old model

Set `maxAppVersion` to the **last release that should still offer it**:

```json
{ "id": "gpt-5.6-sol", "label": "GPT-5.6 Sol", "minAppVersion": null, "maxAppVersion": "0.4.9" }
```

Builds newer than `0.4.9` stop offering it, while users still on `0.4.x` keep
seeing it. To remove a model **everywhere at once** (all versions), just delete
its entry instead.
