### PR TITLE
fix(procKill): never group-SIGKILL a recycled pgid — verify membership before the delayed sweep

### DIFF
--- a/src/main/procKill.ts
+++ b/src/main/procKill.ts
@@ -42,13 +42,67 @@ export function hardKillTree(pid: number): void {
   }
 }
 
+/** Snapshot the live members of process group `pgid` as pid -> start time
+ *  (`lstart`, a stable full-precision timestamp). Returns null when `ps`
+ *  itself fails — callers must treat null as "cannot verify", never as
+ *  "group is empty". */
+export function groupMembers(pgid: number): Map<number, string> | null {
+  try {
+    const r = spawnSync('ps', ['-axo', 'pid=,pgid=,lstart='], { timeout: 2_000 });
+    if (r.error || r.status !== 0) return null;
+    const out = new Map<number, string>();
+    for (const line of String(r.stdout ?? '').split('\n')) {
+      const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.+\S)\s*$/);
+      if (m && Number(m[2]) === pgid) out.set(Number(m[1]), m[3]);
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/** Decide whether the delayed sweep may group-SIGKILL. The hazard this guards
+ *  (seen live 2026-08-30, T1007): once the leader AND its whole group are
+ *  gone, the kernel can recycle the pid as the pgid of an UNRELATED new
+ *  process group — a Claude session's background task, say — and the delayed
+ *  `kill(-pid)` then executes an innocent bystander. Under fork-heavy load
+ *  (parallel pytest suites) recycling happens within the 4s grace.
+ *
+ *  Sweep exactly when the group still holds at least one member from the
+ *  original snapshot (same pid AND same start time — the orphan-reaping case
+ *  this helper exists for). Skip when the group is empty (nothing to reap) or
+ *  when every current member is a stranger (pgid recycled). When either
+ *  snapshot is null (`ps` failed), fall back to sweeping — the pre-guard
+ *  behavior — rather than silently leaking. */
+export function shouldSweep(
+  before: Map<number, string> | null,
+  after: Map<number, string> | null
+): boolean {
+  if (before === null || after === null) return true;
+  if (after.size === 0) return false;
+  for (const [pid, started] of after) {
+    if (before.get(pid) === started) return true;
+  }
+  return false;
+}
+
 /** After a graceful kill (node-pty's SIGHUP), make sure the PIDs actually get
  *  released: wait a short grace, then sweep the process tree. Runs even when
  *  the leader died promptly — the sweep is what reaps grandchildren the polite
- *  signal never reached. The timer is unref'd so it can never keep the app
+ *  signal never reached. Before sweeping, the group membership is re-checked
+ *  against a snapshot taken here, so a recycled pgid is never group-killed
+ *  (see shouldSweep). The timer is unref'd so it can never keep the app
  *  alive during quit. */
 export function ensureKilled(pid: number | undefined, graceMs = KILL_GRACE_MS): void {
   if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return;
-  const t = setTimeout(() => hardKillTree(pid), graceMs);
+  if (process.platform === 'win32') {
+    const t = setTimeout(() => hardKillTree(pid), graceMs);
+    t.unref?.();
+    return;
+  }
+  const before = groupMembers(pid);
+  const t = setTimeout(() => {
+    if (shouldSweep(before, groupMembers(pid))) hardKillTree(pid);
+  }, graceMs);
   t.unref?.();
 }

--- a/test/proc-kill.test.cjs
+++ b/test/proc-kill.test.cjs
@@ -24,7 +24,7 @@ const js = ts.transpileModule(fs.readFileSync(SRC, 'utf8'), {
   compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 }
 }).outputText;
 fs.writeFileSync(path.join(out, 'procKill.js'), js, 'utf8');
-const { isAlive, hardKillTree, ensureKilled } = require(path.join(out, 'procKill.js'));
+const { isAlive, hardKillTree, ensureKilled, groupMembers, shouldSweep } = require(path.join(out, 'procKill.js'));
 
 if (process.platform === 'win32') {
   console.log('  ok  (win32: smoke import only — POSIX group semantics not applicable)');
@@ -98,6 +98,44 @@ async function test(name, fn) {
     ensureKilled(-5);
     ensureKilled(0);
     ensureKilled(1.5);
+  });
+
+  await test('shouldSweep: sweeps survivors, skips recycled or empty groups, sweeps blind on ps failure', async () => {
+    const snap = (pairs) => new Map(pairs);
+    assert.equal(shouldSweep(snap([[5, 'a']]), snap([[5, 'a']])), true, 'same member survives -> reap');
+    assert.equal(shouldSweep(snap([[5, 'a'], [6, 'b']]), snap([[6, 'b']])), true, 'any original survivor -> reap');
+    assert.equal(shouldSweep(snap([[5, 'a']]), snap()), false, 'group gone -> nothing to reap');
+    assert.equal(shouldSweep(snap([[5, 'a']]), snap([[5, 'zzz']])), false, 'same pid, new start time -> recycled, skip');
+    assert.equal(shouldSweep(snap([[5, 'a']]), snap([[7, 'c']])), false, 'all strangers -> recycled, skip');
+    assert.equal(shouldSweep(null, snap([[5, 'a']])), true, 'ps failed at schedule -> pre-guard behavior');
+    assert.equal(shouldSweep(snap([[5, 'a']]), null), true, 'ps failed at sweep -> pre-guard behavior');
+  });
+
+  await test('groupMembers sees a real group and its start times', async () => {
+    const pid = spawnStubbornTree();
+    await sleep(300);
+    const members = groupMembers(pid);
+    assert.ok(members !== null, 'ps must be usable here');
+    assert.ok(members.size >= 2, `expected leader+child, saw ${members.size}`);
+    for (const started of members.values()) assert.ok(started.length > 0, 'every member carries a start time');
+    hardKillTree(pid); // cleanup
+  });
+
+  await test('ensureKilled never group-kills a stranger group that inherited the pgid (T1007)', async () => {
+    // Deterministic pid reuse cannot be forced, so prove the guard at its seam:
+    // a snapshot of tree A (then fully killed) against the live membership of an
+    // unrelated tree B must refuse the sweep.
+    const a = spawnStubbornTree();
+    await sleep(300);
+    const before = groupMembers(a);
+    hardKillTree(a);
+    await sleep(300);
+    const b = spawnStubbornTree();
+    await sleep(300);
+    assert.equal(shouldSweep(before, groupMembers(b)), false, 'stranger group must be spared');
+    hardKillTree(b); // cleanup
+    // And the live path stays intact: with the guard active, a genuinely
+    // surviving group is still reaped (covered by the escalation test above).
   });
 
   process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## The bug

`ensureKilled()`'s 4s-delayed `hardKillTree` fires `kill(-pid, SIGKILL)` with no check that the pid still names the original process group. Once the leader **and** its whole group are gone, the kernel can recycle that pid as the pgid of an unrelated group. Under fork-heavy load (parallel pytest suites cycling the pid space) this happens **within the 4s grace**, and the delayed sweep executes an innocent bystander.

Observed live 2026-08-30 on macOS: two SIGKILL waves (120s apart, each tied to helper-process exits) reaped six long-running Claude Code background tasks whose process groups had inherited recycled pids. Confirmed by pgid mapping of the victims plus a controlled reproduction: a 6,000-pid fork storm alongside a 120s canary task.

## The fix

Snapshot the group's members (`pid` + `ps lstart`) when the sweep is scheduled, and re-check at fire time (`shouldSweep`):

- **reap** when at least one original member is still present — the orphan-reaping case this helper exists for stays fully intact;
- **skip** when the group is empty (nothing to reap) or every current member is a stranger (pgid recycled);
- **sweep blind** only when `ps` itself fails, preserving the pre-guard behavior rather than leaking.

win32 (`taskkill /T /F`) path unchanged.

## Verification

- `node test/proc-kill.test.cjs`: 8/8 — all 5 pre-existing tests (escalation/reaping behavior unchanged) plus 3 new ones covering `shouldSweep` decisions, `groupMembers` snapshots, and the stranger-group refusal.
- `tsc --noEmit -p tsconfig.node.json` clean.
- Hot-patched into the installed app.asar the same night: post-restart, a 6,000-pid fork storm ran alongside a 120s background canary — canary survived (pre-patch, identical churn killed tasks within seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Poe7Z9nsqt9AAy4EuHhNLb