### PR TITLE
fix(hive): quote provider hooks for spaced POSIX paths

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -507,11 +507,9 @@ export class HiveManager {
     return [launcher ? `"${launcher}"` : 'node', `"${script}"`, ...args].join(' ');
   }
 
-  /** Same, but UNQUOTED — for the CLIs whose hook config mangles embedded quotes
-   *  (agy on cmd.exe) or stores the command in a quote-sensitive literal (codex's
-   *  single-quoted TOML). Safe because both the hive root and the launcher inside
-   *  it are space-free by construction; this only preserves each installer's
-   *  existing quoting convention while swapping `node` for the bundled runtime. */
+  /** Same, but UNQUOTED — only for configs or platforms that cannot preserve
+   *  embedded quotes. POSIX JSON hook configs must use nodeRun() because the
+   *  user-selected hive path may legitimately contain spaces. */
   private nodeRunUnquoted(script: string, ...args: string[]): string {
     return [this.nodeLauncher() ?? 'node', script, ...args].join(' ');
   }
@@ -1869,8 +1867,8 @@ export class HiveManager {
    *
    *  Two agy-isms handled: (1) antigravity-cli#49 — agy LOADS hooks from
    *  `~/.gemini/antigravity-cli/hooks.json` but TRIGGERS from `~/.gemini/config/
-   *  hooks.json`, so we write BOTH; (2) commands go to cmd.exe and agy mangles
-   *  embedded quotes, so the shim path must be space-free (hive roots are).
+   *  hooks.json`, so we write BOTH; (2) on Windows commands go to cmd.exe and
+   *  agy mangles embedded quotes, so that platform retains the legacy form.
    *  Runtime-scoped by AGENT_ID (the shim no-ops for non-hive agy sessions), so
    *  this global config never disturbs the user's own `agy` usage. Best-effort,
    *  idempotent (only our own group is overwritten). */
@@ -1881,12 +1879,15 @@ export class HiveManager {
     mkdirSync(join(root, 'bin'), { recursive: true });
     writeFileSync(shim, AGY_HOOK_SHIM, 'utf8');
     // Bundled node, not bare `node` — agy's hooks run with a stripped PATH too.
+    const command = (event: string) => process.platform === 'win32'
+      ? this.nodeRunUnquoted(shim, event)
+      : this.nodeRun(shim, event);
     const tool = (event: string) => ({
       matcher: '*',
-      hooks: [{ type: 'command', command: this.nodeRunUnquoted(shim, event), timeout: 0 }]
+      hooks: [{ type: 'command', command: command(event), timeout: 0 }]
     });
     const plain = (event: string) => ({
-      hooks: [{ type: 'command', command: this.nodeRunUnquoted(shim, event), timeout: 0 }]
+      hooks: [{ type: 'command', command: command(event), timeout: 0 }]
     });
     const group = {
       PreToolUse: [tool('PreToolUse')],
@@ -1929,7 +1930,9 @@ export class HiveManager {
         hooks: [{
           name: `munder-hive-${name}`,
           type: 'command',
-          command: this.nodeRunUnquoted(shim),
+          command: process.platform === 'win32'
+            ? this.nodeRunUnquoted(shim)
+            : this.nodeRun(shim),
           timeout: 30000
         }]
       });

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -169,6 +169,64 @@ test('every hook installer routes through the launcher — none left on bare nod
   }
 });
 
+test('POSIX Gemini and Antigravity hooks survive a hive path containing spaces', { skip: !POSIX }, async (t) => {
+  // Keep the socket short enough for macOS sun_path while retaining a literal
+  // space in the user-selected harness root.
+  const base = fs.mkdtempSync('/tmp/md-provider-space-');
+  const home = path.join(base, 'user');
+  const harness = path.join(base, 'harness space');
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+
+  const realHome = process.env.HOME;
+  const realProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  t.after(() => {
+    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
+    if (realProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = realProfile;
+  });
+  assert.equal(os.homedir(), home, 'home redirect failed — aborting before touching the real home');
+
+  const hive = new HiveManager(() => harness);
+  hive.ensureHive();
+  hive.installAgyHooks();
+  hive.installGeminiHooks(path.join(harness, 'hive/agents/a1'));
+
+  const commands = hookCommandsUnder(home);
+  const providerCommands = [
+    ['antigravity', commands.find((candidate) => candidate.includes('agy-hook.cjs'))],
+    ['gemini', hookCommandsUnder(harness).find((candidate) => candidate.includes('gemini-hook.cjs'))]
+  ];
+
+  const sock = path.join(harness, 'hive', 'hooks.sock');
+  const received = [];
+  const server = net.createServer((conn) => {
+    let buf = '';
+    conn.on('error', () => { /* shim may hang up first */ });
+    conn.on('data', (d) => { buf += d; });
+    conn.on('close', () => { if (buf) received.push(buf); });
+    conn.write(JSON.stringify({ ok: true }) + '\n', () => conn.end());
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(sock, resolve);
+  });
+  t.after(() => server.close());
+
+  for (const [provider, command] of providerCommands) {
+    assert.ok(command, `${provider} installer produced no command`);
+    const result = await run(command, {
+      PATH: STRIPPED_PATH,
+      HOME: home,
+      AGENT_ID: 'a1',
+      HIVE_SOCK: sock
+    });
+    assert.equal(result.code, 0, `${provider} command failed: ${command}\n${result.stderr}`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.equal(received.length, 2, 'both provider hook shims must reach HIVE_SOCK');
+});
+
 test('Codex rollouts remain isolated and are visible under the standard scan roots', (t) => {
   const { home, harness } = isolatedHomes(t);
   const hive = new HiveManager(() => harness);


### PR DESCRIPTION
## What & why

Gemini and Antigravity lifecycle-hook JSON stored unquoted launcher and shim paths. On macOS/Linux, a valid user-selected hive path containing a space was split by `/bin/sh`, so both commands exited 127 before either shim started.

Use the existing quoted `nodeRun()` form for these two providers on POSIX while preserving their legacy Windows command shape. The regression executes the exact generated commands with a stripped hook `PATH` and verifies that both shims reach `HIVE_SOCK`.

Closes #364

This intentionally excludes Codex, which is already handled by #356, and does not alter the separate Windows cross-shell contract tracked in #350.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

![Before: Gemini and Antigravity commands both exit 127 from a spaced hive path](https://raw.githubusercontent.com/drona23/munder-difflin/pr-evidence/pr-evidence/pr364-before.png)

### After

![After: both stored commands execute successfully from the same spaced path](https://raw.githubusercontent.com/drona23/munder-difflin/pr-evidence/pr-evidence/pr364-after.png)

## How I tested it

- OS: macOS arm64
- `node --test test/hive-hook-node.test.cjs` — 11/11 pass
- `npm run test:focused` — 746/746 pass
- `npm run typecheck` — node and web pass
- `npm run build` — production build succeeds
- `git diff --check` — clean

## Checklist

- [x] Before and after evidence is attached above.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is one change.
- [x] I read the diff and removed the overlapping Codex/dependency changes.
- [x] No UI tokens or art are changed.