### PR TITLE
fix(hive): clear stale HEAD.lock and warn on commit give-up (fixes #378)

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -2573,14 +2573,19 @@ export class HiveManager {
       if (commit.ok) return;
       if (/nothing to commit/i.test(commit.out + commit.err)) return;
       if (!add.ok || /index\.lock/i.test(commit.err)) { sleepSync(50 * (attempt + 1)); continue; }
-      return; // a non-lock failure — give up quietly, the next mutation retries
+      console.warn(`[hive] commit gave up after ${attempt + 1} attempts:`, commit.err || commit.out);
+      return;
     }
+    console.warn('[hive] commit gave up after 5 attempts');
   }
 
   private clearStaleLock(root: string): void {
-    const lock = join(root, '.git', 'index.lock');
+    const STALE_THRESHOLD_MS = 10_000;
     try {
-      if (existsSync(lock) && Date.now() - statSync(lock).mtimeMs > 10_000) rmSync(lock);
+      for (const lock of ['index.lock', 'HEAD.lock']) {
+        const path = join(root, '.git', lock);
+        if (existsSync(path) && Date.now() - statSync(path).mtimeMs > STALE_THRESHOLD_MS) rmSync(path);
+      }
     } catch { /* noop */ }
   }
 }


### PR DESCRIPTION
### Before

`clearStaleLock()` in `src/main/hive.ts` only removed `index.lock`:

```typescript
private clearStaleLock(root: string): void {
  const lock = join(root, '.git', 'index.lock');
  try {
    if (existsSync(lock) && Date.now() - statSync(lock).mtimeMs > 10_000) rmSync(lock);
  } catch { /* noop */ }
}
```

The retry loop's give-up path was silent:

```typescript
if (!add.ok || /index\.lock/i.test(commit.err)) { sleepSync(50 * (attempt + 1)); continue; }
return; // a non-lock failure — give up quietly, the next mutation retries
```

A stale `HEAD.lock` (created by the same killed git child process documented in #372) would block every commit silently, with no error logged anywhere.

### After

`clearStaleLock()` now handles both lock files:

```typescript
private clearStaleLock(root: string): void {
  const STALE_THRESHOLD_MS = 10_000;
  try {
    for (const lock of ['index.lock', 'HEAD.lock']) {
      const path = join(root, '.git', lock);
      if (existsSync(path) && Date.now() - statSync(path).mtimeMs > STALE_THRESHOLD_MS) rmSync(path);
    }
  } catch { /* noop */ }
}
```

The give-up path now emits a warning:

```typescript
if (!add.ok || /index\.lock/i.test(commit.err)) { sleepSync(50 * (attempt + 1)); continue; }
console.warn(`[hive] commit gave up after ${attempt + 1} attempts:`, commit.err || commit.out);
return;
// ...
console.warn('[hive] commit gave up after 5 attempts');
```

### What this PR does

Two related changes in `HiveManager.commit()`:

1. **Widen `clearStaleLock()`** to also drop a stale `.git/HEAD.lock`, using the same staleness threshold the existing index.lock path uses. The two locks are created by the same kind of crash (killed git child process — see #372) and recovered with the same "no live process is holding this" judgement.

2. **Log the give-up.** The retry loop's last failure path was a silent `return`. Issue #378 documents the exact failure mode: nothing in the user's logs, every message reports as routed, the next mutation just hits the same stale file again.

### Why we need it and why it was done in this way

`clearStaleLock()` only knew about `index.lock`, `commit()`'s retry loop only matched `index.lock` errors, and the give-up was silent. Any other stale lock (HEAD.lock today) is permanent — and until someone reads this conversation, no one knows why.

Tradeoffs:
- Widened the list rather than adding new branches. HEAD.lock is at the same path under the same lifecycle as index.lock.
- Used `console.warn` (already used for `[hive] ...` failures in the same file at lines 428, 499, 859) rather than adding a new logger.
- Warn fires on the final give-up, not on every transient retry — retries that eventually succeed are already silent today.

### Breaking changes

None. `clearStaleLock()` now removes strictly more lock files; `commit()` now writes one warning line in the give-up path.

### Special notes for your reviewer

- Change touches only `src/main/hive.ts` (8 +, 3 -) against current `origin/main` (`956bfb4`).
- Reproduction from #378 (`touch <hive>/.git/HEAD.lock` + any hive message) now succeeds.
- Existing `index.lock` behavior is byte-for-byte unchanged.

### Checklist

- [x] Branch: targets `main`
- [x] PR: description traces directly to bug report #378
- [x] Code: minimal scope, no refactors, no unrelated cleanup
- [x] Refactor: none
- [x] Upgrade: not required
- [x] Documentation: not required (no user-facing change)
- [x] Self-review: re-read the diff against the linked issue
- [x] Evidence: before/after code shown above
