### PR TITLE
Add MiniMax Code (mcode) provider

### DIFF
--- a/src/main/cliInstall.ts
+++ b/src/main/cliInstall.ts
@@ -32,16 +32,33 @@ export type InstallRungKind = 'npm' | 'node-then-npm' | 'native' | 'manual';
  *  (offline, or a platform nodejs.org ships no package for).
  *
  *  `npmAvailable` means npm is present AND its Node is new enough (see
- *  nodeInstall.NODE_FLOOR_MAJOR) — an ancient Node routes into the upgrade rung. */
+ *  nodeInstall.NODE_FLOOR_MAJOR) — an ancient Node routes into the upgrade rung.
+ *
+ *  `installedNodeMajor` is this machine's Node major, consulted ONLY against a
+ *  provider that declares its own higher floor (`minNodeMajor`). The app's floor is
+ *  20 and every engine but one is happy there, so "npm is present" used to be a
+ *  sufficient test. mcode is not: its package declares `>=22.19 <23 || >=24 <27` and
+ *  its own postinstall enforces it, so on a Node 20/21 machine the npm rung would
+ *  print `npm install -g @minimax-ai/code` and the user would watch EBADENGINE
+ *  scroll past — precisely the doomed-command failure this ladder exists to stop.
+ *  Treating that as "npm unusable" drops it to the node-then-npm rung, which fixes
+ *  the machine and then installs. Undefined (unprobed) never blocks: it fails open
+ *  to today's behavior rather than routing a fine machine into a Node install. */
 export function chooseInstallRung(
   info: ProviderInstallInfo,
   npmAvailable: boolean,
-  nodeInstaller?: NodeInstaller | null
+  nodeInstaller?: NodeInstaller | null,
+  installedNodeMajor?: number | null
 ): { command?: string; kind: InstallRungKind; nodeMissing: boolean } {
-  if (info.command && npmAvailable) return { command: info.command, kind: 'npm', nodeMissing: false };
+  const meetsEngineFloor =
+    info.minNodeMajor === undefined ||
+    installedNodeMajor === undefined || installedNodeMajor === null ||
+    installedNodeMajor >= info.minNodeMajor;
+  const npmUsable = npmAvailable && meetsEngineFloor;
+  if (info.command && npmUsable) return { command: info.command, kind: 'npm', nodeMissing: false };
   if (info.command && nodeInstaller) return { command: info.command, kind: 'node-then-npm', nodeMissing: true };
-  if (info.nativeCommand) return { command: info.nativeCommand, kind: 'native', nodeMissing: !npmAvailable };
-  return { kind: 'manual', nodeMissing: !npmAvailable };
+  if (info.nativeCommand) return { command: info.nativeCommand, kind: 'native', nodeMissing: !npmUsable };
+  return { kind: 'manual', nodeMissing: !npmUsable };
 }
 
 /** Build the shell script the missing-CLI auto-install path runs IN PLACE of a
@@ -57,11 +74,12 @@ export function buildMissingCliScript(
   provider: AgentProvider,
   npmAvailable: boolean,
   platform: string = process.platform,
-  nodeInstaller?: NodeInstaller | null
+  nodeInstaller?: NodeInstaller | null,
+  installedNodeMajor?: number | null
 ): string {
   const info: ProviderInstallInfo = installInfoForProvider(provider, platform);
   const safeBin = (bin || provider).replace(/[^A-Za-z0-9._-]/g, '') || provider;
-  const rung = chooseInstallRung(info, npmAvailable, nodeInstaller);
+  const rung = chooseInstallRung(info, npmAvailable, nodeInstaller, installedNodeMajor);
   // Only the rung that actually needs it gets the Node install spliced in.
   const nodeSteps = rung.kind === 'node-then-npm' && nodeInstaller
     ? buildNodeInstallScript(nodeInstaller, platform)

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -634,6 +634,17 @@ export class HiveManager {
        *  MemPalace dir, which `mempalace` mutates). Absolute paths; ignored
        *  for providers without a sandbox. */
       extraWritableDirs?: string[];
+      /** The model the user picked, for an engine that takes it via CONFIG rather
+       *  than argv. Every other provider gets `--model` spliced into its command by
+       *  buildSpawnCommand, so this stays undefined for them; mcode's interactive
+       *  TUI rejects unknown flags outright, so its model can only arrive here and
+       *  be written into the per-agent config.yaml. */
+      model?: string;
+      /** The floor's auto-mode toggle, for the same config-only engines. Every other
+       *  provider expresses its permission posture as a CLI flag appended by
+       *  buildSpawnCommand; mcode expresses it as config.yaml `permissionMode`, and
+       *  it must stay gated on this toggle like the rest (Pam guardrail #2). */
+      autoMode?: boolean;
     } = {}
   ): Promise<SpawnInjection> {
     const root = this.root();
@@ -813,6 +824,15 @@ export class HiveManager {
               // Point only this worker at a per-agent system settings file so
               // the bridge is trusted and ~/.gemini/settings.json stays untouched.
               env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = this.installGeminiHooks(dir);
+            }
+            else if (desc.shim === 'mcode') {
+              // MiniMax Code reads lifecycle hooks from $MINIMAX_DATA_DIR/hooks/ AND
+              // takes its model + permission posture only from
+              // $MINIMAX_DATA_DIR/config.yaml — its interactive root command declares
+              // a closed flag set and calls allowExcessArguments(false), so neither
+              // can ride on argv. One per-agent data dir therefore carries all three,
+              // with the user's own ~/.minimax left untouched.
+              env.MINIMAX_DATA_DIR = this.installMcodeConfig(dir, opts.model, opts.autoMode);
             }
             else if (desc.shim === 'grok') this.installGrokHooks();
           } else if (desc.kind === 'proxy') {
@@ -2217,6 +2237,143 @@ export class HiveManager {
     return home;
   }
 
+  /** MiniMax Code (`mcode`) bridge. mcode ships a faithful re-implementation of
+   *  Claude Code's hook engine — same event names, the same stdout-JSON / exit-2
+   *  response contract, and `Stop` + `{decision:'block', reason}` resolving to a
+   *  continue-with-prompt — so it reuses the `cth-hook` shim VERBATIM (no
+   *  translator, unlike agy) and gets real Stop->drain rather than nudge-only mail.
+   *
+   *  ONE DIR, THREE JOBS. mcode's interactive root command declares a closed flag
+   *  set (`[prompt] --session -c/--continue --tui-mode --resume`) and then calls
+   *  `allowExcessArguments(false)`, so an unrecognized flag is a hard startup error,
+   *  not a warning. `--model` and `--permission` exist only on `mcode exec`, which
+   *  exits per turn. That means neither the model nor the permission posture can
+   *  ride on argv for a TUI-resident worker: both live in `$MINIMAX_DATA_DIR/
+   *  config.yaml`, and the hook files live in `$MINIMAX_DATA_DIR/hooks/`. Pointing
+   *  the worker at a per-agent data dir is therefore the only lever that carries all
+   *  three at once.
+   *
+   *  ISOLATION + LOGIN. That same dir also holds the user's `mcode login`, so an
+   *  empty one would spawn a logged-out worker. Rather than guess which file carries
+   *  the credential (the shipped bundle does not name one unambiguously), every
+   *  entry of ~/.minimax is symlinked in EXCEPT the two we author — correct whatever
+   *  the credential is called, and the user's own ~/.minimax is never mutated.
+   *
+   *  Returns the data-dir path for the worker's MINIMAX_DATA_DIR.
+   *
+   *  LIVE-UNVERIFIED: the hook schema, the Stop contract and the config keys were
+   *  all read out of the shipped bundle, but firing them end to end needs a MiniMax
+   *  login. Wrapped so a wrong guess can never break the spawn; the renderer's idle
+   *  inbox-wake nudge remains the guaranteed drain either way. */
+  private installMcodeConfig(dir: string, model?: string, autoMode?: boolean): string {
+    const home = join(dir, '.minimax');
+    try {
+      mkdirSync(home, { recursive: true });
+      // 1) Mirror the user's login. Name-agnostic on purpose (see above): every
+      //    top-level FILE except the config we author is linked through, so whatever
+      //    the credential is called it comes with us.
+      //
+      //    FILES ONLY, deliberately. Linking the directories too would look more
+      //    thorough and be worse: ~/.minimax's subdirectories are mcode's session,
+      //    log and event stores, so sharing them would put every concurrent worker
+      //    on one session database — contention plus a cross-agent history leak —
+      //    and would undo the isolation this whole per-agent dir exists to provide.
+      //    mcode recreates those directories on first run, so each worker gets its
+      //    own, and they persist in the agent dir across restarts, which is what
+      //    `--session <id>` resume needs. Credentials are files; state is not.
+      const userHome = join(homedir(), '.minimax');
+      if (existsSync(userHome)) {
+        for (const entry of readdirSync(userHome)) {
+          if (entry === 'config.yaml') continue;
+          const src = join(userHome, entry);
+          const dest = join(home, entry);
+          // lstat, not existsSync: a BROKEN symlink left by an earlier spawn reads
+          // as "does not exist" but still makes symlinkSync throw EEXIST.
+          try { lstatSync(dest); continue; } catch { /* nothing there — link it */ }
+          try {
+            if (!statSync(src).isFile()) continue; // directories: see above
+            symlinkSync(src, dest, 'file');
+          } catch {
+            // Symlinks need privilege on Windows — copy instead. A credential copy
+            // goes stale if the user re-logs in, but it is regenerated every spawn.
+            try { if (statSync(src).isFile()) copyFileSync(src, dest); } catch { /* best-effort */ }
+          }
+        }
+      }
+
+      // 2) config.yaml — seeded from the user's so their provider/BYOK settings carry
+      //    over, with OUR two keys re-stated at the end. Regenerated every spawn.
+      //    permissionMode is gated on the floor's auto toggle exactly like every
+      //    other engine's auto flag: `bypassPermissions` never prompts but keeps
+      //    mcode's own deny rules and Windows hard-safety checks, and `default`
+      //    restores normal prompting when the floor's auto mode is off.
+      const seed = existsSync(join(userHome, 'config.yaml'))
+        ? readFileSync(join(userHome, 'config.yaml'), 'utf8') : '';
+      let config = this.stripTopLevelYamlKeys(seed, ['permissionMode', 'defaultModel']);
+      if (config && !config.endsWith('\n')) config += '\n';
+      config += '\n# --- munder-hive (auto-generated; do not edit) ---\n';
+      config += `permissionMode: ${autoMode ? 'bypassPermissions' : 'default'}\n`;
+      // Omitted entirely for "CLI default", so mcode uses whatever the user
+      // configured rather than a slug this app invented. JSON.stringify gives a
+      // valid YAML double-quoted scalar for ids carrying spaces or punctuation.
+      if (model) config += `defaultModel: ${JSON.stringify(model)}\n`;
+      writeFileSync(join(home, 'config.yaml'), config, 'utf8');
+
+      // 3) Lifecycle hooks. mcode scans `<dataDir>/hooks` for BOTH a `hooks.json`
+      //    and every `*.md` hook file. We write .md files: hooks.json is a single
+      //    un-namespaced object keyed by event, so authoring it would entangle (or
+      //    clobber) hooks the user wrote, whereas a `munder-hive-*.md` per event is
+      //    namespaced by filename and cannot collide. Bundled node, not bare `node`
+      //    — hooks run with a stripped PATH here for the same reason they do under
+      //    agy and grok, where a bare `node` is a 127.
+      const shim = this.shimPath();
+      if (shim) {
+        const hooksDir = join(home, 'hooks');
+        mkdirSync(hooksDir, { recursive: true });
+        const command = this.nodeRunUnquoted(shim);
+        // Tool-scoped events take a matcher (mcode anchors it to ^...$ itself);
+        // the session-scoped ones match everything by definition.
+        const events: Array<[string, string | undefined]> = [
+          ['PreToolUse', '.*'], ['PostToolUse', '.*'],
+          ['Stop', undefined], ['SubagentStop', undefined],
+          ['SessionStart', undefined], ['UserPromptSubmit', undefined],
+          ['PreCompact', undefined], ['PostCompact', undefined]
+        ];
+        for (const [event, matcher] of events) {
+          writeFileSync(
+            join(hooksDir, `munder-hive-${event.toLowerCase()}.md`),
+            mcodeHookFile(event, command, matcher),
+            'utf8'
+          );
+        }
+      }
+    } catch (e) { console.error('[hive] installMcodeConfig failed:', e); }
+    return home;
+  }
+
+  /** Drop the named TOP-LEVEL keys (and any indented continuation lines under them)
+   *  from a YAML document, so re-stating them at the end of the file is an override
+   *  rather than a duplicate-key document. Column-0 only: a `defaultModel:` nested
+   *  inside some other block belongs to that block and is left alone. Deliberately
+   *  line-based — the alternative is parsing and re-emitting the user's whole config
+   *  with a YAML library, which would silently reformat and drop their comments. */
+  private stripTopLevelYamlKeys(text: string, keys: string[]): string {
+    if (!text.trim()) return '';
+    const out: string[] = [];
+    let skipping = false;
+    for (const line of text.split('\n')) {
+      if (skipping) {
+        // A continuation line is indented or blank; anything at column 0 ends the run.
+        if (/^\s+\S/.test(line) || line.trim() === '') continue;
+        skipping = false;
+      }
+      const m = /^([A-Za-z0-9_.-]+)\s*:/.exec(line);
+      if (m && keys.includes(m[1])) { skipping = true; continue; }
+      out.push(line);
+    }
+    return out.join('\n').replace(/\n{3,}$/, '\n');
+  }
+
   /** Crush (charmbracelet/crush) proxy routing. Crush has NO base-URL env override, so
    *  the generic proxy env-rewrite is a no-op for it; instead we write a per-agent
    *  CRUSH_GLOBAL_CONFIG whose standard providers' `base_url` all point at the loopback
@@ -2757,6 +2914,35 @@ searchable MemPalace and you have the \`mempalace\` CLI:
 Your \`memory.md\` is mined into the palace automatically, so the durable facts you
 write there become searchable by every agent. You don't run \`mine\` yourself.
 `;
+
+// ─── mcode hook files (written to <agentDir>/.minimax/hooks/*.md) ────────────
+/**
+ * One MiniMax Code `.md` hook file. Exported so its shape is assertable without
+ * booting a HiveManager.
+ *
+ * The schema is mcode's, read out of its shipped parser: frontmatter must exist and
+ * must carry `hookEvent` (or `event`) and a `type` of `script`/`bash`/`prompt`, and
+ * a `script` hook's BODY must contain a fenced ```bash|shell|sh``` block — the
+ * parser pulls the command out with a regex and skips the file with a warning if
+ * there is no fence. `matcher` is anchored to ^...$ by mcode itself, so a bare
+ * `.*` is the match-everything form.
+ *
+ * `timeout` here is MILLISECONDS (mcode: `typeof n.timeout === 'number' ? n.timeout
+ * : 3e4`). Do NOT copy the Codex hook writer's `timeout = 30`, which is seconds in
+ * that file, and do not copy Claude's `timeout: 0` sentinel — 30_000 is the same
+ * real budget the Codex bridge settled on after cold-start timeouts under load.
+ */
+export function mcodeHookFile(event: string, command: string, matcher?: string): string {
+  const front = [
+    '---',
+    `hookEvent: ${event}`,
+    'type: script',
+    ...(matcher ? [`matcher: "${matcher}"`] : []),
+    'timeout: 30000',
+    '---'
+  ].join('\n');
+  return `${front}\n\n<!-- munder-hive lifecycle bridge (auto-generated; do not edit) -->\n\n\`\`\`bash\n${command}\n\`\`\`\n`;
+}
 
 // ─── cth-hook shim (written to <hive>/bin/cth-hook.cjs) ──────────────────────
 // A minimal pipe: read the hook payload on stdin, tag it with this agent's id,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,7 +79,7 @@ import {
   type AgentProvider
 } from '../shared/agentProvider';
 import { buildMissingCliScript, chooseInstallRung } from './cliInstall';
-import { detectNodeVersion, nodeIsUsable, resolveNodeInstaller } from './nodeInstall';
+import { detectNodeVersion, nodeIsUsable, nodeMajor, resolveNodeInstaller } from './nodeInstall';
 import { toolCatalog, type ToolStatus } from '../shared/toolCatalog';
 import { listLocalSkills, loadCatalog, installSkill, uninstallSkill, type LocalSkill } from './skills';
 import { loadHero } from './hero';
@@ -2506,7 +2506,7 @@ function findCodexHomeForSession(sessionId: string, siblingsRoot: string): strin
 
 /** Spawn options shared by the `pty:spawn` IPC handler and the god-triggered
  *  ephemeral-worker watcher. */
-type AgentSpawnOptions = SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean; requireResume?: boolean; resumeSessionId?: string; provider?: AgentProvider; noAutoInstall?: boolean };
+type AgentSpawnOptions = SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean; requireResume?: boolean; resumeSessionId?: string; provider?: AgentProvider; noAutoInstall?: boolean; model?: string };
 
 /** Map a `ptyManager.spawn` failure string to the closed `agent_spawn_failed.reason`
  *  enum (analytics.ts). The two known strings come from PtyManager.spawn; anything
@@ -2582,14 +2582,23 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       // An npm whose Node is BELOW the floor counts as unavailable: founder rule
       // (2026-08-07) is "their Node newer than ours → leave it alone; absent or
       // older → install the latest stable for them".
+      const installedNodeVersion = detectNodeVersion(ptyManager.commandPath('node'));
       const npmAvailable =
-        ptyManager.isCommandAvailable('npm') &&
-        nodeIsUsable(detectNodeVersion(ptyManager.commandPath('node')));
-      // Only reach the network when we actually need to (npm missing/too old);
-      // resolveNodeInstaller is timeout-bounded and returns null offline, which
-      // simply drops the ladder to the native/manual rung.
-      const nodeInstaller = npmAvailable ? null : await resolveNodeInstaller();
-      const rung = chooseInstallRung(installInfoForProvider(provider), npmAvailable, nodeInstaller);
+        ptyManager.isCommandAvailable('npm') && nodeIsUsable(installedNodeVersion);
+      // An engine may declare a HIGHER Node floor than the app's own (mcode: 22).
+      // Hand the ladder the real major so it can route such a provider into the
+      // upgrade rung instead of an npm install its postinstall would refuse.
+      const installedNodeMajor = nodeMajor(installedNodeVersion);
+      const engineFloor = installInfoForProvider(provider).minNodeMajor;
+      const engineFloorMet =
+        engineFloor === undefined || installedNodeMajor === null || installedNodeMajor >= engineFloor;
+      // Only reach the network when we actually need to (npm missing/too old, or
+      // this engine's own floor unmet); resolveNodeInstaller is timeout-bounded and
+      // returns null offline, which simply drops the ladder to the native/manual rung.
+      const nodeInstaller = npmAvailable && engineFloorMet ? null : await resolveNodeInstaller();
+      const rung = chooseInstallRung(
+        installInfoForProvider(provider), npmAvailable, nodeInstaller, installedNodeMajor
+      );
       const res = ptyManager.spawn(
         {
           id: opts.id,
@@ -2597,7 +2606,9 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
           command: bin,
           cols: opts.cols,
           rows: opts.rows,
-          shellScript: buildMissingCliScript(bin, provider, npmAvailable, process.platform, nodeInstaller)
+          shellScript: buildMissingCliScript(
+            bin, provider, npmAvailable, process.platform, nodeInstaller, installedNodeMajor
+          )
         },
         owner
       );
@@ -2701,7 +2712,12 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
           skillsDir: skillsResourceDir(),
           // The shared palace is mutated by the agent's own `mempalace` calls, so
           // the OS sandbox must let it through (empty when memory is off).
-          extraWritableDirs: [memory.env().MEMPALACE_PALACE_PATH].filter((p): p is string => !!p)
+          extraWritableDirs: [memory.env().MEMPALACE_PALACE_PATH].filter((p): p is string => !!p),
+          // For a config-only engine (mcode) these are the ONLY route the model and
+          // the permission posture have to the CLI — its TUI rejects both as flags.
+          // Ignored by every provider that expresses them on the command line.
+          model: typeof opts.model === 'string' ? opts.model.trim() || undefined : undefined,
+          autoMode: !!readConfig().autoMode
         }
       );
       opts.args = [...(opts.args ?? []), ...inj.args];

--- a/src/main/realtimeActions.ts
+++ b/src/main/realtimeActions.ts
@@ -162,7 +162,7 @@ const PENDING_TTL_MS = 120_000;
 const PROVIDER_COMMAND: Record<string, string> = {
   claude: 'claude', codex: 'codex', antigravity: 'antigravity', gemini: 'gemini',
   opencode: 'opencode', crush: 'crush', pi: 'pi', qwen: 'qwen', copilot: 'copilot',
-  cursor: 'cursor-agent'
+  cursor: 'cursor-agent', mcode: 'mcode'
 };
 
 /** Bare affirmations that must NEVER authorize a destructive op on their own —

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -221,6 +221,11 @@ export interface SpawnPtyOptions {
    *  main process seeds that session's `.jsonl` into the target cwd's project dir
    *  (copying it from wherever it lives) and launches `claude --resume <id>`. */
   resumeSessionId?: string;
+  /** The model the user picked, for an engine that takes it via CONFIG rather than
+   *  argv. For every other provider the model is already baked into `command`/`args`
+   *  as `--model <id>`, so this is redundant and stays unset; mcode's TUI rejects
+   *  unknown flags, so its model can only reach the CLI through here. */
+  model?: string;
 }
 
 export interface PtyExit { exitCode: number; signal?: number | undefined }

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -82,7 +82,7 @@ const DESCRIPTION_TEMPLATES: { labelKey: string; description: string; goal: stri
 // Copy-paste prompt the user hands to any AI to generate a hire manifest. It pins
 // the exact JSON shape the importer accepts and ends with a fill-in section so the
 // user adds their own details (item 7). Kept in sync with the HireManifest schema
-// (src/shared/hire.ts) — provider allowlist is claude | codex | antigravity | cursor.
+// (src/shared/hire.ts) — provider allowlist is claude | codex | antigravity | cursor | mcode.
 const HIRE_PROMPT = `You are designing a "hire" — a ready-to-spawn AI agent for Munder Difflin, an app that runs a team of CLI coding agents. Output ONE JSON object (a hire manifest) and nothing else.
 
 Make the agent genuinely useful: give it a sharp role, a concrete standing goal, and a description that makes it behave like an expert operator of its CLI engine (Claude Code, Codex, or Antigravity/Gemini). It should know how to use the terminal, read and edit files, run and inspect commands, lean on available skills and MCP tools, keep notes in memory, and work autonomously toward its goal without hand-holding.
@@ -103,7 +103,7 @@ Return EXACTLY this shape (omit optional fields you don't need; keep the spec st
 }
 
 Rules:
-- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
+- "provider" MUST be one of: cursor | claude | codex | antigravity | mcode. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)", MiniMax-M3).
 - Do NOT include shell commands or any flags beyond these fields.
 - Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
 
@@ -409,6 +409,10 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       command: exe,
       provider,
       args,
+      // Config-only engines (mcode) cannot take `--model` on argv — their TUI
+      // rejects unknown flags — so the selected model has to travel beside the
+      // command. Ignored by every provider that already carries it in `args`.
+      model,
       cols: 100,
       rows: 30,
       // When set, the main process spawns this agent in its own git worktree.

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -501,6 +501,10 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
         command: exe,
         args,
         provider,
+        // Config-only engines (mcode) cannot take `--model` on argv — their TUI
+        // rejects unknown flags — so the selected model has to travel beside the
+        // command. Ignored by every provider that already carries it in `args`.
+        model,
         cols,
         rows,
         hive,

--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -84,7 +84,8 @@ const PROVIDER_BLURB_KEYS: Partial<Record<AgentProvider, string>> = {
   codex: 'onboarding.providerBlurb.codex',
   antigravity: 'onboarding.providerBlurb.antigravity',
   qwen: 'onboarding.providerBlurb.qwen',
-  cursor: 'onboarding.providerBlurb.cursor'
+  cursor: 'onboarding.providerBlurb.cursor',
+  mcode: 'onboarding.providerBlurb.mcode'
 };
 
 export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {

--- a/src/renderer/src/components/ProviderLogo.tsx
+++ b/src/renderer/src/components/ProviderLogo.tsx
@@ -5,8 +5,8 @@ import type { AgentProvider } from '@/store/config';
  * inline as a single-path SVG so it stays crisp at any size and inherits the
  * surrounding ink color (monochrome, to sit cleanly inside the neo-brutalist UI).
  *
- * Brand marks (Anthropic / OpenAI / Google Gemini / Qwen) are the canonical
- * single-color glyphs from the Simple Icons set. `custom` is a bring-your-own
+ * Brand marks (Anthropic / OpenAI / Google Gemini / Qwen / MiniMax) are the
+ * canonical single-color glyphs from the Simple Icons set. `custom` is a bring-your-own
  * engine with no brand, so it gets a hand-drawn terminal-prompt stroke glyph in
  * the same weight.
  */
@@ -25,6 +25,9 @@ const BRAND_PATHS: Partial<Record<AgentProvider, string>> = {
   // Google Gemini — Antigravity runs Gemini models.
   antigravity:
     'M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81',
+  // MiniMax — powers the MiniMax Code (`mcode`) CLI.
+  mcode:
+    'M11.43 3.92a.86.86 0 1 0-1.718 0v14.236a1.999 1.999 0 0 1-3.997 0V9.022a.86.86 0 1 0-1.718 0v3.87a1.999 1.999 0 0 1-3.997 0V11.49a.57.57 0 0 1 1.139 0v1.404a.86.86 0 0 0 1.719 0V9.022a1.999 1.999 0 0 1 3.997 0v9.134a.86.86 0 0 0 1.719 0V3.92a1.998 1.998 0 1 1 3.996 0v11.788a.57.57 0 1 1-1.139 0zm10.572 3.105a2 2 0 0 0-1.999 1.997v7.63a.86.86 0 0 1-1.718 0V3.923a1.999 1.999 0 0 0-3.997 0v16.16a.86.86 0 0 1-1.719 0V18.08a.57.57 0 1 0-1.138 0v2a1.998 1.998 0 0 0 3.996 0V3.92a.86.86 0 0 1 1.719 0v12.73a1.999 1.999 0 0 0 3.996 0V9.023a.86.86 0 1 1 1.72 0v6.686a.57.57 0 0 0 1.138 0V9.022a2 2 0 0 0-1.998-1.997',
   // Qwen (Alibaba) — the local qwen-code CLI.
   qwen:
     'M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z'

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -406,6 +406,10 @@ export function useHive(config: HarnessConfig | null): void {
         command: exe,
         provider: godProvider,
         args,
+        // Config-only engines (mcode) cannot take `--model` on argv — their TUI
+        // rejects unknown flags — so the selected model has to travel beside the
+        // command. Ignored by every provider that already carries it in `args`.
+        model: godModel,
         cols: 100,
         rows: 30,
         // Restore Michael's prior conversation across an app restart. His session
@@ -1218,6 +1222,10 @@ export function useHive(config: HarnessConfig | null): void {
           command: exe,
           provider,
           args,
+          // Config-only engines (mcode) cannot take `--model` on argv — their TUI
+          // rejects unknown flags — so the selected model has to travel beside the
+          // command. Ignored by every provider that already carries it in `args`.
+          model: a.model,
           cols,
           rows,
           // The worktree (if any) already exists on disk — re-enter it, do NOT

--- a/src/renderer/src/hooks/useRestoreTeam.ts
+++ b/src/renderer/src/hooks/useRestoreTeam.ts
@@ -135,6 +135,10 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
             command: exe,
             provider,
             args,
+            // Config-only engines (mcode) cannot take `--model` on argv — their TUI
+            // rejects unknown flags — so the selected model has to travel beside the
+            // command. Ignored by every provider that already carries it in `args`.
+            model: a.model,
             cols: 100,
             rows: 30,
             // Worktree (if any) already exists on disk — cd into it, don't create a

--- a/src/renderer/src/i18n/locales/ar.json
+++ b/src/renderer/src/i18n/locales/ar.json
@@ -642,7 +642,8 @@
       "antigravity": "Antigravity — Google Gemini",
       "qwen": "Qwen — يشغّل نموذج Qwen محليًا على جهازك",
       "gemini": "Gemini CLI - Google Gemini",
-      "cursor": "Cursor Agent CLI — يستخدم أرصدة Cursor لديك (Luna، Composer، …)"
+      "cursor": "Cursor Agent CLI — يستخدم أرصدة Cursor لديك (Luna، Composer، …)",
+      "mcode": "MiniMax Code — نموذج MiniMax M3 بسياق مليون رمز"
     },
     "home": {
       "descPlain": "أنشئ مجلدًا جديدًا فارغًا ليتّخذه التطبيق منزلًا. كل ما يتذكّره التطبيق — إعداداته الخاصة وذاكرة وكلائك — يُخزَّن هنا. شيء مثل ~/HarnessAgents يفي بالغرض. وسننشئه لك إن لم يكن موجودًا.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -642,7 +642,8 @@
       "antigravity": "Antigravity — Google Gemini",
       "qwen": "Qwen — runs a local Qwen model on your machine",
       "gemini": "Gemini CLI - Google Gemini",
-      "cursor": "Cursor Agent CLI — uses your Cursor credits (Luna, Composer, …)"
+      "cursor": "Cursor Agent CLI — uses your Cursor credits (Luna, Composer, …)",
+      "mcode": "MiniMax Code — MiniMax M3, 1M context"
     },
     "home": {
       "descPlain": "Create a new, empty folder for the app to call home. Everything the app remembers — its own settings and your agents' memory — is stored here. Something like ~/HarnessAgents works well. We'll create it for you if it doesn't exist.",

--- a/src/renderer/src/i18n/locales/zh-CN.json
+++ b/src/renderer/src/i18n/locales/zh-CN.json
@@ -642,7 +642,8 @@
       "antigravity": "Antigravity — Google Gemini",
       "qwen": "Qwen — 在你的机器上运行本地 Qwen 模型",
       "gemini": "Gemini CLI —— Google Gemini",
-      "cursor": "Cursor Agent CLI —— 使用你的 Cursor 额度（Luna、Composer 等）"
+      "cursor": "Cursor Agent CLI —— 使用你的 Cursor 额度（Luna、Composer 等）",
+      "mcode": "MiniMax Code —— MiniMax M3，100 万上下文"
     },
     "home": {
       "descPlain": "为应用创建一个新的空文件夹作为家。应用记住的一切——它自己的设置和你智能体的记忆——都存放在这里。像 ~/HarnessAgents 这样的地方就很合适。如果它不存在，我们会为你创建。",

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -237,6 +237,13 @@ interface ModelCatalog {
  *  - cursor: ids match `cursor-agent models` / `--model` (Cursor account catalog).
  *    Luna is the cheap, high-context default for Michael; the rest are curated
  *    quick-picks and the command field stays editable for any live slug.
+ *  - mcode: bare MiniMax ids (`MiniMax-M3`), NOT `provider/model` slugs — the
+ *    prefixed form is only for third-party providers registered with
+ *    `mcode provider add`. Unlike every other engine this id never reaches argv:
+ *    mcode's TUI declares a closed flag set and rejects `--model` outright, so the
+ *    harness writes the selection into the per-agent config.yaml as `defaultModel`
+ *    instead. The command field therefore stays a bare `mcode` no matter what is
+ *    picked here. // TODO-verify exact live ids (read from the shipped bundle).
  *  - grok: the models reported by the installed Grok CLI (`grok models`).
  *  - kimi: managed Kimi Code aliases accepted by `kimi --model <alias>`.
  *  - custom: no presets at all; the command field is the whole interface.

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -1,8 +1,8 @@
 /**
  * Agent providers — the CLI a worker runs on. The app is no longer Claude-only:
  * a worker can run Claude Code, the OpenAI Codex CLI (`codex`), Kimi Code
- * (`kimi`), xAI Grok (`grok`), the Antigravity CLI (`agy`, Gemini models), or
- * any custom command.
+ * (`kimi`), xAI Grok (`grok`), the Antigravity CLI (`agy`, Gemini models),
+ * MiniMax Code (`mcode`), or any custom command.
  * Each provider declares how to build its spawn command (model/auto-mode flags) and
  * whether it accepts the hive's Claude-specific identity injection
  * (`--append-system-prompt` + `--settings`).
@@ -34,6 +34,7 @@ export type AgentProvider =
   | 'pi'
   | 'copilot'
   | 'cursor'
+  | 'mcode'
   | 'custom';
 
 /** Structured descriptor for how a NON-hiveAware provider gets hive lifecycle
@@ -51,7 +52,7 @@ export type AgentProvider =
  *               and `inboxDelivery` is how mail reaches it ('terminal' work-order
  *               handoff today; 'serve' reserved for a future HTTP push path). */
 export type BridgeDescriptor =
-  | { kind: 'hooks'; shim: 'agy' | 'codex' | 'pi' | 'opencode' | 'grok' | 'gemini' }
+  | { kind: 'hooks'; shim: 'agy' | 'codex' | 'pi' | 'opencode' | 'grok' | 'gemini' | 'mcode' }
   | {
       kind: 'proxy';
       api: 'openai' | 'anthropic';
@@ -148,6 +149,15 @@ export interface AgentProviderPreset {
    *  when undefined, the user is shown a manual instruction only and nothing is
    *  auto-run. MUST be a trusted, hardcoded constant — never user/manifest input. */
   installCommand?: string;
+  /** Minimum Node MAJOR this engine's npm package will install under, when that
+   *  floor is HIGHER than the app's own (nodeInstall.NODE_FLOOR_MAJOR). Every other
+   *  provider is happy on any Node this app tolerates, so `npm present` is a good
+   *  enough test for them; mcode declares `>=22.19 <23 || >=24 <27` and enforces it
+   *  from its own postinstall, so on a Node 20/21 box the npm rung would print a
+   *  command that CANNOT succeed — the exact failure the install ladder exists to
+   *  prevent. `chooseInstallRung` consults this and falls through to the
+   *  node-then-npm upgrade rung instead. Undefined = no extra floor. */
+  minNodeMajor?: number;
   /** A SELF-CONTAINED installer that needs no Node/npm at all, per platform.
    *
    *  `installCommand` is `npm install -g …` for every provider, which silently
@@ -565,6 +575,69 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     docsUrl: 'https://cursor.com/docs/cli/install'
   },
   {
+    // MiniMax Code (`mcode`, npm @minimax-ai/code) — MiniMax's terminal coding agent.
+    // Run as its interactive TUI in a PTY and seeded by a POSITIONAL prompt, like
+    // codex. Non-hiveAware (no --append-system-prompt/--settings), but it ships a
+    // faithful re-implementation of Claude Code's hook engine — same event names,
+    // same stdout-JSON/exit-2 response contract, and Stop + {decision:'block',reason}
+    // resolves to a continue-with-prompt — so it gets FULL hive parity through the
+    // 'mcode' hooks shim (installMcodeConfig), no translator needed.
+    id: 'mcode',
+    label: 'MiniMax Code',
+    defaultCommand: 'mcode',
+    commandGroups: [],
+    // NO auto flag, and this is NOT an oversight to be "fixed" later. mcode's
+    // interactive root command declares exactly `[prompt] --session -c/--continue
+    // --tui-mode --resume` and then calls `.allowExcessArguments(false)`, so ANY
+    // other flag is a hard startup error, not a warning. `--permission` and
+    // `--model` are `mcode exec`-only (headless, exits per turn — the shape that
+    // costs copilot its inbox). So the permission posture rides in
+    // $MINIMAX_DATA_DIR/config.yaml as `permissionMode`, written per spawn by
+    // hive.installMcodeConfig and gated on the floor's config.autoMode exactly like
+    // every other engine (Pam guardrail #2). Same reasoning as opencode's empty flag.
+    autoModeFlag: '',
+    autoFlag: '',
+    // Picker ON, flag OFF. `supportsModel` is what keeps the model picker visible and
+    // makes mcode god-eligible; the deliberately-absent `modelFlag` makes
+    // buildSpawnCommand emit no `--model`, which the TUI would reject outright. The
+    // selected id reaches the CLI as config.yaml `defaultModel` instead.
+    supportsModel: true,
+    modelFlag: undefined,
+    hiveAware: false,
+    bridge: { kind: 'hooks', shim: 'mcode' },
+    // god-eligible via the hooks bridge's native Stop->drain. The renderer's idle
+    // inbox-wake nudge remains the fallback, as for every bridged provider.
+    canReceiveInbox: true,
+    // `mcode [prompt]` takes the hive protocol as a trailing positional (verified
+    // against the shipped argument parser), so no prompt FLAG exists to name.
+    initialPromptFlag: undefined,
+    positionalInitialPrompt: true,
+    // mcode's own default model; 1M-context tier, which is what the "give Michael a
+    // longer-context model" advisory wants. // TODO-verify against a live catalog.
+    recommendedOrchestratorModel: 'MiniMax-M3',
+    // `mcode --session <id>` reopens a session by id (`--continue` takes the latest
+    // instead, and the two cannot be combined).
+    resumeFlag: '--session',
+    installCommand: 'npm install -g @minimax-ai/code', // trusted, hardcoded
+    // MiniMax's own installers, and the ONLY route its docs actually document (the
+    // npm package above is public and works, but the quick-start lists only these).
+    // Genuinely node-free, which matters more here than for any other engine: the
+    // script downloads a pinned Node 24.19.0 into ~/.minimax-code and pins the
+    // mcode launcher to it, so it succeeds on a machine with no Node, an ancient
+    // Node, or a Node 23/27 that this package's own engines range rejects — every
+    // case where the npm rung cannot work. Trusted, hardcoded constants with no
+    // double-quotes; the win32 form is `powershell -c` + a `^|`-escaped pipe
+    // because it is wrapped verbatim in `cmd /d /s /c "…"` (see Claude's).
+    nativeInstallCommand: {
+      posix: 'curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash',
+      win32: 'powershell -c irm https://filecdn.minimax.chat/public/install.ps1 ^| iex'
+    },
+    // engines: ">=22.19 <23 || >=24 <27" — higher than the app's own Node floor, and
+    // enforced by the package's own postinstall, so the ladder must know about it.
+    minNodeMajor: 22,
+    docsUrl: 'https://agent.minimax.io/docs/cli/quick-start'
+  },
+  {
     id: 'custom',
     label: 'Custom',
     defaultCommand: '',
@@ -591,6 +664,7 @@ export function isAgentProvider(value: unknown): value is AgentProvider {
     value === 'pi' ||
     value === 'copilot' ||
     value === 'cursor' ||
+    value === 'mcode' ||
     value === 'custom'
   );
 }
@@ -642,6 +716,8 @@ export function inferAgentProvider(command: string | undefined, explicit?: unkno
   if (bin === 'crush') return 'crush';
   if (bin === 'pi') return 'pi';
   if (bin === 'copilot') return 'copilot';
+  // MiniMax Code ships as `mcode` (npm @minimax-ai/code).
+  if (bin === 'mcode') return 'mcode';
   // Cursor ships as `cursor-agent`; `agent` is a shorter alias (generic name — check last).
   if (bin === 'cursor-agent') return 'cursor';
   if (bin === 'agent') return 'cursor';
@@ -717,6 +793,8 @@ export interface ProviderInstallInfo {
   command?: string;
   /** A node-free installer for this platform, when the vendor ships one. */
   nativeCommand?: string;
+  /** An engine-specific minimum Node major, when it exceeds the app's own floor. */
+  minNodeMajor?: number;
   label: string;
   docsUrl?: string;
 }
@@ -730,6 +808,7 @@ export function installInfoForProvider(
   return {
     command: p.installCommand,
     nativeCommand: native ? (platform === 'win32' ? native.win32 : native.posix) : undefined,
+    minNodeMajor: p.minNodeMajor,
     label: p.label,
     docsUrl: p.docsUrl
   };

--- a/src/shared/hire.ts
+++ b/src/shared/hire.ts
@@ -38,7 +38,7 @@ export const BUNDLED_SKILL_IDS: ReadonlySet<string> = new Set([
 /** Providers a manifest may request ('agy' is accepted as an alias for
  *  'antigravity'). 'custom' is deliberately NOT allowed — it would let a
  *  manifest choose an arbitrary local binary. */
-export type HireProvider = 'claude' | 'antigravity' | 'codex' | 'cursor';
+export type HireProvider = 'claude' | 'antigravity' | 'codex' | 'cursor' | 'mcode';
 
 export interface HireManifest {
   /** Spec tag; exactly `munder-difflin/hire@1` for this version. */
@@ -91,7 +91,7 @@ export interface HireValidation {
   consentRequired?: string[];
 }
 
-const PROVIDERS: readonly string[] = ['claude', 'antigravity', 'codex', 'cursor'];
+const PROVIDERS: readonly string[] = ['claude', 'antigravity', 'codex', 'cursor', 'mcode'];
 const MAX_BYTES = 64 * 1024;
 
 /** A flag ("-x", "--flag", "--flag=value") or a bare value token that may follow

--- a/src/shared/modelCatalog.json
+++ b/src/shared/modelCatalog.json
@@ -101,6 +101,11 @@
       { "id": "claude-opus-4-8-high", "label": "Opus 4.8 1M", "minAppVersion": null, "maxAppVersion": null },
       { "id": "claude-sonnet-5-thinking-high", "label": "Sonnet 5 1M Thinking", "minAppVersion": null, "maxAppVersion": null }
     ],
+    "mcode": [
+      { "label": "CLI default", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "MiniMax-M3", "label": "MiniMax M3", "minAppVersion": null, "maxAppVersion": null },
+      { "id": "MiniMax-M2.7", "label": "MiniMax M2.7", "minAppVersion": null, "maxAppVersion": null }
+    ],
     "custom": []
   }
 }

--- a/src/shared/providerAutomation.ts
+++ b/src/shared/providerAutomation.ts
@@ -144,6 +144,17 @@ const CONTEXT_COMMANDS: Record<AgentProvider, ProviderContextCommands> = {
   // auto-compact. Revisit when a shipped command table is transcribed.
   cursor: NO_CONTEXT_COMMANDS,
 
+  // MiniMax Code's bundled command registry, verbatim:
+  //   { name:"compact", description:"Manually compact the session context" }
+  //   { name:"new",     description:"Start a new session" }
+  // Read out of the SHIPPED BINARY, which is why it outranks the docs site. There
+  // is no `/clear` literal anywhere in it, so `/new` is the fresh-session verb.
+  // compactTakesFocus is FALSE: unlike pi (whose docs spell `/compact
+  // [instructions]`) mcode's description declares no argument, and a TUI that
+  // re-read the trailing prose as a fresh prompt would turn one compaction into a
+  // whole extra turn — the exact failure this flag exists to prevent.
+  mcode: { compact: '/compact', clear: '/new', compactTakesFocus: false },
+
   // An arbitrary user binary. We cannot know its command surface, and guessing
   // means typing slashes into someone's unknown REPL.
   custom: NO_CONTEXT_COMMANDS

--- a/test/agent-provider.test.cjs
+++ b/test/agent-provider.test.cjs
@@ -88,6 +88,66 @@ test('cursor preset is interactive (no -p), uses force+trust auto flags, types s
   assert.strictEqual(ap.bridgeOf('cursor'), undefined, 'no hook/proxy bridge yet');
 });
 
+test('mcode is a recognized, selectable, god-eligible provider', () => {
+  assert.ok(ap.isAgentProvider('mcode'), 'isAgentProvider("mcode")');
+  assert.ok(ap.AGENT_PROVIDER_PRESETS.some((p) => p.id === 'mcode'), 'preset registered');
+  assert.strictEqual(ap.canReceiveInbox('mcode'), true, 'hooks bridge drains on Stop');
+});
+
+test('inferAgentProvider maps the mcode binary, with or without a path', () => {
+  assert.strictEqual(ap.inferAgentProvider('mcode'), 'mcode');
+  assert.strictEqual(ap.inferAgentProvider('/opt/homebrew/bin/mcode'), 'mcode');
+  assert.strictEqual(ap.inferAgentProvider('C:\\Users\\me\\AppData\\npm\\mcode.cmd'), 'mcode');
+});
+
+test('mcode preset carries NO argv flags — its TUI rejects unknown ones', () => {
+  // mcode's interactive root command declares exactly [prompt] --session
+  // -c/--continue --tui-mode --resume and then calls allowExcessArguments(false),
+  // so a stray flag is a hard startup error rather than a warning. --model and
+  // --permission exist only on `mcode exec`. These four assertions are the guard:
+  // if someone "helpfully" fills them in, every mcode spawn dies at boot.
+  const p = ap.providerPreset('mcode');
+  assert.strictEqual(p.defaultCommand, 'mcode', 'default command binary');
+  assert.strictEqual(ap.autoModeFlagForProvider('mcode'), '', 'no auto flag on argv');
+  assert.strictEqual(p.autoFlag, '', 'autoFlag mirrors autoModeFlag');
+  assert.strictEqual(p.modelFlag, undefined, 'no --model on argv');
+  assert.strictEqual(p.initialPromptFlag, undefined, 'no prompt flag');
+  // …but the picker must stay visible, and the seed must ride as a positional.
+  assert.strictEqual(p.supportsModel, true, 'model picker stays on (config carries it)');
+  assert.strictEqual(p.positionalInitialPrompt, true, 'hive protocol rides positionally');
+  assert.strictEqual(p.resumeFlag, '--session', 'session resume flag');
+  assert.strictEqual(p.hiveAware, false, 'no Claude-only identity injection');
+  assert.strictEqual(p.recommendedOrchestratorModel, 'MiniMax-M3');
+  assert.strictEqual(p.minNodeMajor, 22, 'engines: >=22.19 <23 || >=24 <27');
+});
+
+test('mcode rides the hooks bridge with its own shim', () => {
+  assert.deepStrictEqual(ap.bridgeOf('mcode'), { kind: 'hooks', shim: 'mcode' });
+});
+
+test('argsWithAutoModeFlag never appends anything for mcode', () => {
+  // The generic auto-flag helper runs on every main-only spawn (ephemeral workers,
+  // voice hires). An empty preset flag must make it a no-op, not append ''.
+  assert.deepStrictEqual(ap.argsWithAutoModeFlag(['hello'], true, 'mcode'), ['hello']);
+  assert.deepStrictEqual(ap.argsWithAutoModeFlag(['hello'], false, 'mcode'), ['hello']);
+});
+
+test('installInfoForProvider surfaces mcode installer + its higher Node floor', () => {
+  const info = ap.installInfoForProvider('mcode', 'darwin');
+  assert.strictEqual(info.command, 'npm install -g @minimax-ai/code');
+  assert.strictEqual(info.minNodeMajor, 22);
+  assert.strictEqual(info.label, 'MiniMax Code');
+  // MiniMax's own installer is the node-free rung — the one that still works on a
+  // machine whose Node the npm package would refuse.
+  assert.ok(info.nativeCommand.includes('filecdn.minimax.chat'), 'node-free rung');
+  const win = ap.installInfoForProvider('mcode', 'win32');
+  assert.ok(win.nativeCommand.includes('install.ps1'), 'Windows takes the ps1 form');
+  // Wrapped verbatim in `cmd /d /s /c "…"`, so an embedded quote truncates it and
+  // a bare `|` would pipe in cmd.exe rather than PowerShell.
+  assert.ok(!win.nativeCommand.includes('"'), 'no double quotes in the win32 form');
+  assert.ok(win.nativeCommand.includes('^|'), 'pipe must be cmd-escaped');
+});
+
 test('codex preset still resolves (no regression)', () => {
   assert.strictEqual(ap.inferAgentProvider('codex'), 'codex');
   assert.strictEqual(ap.providerPreset('codex').defaultCommand, 'codex');

--- a/test/cli-install-ladder.test.cjs
+++ b/test/cli-install-ladder.test.cjs
@@ -45,6 +45,66 @@ test('cursor prefers its native curl installer (no npm package)', () => {
   assert.match(withoutNpm.command, /cursor\.com\/install/);
 });
 
+test('an engine with a higher Node floor than ours skips the doomed npm rung', () => {
+  // mcode's package declares `>=22.19 <23 || >=24 <27` and enforces it from its own
+  // postinstall, so on a Node 20 machine `npm install -g @minimax-ai/code` is
+  // exactly the doomed command this ladder exists to never print. npm being
+  // present is not enough for it.
+  const info = installInfoForProvider('mcode');
+  assert.equal(info.minNodeMajor, 22, 'fixture assumes mcode declares a floor');
+  const installer = { version: 'v24.19.0', file: 'node.pkg', url: 'https://x', sha256: 'a', kind: 'pkg' };
+
+  const onNode20 = chooseInstallRung(info, true, installer, 20);
+  assert.equal(onNode20.kind, 'node-then-npm', 'fix the machine, then install');
+  assert.equal(onNode20.nodeMissing, true);
+
+  const onNode24 = chooseInstallRung(info, true, installer, 24);
+  assert.equal(onNode24.kind, 'npm', 'a Node in range takes the plain npm rung');
+  assert.equal(onNode24.nodeMissing, false);
+});
+
+test('mcode falls back to MiniMax\'s own node-free installer when npm cannot work', () => {
+  // The npm rung needs a Node in mcode's engines range; its own installer needs no
+  // Node at all (it downloads a pinned one into ~/.minimax-code). So the machines
+  // where the npm rung is impossible are exactly the ones this rung rescues.
+  const info = installInfoForProvider('mcode', 'darwin');
+  assert.ok(info.nativeCommand, 'mcode must ship a node-free rung');
+  assert.doesNotMatch(info.nativeCommand, /\bnpm\b/, 'the whole point is that npm is absent');
+
+  // No npm and no resolvable Node installer (offline / unsupported platform) —
+  // previously the manual rung, i.e. install nothing.
+  const rung = chooseInstallRung(info, false, null, null);
+  assert.equal(rung.kind, 'native');
+  assert.match(rung.command, /filecdn\.minimax\.chat/);
+
+  // Windows gets the PowerShell form, not the curl one.
+  const win = installInfoForProvider('mcode', 'win32');
+  assert.match(win.nativeCommand, /powershell/);
+  assert.doesNotMatch(win.nativeCommand, /curl/);
+});
+
+test('the ladder still prefers fixing the machine over routing around it', () => {
+  // Founder decision (2026-08-07): node-then-npm outranks native, because a user
+  // who only ever gets node-free installers still has no runtime for MCP servers
+  // or hooks. Adding mcode's native rung must NOT quietly flip that ordering.
+  const installer = { version: 'v24.19.0', file: 'node.pkg', url: 'https://x', sha256: 'a', kind: 'pkg' };
+  const rung = chooseInstallRung(installInfoForProvider('mcode'), false, installer, null);
+  assert.equal(rung.kind, 'node-then-npm', 'a resolvable Node installer still wins');
+});
+
+test('the extra Node floor never blocks a provider that has none, or an unprobed Node', () => {
+  const installer = { version: 'v24.19.0', file: 'node.pkg', url: 'https://x', sha256: 'a', kind: 'pkg' };
+  // A provider with no declared floor is unaffected by an old Node major…
+  const codex = chooseInstallRung(installInfoForProvider('codex'), true, installer, 20);
+  assert.equal(codex.kind, 'npm', 'no minNodeMajor → the major is irrelevant');
+  // …and an UNPROBED Node fails open rather than routing a fine machine into an
+  // install it does not need.
+  const unprobed = chooseInstallRung(installInfoForProvider('mcode'), true, installer, null);
+  assert.equal(unprobed.kind, 'npm', 'unknown Node major must not block');
+  const omitted = chooseInstallRung(installInfoForProvider('mcode'), true, installer);
+  assert.equal(omitted.kind, 'npm', 'omitted Node major must not block');
+});
+
 test('with npm absent and no native installer, NOTHING is run', () => {
   const info = installInfoForProvider('codex');
   assert.equal(info.nativeCommand, undefined, 'fixture assumes codex has no native installer');
@@ -81,7 +141,7 @@ test('with npm present nothing mentions a missing Node', () => {
 test('the Windows script stays a single quote-free cmd.exe line', () => {
   // It is wrapped verbatim in `cmd /d /s /c "<script>"` — one embedded double
   // quote ends the command line early and the rest executes as garbage.
-  for (const provider of ['claude', 'codex']) {
+  for (const provider of ['claude', 'codex', 'mcode']) {
     for (const npm of [true, false]) {
       const out = buildMissingCliScript(provider, provider, npm, 'win32');
       assert.ok(!out.includes('"'), `${provider}/${npm}: embedded quote`);

--- a/test/command-name-validation.test.cjs
+++ b/test/command-name-validation.test.cjs
@@ -29,7 +29,7 @@ const { buildWorkerLaunch } = loadTs('src/main/workerLaunch.ts');
 
 test('legit engine binary names are accepted', () => {
   for (const name of ['claude', 'codex', 'grok', 'kimi', 'agy', 'qwen', 'opencode',
-                       'crush', 'pi', 'copilot', 'cursor-agent', 'node', 'npm', 'node.js', 'a_b+c']) {
+                       'crush', 'pi', 'copilot', 'cursor-agent', 'mcode', 'node', 'npm', 'node.js', 'a_b+c']) {
     assert.equal(isSafeCommandName(name), true, `${name} should be safe`);
   }
 });

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -75,6 +75,8 @@ function hookCommandsUnder(home) {
     // JSON hook configs: "command": "<…>"      TOML (codex): command = '<…>'
     for (const m of text.matchAll(/"command"\s*:\s*"((?:[^"\\]|\\.)*)"/g)) found.push(JSON.parse(`"${m[1]}"`));
     for (const m of text.matchAll(/command = '([^']+)'/g)) found.push(m[1]);
+    // Markdown script hooks (mcode): the command is the body of a bash fence.
+    for (const m of text.matchAll(/```(?:bash|shell|sh)\s*\n([\s\S]*?)```/g)) found.push(m[1].trim());
   }
   return found.filter((c) => shim.test(c));
 }
@@ -156,11 +158,12 @@ test('every hook installer routes through the launcher — none left on bare nod
   hive.installGrokHooks();
   hive.installGeminiHooks(path.join(home, 'hive/agents/a1'));
   hive.installCodexHooks(path.join(home, 'hive/agents/a1'), 'a1');
+  hive.installMcodeConfig(path.join(home, 'hive/agents/a1'), 'MiniMax-M3', true);
 
   const launcher = launcherIn(home);
   const commands = hookCommandsUnder(home);
-  // claude (Stop/statusLine/…) + agy + grok + codex.
-  assert.ok(commands.length >= 4, `expected commands from all installers, got ${commands.length}`);
+  // claude (Stop/statusLine/…) + agy + grok + codex + mcode.
+  assert.ok(commands.length >= 5, `expected commands from all installers, got ${commands.length}`);
   const bare = commands.filter((c) => !usesLauncher(c, launcher));
   assert.deepEqual(bare, [], 'these hook commands would exit 127 wherever node is not on the bare PATH');
 

--- a/test/mcode-provider-config.test.cjs
+++ b/test/mcode-provider-config.test.cjs
@@ -1,0 +1,233 @@
+'use strict';
+
+/**
+ * MiniMax Code (`mcode`) bridge.
+ *
+ * mcode's interactive root command declares a CLOSED flag set — `[prompt]
+ * --session -c/--continue --tui-mode --resume` — and then calls
+ * `allowExcessArguments(false)`, so an unrecognized flag is a hard startup error.
+ * `--model` and `--permission` live only on `mcode exec`, which exits per turn.
+ * A TUI-resident hive worker therefore cannot receive its model or its permission
+ * posture on argv: both are written into `$MINIMAX_DATA_DIR/config.yaml`, which is
+ * also the directory mcode scans for lifecycle hooks.
+ *
+ * These tests pin that contract end to end — the env var, the two config keys and
+ * their auto-mode gating, and hook files that survive mcode's OWN parser rules
+ * (frontmatter + a fenced bash block), which are re-implemented below verbatim
+ * from the shipped bundle so a formatting change here fails loudly instead of
+ * silently producing files mcode skips with a warning.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { HiveManager, mcodeHookFile } = loadTs('src/main/hive.ts');
+
+// --- mcode's own parser rules, transcribed from the shipped bundle -------------
+// BA(): frontmatter is required; `hookEvent` (or `event`) and a `type` of
+// script/bash/prompt are required; priority/timeout are numbers when present.
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---/;
+// V$(): a script hook's command is pulled out of the FIRST bash/shell/sh fence.
+const SCRIPT_FENCE = /```(?:bash|shell|sh)\s*\n([\s\S]*?)```/;
+
+function parseMcodeHook(text) {
+  const fm = FRONTMATTER.exec(text);
+  assert.ok(fm, 'mcode rejects a hook file with no frontmatter');
+  const front = Object.fromEntries(
+    fm[1].split('\n').filter(Boolean).map((line) => {
+      const i = line.indexOf(':');
+      return [line.slice(0, i).trim(), line.slice(i + 1).trim()];
+    })
+  );
+  const body = text.slice(fm[0].length);
+  const fence = SCRIPT_FENCE.exec(body);
+  return { front, command: fence ? fence[1].trim() : null };
+}
+
+function tmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'md-mcode-config-'));
+}
+
+async function spawnMcode(t, opts = {}) {
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HiveManager(() => home);
+  const injection = await hive.ensureAgent(
+    { id: 'mcode-1', name: 'MiniMax Worker', provider: 'mcode', cwd: home },
+    opts
+  );
+  return { home, injection, agentDir: path.join(home, 'hive', 'agents', 'mcode-1') };
+}
+
+test('mcode gets a per-agent MINIMAX_DATA_DIR, not the user\'s ~/.minimax', async (t) => {
+  const { injection, agentDir } = await spawnMcode(t, { autoMode: true });
+  assert.equal(injection.env.MINIMAX_DATA_DIR, path.join(agentDir, '.minimax'));
+  assert.notEqual(injection.env.MINIMAX_DATA_DIR, path.join(os.homedir(), '.minimax'));
+  // The hooks bridge must also arm the socket the shim posts to.
+  assert.ok(injection.env.HIVE_SOCK, 'HIVE_SOCK is what the cth-hook shim talks to');
+});
+
+test('the model reaches the CLI through config.yaml, never through argv', async (t) => {
+  const { injection, agentDir } = await spawnMcode(t, { model: 'MiniMax-M3', autoMode: true });
+  const config = fs.readFileSync(path.join(agentDir, '.minimax', 'config.yaml'), 'utf8');
+  assert.match(config, /^defaultModel: "MiniMax-M3"$/m);
+  // The spawn injection must stay flag-free — anything here lands on a command
+  // line that mcode refuses to start with.
+  assert.equal(injection.args.includes('--model'), false, 'no --model on argv');
+  assert.equal(injection.args.includes('--permission'), false, 'no --permission on argv');
+});
+
+test('auto mode gates permissionMode exactly like every other engine\'s auto flag', async (t) => {
+  const on = await spawnMcode(t, { autoMode: true });
+  assert.match(
+    fs.readFileSync(path.join(on.agentDir, '.minimax', 'config.yaml'), 'utf8'),
+    /^permissionMode: bypassPermissions$/m
+  );
+  const off = await spawnMcode(t, { autoMode: false });
+  assert.match(
+    fs.readFileSync(path.join(off.agentDir, '.minimax', 'config.yaml'), 'utf8'),
+    /^permissionMode: default$/m
+  );
+});
+
+test('a "CLI default" model writes no defaultModel at all', async (t) => {
+  // Inventing a slug here would override whatever the user configured in mcode
+  // itself — the exact failure the OpenCode preset's missing recommended model
+  // documents. Absent means absent.
+  const { agentDir } = await spawnMcode(t, { autoMode: true });
+  const config = fs.readFileSync(path.join(agentDir, '.minimax', 'config.yaml'), 'utf8');
+  assert.doesNotMatch(config, /defaultModel/);
+});
+
+test('every hook file parses under mcode\'s own rules and runs the cth-hook shim', async (t) => {
+  const { agentDir } = await spawnMcode(t, { autoMode: true });
+  const hooksDir = path.join(agentDir, '.minimax', 'hooks');
+  const files = fs.readdirSync(hooksDir).sort();
+
+  // Stop is the one that matters: it is what turns "status went idle" into an
+  // actual inbox drain instead of a bounce to the god.
+  assert.ok(files.includes('munder-hive-stop.md'), 'Stop hook is the inbox drain');
+  assert.deepEqual(files, [
+    'munder-hive-precompact.md', 'munder-hive-postcompact.md',
+    'munder-hive-posttooluse.md', 'munder-hive-pretooluse.md',
+    'munder-hive-sessionstart.md', 'munder-hive-stop.md',
+    'munder-hive-subagentstop.md', 'munder-hive-userpromptsubmit.md'
+  ].sort());
+
+  for (const name of files) {
+    const { front, command } = parseMcodeHook(fs.readFileSync(path.join(hooksDir, name), 'utf8'));
+    assert.ok(front.hookEvent, `${name}: mcode requires hookEvent`);
+    assert.equal(front.type, 'script', `${name}: must be a script hook`);
+    // Milliseconds here — mcode reads `timeout` as ms and defaults to 3e4. Codex's
+    // writer uses SECONDS in the same-named key, which is why this is asserted.
+    assert.equal(front.timeout, '30000', `${name}: timeout is milliseconds`);
+    assert.ok(command, `${name}: mcode skips a script hook with no bash fence`);
+    assert.match(command, /cth-hook\.cjs$/, `${name}: reuses the Claude shim verbatim`);
+    // Bundled node, not a bare `node` — hooks run with a stripped PATH. The
+    // cross-installer guard for that lives in hive-hook-node.test.cjs, which now
+    // parses these .md fences too; asserting the launcher prefix again here would
+    // be the same check written weaker.
+  }
+
+  // Tool events carry a matcher; session-scoped ones match by definition.
+  const tooled = parseMcodeHook(fs.readFileSync(path.join(hooksDir, 'munder-hive-pretooluse.md'), 'utf8'));
+  assert.equal(tooled.front.matcher, '".*"');
+  const stop = parseMcodeHook(fs.readFileSync(path.join(hooksDir, 'munder-hive-stop.md'), 'utf8'));
+  assert.equal(stop.front.matcher, undefined, 'Stop takes no matcher');
+});
+
+test('mcodeHookFile omits the matcher key entirely when there is none', () => {
+  // An empty `matcher:` would be read as the string "", which mcode anchors to
+  // `^$` — a matcher that matches nothing. Omission is the match-everything form.
+  const { front, command } = parseMcodeHook(mcodeHookFile('Stop', '/usr/bin/node /h/cth-hook.cjs'));
+  assert.equal(front.hookEvent, 'Stop');
+  assert.equal('matcher' in front, false);
+  assert.equal(command, '/usr/bin/node /h/cth-hook.cjs');
+});
+
+test('the login is mirrored as files; state directories stay per-agent', async (t) => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'md-mcode-home-'));
+  const home = path.join(base, 'user');
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+
+  const realHome = process.env.HOME;
+  const realProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  t.after(() => {
+    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
+    if (realProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = realProfile;
+  });
+  // Refuse to run rather than read/link the developer's real ~/.minimax.
+  assert.equal(os.homedir(), home, 'home redirect failed — aborting');
+
+  const userMinimax = path.join(home, '.minimax');
+  fs.mkdirSync(path.join(userMinimax, 'sessions'), { recursive: true });
+  fs.writeFileSync(path.join(userMinimax, 'auth.json'), '{"token":"user-login"}');
+  fs.writeFileSync(path.join(userMinimax, 'credentials.json'), '{"k":1}');
+  fs.writeFileSync(path.join(userMinimax, 'config.yaml'), 'permissionMode: acceptEdits\n');
+  fs.writeFileSync(path.join(userMinimax, 'sessions', 'other-agent.db'), 'x');
+
+  const hive = new HiveManager(() => home);
+  await hive.ensureAgent(
+    { id: 'mcode-2', name: 'M', provider: 'mcode', cwd: home },
+    { autoMode: true }
+  );
+  const dataDir = path.join(home, 'hive', 'agents', 'mcode-2', '.minimax');
+
+  // Whatever the credential is called, it came with us — that is the point of
+  // mirroring by shape instead of by filename.
+  for (const f of ['auth.json', 'credentials.json']) {
+    assert.equal(fs.existsSync(path.join(dataDir, f)), true, `${f} must reach the worker`);
+    assert.equal(fs.readFileSync(path.join(dataDir, f), 'utf8'),
+      fs.readFileSync(path.join(userMinimax, f), 'utf8'), `${f} must resolve to the user's file`);
+  }
+  // …but the session store must NOT be shared: one sqlite store across concurrent
+  // workers is contention plus a cross-agent history leak.
+  assert.equal(fs.existsSync(path.join(dataDir, 'sessions')), false,
+    'state directories must stay per-agent, not link back to the user\'s');
+  // And our config wins over the user's, without losing the rest of their file.
+  const config = fs.readFileSync(path.join(dataDir, 'config.yaml'), 'utf8');
+  assert.match(config, /^permissionMode: bypassPermissions$/m);
+  assert.doesNotMatch(config, /acceptEdits/, 'the user\'s value must be overridden, not duplicated');
+
+  // Idempotent: a second spawn over the same dir must not throw or double-link.
+  await hive.ensureAgent(
+    { id: 'mcode-2', name: 'M', provider: 'mcode', cwd: home },
+    { autoMode: false }
+  );
+  assert.match(fs.readFileSync(path.join(dataDir, 'config.yaml'), 'utf8'),
+    /^permissionMode: default$/m, 'respawn re-applies the current auto-mode state');
+});
+
+test('a user config.yaml is preserved, and our keys override rather than duplicate', async (t) => {
+  const { HiveManager: HM } = loadTs('src/main/hive.ts');
+  const home = tmpHome();
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const hive = new HM(() => home);
+
+  // Exercise the stripper directly: reformatting a user's whole YAML with a
+  // library would silently drop their comments, so this is line-based and its
+  // one real hazard is eating a NESTED key of the same name.
+  const strip = hive.stripTopLevelYamlKeys.bind(hive);
+  const out = strip([
+    '# my settings',
+    'permissionMode: acceptEdits',
+    'defaultModel: SomethingElse',
+    'provider:',
+    '  minimax:',
+    '    defaultModel: keep-me',
+    'sessionTitle:',
+    '  enabled: false'
+  ].join('\n'), ['permissionMode', 'defaultModel']);
+
+  assert.doesNotMatch(out, /^permissionMode:/m, 'top-level key removed');
+  assert.doesNotMatch(out, /^defaultModel:/m, 'top-level key removed');
+  assert.match(out, /^# my settings$/m, 'comments survive');
+  assert.match(out, /^ {4}defaultModel: keep-me$/m, 'a NESTED same-named key is left alone');
+  assert.match(out, /^ {2}enabled: false$/m, 'unrelated blocks survive intact');
+});

--- a/test/model-catalog.test.cjs
+++ b/test/model-catalog.test.cjs
@@ -137,7 +137,7 @@ test('the catalog is the schema config.ts expects', () => {
   assert.deepEqual(
     Object.keys(catalog.providers).sort(),
     ['antigravity', 'claude', 'copilot', 'codex', 'crush', 'cursor', 'custom',
-      'gemini', 'grok', 'kimi', 'opencode', 'pi', 'qwen'].sort()
+      'gemini', 'grok', 'kimi', 'mcode', 'opencode', 'pi', 'qwen'].sort()
   );
 });
 

--- a/test/provider-automation.test.cjs
+++ b/test/provider-automation.test.cjs
@@ -17,7 +17,7 @@ const {
 // — the queue's one-pending-compact invariant depends entirely on this predicate —
 
 test('isCompactionCommand matches every provider that has a compact verb', () => {
-  for (const p of ['claude', 'codex', 'grok', 'kimi', 'qwen', 'opencode', 'pi', 'copilot', 'cursor']) {
+  for (const p of ['claude', 'codex', 'grok', 'kimi', 'qwen', 'opencode', 'pi', 'copilot', 'cursor', 'mcode']) {
     const cmd = compactionCommandForProvider(p, '');
     if (!cmd) continue; // provider has no typeable compaction — nothing to dedupe
     assert.equal(isCompactionCommand(cmd), true, `${p}: ${cmd}`);

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -128,10 +128,10 @@ test('God only sees providers that can drain hive inbox messages', () => {
   // Cursor is interactive (no -p) so it IS god-eligible.
   assert.deepEqual(
     modelProvidersForAgent(true).map((preset) => preset.id),
-    ['claude', 'codex', 'grok', 'gemini', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'cursor']
+    ['claude', 'codex', 'grok', 'gemini', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'cursor', 'mcode']
   );
   assert.deepEqual(
     modelProvidersForAgent(false).map((preset) => preset.id),
-    ['claude', 'codex', 'grok', 'kimi', 'gemini', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'copilot', 'cursor']
+    ['claude', 'codex', 'grok', 'kimi', 'gemini', 'antigravity', 'qwen', 'opencode', 'crush', 'pi', 'copilot', 'cursor', 'mcode']
   );
 });


### PR DESCRIPTION
Adds mcode as a full provider with hooks bridge, model catalog, i18n, and install support.

Closes chaitanyagiri#387