### PR TITLE
fix(config): preserve malformed Claude config files

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -779,6 +779,55 @@ export function ensureHarnessHome(path: string): { ok: boolean; error?: string }
   }
 }
 
+function ensureClaudeGlobalPermissions(home: string): void {
+  try {
+    const dir = join(home, '.claude');
+    const p = join(dir, 'settings.json');
+    let s: Record<string, unknown> = {};
+    if (existsSync(p)) {
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+        s = parsed as Record<string, unknown>;
+      } catch {
+        // Existing unreadable or malformed user config is not safe to mutate.
+        return;
+      }
+    }
+    if (s.skipDangerousModePermissionPrompt !== true || s.skipAutoPermissionPrompt !== true) {
+      s.skipDangerousModePermissionPrompt = true;
+      s.skipAutoPermissionPrompt = true;
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(p, JSON.stringify(s, null, 2), 'utf8');
+    }
+  } catch { /* best-effort; never block a spawn */ }
+}
+
+type ClaudeProjectConfig = Record<string, unknown> & { hasTrustDialogAccepted?: boolean };
+type ClaudeConfig = Record<string, unknown> & { projects?: Record<string, ClaudeProjectConfig> };
+
+function ensureClaudeProjectTrust(home: string, cwd: string): void {
+  try {
+    const p = join(home, '.claude.json');
+    let c: ClaudeConfig = {};
+    if (existsSync(p)) {
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+        c = parsed as ClaudeConfig;
+      } catch {
+        // Existing unreadable or malformed user config is not safe to mutate.
+        return;
+      }
+    }
+    if (c.projects?.[cwd]?.hasTrustDialogAccepted !== true) {
+      c.projects = c.projects ?? {};
+      c.projects[cwd] = { ...(c.projects[cwd] ?? {}), hasTrustDialogAccepted: true };
+      writeFileSync(p, JSON.stringify(c, null, 2), 'utf8');
+    }
+  } catch { /* best-effort; never block a spawn */ }
+}
+
 /** Idempotently pre-accept Claude Code's first-run prompts so agents spawned with
  *  `--permission-mode bypassPermissions` start cleanly. Without this, a fresh
  *  install shows an interactive "WARNING: Bypass Permissions mode … 1. No, exit /
@@ -790,38 +839,17 @@ export function ensureHarnessHome(path: string): { ok: boolean; error?: string }
  *   1. `~/.claude/settings.json` → `skipDangerousModePermissionPrompt` +
  *      `skipAutoPermissionPrompt` — these gate the bypass-mode warning (global).
  *   2. `~/.claude.json` → `projects[cwd].hasTrustDialogAccepted` — the per-folder
- *      "do you trust the files in this folder?" dialog. */
+ *      "do you trust the files in this folder?" dialog.
+ *
+ *  Each file is an independent best-effort boundary: unsafe existing contents
+ *  are preserved without preventing the other file from being handled safely. */
 export function ensureClaudePermissionsAccepted(cwd?: string): void {
-  const home = homedir();
+  let home: string;
+  try { home = homedir(); } catch { return; }
   if (!home) return;
-  // 1) Global bypass-mode warning gate.
-  try {
-    const dir = join(home, '.claude');
-    const p = join(dir, 'settings.json');
-    let s: Record<string, unknown> = {};
-    if (existsSync(p)) {
-      try { s = JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>; } catch { s = {}; }
-    }
-    if (s.skipDangerousModePermissionPrompt !== true || s.skipAutoPermissionPrompt !== true) {
-      s.skipDangerousModePermissionPrompt = true;
-      s.skipAutoPermissionPrompt = true;
-      mkdirSync(dir, { recursive: true });
-      writeFileSync(p, JSON.stringify(s, null, 2), 'utf8');
-    }
-  } catch { /* best-effort; never block a spawn */ }
-  // 2) Per-folder trust dialog gate (only when this cwd isn't already trusted).
+
+  ensureClaudeGlobalPermissions(home);
   if (cwd) {
-    try {
-      const p = join(home, '.claude.json');
-      let c: { projects?: Record<string, { hasTrustDialogAccepted?: boolean }> } = {};
-      if (existsSync(p)) {
-        try { c = JSON.parse(readFileSync(p, 'utf8')); } catch { c = {}; }
-      }
-      if (c.projects?.[cwd]?.hasTrustDialogAccepted !== true) {
-        c.projects = c.projects ?? {};
-        c.projects[cwd] = { ...(c.projects[cwd] ?? {}), hasTrustDialogAccepted: true };
-        writeFileSync(p, JSON.stringify(c, null, 2), 'utf8');
-      }
-    } catch { /* best-effort */ }
+    ensureClaudeProjectTrust(home, cwd);
   }
 }

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -780,19 +780,14 @@ export function ensureHarnessHome(path: string): { ok: boolean; error?: string }
 }
 
 function ensureClaudeGlobalPermissions(home: string): void {
+  const dir = join(home, '.claude');
+  const p = join(dir, 'settings.json');
   try {
-    const dir = join(home, '.claude');
-    const p = join(dir, 'settings.json');
     let s: Record<string, unknown> = {};
     if (existsSync(p)) {
-      try {
-        const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
-        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
-        s = parsed as Record<string, unknown>;
-      } catch {
-        // Existing unreadable or malformed user config is not safe to mutate.
-        return;
-      }
+      const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+      s = parsed as Record<string, unknown>;
     }
     if (s.skipDangerousModePermissionPrompt !== true || s.skipAutoPermissionPrompt !== true) {
       s.skipDangerousModePermissionPrompt = true;
@@ -800,32 +795,37 @@ function ensureClaudeGlobalPermissions(home: string): void {
       mkdirSync(dir, { recursive: true });
       writeFileSync(p, JSON.stringify(s, null, 2), 'utf8');
     }
-  } catch { /* best-effort; never block a spawn */ }
+  } catch (error) {
+    console.warn(
+      `[config] Could not safely update Claude config at ${p}:`,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
 }
 
 type ClaudeProjectConfig = Record<string, unknown> & { hasTrustDialogAccepted?: boolean };
 type ClaudeConfig = Record<string, unknown> & { projects?: Record<string, ClaudeProjectConfig> };
 
 function ensureClaudeProjectTrust(home: string, cwd: string): void {
+  const p = join(home, '.claude.json');
   try {
-    const p = join(home, '.claude.json');
     let c: ClaudeConfig = {};
     if (existsSync(p)) {
-      try {
-        const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
-        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
-        c = parsed as ClaudeConfig;
-      } catch {
-        // Existing unreadable or malformed user config is not safe to mutate.
-        return;
-      }
+      const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+      c = parsed as ClaudeConfig;
     }
     if (c.projects?.[cwd]?.hasTrustDialogAccepted !== true) {
       c.projects = c.projects ?? {};
       c.projects[cwd] = { ...(c.projects[cwd] ?? {}), hasTrustDialogAccepted: true };
       writeFileSync(p, JSON.stringify(c, null, 2), 'utf8');
     }
-  } catch { /* best-effort; never block a spawn */ }
+  } catch (error) {
+    console.warn(
+      `[config] Could not safely update Claude config at ${p}:`,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
 }
 
 /** Idempotently pre-accept Claude Code's first-run prompts so agents spawned with

--- a/test/claude-permissions-config.test.cjs
+++ b/test/claude-permissions-config.test.cjs
@@ -1,0 +1,149 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+// ensureClaudePermissionsAccepted() writes below os.homedir(). Redirect both
+// home variables before loading config.ts so this test can never touch the
+// user's real Claude configuration.
+const realHome = process.env.HOME;
+const realUserProfile = process.env.USERPROFILE;
+const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-claude-config-'));
+process.env.HOME = home;
+process.env.USERPROFILE = home;
+assert.equal(os.homedir(), home, 'home redirect failed; refusing to run against the real home');
+
+const userData = path.join(home, 'user-data');
+const electron = require.resolve('electron');
+require.cache[electron] = {
+  id: electron,
+  filename: electron,
+  loaded: true,
+  exports: { app: { getPath: () => userData } }
+};
+
+const { ensureClaudePermissionsAccepted } = loadTs('src/main/config.ts');
+const settingsDir = path.join(home, '.claude');
+const settingsPath = path.join(settingsDir, 'settings.json');
+const projectConfigPath = path.join(home, '.claude.json');
+const cwd = path.join(home, 'workspace', 'project');
+
+function writeSettings(contents) {
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.writeFileSync(settingsPath, contents, 'utf8');
+}
+
+function resetConfigs() {
+  fs.rmSync(settingsDir, { recursive: true, force: true });
+  fs.rmSync(projectConfigPath, { force: true });
+}
+
+test.beforeEach(resetConfigs);
+test.after(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  if (realUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = realUserProfile;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('preserves malformed Claude config files byte-for-byte', () => {
+  const malformedSettings = '{\n  "env": {\n    "CUSTOM_VALUE": "preserve-me"\n  },\n';
+  const malformedProjectConfig = '{\n  "projects": {\n';
+  writeSettings(malformedSettings);
+  fs.writeFileSync(projectConfigPath, malformedProjectConfig, 'utf8');
+
+  ensureClaudePermissionsAccepted(cwd);
+
+  assert.equal(fs.readFileSync(settingsPath, 'utf8'), malformedSettings);
+  assert.equal(fs.readFileSync(projectConfigPath, 'utf8'), malformedProjectConfig);
+});
+
+test('merges required fields into valid configs without losing unrelated data', () => {
+  writeSettings(JSON.stringify({
+    env: { CUSTOM_VALUE: 'preserve-me' },
+    hooks: { example: true }
+  }, null, 2));
+  fs.writeFileSync(projectConfigPath, JSON.stringify({
+    numStartups: 7,
+    projects: {
+      [cwd]: { allowedTools: ['Read'], custom: 'keep' },
+      '/another/project': { hasTrustDialogAccepted: false }
+    }
+  }, null, 2));
+
+  ensureClaudePermissionsAccepted(cwd);
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), {
+    env: { CUSTOM_VALUE: 'preserve-me' },
+    hooks: { example: true },
+    skipDangerousModePermissionPrompt: true,
+    skipAutoPermissionPrompt: true
+  });
+  assert.deepEqual(JSON.parse(fs.readFileSync(projectConfigPath, 'utf8')), {
+    numStartups: 7,
+    projects: {
+      [cwd]: {
+        allowedTools: ['Read'],
+        custom: 'keep',
+        hasTrustDialogAccepted: true
+      },
+      '/another/project': { hasTrustDialogAccepted: false }
+    }
+  });
+});
+
+test('creates minimal config files when they are missing', () => {
+  ensureClaudePermissionsAccepted(cwd);
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), {
+    skipDangerousModePermissionPrompt: true,
+    skipAutoPermissionPrompt: true
+  });
+  assert.deepEqual(JSON.parse(fs.readFileSync(projectConfigPath, 'utf8')), {
+    projects: { [cwd]: { hasTrustDialogAccepted: true } }
+  });
+});
+
+test('a malformed settings file does not prevent safe project trust updates', () => {
+  const malformedSettings = '{ "preserve": true,';
+  writeSettings(malformedSettings);
+  fs.writeFileSync(projectConfigPath, JSON.stringify({ custom: 'keep' }), 'utf8');
+
+  ensureClaudePermissionsAccepted(cwd);
+
+  assert.equal(fs.readFileSync(settingsPath, 'utf8'), malformedSettings);
+  assert.deepEqual(JSON.parse(fs.readFileSync(projectConfigPath, 'utf8')), {
+    custom: 'keep',
+    projects: { [cwd]: { hasTrustDialogAccepted: true } }
+  });
+});
+
+test('does not rewrite configs that already contain every required field', () => {
+  const settings = '{"skipDangerousModePermissionPrompt":true,"skipAutoPermissionPrompt":true}\n';
+  const projectConfig = JSON.stringify({
+    projects: { [cwd]: { hasTrustDialogAccepted: true } }
+  }) + '\n';
+  writeSettings(settings);
+  fs.writeFileSync(projectConfigPath, projectConfig, 'utf8');
+
+  ensureClaudePermissionsAccepted(cwd);
+  ensureClaudePermissionsAccepted(cwd);
+
+  assert.equal(fs.readFileSync(settingsPath, 'utf8'), settings);
+  assert.equal(fs.readFileSync(projectConfigPath, 'utf8'), projectConfig);
+});
+
+test('preserves existing config files with unsafe JSON root shapes', () => {
+  writeSettings('null\n');
+  fs.writeFileSync(projectConfigPath, '["keep"]\n', 'utf8');
+
+  ensureClaudePermissionsAccepted(cwd);
+
+  assert.equal(fs.readFileSync(settingsPath, 'utf8'), 'null\n');
+  assert.equal(fs.readFileSync(projectConfigPath, 'utf8'), '["keep"]\n');
+});

--- a/test/claude-permissions-config.test.cjs
+++ b/test/claude-permissions-config.test.cjs
@@ -54,13 +54,24 @@ test.after(() => {
 test('preserves malformed Claude config files byte-for-byte', () => {
   const malformedSettings = '{\n  "env": {\n    "CUSTOM_VALUE": "preserve-me"\n  },\n';
   const malformedProjectConfig = '{\n  "projects": {\n';
+  const warnings = [];
+  const originalWarn = console.warn;
   writeSettings(malformedSettings);
   fs.writeFileSync(projectConfigPath, malformedProjectConfig, 'utf8');
 
-  ensureClaudePermissionsAccepted(cwd);
+  console.warn = (...args) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  try {
+    ensureClaudePermissionsAccepted(cwd);
+  } finally {
+    console.warn = originalWarn;
+  }
 
   assert.equal(fs.readFileSync(settingsPath, 'utf8'), malformedSettings);
   assert.equal(fs.readFileSync(projectConfigPath, 'utf8'), malformedProjectConfig);
+  assert.ok(warnings.some((line) => line.includes(settingsPath)));
+  assert.ok(warnings.some((line) => line.includes(projectConfigPath)));
 });
 
 test('merges required fields into valid configs without losing unrelated data', () => {


### PR DESCRIPTION
## What & why

Existing Claude config files could be replaced with a minimal generated config when JSON parsing failed, which could discard unrelated user settings.

This change makes Claude config mutation fail closed for malformed, unreadable, or unsafe root values while keeping permission and project trust setup isolated. One invalid config file no longer prevents the other config from being updated safely.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

Focused regression coverage against the original `main` implementation reproduces the unsafe behavior.

The Claude config regression suite reports:

```text
tests 6
pass 3
fail 3
```

The failing cases cover malformed config preservation, failure isolation, and unsafe JSON root handling.

<img width="757" height="359" alt="2026-08-30-165636" src="https://github.com/user-attachments/assets/f8724fbe-c189-4efc-b420-f07261963d4d" />

### After

The same focused regression suite passes with the fix applied.

```text
tests 6
pass 6
fail 0
```

<img width="761" height="309" alt="2026-08-30-173747" src="https://github.com/user-attachments/assets/886f2880-e797-42c9-828d-90fd6e7b9615" />

## How I tested it

- OS: Windows
- Node: 22
- Steps:
  - Ran `node --test .\test\claude-permissions-config.test.cjs`
  - Confirmed the regression suite fails 3 of 6 cases against the original `main` implementation
  - Confirmed the same suite passes 6 of 6 cases after the fix
  - Ran `npm run typecheck`
  - Ran `npm run test:focused`
  - Ran `npm run build`
  - Ran `git diff --check`

Focused Claude config regression suite after the fix:

```text
tests 6
pass 6
fail 0
```

`npm run test:focused` on this branch:

```text
731 passed
15 failed
2 skipped
```

The same suite against `origin/main`, with the regression tests from this PR kept in place:

```text
728 passed
18 failed
2 skipped
```

The three additional failures on `origin/main` are the Claude config regressions fixed by this PR. The remaining 15 failures reproduce on the same Windows environment, so this change does not introduce additional focused suite failures.

`npm run typecheck`, `npm run build`, and `git diff --check` all pass.

`package-lock.json` was restored after validation and this change introduces no dependency updates.

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`.

Close: #389 