### PR TITLE
feat: DeepSeek BYOK backend, deepseek default models, per-agent pi pl…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,29 +1961,6 @@
         }
       }
     },
-    "node_modules/@openai/agents-core/node_modules/ws": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
-      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@openai/agents-realtime": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.11.8.tgz",

--- a/package.json
+++ b/package.json
@@ -81,5 +81,12 @@
     "app-builder-lib": {
       "@electron/rebuild": "$@electron/rebuild"
     }
+  },
+  "allowScripts": {
+    "electron@32.3.3": true,
+    "esbuild@0.21.5": true,
+    "node-pty@1.1.0": true,
+    "tunnelmole@2.4.0": true,
+    "better-sqlite3@11.10.0": true
   }
 }

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -23,7 +23,7 @@ import {
   readdirSync, statSync, lstatSync, realpathSync, rmSync, appendFileSync,
   symlinkSync, unlinkSync, copyFileSync, cpSync, chmodSync
 } from 'node:fs';
-import { join, dirname, basename, isAbsolute, relative } from 'node:path';
+import { join, dirname, basename, isAbsolute, relative, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync, spawn, type ChildProcess } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
@@ -131,6 +131,12 @@ export interface HiveTask {
 }
 
 export interface AgentMeta {
+  /**
+   * Pi packages (plugins) to seed into this agent's isolated `.pi-agent` dir on
+   * spawn (e.g. `git:github.com/PSU3D0/pi-dcp`). Empty/undefined = the user's
+   * global `~/.pi/agent` package list.
+   */
+  piPackages?: string[];
   id: string;
   name: string;
   /** Which CLI this agent runs on. Defaults to 'claude' when unset (legacy). */
@@ -797,7 +803,7 @@ export class HiveManager {
               // config.autoMode) gates the auto-allow — Pam guardrail #5.
               // LIVE-UNVERIFIED: the exact extension API surface needs BYOK keys to
               // prove; the renderer idle inbox-wake nudge is the guaranteed drain.
-              env.PI_CODING_AGENT_DIR = this.installPiHooks(dir);
+              env.PI_CODING_AGENT_DIR = this.installPiHooks(dir, meta.piPackages ?? prev?.piPackages);
             }
             else if (desc.shim === 'opencode') {
               // OpenCode (anomalyco/opencode) has no Claude-shaped Stop hook, but its
@@ -2158,7 +2164,7 @@ export class HiveManager {
    *  LIVE-UNVERIFIED: Pi's exact extension-discovery path + event API need BYOK keys
    *  to confirm; this is written best-effort and wrapped so a wrong guess can never
    *  break the spawn. The renderer nudge is the guaranteed drain regardless. */
-  private installPiHooks(dir: string): string {
+  private installPiHooks(dir: string, packages?: string[]): string {
     const home = join(dir, '.pi-agent');
     try {
       // Pi discovers extensions under its agent dir; we write to the documented
@@ -2170,8 +2176,78 @@ export class HiveManager {
       // Pi ignores it). Kept minimal and hive-authored.
       const manifest = { name: 'munder-hive-bridge', version: '0.3.1', main: 'extensions/hive-bridge.js', auto: true };
       writeFileSync(join(home, 'extensions.json'), JSON.stringify(manifest, null, 2), 'utf8');
+      // Pi packages (plugins): the agent's selected list (or the user's global
+      // list when unset) is written into the per-agent settings.json — the only
+      // place pi reads `packages` from under PI_CODING_AGENT_DIR — and the
+      // resolved plugin dirs are pre-seeded from the user's global pi cache
+      // (~/.pi/agent/{git,npm}) so pi finds them offline without re-cloning.
+      this.seedPiPackages(home, packages);
     } catch (e) { console.error('[hive] installPiHooks failed:', e); }
     return home;
+  }
+
+  /** The user's global pi package list (~/.pi/agent/settings.json → packages). */
+  private globalPiPackages(): string[] {
+    try {
+      const p = join(homedir(), '.pi', 'agent', 'settings.json');
+      if (!existsSync(p)) return [];
+      const raw = JSON.parse(readFileSync(p, 'utf8')) as { packages?: unknown };
+      return Array.isArray(raw.packages) ? raw.packages.filter((x): x is string => typeof x === 'string') : [];
+    } catch { return []; }
+  }
+
+  /** Map a package spec to the dir pi expects it under an agent dir, mirroring
+   *  pi's own layout (git/url → git/<host>/<path>, npm → npm/ workspace).
+   *  Returns the per-agent rel path and the global-cache source when one exists. */
+  private piPackageTargetDir(home: string, spec: string): { rel: string; src?: string } | undefined {
+    const s = spec.trim();
+    const globalAgentDir = join(homedir(), '.pi', 'agent');
+    if (s.startsWith('git:') || s.startsWith('github:') || s.startsWith('http:') || s.startsWith('https:') || s.startsWith('ssh:')) {
+      const url = s.startsWith('git:') ? s.slice(4)
+        : s.startsWith('github:') ? `github.com/${s.slice(7)}`
+        : s.replace(/^[a-z]+:\/\//, '');
+      const segs = url.split('/').filter(Boolean).map((p) => p.replace(/\.git$/, ''));
+      if (segs.length < 2) return undefined;
+      const rel = join('git', ...segs);
+      return { rel, src: join(globalAgentDir, rel) };
+    }
+    if (s.startsWith('npm:')) {
+      return { rel: 'npm', src: join(globalAgentDir, 'npm') };
+    }
+    return undefined; // local path — used in place (absolutized at write time)
+  }
+
+  /** Write the agent's packages into the per-agent settings.json (read-modify-
+   *  write so pi's own keys survive) and pre-seed the resolved plugin dirs from
+   *  the user's global cache so pi finds them without network. */
+  private seedPiPackages(home: string, packages?: string[]): void {
+    const list = packages?.length ? packages : this.globalPiPackages();
+    if (!list.length) return;
+    try {
+      for (const spec of list) {
+        const t = this.piPackageTargetDir(home, spec);
+        if (t?.src && existsSync(t.src) && !existsSync(join(home, t.rel))) {
+          cpSync(t.src, join(home, t.rel), { recursive: true });
+        }
+      }
+      // settings.json: merge `packages`, absolutizing local relative paths
+      // against the global settings dir so they resolve from the per-agent dir.
+      const settingsPath = join(home, 'settings.json');
+      let settings: Record<string, unknown> = {};
+      try {
+        if (existsSync(settingsPath)) settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+      } catch { /* fresh file */ }
+      const globalAgentDir = join(homedir(), '.pi', 'agent');
+      const resolved = list.map((spec) => {
+        const s = spec.trim();
+        if (s.startsWith('/') || s.startsWith('~') || s.startsWith('.')) {
+          return isAbsolute(s) ? s : resolve(globalAgentDir, s);
+        }
+        return spec;
+      });
+      settings = { ...settings, packages: resolved };
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
+    } catch (e) { console.error('[hive] seedPiPackages failed:', e); }
   }
 
   /** OpenCode (anomalyco/opencode) bridge — god Decision 1 (native plugin, not proxy).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -393,7 +393,8 @@ const BACKEND_KEY_ENV: Record<string, string> = {
   openai: 'OPENAI_API_KEY',
   google: 'GEMINI_API_KEY',
   openrouter: 'OPENROUTER_API_KEY',
-  groq: 'GROQ_API_KEY'
+  groq: 'GROQ_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY'
 };
 const providerKeyRef = (backend: string): string => `apikey:${backend}`;
 
@@ -2749,9 +2750,13 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
     // GOD is special-cased: it has its own engine config (godProvider/godModel), so
     // modelForRole resolves it and that wins over the worker-oriented defaultModel.
     if (!args.includes('--model')) {
+      // `cfg.defaultModel` may now be a `deepseek/…` slug (Settings → Default
+      // Agent Model) which Claude cannot run — only bare Claude ids apply here;
+      // provider-prefixed defaults fall back to the role-based tier.
+      const claudeDefault = cfg.defaultModel && !cfg.defaultModel.includes('/') ? cfg.defaultModel : undefined;
       const m = opts.hive.isGod
         ? modelForRole(opts.hive, cfg)
-        : cfg.defaultModel ?? modelForRole(opts.hive, cfg);
+        : claudeDefault ?? modelForRole(opts.hive, cfg);
       if (m) args.push('--model', m);
     }
     // Name the Remote Control session after the agent (Michael, Jim, Dev1…) so it
@@ -2885,7 +2890,7 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
     const modelSlug = modelIdx >= 0 ? (opts.args?.[modelIdx + 1] ?? '') : '';
     const prefix = modelSlug.includes('/') ? modelSlug.split('/')[0].toLowerCase() : '';
     const PREFIX_BACKEND: Record<string, string> = {
-      anthropic: 'anthropic', openai: 'openai', google: 'google', gemini: 'google', groq: 'groq', openrouter: 'openrouter'
+      anthropic: 'anthropic', openai: 'openai', google: 'google', gemini: 'google', groq: 'groq', openrouter: 'openrouter', deepseek: 'deepseek'
     };
     const scoped = PREFIX_BACKEND[prefix];
     const backends = scoped ? [scoped] : Object.keys(BACKEND_KEY_ENV);
@@ -2917,6 +2922,14 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
         };
       }
       extra.OPENCODE_CONFIG_CONTENT = JSON.stringify(oc);
+    }
+    // 4) Global default agent model — the user's Settings → Default Agent Model
+    //    pick may be a `deepseek/…` slug; apply it to main-only spawns (ephemeral
+    //    workers, voice hires) that carried no --model. Claude ids never reach
+    //    here (Claude agents don't run on these CLIs) and qwen routes through its
+    //    own local upstream, so only pi/opencode/crush take the slug.
+    if (provider !== 'qwen' && !(opts.args ?? []).includes('--model') && cfg.defaultModel?.startsWith('deepseek/')) {
+      opts.args = [...(opts.args ?? []), '--model', cfg.defaultModel];
     }
     opts.env = { ...(opts.env ?? {}), ...extra };
   }
@@ -3071,6 +3084,53 @@ ipcMain.handle('providerKey:set', (_evt, payload: unknown) => {
 });
 ipcMain.handle('providerKey:has', (_evt, backend: unknown) =>
   typeof backend === 'string' ? integrations.hasSecret(providerKeyRef(backend)) : false);
+/** Available pi packages (plugins) the user configured for their own pi
+ *  (`~/.pi/agent/settings.json` → packages). Rendered as the per-agent plugin
+ *  picker for pi agents; selected specs are seeded into each agent's isolated
+ *  .pi-agent dir at spawn (hive.installPiHooks). `installed` = already resolved
+ *  in the global cache (git clone / npm workspace), so seeding is a local copy. */
+function listPiPackages(): Array<{ spec: string; kind: 'git' | 'npm' | 'path' | 'url'; label: string; installed: boolean }> {
+  const globalAgentDir = join(homedir(), '.pi', 'agent');
+  try {
+    const settingsPath = join(globalAgentDir, 'settings.json');
+    if (!existsSync(settingsPath)) return [];
+    const raw = JSON.parse(readFileSync(settingsPath, 'utf8')) as { packages?: unknown };
+    const specs = Array.isArray(raw.packages) ? raw.packages.filter((x): x is string => typeof x === 'string') : [];
+    return specs.map((spec) => {
+      const s = spec.trim();
+      let kind: 'git' | 'npm' | 'path' | 'url' = 'path';
+      let label = s;
+      let installed = false;
+      if (s.startsWith('git:') || s.startsWith('github:')) {
+        kind = 'git';
+        const url = s.startsWith('git:') ? s.slice(4) : `github.com/${s.slice(7)}`;
+        const segs = url.split('/').filter(Boolean);
+        label = segs.pop()?.replace(/\.git$/, '') ?? s;
+        installed = existsSync(join(globalAgentDir, 'git', ...segs));
+      } else if (s.startsWith('http:') || s.startsWith('https:') || s.startsWith('ssh:')) {
+        kind = 'url';
+        const segs = s.replace(/^[a-z]+:\/\//, '').split('/').filter(Boolean);
+        label = segs.pop()?.replace(/\.git$/, '') ?? s;
+        installed = existsSync(join(globalAgentDir, 'git', ...segs));
+      } else if (s.startsWith('npm:')) {
+        kind = 'npm';
+        // strip a trailing @version; keep scoped names (@scope/name)
+        const full = s.slice(4);
+        const at = full.lastIndexOf('@');
+        label = at > 0 ? full.slice(0, at) : full;
+        installed = existsSync(join(globalAgentDir, 'npm', 'node_modules', label));
+      } else {
+        kind = 'path';
+        label = s.split(/[\\/]/).filter(Boolean).pop() ?? s;
+        installed = existsSync(isAbsolute(s) ? s : resolve(globalAgentDir, s));
+      }
+      return { spec, kind, label, installed };
+    });
+  } catch { return []; }
+}
+
+ipcMain.handle('piPlugins:list', () => listPiPackages());
+
 ipcMain.handle('providerKey:clear', (_evt, backend: unknown) => {
   if (typeof backend !== 'string' || !(backend in BACKEND_KEY_ENV)) return { ok: false, error: 'unknown backend' };
   try { integrations.deleteSecret(providerKeyRef(backend)); return { ok: true }; }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,10 @@ export interface HiveAgentMeta {
   name: string;
   /** Which CLI this agent runs on (claude/codex/grok/antigravity/custom); defaults claude. */
   provider?: AgentProvider;
+  /** Pi packages (plugins) to seed into this agent's isolated `.pi-agent` dir on
+   *  spawn (e.g. `git:github.com/PSU3D0/pi-dcp`). Empty/undefined = the user's
+   *  global `~/.pi/agent` package list. */
+  piPackages?: string[];
   role?: string;
   capabilities?: string[];
   cwd: string;
@@ -1291,6 +1295,11 @@ const api = {
     ipcRenderer.invoke('providerKey:has', backend),
   providerKeyClear: (backend: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('providerKey:clear', backend),
+  // Pi packages (plugins) the user configured for their own pi — the per-agent
+  // plugin picker for pi agents reads this; selected specs are seeded into each
+  // agent's isolated .pi-agent dir at spawn (see hive.installPiHooks).
+  piPluginsList: (): Promise<Array<{ spec: string; kind: 'git' | 'npm' | 'path' | 'url'; label: string; installed: boolean }>> =>
+    ipcRenderer.invoke('piPlugins:list'),
   // Realtime Michael (voice orchestrator) — MAIN mints a short-lived EPHEMERAL token
   // from the BYOK OpenAI key; the real key NEVER crosses IPC. `realtimeHasOpenAiKey`
   // is a presence boolean only (gates the voice toggle, like providerKeyHas).

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -186,7 +186,16 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   // Default provider follows whatever the global default command is (claude
   // unless the user reconfigured it); the model only carries over for Claude.
   const initialProvider = inferAgentProvider(config.defaultCommand);
-  const initialModel = isClaudeProvider(initialProvider) ? config.defaultModel : undefined;
+  const deepseekDefaultFor = (id: AgentProvider): string | undefined => {
+    const d = config.defaultModel;
+    return d?.startsWith('deepseek/') && (id === 'pi' || id === 'opencode' || id === 'crush') ? d : undefined;
+  };
+  // The global default may be a Claude id (Claude agents) or a `deepseek/…` slug
+  // (pi/opencode/crush). Claude can't run deepseek slugs; BYOK CLIs can't run
+  // bare Claude ids — seed only what matches the engine.
+  const initialModel = isClaudeProvider(initialProvider)
+    ? (config.defaultModel && !config.defaultModel.includes('/') ? config.defaultModel : undefined)
+    : deepseekDefaultFor(initialProvider);
 
   const [name, setName] = useState(pendingHire?.name ?? 'Jim');
   const [character, setCharacter] = useState<OfficeCharacterName>(knownCharacter(pendingHire?.character));
@@ -204,6 +213,10 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   );
   const [description, setDescription] = useState(pendingHire?.description ?? 'a fresh harness');
   const [hireMeta, setHireMeta] = useState<HireManifest | null>(pendingHire);
+  // Pi plugins (packages) — seeded into the new agent's isolated .pi-agent dir
+  // on spawn. Defaults to ALL of the user's global pi packages; uncheck to slim.
+  const [piPlugins, setPiPlugins] = useState<Array<{ spec: string; kind: string; label: string; installed: boolean }>>([]);
+  const [piPackages, setPiPackages] = useState<string[]>([]);
 
   // Picking a model rebuilds the command; the command field stays editable for
   // power users (it's the source of truth for the actual spawn).
@@ -217,10 +230,13 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   // user's typed command rather than blanking it.
   const pickProvider = (id: AgentProvider) => {
     setProvider(id);
-    // Seed the model: Claude from the global defaultModel; other engines from the
-    // per-engine default set in Settings → AI Engines (providerDefaultModels), else
-    // the CLI default. This is what makes that Settings field live (Dwight NIT-1).
-    const nextModel = isClaudeProvider(id) ? config.defaultModel : config.providerDefaultModels?.[id];
+    // Seed the model: Claude from the global defaultModel (bare Claude ids only);
+    // other engines from the per-engine default set in Settings → AI Engines
+    // (providerDefaultModels), else the global `deepseek/…` default, else the CLI
+    // default. This is what makes those Settings fields live (Dwight NIT-1).
+    const nextModel = isClaudeProvider(id)
+      ? (config.defaultModel && !config.defaultModel.includes('/') ? config.defaultModel : undefined)
+      : (config.providerDefaultModels?.[id] ?? deepseekDefaultFor(id));
     setModel(nextModel);
     const nextPreset = providerPreset(id);
     if (!isClaudeProvider(id) && !nextPreset.resumeFlag && !nextPreset.resumeSubcommand) {
@@ -269,6 +285,20 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     window.addEventListener('keydown', onKey, true);
     return () => window.removeEventListener('keydown', onKey, true);
   }, [onClose]);
+
+  // Pi plugins (packages) — fetch the user's global pi package list; new pi
+  // agents default to ALL available plugins (uncheck to slim).
+  useEffect(() => {
+    let alive = true;
+    void window.cth.piPluginsList()
+      .then((list) => {
+        if (!alive) return;
+        setPiPlugins(list);
+        setPiPackages((cur) => (cur.length ? cur : list.map((p) => p.spec)));
+      })
+      .catch(() => { /* keep empty list */ });
+    return () => { alive = false; };
+  }, []);
 
   // Zero-step resume: when a session id is entered, look up the cwd it originally
   // ran in (from the transcript) and pre-fill the Folder so the user doesn't have
@@ -425,7 +455,9 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
         cwd,
         role: description.trim() || undefined,
         // A hire manifest may carry validated capability tags (routing hints).
-        capabilities: hireMeta?.capabilities
+        capabilities: hireMeta?.capabilities,
+        // Pi plugins to seed into the isolated .pi-agent dir (undefined for non-pi).
+        piPackages: provider === 'pi' ? piPackages : undefined
       }
     });
     if (!spawnRes.ok) {
@@ -1009,6 +1041,38 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                           style={ossLink}
                         >{tr('addAgent.setUpMacMini')}</a>.
                       </div>
+                    )}
+
+                    {provider === 'pi' && (
+                      <Row label="Plugins">
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                          {piPlugins.length === 0 && (
+                            <span style={{ fontSize: 11, color: 'var(--cth-ink-500)', lineHeight: '15px' }}>
+                              No pi packages found in ~/.pi/agent/settings.json — install some with `pi /packages add &lt;spec&gt;` in your own pi.
+                            </span>
+                          )}
+                          {piPlugins.map((p) => (
+                            <label key={p.spec} style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                              <input
+                                type="checkbox"
+                                checked={piPackages.includes(p.spec)}
+                                onChange={() =>
+                                  setPiPackages((cur) => (cur.includes(p.spec) ? cur.filter((s) => s !== p.spec) : [...cur, p.spec]))
+                                }
+                              />
+                              <span style={{ fontSize: 11, color: 'var(--cth-ink-700)' }}>{p.label}</span>
+                              <span style={{ fontSize: 10, color: 'var(--cth-ink-500)' }}>
+                                {p.installed ? '· installed' : '· downloads on first run'}
+                              </span>
+                            </label>
+                          ))}
+                          {piPlugins.length > 0 && (
+                            <span style={{ fontSize: 10, color: 'var(--cth-ink-500)' }}>
+                              seeded into this agent's isolated .pi-agent dir on spawn
+                            </span>
+                          )}
+                        </div>
+                      </Row>
                     )}
 
                     <Row label={config.autoMode && preset.autoFlag ? tr('addAgent.commandAuto') : tr('addAgent.command')}>

--- a/src/renderer/src/components/AiEnginesSettings.tsx
+++ b/src/renderer/src/components/AiEnginesSettings.tsx
@@ -24,7 +24,8 @@ const BACKENDS: Array<{ id: string; label: string; envVar: string }> = [
   { id: 'openai', label: 'OpenAI', envVar: 'OPENAI_API_KEY' },
   { id: 'google', label: 'Google · Gemini', envVar: 'GEMINI_API_KEY' },
   { id: 'openrouter', label: 'OpenRouter', envVar: 'OPENROUTER_API_KEY' },
-  { id: 'groq', label: 'Groq', envVar: 'GROQ_API_KEY' }
+  { id: 'groq', label: 'Groq', envVar: 'GROQ_API_KEY' },
+  { id: 'deepseek', label: 'DeepSeek', envVar: 'DEEPSEEK_API_KEY' }
 ];
 
 /** CLI engines that take a per-provider local base-URL + default model. `hint`

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -814,10 +814,10 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                 {modelProvidersForAgent(a.isGod).map((preset) => (
                   <optgroup key={preset.id} label={preset.label}>
                     {modelsForProvider(preset.id).map((model) => {
-                      // `defaultModel` is a Claude model id, so it can only mark
-                      // an entry in the Claude group.
-                      const isHarnessDefault = preset.id === 'claude'
-                        && !!defaultModel && model.id === defaultModel;
+                      // `defaultModel` is a Claude id (marks the Claude group)
+                      // or a `deepseek/…` slug (marks the pi/opencode/crush
+                      // groups whose catalog carries it).
+                      const isHarnessDefault = !!defaultModel && model.id === defaultModel;
                       return (
                         <option
                           key={`${preset.id}:${model.id ?? 'cli-default'}`}

--- a/src/renderer/src/components/EditAgentModal.tsx
+++ b/src/renderer/src/components/EditAgentModal.tsx
@@ -40,11 +40,30 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
     inferAgentProvider(agent.command, agent.provider)
   );
   const [model, setModel] = useState<string | undefined>(agent.model);
+  // Pi plugins (packages): the per-agent picker mirrors the user's global pi
+  // package list (~/.pi/agent/settings.json). Seeded into the agent's isolated
+  // .pi-agent dir on spawn (installPiHooks). Unset selection = all available.
+  const [piPlugins, setPiPlugins] = useState<Array<{ spec: string; kind: string; label: string; installed: boolean }>>([]);
+  const [piPackages, setPiPackages] = useState<string[]>(agent.piPackages ?? []);
   const [description, setDescription] = useState(agent.description);
   const [goal, setGoal] = useState(agent.goal ?? '');
 
   useEffect(() => {
     void window.cth.getConfig().then(setConfig).catch(() => setConfig(null));
+  }, []);
+
+  // Fetch the user's pi packages; agents without an explicit selection default
+  // to ALL available (matching the spawn default of the global pi package list).
+  useEffect(() => {
+    let alive = true;
+    void window.cth.piPluginsList()
+      .then((list) => {
+        if (!alive) return;
+        setPiPlugins(list);
+        setPiPackages((cur) => (cur.length ? cur : list.map((p) => p.spec)));
+      })
+      .catch(() => { /* keep empty list */ });
+    return () => { alive = false; };
   }, []);
 
   // Keep form in sync when the selected agent changes while the modal is open.
@@ -54,6 +73,7 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
     setAccent(agent.accent);
     setProvider(inferAgentProvider(agent.command, agent.provider));
     setModel(agent.model);
+    setPiPackages(agent.piPackages ?? []);
     setDescription(agent.description);
     setGoal(agent.goal ?? '');
   }, [agent.id]);
@@ -86,7 +106,8 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
       model,
       command,
       description: trimmedDescription,
-      goal: trimmedGoal || undefined
+      goal: trimmedGoal || undefined,
+      ...(provider === 'pi' ? { piPackages } : {})
     });
     onClose();
   };
@@ -254,6 +275,33 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
                 Engine changes are saved for the next restart. Use Command Center → Floor to restart a live session onto a new provider/model now.
               </span>
             </Section>
+
+            {provider === 'pi' && (
+              <Section label="Plugins" hint="pi packages · seeded into the isolated agent dir on next spawn">
+                {piPlugins.length === 0 && (
+                  <span style={{ fontSize: 12, color: 'var(--cth-ink-500)', lineHeight: '16px' }}>
+                    No pi packages found in ~/.pi/agent/settings.json — install some with `pi /packages add &lt;spec&gt;` in your own pi, then reopen.
+                  </span>
+                )}
+                {piPlugins.map((p) => (
+                  <Row key={p.spec} label={p.label}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                      <input
+                        type="checkbox"
+                        checked={piPackages.includes(p.spec)}
+                        onChange={() =>
+                          setPiPackages((cur) => (cur.includes(p.spec) ? cur.filter((s) => s !== p.spec) : [...cur, p.spec]))
+                        }
+                      />
+                      <span style={{ fontSize: 11, color: 'var(--cth-ink-700)' }}>{p.spec}</span>
+                      <span style={{ fontSize: 10, color: 'var(--cth-ink-500)' }}>
+                        {p.installed ? '· installed (copied from ~/.pi/agent)' : '· downloads on first run'}
+                      </span>
+                    </div>
+                  </Row>
+                ))}
+              </Section>
+            )}
 
               </div>
               <div style={{ minWidth: 0 }}>

--- a/src/renderer/src/hooks/useRestoreTeam.ts
+++ b/src/renderer/src/hooks/useRestoreTeam.ts
@@ -147,7 +147,7 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
             // agent id is preserved across restart, so its registry entry,
             // memory.md and inbox reattach by id. No-op without a recorded session.
             resume: true,
-            hive: { id: a.id, name: a.name, provider, cwd, role: roleForHiveSpawn(a) }
+            hive: { id: a.id, name: a.name, provider, cwd, role: roleForHiveSpawn(a), piPackages: a.piPackages }
           });
           if (res.ok) {
             restored++;

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -251,7 +251,7 @@
     },
     "agentsModels": {
       "defaultModel": "Default agent model",
-      "defaultModelDesc": "Every newly spawned Claude agent ({{godName}} included) starts on this model unless picked per-agent. Marked \"· default\" in the model pickers.",
+      "defaultModelDesc": "Every newly spawned agent starts on this model unless picked per-agent. Claude agents take a Claude model from this list; Pi, OpenCode and Crush agents take the DeepSeek slugs. Marked \"· default\" in the model pickers.",
       "savedNote": "saved — applies to newly spawned agents",
       "saveFailed": "save failed",
       "advanced": "Advanced",

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -294,7 +294,14 @@ export function modelsForProvider(provider: AgentProvider): ModelOption[] {
 }
 
 /** The Claude presets, for the surfaces that only ever offer Claude models. */
-export const AGENT_MODELS: ModelOption[] = modelsForProvider('claude');
+/** BYOK slugs offered alongside Claude's in the Settings → Default Agent Model
+ *  picker. Claude agents take a bare Claude id; pi/opencode/crush agents take
+ *  these `deepseek/…` slugs (key: DEEPSEEK_API_KEY, set in AI Engines). */
+const AGENT_MODEL_EXTRAS: ModelOption[] = [
+  { id: 'deepseek/deepseek-v4-pro', label: 'DeepSeek V4 Pro' },
+  { id: 'deepseek/deepseek-v4-flash', label: 'DeepSeek V4 Flash' }
+];
+export const AGENT_MODELS: ModelOption[] = [...modelsForProvider('claude'), ...AGENT_MODEL_EXTRAS];
 
 /** Providers shown in the Command Center's cross-provider model picker.
  *  God must remain on a provider with a working inbox drain; otherwise switching

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -79,6 +79,10 @@ export interface Agent {
   /** the model this agent runs on (e.g. 'claude-sonnet-4-6[1m]' or 'gemini-3-pro');
    *  drives the model selector + the --model arg used when (re)spawning the agent */
   model?: string;
+  /** Pi packages (plugins) seeded into this agent's isolated `.pi-agent` dir on
+   *  spawn (specs like `git:github.com/PSU3D0/pi-dcp`). Empty/undefined = the
+   *  user's global `~/.pi/agent` package list. */
+  piPackages?: string[];
   /** the last prompt the user submitted to this agent in Claude Code —
    *  shown on the floor as a card above the seated avatar */
   lastPrompt?: string;

--- a/src/shared/modelCatalog.json
+++ b/src/shared/modelCatalog.json
@@ -79,6 +79,8 @@
       { "id": "openai/gpt-5", "label": "GPT-5 (OpenAI)", "minAppVersion": null, "maxAppVersion": null },
       { "id": "google/gemini-2.5-pro", "label": "Gemini 2.5 Pro (Google)", "minAppVersion": null, "maxAppVersion": null },
       { "id": "groq/llama-3.3-70b", "label": "Llama 3.3 70B (Groq)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "deepseek/deepseek-v4-pro", "label": "DeepSeek V4 Pro (DeepSeek)", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "deepseek/deepseek-v4-flash", "label": "DeepSeek V4 Flash (DeepSeek)", "minAppVersion": null, "maxAppVersion": null },
       { "id": "local/llama3", "label": "Local · OpenAI-compatible (set base-URL)", "minAppVersion": null, "maxAppVersion": null }
     ],
     "copilot": [

--- a/src/shared/ossModels.ts
+++ b/src/shared/ossModels.ts
@@ -50,6 +50,7 @@ export const OSS_PROVIDER_PICKS: OssProviderPick[] = [
   { label: 'Llama 3.3 70B · Groq', slug: 'groq/llama-3.3-70b-versatile', keyEnv: 'GROQ_API_KEY' },
   { label: 'DeepSeek-V4-Flash · OpenRouter', slug: 'openrouter/deepseek/deepseek-v4-flash', keyEnv: 'OPENROUTER_API_KEY' },
   { label: 'DeepSeek-V4-Flash · DeepSeek', slug: 'deepseek/deepseek-v4-flash', keyEnv: 'DEEPSEEK_API_KEY' },
+  { label: 'DeepSeek-V4-Pro · DeepSeek', slug: 'deepseek/deepseek-v4-pro', keyEnv: 'DEEPSEEK_API_KEY' },
   { label: 'GLM-4.6 · OpenRouter', slug: 'openrouter/z-ai/glm-4.6', keyEnv: 'OPENROUTER_API_KEY' },
   { label: 'Kimi K2.6 · OpenRouter', slug: 'openrouter/moonshotai/kimi-k2.6', keyEnv: 'OPENROUTER_API_KEY' },
   { label: 'Qwen3-Coder 480B · OpenRouter', slug: 'openrouter/qwen/qwen3-coder', keyEnv: 'OPENROUTER_API_KEY' },

--- a/test/model-catalog.test.cjs
+++ b/test/model-catalog.test.cjs
@@ -72,6 +72,8 @@ const SHIPPED = {
     ["openai/gpt-5", "GPT-5 (OpenAI)"],
     ["google/gemini-2.5-pro", "Gemini 2.5 Pro (Google)"],
     ["groq/llama-3.3-70b", "Llama 3.3 70B (Groq)"],
+    ["deepseek/deepseek-v4-pro", "DeepSeek V4 Pro (DeepSeek)"],
+    ["deepseek/deepseek-v4-flash", "DeepSeek V4 Flash (DeepSeek)"],
     ["local/llama3", "Local · OpenAI-compatible (set base-URL)"]
   ],
   copilot: [


### PR DESCRIPTION
…ugins

- DeepSeek API key backend (DEEPSEEK_API_KEY) in AI Engines settings; least-privilege key injection for deepseek/* model slugs at spawn
- DeepSeek V4 Pro + V4 Flash in the Default Agent Model picker; the default applies per engine (Claude ids to Claude, deepseek slugs to pi/opencode/crush) with '· default' marking in the Command Center
- Per-agent Pi plugin picker (available packages from ~/.pi/agent): selected packages are written into the agent's isolated .pi-agent settings.json and pre-seeded from the global cache (git/npm) so pi loads them offline; local-path plugins are absolutized

<!-- Thanks for contributing to Munder Difflin.

     Read this line before you go further: a PR without a BEFORE and an AFTER
     is not reviewable and will not be merged. The `PR evidence` check runs the
     moment you open this and will tell you if it is missing. Keep the `Before`
     and `After` headings below exactly as they are — the check reads them. -->

## What & why

<!-- What changed, and why it needed to. Two or three sentences beats a
     bullet list of file names — we can read the diff, we cannot read your
     reasoning. If this fixes an issue, link it: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

<!-- REQUIRED. Drag images or a screen recording directly under each heading —
     GitHub uploads them inline. Both headings must have something under them.

     No visible UI? You still owe evidence. Record the failing behaviour and
     then the same steps passing: a terminal capture, a log diff, a test that
     goes from red to green. "It has no UI" is not an exemption.

     Truly nothing observable, like a CI tweak or a typo? Say so in
     "What & why" and ask a maintainer for the `no-visual-change` label. -->

### Before

<!-- The problem, as it exists on main right now. -->

### After

<!-- The same view or the same steps, with your change applied.
     Same window size, same theme, same data — a reviewer should be able to
     flip between the two and see only what you changed. -->

## How I tested it

<!-- The actual steps you ran, on which OS. Not "tested locally". -->

- OS:
- Steps:

## Discord (optional)

<!-- For the `employee of the month` role in our Discord when this merges.
     Join first so we can find you: https://discord.gg/SEDzP5ZPk5 -->

Discord:

## Checklist

- [ ] **Before and after evidence is attached above**, under both headings.
- [ ] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes.
- [ ] `npm run build` succeeds.
- [ ] This PR is **one change**. Unrelated fixes belong in their own PR.
- [ ] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [ ] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [ ] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.
