### PR TITLE
fix(hive): inject standing goals only when changed

### DIFF
--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -59,6 +59,11 @@ export class HookServer {
    *  get_agent_detail / list_agents) can report "how full is each agent's context"
    *  without depending on a renderer round-trip. */
   private contextById = new Map<string, { tokens: number; limit: number; ts: number }>();
+  /** The goal last delivered to each agent's current session. Goals are durable
+   *  roster state, so repeating an unchanged multi-kilobyte briefing on every
+   *  prompt only bloats the transcript. One entry per agent is sufficient: an
+   *  agent has one live session, and a new session id replaces the old entry. */
+  private deliveredGoalByAgent = new Map<string, { sessionId: string | null; goal: string | null }>();
 
   constructor(
     private hive: HiveManager,
@@ -70,7 +75,7 @@ export class HookServer {
      *  repeated identical tool calls). Optional so the server still runs without it. */
     private breaker?: CircuitBreaker,
     /** Standing goal text for an agent (from the durable roster). Optional so
-     *  tests can omit it; when set, injected on SessionStart / UserPromptSubmit. */
+     *  tests can omit it; when set, injected at session start and when changed. */
     private getStandingGoal?: (agentId: string) => string | null,
     /** Optional observer of every hook boundary (agentId, event, message). The
      *  worker inbox-wake watchdog (workerWake.ts) feeds on this to learn when an
@@ -273,14 +278,31 @@ export class HookServer {
       : null;
 
     // Standing goal (hire Briefing) — durable roster field, re-read every cycle so
-    // an Edit Agent save is picked up on the next SessionStart / UserPromptSubmit
-    // without restarting the worker. Kept out of --append-system-prompt (volatile-
-    // free cache invariant); lives on the live hook channel instead.
+    // an Edit Agent save is picked up on the next UserPromptSubmit without
+    // restarting the worker. Deliver it once at SessionStart, then only when its
+    // value changes; repeating an unchanged briefing on every prompt can make it
+    // one of the largest elements in a long transcript. Kept out of
+    // --append-system-prompt (volatile-free cache invariant); lives on the live
+    // hook channel instead.
     const wantsGoal = (event === 'SessionStart' || event === 'UserPromptSubmit') && !!agentId;
     const goalRaw = wantsGoal ? (this.getStandingGoal?.(agentId) ?? null) : null;
-    const goal = goalRaw
-      ? `<goal>\n${goalRaw}\n</goal>`
-      : null;
+    let goal: string | null = null;
+    if (wantsGoal) {
+      const sessionId = p.session_id ?? null;
+      const delivered = this.deliveredGoalByAgent.get(agentId);
+      const newSession = !delivered || delivered.sessionId !== sessionId;
+      const changed = !!delivered && delivered.sessionId === sessionId && delivered.goal !== goalRaw;
+      if (event === 'SessionStart' || newSession || changed) {
+        this.deliveredGoalByAgent.set(agentId, { sessionId, goal: goalRaw });
+        if (goalRaw) {
+          goal = `<goal>\n${goalRaw}\n</goal>`;
+        } else if (changed && delivered?.goal) {
+          // Silence would leave the old briefing alive in the model's context.
+          // Explicitly revoke it when the operator clears the durable field.
+          goal = '<goal>\n[Cleared by the operator. Stop following the previous standing goal.]\n</goal>';
+        }
+      }
+    }
 
     if (steer || roster || goal) {
       this.emit(agentId, event, p);

--- a/test/standing-goal-injection.test.cjs
+++ b/test/standing-goal-injection.test.cjs
@@ -1,0 +1,90 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+// hooks.ts imports Electron's Notification class. Node tests only exercise the
+// hook return value, so provide the tiny surface needed to load the module.
+const electron = require.resolve('electron');
+require.cache[electron] = {
+  id: electron,
+  filename: electron,
+  loaded: true,
+  exports: { Notification: class { show() {} static isSupported() { return false; } } }
+};
+
+const { HookServer } = loadTs('src/main/hooks.ts');
+
+function harness(initialGoal = 'Ship the release safely.') {
+  let goal = initialGoal;
+  const hive = {
+    recordSession() {},
+    isGod() { return false; }
+  };
+  const server = new HookServer(
+    hive,
+    () => null,
+    () => ({ notifications: false }),
+    undefined,
+    undefined,
+    () => goal
+  );
+  const fire = (event, sessionId = 'session-1', agentId = 'jim-1') => server.handle({
+    agent_id: agentId,
+    hook_event_name: event,
+    session_id: sessionId
+  });
+  return { fire, setGoal: (next) => { goal = next; } };
+}
+
+const context = (res) => res?.hookSpecificOutput?.additionalContext ?? '';
+
+test('an unchanged standing goal is injected once, not on every prompt', () => {
+  const { fire } = harness();
+
+  assert.match(context(fire('SessionStart')), /Ship the release safely/);
+  assert.equal(context(fire('UserPromptSubmit')), '');
+  assert.equal(context(fire('UserPromptSubmit')), '');
+});
+
+test('a goal edit is delivered on the next prompt and only once', () => {
+  const { fire, setGoal } = harness();
+  fire('SessionStart');
+
+  setGoal('Prepare the customer handoff.');
+  assert.match(context(fire('UserPromptSubmit')), /Prepare the customer handoff/);
+  assert.equal(context(fire('UserPromptSubmit')), '');
+});
+
+test('a new session receives the standing goal even when its text is unchanged', () => {
+  const { fire } = harness();
+  fire('SessionStart', 'session-1');
+
+  assert.match(context(fire('SessionStart', 'session-2')), /Ship the release safely/);
+  assert.equal(context(fire('UserPromptSubmit', 'session-2')), '');
+});
+
+test('a prompt that arrives before SessionStart still receives the goal once', () => {
+  const { fire } = harness();
+
+  assert.match(context(fire('UserPromptSubmit')), /Ship the release safely/);
+  assert.equal(context(fire('UserPromptSubmit')), '');
+});
+
+test('clearing a goal explicitly revokes the old briefing', () => {
+  const { fire, setGoal } = harness();
+  fire('SessionStart');
+
+  setGoal(null);
+  assert.match(context(fire('UserPromptSubmit')), /Cleared by the operator/);
+  assert.equal(context(fire('UserPromptSubmit')), '');
+});
+
+test('goal delivery state is isolated per agent', () => {
+  const { fire } = harness();
+  fire('SessionStart', 'session-1', 'jim-1');
+
+  assert.match(context(fire('UserPromptSubmit', 'session-1', 'pam-1')), /Ship the release safely/);
+  assert.equal(context(fire('UserPromptSubmit', 'session-1', 'jim-1')), '');
+});


### PR DESCRIPTION
## What & why

Standing goals were re-injected as `additionalContext` on every `UserPromptSubmit`, even when the briefing had not changed. Long sessions therefore paid for and stored the same multi-kilobyte goal hundreds of times.

Track the last delivered goal per agent session: inject at `SessionStart`, on the first prompt if start was missed, and on actual edits. Clearing a goal explicitly revokes the previous briefing instead of leaving stale instructions alive.

Closes #359

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

![Before: unchanged standing goal repeats on every prompt](https://raw.githubusercontent.com/drona23/munder-difflin/pr-evidence/pr-evidence/pr359-before.png)

### After

![After: standing goal is delivered once and again only after an edit](https://raw.githubusercontent.com/drona23/munder-difflin/pr-evidence/pr-evidence/pr359-after.png)

## How I tested it

- OS: macOS arm64
- `node --test test/standing-goal-injection.test.cjs` — 6/6 pass
- `npm run test:focused` — 751/751 pass
- `npm run typecheck` — node and web pass
- `npm run build` — production build succeeds
- `git diff --check` — clean

## Checklist

- [x] Before and after evidence is attached above.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is one change.
- [x] I read the diff and removed unrelated changes.
- [x] No UI tokens or art are changed.