### PR TITLE
fix(wake): announce only newly arrived inbox mail

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5055,7 +5055,7 @@ function runWorkerWakeBeat(): void {
       isGod: agentId === reg.godId,
       ptyId,
       lastOutputAt: ptyManager.lastOutputAt(ptyId) ?? 0,
-      inboxCount: hive.inbox(agentId).length,
+      inboxIds: hive.inbox(agentId).map((message) => message.id).filter(Boolean),
       autoDeliveryPaused: snap.autoDeliveryPaused,
       paused: snap.paused,
       halted: snap.halted

--- a/src/main/workerWake.ts
+++ b/src/main/workerWake.ts
@@ -9,9 +9,11 @@
  * because the main process re-engages it on its own heartbeat cadence.
  *
  * This watchdog is the worker-side counterpart: on a cadence it finds live
- * workers that are genuinely idle, have undrained inbox mail, are not paused /
- * not awaiting a human decision, and have not been nudged recently — then types
- * the same guarded nudge the renderer would have, directly into the PTY.
+ * workers that are genuinely idle, have newly arrived inbox mail, are not
+ * paused / not awaiting a human decision, and have not been nudged recently —
+ * then types the same guarded nudge the renderer would have, directly into the
+ * PTY. Message ids make this edge-triggered: unchanged undrained mail is never
+ * re-announced once a minute forever.
  *
  * Safety mirrors the renderer's guarded queue-drain (useHive.ts dispatch):
  *  - only a GENUINELY idle worker is nudged (no PTY output for IDLE_MS — the
@@ -75,8 +77,8 @@ export interface WorkerWakeFacts {
   ptyId?: string;
   /** Timestamp of the PTY's last output (0 = never output). */
   lastOutputAt: number;
-  /** Count of undrained inbox messages (0 → nothing to wake for). */
-  inboxCount: number;
+  /** IDs of undrained inbox messages (empty → nothing to wake for). */
+  inboxIds: readonly string[];
   /** ControlRegistry snapshot flags. */
   autoDeliveryPaused: boolean;
   paused: boolean;
@@ -88,6 +90,9 @@ export class WorkerWakeWatchdog {
   private spawnedAt = new Map<string, number>();
   /** agentId → last nudge timestamp (cooldown). */
   private lastNudgeAt = new Map<string, number>();
+  /** agentId → inbox ids included in the last nudge. This turns the watchdog
+   *  into an edge trigger: a worker is nudged again only when a new id appears. */
+  private announcedInboxIds = new Map<string, Set<string>>();
   /** agentId → timestamp of the last needsHuman hook notification. */
   private lastHumanNeedsAt = new Map<string, number>();
 
@@ -105,6 +110,7 @@ export class WorkerWakeWatchdog {
   /** Forget per-agent state (e.g. the agent's PTY was closed). */
   forget(agentId: string, ptyId?: string): void {
     this.lastNudgeAt.delete(agentId);
+    this.announcedInboxIds.delete(agentId);
     this.lastHumanNeedsAt.delete(agentId);
     if (ptyId) this.spawnedAt.delete(ptyId);
   }
@@ -114,7 +120,14 @@ export class WorkerWakeWatchdog {
   decide(facts: readonly WorkerWakeFacts[], now = Date.now()): string[] {
     const out: string[] = [];
     for (const f of facts) {
-      if (f.isGod || f.inboxCount <= 0 || !f.ptyId) continue;
+      const inboxIds = new Set(f.inboxIds.filter((id) => typeof id === 'string' && id.length > 0));
+      if (inboxIds.size === 0) {
+        // A fully drained inbox starts a fresh announcement cycle and bounds the
+        // remembered set even for a worker that lives for months.
+        this.announcedInboxIds.delete(f.agentId);
+        continue;
+      }
+      if (f.isGod || !f.ptyId) continue;
       if (f.autoDeliveryPaused || f.paused || f.halted) continue;
       if (f.lastOutputAt <= 0) continue; // never produced output → still booting
       if (now - f.lastOutputAt < WORKER_WAKE_IDLE_MS) continue; // mid-turn
@@ -122,9 +135,12 @@ export class WorkerWakeWatchdog {
       if (spawned > 0 && now - spawned < WORKER_WAKE_BOOT_GRACE_MS) continue;
       const lastHuman = this.lastHumanNeedsAt.get(f.agentId) ?? 0;
       if (lastHuman > 0 && now - lastHuman < WORKER_WAKE_HITL_REARM_MS) continue;
+      const announced = this.announcedInboxIds.get(f.agentId);
+      if (announced && !Array.from(inboxIds).some((id) => !announced.has(id))) continue;
       const lastNudge = this.lastNudgeAt.get(f.agentId) ?? 0;
       if (lastNudge > 0 && now - lastNudge < WORKER_WAKE_COOLDOWN_MS) continue;
       this.lastNudgeAt.set(f.agentId, now);
+      this.announcedInboxIds.set(f.agentId, inboxIds);
       out.push(f.agentId);
     }
     return out;

--- a/test/worker-wake.test.cjs
+++ b/test/worker-wake.test.cjs
@@ -18,7 +18,7 @@ function fact(overrides = {}) {
     agentId: 'alice',
     ptyId: 'pty-alice',
     lastOutputAt: 100_000,
-    inboxCount: 1,
+    inboxIds: ['mail-1'],
     autoDeliveryPaused: false,
     paused: false,
     halted: false,
@@ -50,7 +50,7 @@ test('never nudges when there is no inbox mail', () => {
   const w = new WorkerWakeWatchdog();
   w.noteSpawn('pty-alice', 0);
   const now = 200_000;
-  const out = w.decide([fact({ inboxCount: 0 })], now);
+  const out = w.decide([fact({ inboxIds: [] })], now);
   assert.deepEqual(out, []);
 });
 
@@ -111,13 +111,58 @@ test('an idle-waiting notification does NOT count as a HITL hold', () => {
   assert.deepEqual(w.decide([fact()], now), ['alice']);
 });
 
-test('a nudge is not repeated within the cooldown', () => {
+test('the same inbox mail is not re-announced after the cooldown', () => {
   const w = new WorkerWakeWatchdog();
   w.noteSpawn('pty-alice', 0);
   const now = 200_000;
   assert.deepEqual(w.decide([fact()], now), ['alice']);
   assert.deepEqual(w.decide([fact()], now + WORKER_WAKE_COOLDOWN_MS - 1), []);
-  assert.deepEqual(w.decide([fact({ lastOutputAt: now + WORKER_WAKE_COOLDOWN_MS + 1 - WORKER_WAKE_IDLE_MS - 1 })], now + WORKER_WAKE_COOLDOWN_MS + 1), ['alice']);
+  assert.deepEqual(w.decide([fact({ lastOutputAt: now + WORKER_WAKE_COOLDOWN_MS + 1 - WORKER_WAKE_IDLE_MS - 1 })], now + WORKER_WAKE_COOLDOWN_MS + 1), []);
+});
+
+test('new mail is announced after the cooldown even while older mail remains', () => {
+  const w = new WorkerWakeWatchdog();
+  w.noteSpawn('pty-alice', 0);
+  const now = 200_000;
+  assert.deepEqual(w.decide([fact()], now), ['alice']);
+
+  const duringCooldown = now + WORKER_WAKE_COOLDOWN_MS - 1;
+  assert.deepEqual(w.decide([fact({
+    inboxIds: ['mail-1', 'mail-2'],
+    lastOutputAt: duringCooldown - WORKER_WAKE_IDLE_MS - 1
+  })], duringCooldown), []);
+
+  const afterCooldown = now + WORKER_WAKE_COOLDOWN_MS + 1;
+  assert.deepEqual(w.decide([fact({
+    inboxIds: ['mail-1', 'mail-2'],
+    lastOutputAt: afterCooldown - WORKER_WAKE_IDLE_MS - 1
+  })], afterCooldown), ['alice']);
+});
+
+test('filing one of several announced messages does not re-announce the remainder', () => {
+  const w = new WorkerWakeWatchdog();
+  w.noteSpawn('pty-alice', 0);
+  const now = 200_000;
+  assert.deepEqual(w.decide([fact({ inboxIds: ['mail-1', 'mail-2'] })], now), ['alice']);
+
+  const later = now + WORKER_WAKE_COOLDOWN_MS + 1;
+  assert.deepEqual(w.decide([fact({
+    inboxIds: ['mail-2'],
+    lastOutputAt: later - WORKER_WAKE_IDLE_MS - 1
+  })], later), []);
+});
+
+test('draining the inbox resets announcement memory', () => {
+  const w = new WorkerWakeWatchdog();
+  w.noteSpawn('pty-alice', 0);
+  const now = 200_000;
+  assert.deepEqual(w.decide([fact()], now), ['alice']);
+  assert.deepEqual(w.decide([fact({ inboxIds: [] })], now + 1), []);
+
+  const later = now + WORKER_WAKE_COOLDOWN_MS + 1;
+  assert.deepEqual(w.decide([fact({
+    lastOutputAt: later - WORKER_WAKE_IDLE_MS - 1
+  })], later), ['alice']);
 });
 
 test('forget clears cooldown + boot grace + HITL state', () => {


### PR DESCRIPTION
## What & why

The main-process worker wake watchdog treated `inboxCount > 0` as a level trigger. Once a worker had any undrained mail, the same notice was typed every 60 seconds indefinitely—even when the pending message IDs had not changed.

Pass the actual inbox IDs into the watchdog and remember the IDs included in the last nudge. Existing mail is not re-announced; a newly arrived ID still triggers a wake after the safety cooldown. Filing only part of an announced set does not re-announce the remainder, and a fully drained inbox resets the remembered set.

Closes #358

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

![Before: identical inbox mail is announced again after every cooldown](https://raw.githubusercontent.com/drona23/munder-difflin/pr-evidence/pr-evidence/pr358-before.png)

### After

![After: unchanged mail is silent while a new ID still triggers a wake](https://raw.githubusercontent.com/drona23/munder-difflin/pr-evidence/pr-evidence/pr358-after.png)

## How I tested it

- OS: macOS arm64
- `node --test test/worker-wake.test.cjs` — 17/17 pass
- `npm run test:focused` — 748/748 pass
- `npm run typecheck` — node and web pass
- `npm run build` — production build succeeds
- `git diff --check` — clean

## Checklist

- [x] Before and after evidence is attached above.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is one change.
- [x] I read the diff and removed unrelated changes.
- [x] No UI tokens or art are changed.