### PR TITLE
fix(hive): quote Codex hooks for spaced paths

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -507,11 +507,8 @@ export class HiveManager {
     return [launcher ? `"${launcher}"` : 'node', `"${script}"`, ...args].join(' ');
   }
 
-  /** Same, but UNQUOTED — for the CLIs whose hook config mangles embedded quotes
-   *  (agy on cmd.exe) or stores the command in a quote-sensitive literal (codex's
-   *  single-quoted TOML). Safe because both the hive root and the launcher inside
-   *  it are space-free by construction; this only preserves each installer's
-   *  existing quoting convention while swapping `node` for the bundled runtime. */
+  /** Same, but UNQUOTED — preserve the legacy convention for hook configs that
+   *  mangle embedded quotes. Prefer nodeRun() whenever the config can encode it. */
   private nodeRunUnquoted(script: string, ...args: string[]): string {
     return [this.nodeLauncher() ?? 'node', script, ...args].join(' ');
   }
@@ -2000,9 +1997,11 @@ export class HiveManager {
       // over) and append a `[[hooks.<Event>]]` group per event, each pointing at the
       // SAME cth-hook shim — reused verbatim (Codex's hook payload + response are
       // already Claude-shaped, so HookServer/drainForStop run unchanged). Regenerated
-      // each spawn (idempotent). A single-quoted TOML literal avoids path escaping
-      // (hive roots are space/quote-free). NOTE: hooks fire in INTERACTIVE codex
-      // sessions (how hive workers run), not in headless `codex exec`.
+      // each spawn (idempotent). Serialize the generated command as a TOML basic
+      // string; JSON string escaping is compatible here and, on POSIX, preserves
+      // the embedded quotes required when a user-selected hive path has spaces.
+      // NOTE: hooks fire in INTERACTIVE codex sessions (how hive workers run),
+      // not in headless `codex exec`.
       //
       // `timeout` IS SECONDS HERE — do NOT copy Claude's `timeout: 0` sentinel into
       // this file. Codex parses the key as `timeout_sec` and normalizes it with
@@ -2024,9 +2023,15 @@ export class HiveManager {
       if (shim) {
         const events = ['PreToolUse', 'PostToolUse', 'Stop', 'SubagentStop',
           'SessionStart', 'UserPromptSubmit', 'PreCompact', 'PostCompact'];
+        // Preserve the existing Windows .cmd shape: nested command quotes pass
+        // through a different shell stack there (#350). The reported Codex bug
+        // is POSIX, where ordinary shell quoting is both necessary and verified.
+        const command = process.platform === 'win32'
+          ? this.nodeRunUnquoted(shim)
+          : this.nodeRun(shim);
         config += '\n# --- munder-hive lifecycle hooks (auto-generated; do not edit) ---\n';
         for (const ev of events) {
-          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = '${this.nodeRunUnquoted(shim)}'\ntimeout = 30\n`;
+          config += `\n[[hooks.${ev}]]\n[[hooks.${ev}.hooks]]\ntype = "command"\ncommand = ${JSON.stringify(command)}\ntimeout = 30\n`;
         }
       }
       writeFileSync(join(home, 'config.toml'), config, 'utf8');

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -28,12 +28,12 @@ const { HiveManager } = loadTs('src/main/hive.ts');
 const POSIX = process.platform !== 'win32';
 const STRIPPED_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
 
-function tmpHome() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-hive-node-'));
+function tmpHome(prefix = 'md-hive-node-', root = os.tmpdir()) {
+  return fs.mkdtempSync(path.join(root, prefix));
 }
 
-function isolatedHomes(t) {
-  const base = tmpHome();
+function isolatedHomes(t, prefix, root) {
+  const base = tmpHome(prefix, root);
   const home = path.join(base, 'user');
   const harness = path.join(base, 'harness');
   t.after(() => fs.rmSync(base, { recursive: true, force: true }));
@@ -72,9 +72,11 @@ function hookCommandsUnder(home) {
     let text;
     try { text = fs.readFileSync(file, 'utf8'); } catch { continue; }
     if (!shim.test(text)) continue;
-    // JSON hook configs: "command": "<…>"      TOML (codex): command = '<…>'
+    // JSON hook configs: "command": "<…>"      TOML (codex): command = "<…>"
     for (const m of text.matchAll(/"command"\s*:\s*"((?:[^"\\]|\\.)*)"/g)) found.push(JSON.parse(`"${m[1]}"`));
-    for (const m of text.matchAll(/command = '([^']+)'/g)) found.push(m[1]);
+    for (const m of text.matchAll(/^command\s*=\s*("(?:[^"\\]|\\.)*"|'[^']*')\s*$/gm)) {
+      found.push(m[1].startsWith('"') ? JSON.parse(m[1]) : m[1].slice(1, -1));
+    }
   }
   return found.filter((c) => shim.test(c));
 }
@@ -167,6 +169,53 @@ test('every hook installer routes through the launcher — none left on bare nod
   for (const shim of ['agy-hook.cjs', 'grok-hook.cjs', 'gemini-hook.cjs']) {
     assert.ok(commands.some((c) => c.includes(shim)), `${shim} installer produced no command`);
   }
+});
+
+test('Codex hook commands survive a hive path containing spaces', { skip: !POSIX, timeout: 10_000 }, async (t) => {
+  // Keep this root short enough for macOS's Unix-domain socket path limit while
+  // putting the literal space after a unique component. The shell's first token
+  // is then guaranteed absent, which makes the exit-127 negative control stable.
+  const isolated = isolatedHomes(t, undefined, '/tmp');
+  const home = isolated.home;
+  const harness = `${isolated.harness} space`;
+  const hive = new HiveManager(() => harness);
+  hive.ensureHive();
+  const agentDir = path.join(harness, 'hive', 'agents', 'a1');
+  const codexHome = hive.installCodexHooks(agentDir, 'a1');
+  const config = fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8');
+  const commands = [...config.matchAll(/^command\s*=\s*(.+)$/gm)].map((m) => {
+    const literal = m[1].trim();
+    return literal.startsWith('"') ? JSON.parse(literal) : literal.slice(1, -1);
+  });
+
+  assert.equal(commands.length, 8, 'every Codex lifecycle hook must be generated');
+  const launcher = launcherIn(harness);
+  const shim = path.join(harness, 'hive', 'bin', 'cth-hook.cjs');
+  const sock = path.join(harness, 'hive', 'hooks.sock');
+  const env = { PATH: STRIPPED_PATH, HIVE_SOCK: sock, AGENT_ID: 'a1', HOME: home };
+
+  const before = await run(`${launcher} ${shim}`, env);
+  assert.equal(before.code, 127, 'negative control: the current unquoted command must fail at the first space');
+
+  try { fs.unlinkSync(sock); } catch { /* not there */ }
+  const received = [];
+  const server = net.createServer((conn) => {
+    let buf = '';
+    conn.on('error', () => { /* the shim may hang up first */ });
+    conn.on('data', (d) => { buf += d; });
+    conn.on('close', () => { if (buf) received.push(buf); });
+    conn.write(JSON.stringify({ ok: true }) + '\n', () => conn.end());
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(sock, resolve);
+  });
+  t.after(() => server.close());
+
+  const after = await run(commands[0], env);
+  assert.equal(after.code, 0, `Codex hook failed from a space-containing hive path: ${after.stderr}`);
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.ok(received.length > 0, 'the quoted hook command never reached HIVE_SOCK');
 });
 
 test('Codex rollouts remain isolated and are visible under the standard scan roots', (t) => {


### PR DESCRIPTION
## Summary

- quote the bundled-node launcher and hook shim in POSIX Codex lifecycle commands
- serialize the quoted command as an escaped TOML basic string
- preserve the existing Windows `.cmd` command shape pending its separate cross-shell contract
- add a real shell/socket regression for hive paths containing spaces

Fixes #354

## Why

Codex currently writes unquoted absolute launcher and shim paths to each isolated `config.toml`. When a valid user-selected hive path contains a space, `/bin/sh` splits the command at that space and every lifecycle hook exits 127.

The regression test includes an exit-127 negative control, executes the generated command with a stripped hook `PATH`, and verifies that the payload reaches `HIVE_SOCK`.

## Test plan

- [x] RED on upstream main: generated command exits 127 at the first space
- [x] GREEN after fix: generated command exits 0 and reaches `HIVE_SOCK`
- [x] `node --test --test-name-pattern='Codex hook commands survive' test/hive-hook-node.test.cjs` — 1/1
- [x] `node --test test/hive-hook-node.test.cjs` — 11/11
- [x] `npm run test:focused` — 746/746
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `git diff --check upstream/main...HEAD`

## Scope

This intentionally changes only POSIX Codex hook generation. Windows keeps the existing unquoted `.cmd` shape because its Git Bash / Windows command-interpreter quoting behavior is tracked separately in #350.

### Before

<img width="1050" height="325" alt="clipboard" src="https://github.com/user-attachments/assets/14f66781-a944-4257-85d1-d1cc3faa416a" />

### After

<img width="1050" height="325" alt="clipboard" src="https://github.com/user-attachments/assets/f80cd55a-7b78-4af5-bc50-a476bf8f89c4" />
