### PR TITLE
Open each project in its own window

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -583,7 +583,27 @@ function migrateTriggersV1(cfg: HarnessConfig): HarnessConfig {
   }
 }
 
-export function readConfig(): HarnessConfig {
+/** Per-PROCESS hive override, set once at startup from `--hive=<path>`. When
+ *  present it wins over the harnessHome persisted in config.json for THIS
+ *  process only — that is what lets several instances run different hives off
+ *  one shared config.json. Never persisted: writeConfig bases its merge on
+ *  readConfigRaw(), so an overridden instance cannot rewrite the global home. */
+let hiveOverride: string | null = null;
+
+/** Install the per-process hive override. Must run before anything reads config. */
+export function setHiveOverride(home: string | null): void {
+  hiveOverride = home && home.trim() ? expandTilde(home.trim()) : null;
+}
+
+/** This process's hive override, or null when it follows config.json. */
+export function getHiveOverride(): string | null {
+  return hiveOverride;
+}
+
+/** Config EXACTLY as persisted, with NO override applied. Use for writes — so a
+ *  `--hive` instance can never rewrite the global home — and for anything that
+ *  must reason about the configured default rather than this instance's hive. */
+export function readConfigRaw(): HarnessConfig {
   const p = configPath();
   // No file yet = a first run with nothing to migrate; the defaults ARE the
   // post-migration shape. Deliberately does not persist — a bare read must not
@@ -596,6 +616,16 @@ export function readConfig(): HarnessConfig {
   } catch {
     return withTriggerDefaults({ ...DEFAULTS });
   }
+}
+
+/** Config as THIS process sees it: persisted values, with harnessHome replaced by
+ *  the `--hive` override when one was given. Every service resolves the hive
+ *  lazily through here (`() => readConfig().harnessHome`), so a single override
+ *  reaches all of them without touching a single call site. */
+export function readConfig(): HarnessConfig {
+  const cfg = readConfigRaw();
+  if (hiveOverride) cfg.harnessHome = hiveOverride;
+  return cfg;
 }
 
 /** (#140, the upgrade path) A config.json persisted BEFORE `writeConfig`
@@ -652,7 +682,9 @@ function persistConfig(next: HarnessConfig): HarnessConfig {
 }
 
 export function writeConfig(patch: Partial<HarnessConfig>): HarnessConfig {
-  const current = readConfig();
+  // RAW on purpose: merging onto readConfig() would bake this process's `--hive`
+  // override into config.json, silently repointing every OTHER instance's home.
+  const current = readConfigRaw();
   const next: HarnessConfig = { ...current, ...patch };
   // Project INGESTION — a registered repo is typed by hand ("~/dev/foo") as often
   // as it is picked from the folder dialog. Expand `~` here so the persisted list

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,7 +14,8 @@ import { resolveCommand as resolveCliCommand, isSafeCommandName } from './shellE
 import { initAutoUpdater, abortPendingRestart } from './updater';
 import { RealtimeFloorWatcher } from './realtimeFloorWatcher';
 import {
-  readConfig, writeConfig, setAgentTokenCap, resetConfig, onConfigWritten, ensureHarnessHome, ensureClaudePermissionsAccepted,
+  readConfig, writeConfig, setHiveOverride, getHiveOverride,
+  setAgentTokenCap, resetConfig, onConfigWritten, ensureHarnessHome, ensureClaudePermissionsAccepted,
   modelForRole, OPS_STANDUP_MISSION, HEARTBEAT_MISSION, COMPACT_MAINTENANCE_MISSION, type HarnessConfig, type ScheduledMission
 } from './config';
 import { listDir, readFileText, readFileBinary, writeFileText, statAbs, expandTilde } from './fs';
@@ -92,6 +93,18 @@ import {
 } from '../shared/codexRemote';
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
+
+// `--hive=<path>` makes THIS process run that hive instead of the one persisted
+// in config.json. It is how "open another project" works: a second instance runs
+// beside the first on its own hive, sharing userData (harness.db is WAL with a
+// busy timeout; every server binds port 0; the hook pipe is hashed per hive root)
+// but never its harnessHome. Parsed before anything reads config so that every
+// `() => readConfig().harnessHome` closure resolves to the override from the start.
+const hiveArg = ((): string | null => {
+  const a = process.argv.find((x) => x.startsWith('--hive='));
+  return a ? a.slice('--hive='.length).trim() || null : null;
+})();
+setHiveOverride(hiveArg);
 
 // Keep the main process alive on an unexpected throw/rejection. The harness is a
 // multi-agent supervisor — a single stray throw (e.g. node-pty's ConPTY console
@@ -2158,7 +2171,11 @@ if (process.defaultApp) {
 // single-instance lock and forward them to the running instance. (macOS gets
 // the 'open-url' event instead.) The lock also rules out two harnesses fighting
 // over the same hive, which was previously possible but never useful.
-const gotInstanceLock = app.requestSingleInstanceLock();
+// A `--hive` process is a DELIBERATE second instance running a different hive, so
+// it must not be folded into the running one. The default instance (no --hive)
+// still takes the lock, so a stray relaunch focuses the existing window and deep
+// links keep landing there.
+const gotInstanceLock = hiveArg ? true : app.requestSingleInstanceLock();
 if (!gotInstanceLock) {
   allowQuit = true;
   app.quit();
@@ -2213,12 +2230,22 @@ ipcMain.handle('hire:openFile', async () => {
  * window — cascades its position, and on close stops only its OWN terminals
  * while the app keeps running.
  */
+/** Saved-geometry key, scoped PER HIVE. Instances run side by side on different
+ *  projects; one shared key would make every instance restore the same rect —
+ *  stacking them exactly on top of each other — and overwrite the others' saved
+ *  position on every move. */
+function boundsKey(): string {
+  const home = readConfig().harnessHome;
+  if (!home) return 'window.bounds';
+  return `window.bounds:${createHash('sha1').update(home).digest('hex').slice(0, 12)}`;
+}
+
 function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   const isFloor = opts.floor === true;
 
   // Primary restores saved geometry; floors cascade off the focused window.
   let saved: WindowBounds | null = null;
-  if (!isFloor) { try { saved = clampBounds(persist.getKv('window.bounds')); } catch { saved = null; } }
+  if (!isFloor) { try { saved = clampBounds(persist.getKv(boundsKey())); } catch { saved = null; } }
   const cascade = isFloor ? floorCascade() : null;
   const geom = cascade ?? saved;
 
@@ -2296,13 +2323,13 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   if (!isFloor) {
     const saveBounds = debounce(() => {
       if (win.isDestroyed() || win.isMinimized() || win.isMaximized()) return;
-      try { persist.setKv('window.bounds', win.getBounds()); } catch { /* DB best-effort */ }
+      try { persist.setKv(boundsKey(), win.getBounds()); } catch { /* DB best-effort */ }
     }, 400);
     win.on('resized', saveBounds);
     win.on('moved', saveBounds);
     win.on('close', () => {
       if (win.isDestroyed() || win.isMinimized() || win.isMaximized()) return;
-      try { persist.setKv('window.bounds', win.getBounds()); } catch { /* DB best-effort */ }
+      try { persist.setKv(boundsKey(), win.getBounds()); } catch { /* DB best-effort */ }
     });
   }
 
@@ -2361,10 +2388,17 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
     if (details.isMainFrame) rendererReadyForHires = false;
   });
 
+  // Floors carry a `#floor` marker so the renderer can tell, on its very first
+  // render, that this is not a launch window. A floor opens INTO the hive the
+  // app is already running, so it must never show the launch-time hive picker.
+  // `#floor` means "you are already inside a hive — do not render the launch
+  // picker". True for every floor, and for the primary window of a `--hive`
+  // instance, which was told on the command line exactly which hive to open.
+  const skipPicker = isFloor || !!getHiveOverride();
   if (isDev && process.env.ELECTRON_RENDERER_URL) {
-    win.loadURL(process.env.ELECTRON_RENDERER_URL);
+    win.loadURL(process.env.ELECTRON_RENDERER_URL + (skipPicker ? '#floor' : ''));
   } else {
-    win.loadFile(join(__dirname, '../renderer/index.html'));
+    win.loadFile(join(__dirname, '../renderer/index.html'), skipPicker ? { hash: 'floor' } : {});
   }
 
   win.on('closed', () => {
@@ -2390,6 +2424,68 @@ function openFloor(): BrowserWindow | null {
   return createWindow({ floor: true });
 }
 
+/** Hives running in a process we launched: hive root → child pid. Probed for
+ *  liveness before it is trusted, so closing an instance frees its project. */
+const spawnedInstances = new Map<string, number>();
+
+/** Does `pid` still exist? Signal 0 checks without delivering anything. */
+function pidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+/** Reason `home` cannot be opened again, or null when it is free. Two processes
+ *  on ONE hive would collide on its hook pipe (hashed from the hive root) and
+ *  contend for its git repo — different hives are safe, duplicates are not. */
+function hiveAlreadyOpen(home: string): string | null {
+  const mine = readConfig().harnessHome;
+  if (mine && resolve(mine) === resolve(home)) return 'That project is already open in this window.';
+  for (const [root, pid] of [...spawnedInstances]) {
+    if (!pidAlive(pid)) { spawnedInstances.delete(root); continue; }
+    if (resolve(root) === resolve(home)) return 'That project is already open in another window.';
+  }
+  return null;
+}
+
+/** Open `home` as a SECOND instance, leaving this one exactly as it is. The
+ *  non-destructive counterpart to config:changeHome, which repoints THIS process
+ *  and relaunches — closing every window the user had open. */
+function openProjectInNewInstance(home: string): { ok: boolean; error?: string } {
+  const target = expandTilde(String(home ?? '').trim());
+  if (!target) return { ok: false, error: 'No folder given.' };
+  const busy = hiveAlreadyOpen(target);
+  if (busy) return { ok: false, error: busy };
+  const made = ensureHarnessHome(target);
+  if (!made.ok) return { ok: false, error: made.error ?? 'Could not create that folder.' };
+  try {
+    // Packaged: our own exe. Dev: electron + the app dir, mirroring how we booted.
+    const args = app.isPackaged ? [`--hive=${target}`] : [app.getAppPath(), `--hive=${target}`];
+    const child = spawn(process.execPath, args, { detached: true, stdio: 'ignore' });
+    child.unref();
+    if (child.pid) spawnedInstances.set(target, child.pid);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Folder dialog → new instance. Backs File ▸ Open Other Project…. */
+async function promptOpenOtherProject(): Promise<void> {
+  const parent = BrowserWindow.getFocusedWindow() ?? mainWindow;
+  const opts: Electron.OpenDialogOptions = {
+    properties: ['openDirectory', 'createDirectory'],
+    title: 'Open another project in a new window'
+  };
+  const res = parent
+    ? await dialog.showOpenDialog(parent, opts)
+    : await dialog.showOpenDialog(opts);
+  if (res.canceled || !res.filePaths[0]) return;
+  const out = openProjectInNewInstance(res.filePaths[0]);
+  if (!out.ok) {
+    const box = { type: 'info' as const, message: 'Could not open that project', detail: out.error ?? '' };
+    if (parent) dialog.showMessageBox(parent, box); else dialog.showMessageBox(box);
+  }
+}
+
 /** Build + install the application menu. Only called when multiWindow is on, so
  *  flag-off keeps Electron's default menu (zero behavior change). Uses standard
  *  role-based items so copy/paste/quit/etc. work per-platform, and adds the
@@ -2401,13 +2497,20 @@ function installAppMenu(): void {
     accelerator: 'CmdOrCtrl+Shift+N',
     click: () => { openFloor(); }
   };
+  // A floor is another window on the SAME hive; this is another PROJECT, which
+  // needs its own process because the hive is process-global.
+  const openProjectItem = {
+    label: 'Open Other Project…',
+    accelerator: 'CmdOrCtrl+Shift+O',
+    click: () => { void promptOpenOtherProject(); }
+  };
   const template: Electron.MenuItemConstructorOptions[] = [
     ...(isMac ? [{ role: 'appMenu' as const }] : []),
     {
       label: 'File',
       submenu: isMac
-        ? [newFloorItem, { type: 'separator' as const }, { role: 'close' as const }]
-        : [newFloorItem, { type: 'separator' as const }, { role: 'quit' as const }]
+        ? [newFloorItem, openProjectItem, { type: 'separator' as const }, { role: 'close' as const }]
+        : [newFloorItem, openProjectItem, { type: 'separator' as const }, { role: 'quit' as const }]
     },
     // The Edit menu is spelled out rather than `{ role: 'editMenu' }` for one
     // reason: `registerAccelerator: false` on the clipboard items.
@@ -3012,6 +3115,15 @@ ipcMain.on('app:readClipboardSync', (evt) => {
 // settings at spawn (hive.ensureAgent theme option) — deliberately NOT via
 // `claude config set -g theme`, which would also restyle the user's own
 // Claude sessions outside the app.
+
+// Open a DIFFERENT project as its own instance. Unlike config:changeHome — which
+// repoints this process and relaunches it, taking every open window down — this
+// leaves the caller untouched and stands a second app up beside it.
+ipcMain.handle('config:openInNewInstance', (_evt, payload: unknown) => {
+  const home = (payload as { home?: unknown } | null)?.home;
+  if (typeof home !== 'string') return { ok: false as const, error: 'no folder given' };
+  return openProjectInNewInstance(home);
+});
 
 // ─── IPC: folder picker ─────────────────────────────────────────────────────
 ipcMain.handle('dialog:chooseFolder', async (evt) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -973,6 +973,11 @@ const api = {
   /** Open a new floor (independent office window). No-op when the multiWindow
    *  flag is off. Resolves { ok } indicating whether a window opened. */
   newFloor: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('window:newFloor'),
+  /** Open ANOTHER project (harness config) as a second app instance, leaving this
+   *  one running. The hive is process-global, so a different project needs a
+   *  different process — unlike changeHome, nothing here closes existing windows. */
+  openInNewInstance: (home: string): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('config:openInNewInstance', { home }),
 
   // ─── Closing time (graceful shutdown via the hive) ─────────────────────────
   /** Start the closing-time protocol: the god broadcasts shutdown, every worker

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,6 +64,12 @@ export function App() {
   // leaves a one-shot localStorage flag so we don't bounce back onto the picker for
   // the hive we just chose. Also set true on onboarding completion (below).
   const [hiveOpened, setHiveOpened] = useState<boolean>(() => {
+    // A FLOOR window (main tags it `#floor`) is already inside the hive — there
+    // is nothing to pick. This must come first: floors get their own session
+    // partition, so their localStorage is always empty and the one-shot flag
+    // below can never be present. Without this, every floor lands on the picker
+    // forever, where the only other controls relaunch the whole app.
+    if (window.location.hash === '#floor') return true;
     try {
       if (window.localStorage.getItem('cth.skipHivePickerOnce')) {
         window.localStorage.removeItem('cth.skipHivePickerOnce');

--- a/src/renderer/src/components/HivePicker.tsx
+++ b/src/renderer/src/components/HivePicker.tsx
@@ -10,48 +10,45 @@ export interface HivePickerProps {
   onOpenCurrent: () => void;
 }
 
-// Set right before a hive SWITCH so App skips this picker once after the relaunch
-// changeHome triggers — otherwise the user would land back on the picker for the
-// hive they just chose. App.tsx reads + clears it on mount.
-const SKIP_KEY = 'cth.skipHivePickerOnce';
-
 function folderName(path: string): string {
-  return path.split('/').filter(Boolean).pop() ?? path;
+  // Split on BOTH separators: a Windows home ("D:\work\hive") contains no
+  // forward slash, so a '/'-only split renders the whole path as its own name.
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
 }
 
 /**
  * HivePicker — the launch-time workspace selector. A "hive" is a harness home
  * folder: its own agents, memory, tasks, and history. On reopen the user can open
  * the hive they were in (fast, in-place), jump to a recent one, browse to an
- * existing folder, or start a new one. Switching to a DIFFERENT home goes through
- * changeHome('fresh'), which tears down services and relaunches against it — so
- * every switch is a clean process restart (cheap here, before any work is live).
+ * existing folder, or start a new one. A DIFFERENT home opens as its OWN app
+ * instance (`--hive=<path>`): the hive is process-global, so a second project
+ * needs a second process. Nothing here restarts or closes the current window.
  */
 export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
   const current = config.harnessHome;
   const recents = (config.recentHives ?? []).filter((h) => h && h !== current);
   const [busy, setBusy] = useState<string | undefined>();
+  /** Hive just launched in another window — confirms the spawn, since nothing
+   *  visibly changes in THIS window when a second instance comes up. */
+  const [opened, setOpened] = useState<string | undefined>();
   const [error, setError] = useState<string | undefined>();
 
-  // Open a hive. Same folder as the current one → just enter it (no relaunch).
-  // A different folder → changeHome('fresh') re-points + relaunches the process.
+  // Open a hive. Same folder as the current one → just enter it, in place. A
+  // DIFFERENT folder → a second app instance on that project, running beside this
+  // one. This window is never torn down, so open as many projects as you like.
   const openHive = async (path: string) => {
     if (!path) return;
     if (current && path === current) { onOpenCurrent(); return; }
     setError(undefined);
+    setOpened(undefined);
     setBusy(path);
     try {
-      window.localStorage.setItem(SKIP_KEY, '1');
-      const res = await window.cth.changeHome(path, 'fresh');
-      // Success never returns (the process relaunches). A return means an error.
-      if (!res.ok) {
-        window.localStorage.removeItem(SKIP_KEY);
-        setError(res.error ?? 'Could not open that folder.');
-        setBusy(undefined);
-      }
+      const res = await window.cth.openInNewInstance(path);
+      if (res.ok) setOpened(path);
+      else setError(res.error ?? 'Could not open that folder.');
     } catch (e) {
-      window.localStorage.removeItem(SKIP_KEY);
       setError(e instanceof Error ? e.message : String(e));
+    } finally {
       setBusy(undefined);
     }
   };
@@ -79,8 +76,8 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
             <p style={{ margin: 0, fontSize: 12, lineHeight: '19px', color: 'var(--cth-ink-700)' }}>
               A <strong>harness config</strong> is the folder where the app keeps everything for one
               workspace — its settings, your agents and their memory, tasks, triggers, and history.
-              Each config is separate and self-contained, so you can run different setups side by side.
-              Open the one you were working in, switch to another, or start a new one.
+              Each config opens in its own window, so you can keep several projects running side by
+              side. Open the one you were working in, or start another.
             </p>
 
             {/* CURRENT — the last-used home, the one-click default. */}
@@ -122,7 +119,7 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
                       key={h}
                       onClick={() => openHive(h)}
                       disabled={!!busy}
-                      title={`Switch to ${h} (reloads the app)`}
+                      title={`Open ${h} in a new window`}
                       style={{
                         display: 'flex', alignItems: 'center', gap: 10, padding: '8px 12px',
                         background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
@@ -141,7 +138,7 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
                         }}>{h}</div>
                       </div>
                       <span style={{ fontSize: 11, color: 'var(--cth-ink-500)', flexShrink: 0 }}>
-                        {busy === h ? 'opening…' : 'switch →'}
+                        {busy === h ? 'opening…' : 'open →'}
                       </span>
                     </button>
                   ))}
@@ -158,7 +155,16 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
 
             {busy && (
               <div style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>
-                Opening {folderName(busy)} — the app will reload…
+                Opening {folderName(busy)} in a new window…
+              </div>
+            )}
+
+            {opened && (
+              <div style={{
+                padding: '6px 10px', background: 'var(--cth-mint-light)',
+                boxShadow: 'inset 0 0 0 1px var(--cth-mint)', fontSize: 12, color: 'var(--cth-ink-900)'
+              }}>
+                <strong>{folderName(opened)}</strong> opened in a new window. This one is untouched.
               </div>
             )}
 

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -795,6 +795,11 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     // same renderer-side roster - keep localStorage. A 'fresh' home starts empty,
     // so clear the renderer cache to match.
     if (changeMode === 'fresh') clearLocalState();
+    // This is the deliberate MOVE-my-workspace path and still relaunches, so leave
+    // the one-shot flag App.tsx reads — otherwise the restart lands on the picker
+    // for the very home the user just chose. (The picker no longer sets it: it
+    // opens other projects as separate instances instead of relaunching.)
+    try { window.localStorage.setItem('cth.skipHivePickerOnce', '1'); } catch { /* best-effort */ }
     try {
       const res = await window.cth.changeHome(changeHome, changeMode);
       if (!res.ok) { setChangeErr(res.error ?? 'Could not change the home folder.'); setChangeBusy(false); }


### PR DESCRIPTION
## What & why

Switching projects from the hive picker rewrote the global `harnessHome` and relaunched the app, which destroyed every window you already had open. Opening another floor was not a way around it either, because floors share the process-global hive and so always point at the same project. The practical effect is that you can only ever have one project open at a time, and picking a different one costs you whatever was running in the first.

This adds a `--hive=<path>` flag that overrides the home for a single process. It is read once at startup and applied inside `readConfig()`, and since every service already resolves the hive lazily through that function, they all pick it up with no further changes. A process started with the flag also skips the single-instance lock, so several projects can run side by side out of one userData directory: ports are already OS-assigned, the hook pipe is hashed per hive root, and `harness.db` is WAL with a busy timeout, so nothing collides. The one subtlety I would like a reviewer to look at is that `writeConfig` now merges onto `readConfigRaw()` rather than `readConfig()` — merging onto the latter would bake the override into `config.json` and silently repoint every other instance's home.

On top of that, File ▸ Open Other Project… (`Ctrl+Shift+O`) and the picker's button now spawn a detached instance instead of relaunching, and refuse a hive that is already open. Window geometry is saved per hive so two instances stop stacking on the identical rectangle, and floors and `--hive` instances load with a `#floor` hash so they bypass the picker. The picker's button label went from `switch →` to `open →` because it no longer switches anything, and folder names in that list now render correctly on Windows — the old split only handled forward slashes, so every row showed its full path where its name should be. You can see both of those in the screenshots below.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

Both runs start from an identical state and use the same window size, theme and data: `D:\demo-alpha` is the current config and `D:\demo-beta` sits in the recent list. These are two throwaway configs created for the recording, so nothing personal is in frame. In each run I click the one button on the `demo-beta` row and capture what happens to the windows.

### Before

Clicking `switch →` tears the whole process down and relaunches it. The pid changes from 12856 to 39980, and you are left with one window that is now on `demo-beta`; the window you were working in is gone.

![Before: switching replaces the running process, leaving a single window](https://raw.githubusercontent.com/PawanRamaMali/munder-difflin/pr-evidence/before.png)

### After

Clicking `open →` spawns a second instance. The new window (pid 9748) comes up on `demo-beta` on the right while the original window (pid 29004) is still alive on the left, and `config.json` still records `harnessHome` as `D:\demo-alpha`, so the override never leaked out of the child process.

![After: opening spawns a second instance and both windows stay alive](https://raw.githubusercontent.com/PawanRamaMali/munder-difflin/pr-evidence/after.png)

## How I tested it

- OS: Windows 11 (26100), Electron production build via `npm run build`, run from `node_modules/electron`.
- Steps: built `upstream/main` and captured the before run, then built this branch and repeated the exact same clicks for the after run, resetting `config.json` in between so both started identically. Separately I confirmed the two live instances resolve to distinct per-hive hook pipes, and that the pids in the screenshots are two genuinely separate processes rather than one process with two windows.

`npm run typecheck` passes clean on both the node and web projects. `npm run build` succeeds.

`npm run test:focused` reports 8 failures, and I want to be upfront that I did not fix them: they are identical on `upstream/main` with this branch checked out or not. They are `consecutive agent caps survive an interleaved config update`, `the native rung actually runs, and says why it differs`, `with npm present nothing mentions a missing Node`, `Codex remote uses a short stable per-agent home alias`, and four `transcript-project-dir` cases. They look like Windows environment failures — the transcript ones assert against a fake `HOME` that `os.homedir()` ignores on Windows — but I have not dug in, and none of them touch the files in this diff.

## Things I could not verify, and one wrinkle

I have only run this on Windows. The `--hive` argument handling and the `spawn` call are platform-neutral, but the pipe naming and the instance lock deserve a look from someone who can run macOS or Linux.

The wrinkle is visible if you compare the two windows in the after shot before I matched their themes: a newly spawned instance cannot read the first process's `localStorage`, because Chromium's profile storage is locked by the process that got there first, so it starts on the default theme rather than the one you picked. The same lock is why the second instance logs `Unable to create cache` and `Gpu Cache Creation failed`; it falls back to in-memory and is otherwise fine. Giving each instance its own `--user-data-dir` would fix both but would orphan integration secrets and the knowledge graph, so I left it alone. If you would rather have per-instance UI preferences persist, that is worth solving separately.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes — 8 pre-existing failures, identical on `upstream/main`, detailed above.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`. (No art added.)
