### PR TITLE
fix(hooks): harden socket frame decoding and bounds

### DIFF
--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -89,18 +89,29 @@ export class HookServer {
 
     this.server = createServer((conn) => {
       let pending = Buffer.alloc(0);
+      const rejectOversizedFrame = (bytes: number): void => {
+        this.hive.appendLog({
+          kind: 'hook-frame-rejected',
+          reason: 'frame-too-large',
+          bytes,
+          limit: MAX_HOOK_FRAME_BYTES,
+        });
+        conn.destroy();
+      };
       conn.on('data', (chunk) => {
         pending = Buffer.concat([pending, chunk]);
         const nl = pending.indexOf(0x0a);
         if (nl === -1) {
-          if (pending.length > MAX_HOOK_FRAME_BYTES) conn.destroy();
+          if (pending.length > MAX_HOOK_FRAME_BYTES) rejectOversizedFrame(pending.length);
           return; // wait for the full line
         }
         // The byte limit covers the JSON payload and excludes its newline.
         if (nl > MAX_HOOK_FRAME_BYTES) {
-          conn.destroy();
+          rejectOversizedFrame(nl);
           return;
         }
+        // Hook shims send one newline-delimited request per connection and stop writing.
+        // conn.end() below closes the connection after that single frame is handled.
         const frame = pending.subarray(0, nl).toString('utf8');
         let payload: HookPayload = {};
         try { payload = JSON.parse(frame); } catch { /* ignore */ }

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -20,6 +20,9 @@ import type { CircuitBreaker } from './breaker';
 import { estimateCostUsd } from './pricing';
 import { validateHookEvent } from '../shared/hookEvents';
 
+/** Maximum JSON payload bytes in one newline-delimited hook frame. */
+const MAX_HOOK_FRAME_BYTES = 256 * 1024;
+
 interface HookPayload {
   hook_event_name?: string;
   agent_id?: string | null;
@@ -85,13 +88,22 @@ export class HookServer {
     try { if (existsSync(sock)) rmSync(sock); } catch { /* noop */ }
 
     this.server = createServer((conn) => {
-      let buf = '';
-      conn.on('data', (d) => {
-        buf += d.toString();
-        const nl = buf.indexOf('\n');
-        if (nl === -1) return; // wait for the full line
+      let pending = Buffer.alloc(0);
+      conn.on('data', (chunk) => {
+        pending = Buffer.concat([pending, chunk]);
+        const nl = pending.indexOf(0x0a);
+        if (nl === -1) {
+          if (pending.length > MAX_HOOK_FRAME_BYTES) conn.destroy();
+          return; // wait for the full line
+        }
+        // The byte limit covers the JSON payload and excludes its newline.
+        if (nl > MAX_HOOK_FRAME_BYTES) {
+          conn.destroy();
+          return;
+        }
+        const frame = pending.subarray(0, nl).toString('utf8');
         let payload: HookPayload = {};
-        try { payload = JSON.parse(buf.slice(0, nl)); } catch { /* ignore */ }
+        try { payload = JSON.parse(frame); } catch { /* ignore */ }
         let res: unknown = {};
         try { res = this.handle(payload); } catch { res = {}; }
         conn.end(JSON.stringify(res ?? {}));

--- a/test/hooks-framing.test.cjs
+++ b/test/hooks-framing.test.cjs
@@ -1,0 +1,168 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { once } = require('node:events');
+const loadTs = require('./load-ts.cjs');
+
+const electron = require.resolve('electron');
+require.cache[electron] = {
+  id: electron,
+  filename: electron,
+  loaded: true,
+  exports: { Notification: class { static isSupported() { return false; } } }
+};
+
+const { HookServer } = loadTs('src/main/hooks.ts');
+const MAX_HOOK_FRAME_BYTES = 256 * 1024;
+let socketSequence = 0;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function socketPath(base) {
+  const id = `${process.pid}-${Date.now()}-${socketSequence++}`;
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\md-hooks-frame-${id}`
+    : path.join(base, `hooks-${id}.sock`);
+}
+
+async function openServer(t) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'md-hooks-frame-'));
+  const sock = socketPath(base);
+  const routed = [];
+  const hive = { sockPath: () => sock };
+  const server = new HookServer(hive, () => null, () => ({ notifications: false }));
+
+  // Exercise the real net.Server framing path while isolating these tests from
+  // HookServer's unrelated routing behavior.
+  server.handle = (payload) => {
+    routed.push(payload);
+    return {};
+  };
+
+  server.start();
+  assert.ok(server.server, 'HookServer did not create its net.Server');
+  if (!server.server.listening) await once(server.server, 'listening');
+
+  t.after(() => {
+    server.stop();
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+  return { sock, routed };
+}
+
+async function sendChunks(sock, chunks, pauseMs = 0, timeoutMs = 1000) {
+  const socket = net.createConnection(sock);
+  socket.on('error', () => { /* rejection may reset the client connection */ });
+  await once(socket, 'connect');
+
+  const response = [];
+  socket.on('data', (chunk) => response.push(chunk));
+  const closed = new Promise((resolve) => {
+    socket.once('end', () => resolve(true));
+    socket.once('close', () => resolve(true));
+  });
+
+  for (let i = 0; i < chunks.length; i += 1) {
+    socket.write(chunks[i]);
+    if (pauseMs > 0 && i < chunks.length - 1) await delay(pauseMs);
+  }
+
+  const didClose = await Promise.race([
+    closed,
+    delay(timeoutMs).then(() => false)
+  ]);
+  if (!didClose) socket.destroy();
+  return { didClose, response: Buffer.concat(response).toString('utf8') };
+}
+
+function framedPayloadWithByteLength(byteLength) {
+  const empty = Buffer.byteLength(JSON.stringify({ message: '' }), 'utf8');
+  assert.ok(byteLength >= empty);
+  const text = JSON.stringify({ message: 'x'.repeat(byteLength - empty) });
+  assert.equal(Buffer.byteLength(text, 'utf8'), byteLength);
+  return Buffer.from(`${text}\n`, 'utf8');
+}
+
+function splitInside(frame, character) {
+  const start = frame.indexOf(Buffer.from(character, 'utf8'));
+  assert.notEqual(start, -1, `test frame does not contain ${character}`);
+  return start + 1;
+}
+
+test('CJK payload survives a split inside a multibyte code point', async (t) => {
+  const { sock, routed } = await openServer(t);
+  const payload = { message: '靽桀儔皜祈岫' };
+  const frame = Buffer.from(`${JSON.stringify(payload)}\n`, 'utf8');
+  const split = splitInside(frame, '靽');
+
+  const result = await sendChunks(sock, [frame.subarray(0, split), frame.subarray(split)], 25);
+
+  assert.equal(result.didClose, true);
+  assert.deepEqual(routed, [payload]);
+});
+
+test('emoji payload survives a split inside a four-byte code point', async (t) => {
+  const { sock, routed } = await openServer(t);
+  const payload = { message: 'deploy 🚀 ready' };
+  const frame = Buffer.from(`${JSON.stringify(payload)}\n`, 'utf8');
+  const split = splitInside(frame, '🚀');
+
+  const result = await sendChunks(sock, [frame.subarray(0, split), frame.subarray(split)], 25);
+
+  assert.equal(result.didClose, true);
+  assert.deepEqual(routed, [payload]);
+});
+
+test('ordinary fragmented frame retains existing one-request behavior', async (t) => {
+  const { sock, routed } = await openServer(t);
+  const payload = { hook_event_name: 'Stop', message: 'plain ASCII' };
+  const frame = Buffer.from(`${JSON.stringify(payload)}\n`, 'utf8');
+
+  const result = await sendChunks(sock, [
+    frame.subarray(0, 5),
+    frame.subarray(5, 17),
+    frame.subarray(17)
+  ], 10);
+
+  assert.equal(result.didClose, true);
+  assert.deepEqual(routed, [payload]);
+  assert.equal(result.response, '{}');
+});
+
+test('oversized incomplete frame is rejected without routing a payload', async (t) => {
+  const { sock, routed } = await openServer(t);
+
+  const result = await sendChunks(sock, [Buffer.alloc(MAX_HOOK_FRAME_BYTES + 1, 0x78)], 0, 400);
+
+  assert.equal(result.didClose, true, 'server retained an oversized incomplete frame');
+  assert.deepEqual(routed, []);
+  assert.equal(result.response, '');
+});
+
+test('payload exactly at the byte limit is accepted', async (t) => {
+  const { sock, routed } = await openServer(t);
+  const frame = framedPayloadWithByteLength(MAX_HOOK_FRAME_BYTES);
+
+  const result = await sendChunks(sock, [frame]);
+
+  assert.equal(result.didClose, true);
+  assert.equal(routed.length, 1);
+  assert.equal(routed[0].message.length > 0, true);
+  assert.equal(result.response, '{}');
+});
+
+test('payload one byte above the limit is rejected', async (t) => {
+  const { sock, routed } = await openServer(t);
+  const frame = framedPayloadWithByteLength(MAX_HOOK_FRAME_BYTES + 1);
+
+  const result = await sendChunks(sock, [frame]);
+
+  assert.equal(result.didClose, true);
+  assert.deepEqual(routed, []);
+  assert.equal(result.response, '');
+});

--- a/test/hooks-framing.test.cjs
+++ b/test/hooks-framing.test.cjs
@@ -34,7 +34,11 @@ async function openServer(t) {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'md-hooks-frame-'));
   const sock = socketPath(base);
   const routed = [];
-  const hive = { sockPath: () => sock };
+  const logs = [];
+  const hive = {
+    sockPath: () => sock,
+    appendLog: (entry) => logs.push(entry)
+  };
   const server = new HookServer(hive, () => null, () => ({ notifications: false }));
 
   // Exercise the real net.Server framing path while isolating these tests from
@@ -52,7 +56,7 @@ async function openServer(t) {
     server.stop();
     fs.rmSync(base, { recursive: true, force: true });
   });
-  return { sock, routed };
+  return { sock, routed, logs };
 }
 
 async function sendChunks(sock, chunks, pauseMs = 0, timeoutMs = 1000) {
@@ -135,13 +139,19 @@ test('ordinary fragmented frame retains existing one-request behavior', async (t
 });
 
 test('oversized incomplete frame is rejected without routing a payload', async (t) => {
-  const { sock, routed } = await openServer(t);
+  const { sock, routed, logs } = await openServer(t);
 
   const result = await sendChunks(sock, [Buffer.alloc(MAX_HOOK_FRAME_BYTES + 1, 0x78)], 0, 400);
 
   assert.equal(result.didClose, true, 'server retained an oversized incomplete frame');
   assert.deepEqual(routed, []);
   assert.equal(result.response, '');
+  assert.deepEqual(logs, [{
+    kind: 'hook-frame-rejected',
+    reason: 'frame-too-large',
+    bytes: MAX_HOOK_FRAME_BYTES + 1,
+    limit: MAX_HOOK_FRAME_BYTES
+  }]);
 });
 
 test('payload exactly at the byte limit is accepted', async (t) => {
@@ -157,7 +167,7 @@ test('payload exactly at the byte limit is accepted', async (t) => {
 });
 
 test('payload one byte above the limit is rejected', async (t) => {
-  const { sock, routed } = await openServer(t);
+  const { sock, routed, logs } = await openServer(t);
   const frame = framedPayloadWithByteLength(MAX_HOOK_FRAME_BYTES + 1);
 
   const result = await sendChunks(sock, [frame]);
@@ -165,4 +175,10 @@ test('payload one byte above the limit is rejected', async (t) => {
   assert.equal(result.didClose, true);
   assert.deepEqual(routed, []);
   assert.equal(result.response, '');
+  assert.deepEqual(logs, [{
+    kind: 'hook-frame-rejected',
+    reason: 'frame-too-large',
+    bytes: MAX_HOOK_FRAME_BYTES + 1,
+    limit: MAX_HOOK_FRAME_BYTES
+  }]);
 });


### PR DESCRIPTION
## What & why

- HookServer currently decodes each socket chunk before newline framing, so a multibyte UTF-8 code point split across chunks can be silently replaced while the JSON still parses successfully. Incomplete frames also have no explicit byte limit and can continue growing when a local peer never sends a newline.

- This change keeps framing byte-oriented until a complete request is available, then decodes UTF-8 once and rejects frames above a fixed byte limit. It preserves the existing one-request-per-connection behavior.

Closes #399 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

On current `main`, splitting a valid UTF-8 payload inside a multibyte CJK code point changes the received value even though the request remains parseable.

The regression reproduces the issue through real socket byte writes. The assertion shows replacement characters in the received payload after the split.

<img width="985" height="466" alt="2026-08-31-222944" src="https://github.com/user-attachments/assets/edd6eedd-7ed2-461b-b198-2c5eb5cb6f03" />

<!--
Use the screenshot showing:

CJK payload survives a split inside a multibyte code point
AssertionError [ERR_ASSERTION]
+ actual
- expected
+ message containing replacement characters
-->

### After

HookServer now keeps incoming data as bytes until a complete newline-delimited frame is available. UTF-8 is decoded only after framing, and oversized incomplete frames are rejected before routing a payload.

The focused framing regression covers:

- CJK code point split across chunks
- Four-byte emoji split across chunks
- Ordinary fragmented frames
- Oversized incomplete frames
- Payloads exactly at the byte limit
- Payloads one byte above the limit

All six cases pass after the fix.

<img width="894" height="420" alt="2026-08-31-185707" src="https://github.com/user-attachments/assets/b4bd8467-74e8-4772-8e45-242ee822762c" />

<!--
Use the screenshot showing:

tests 6
pass 6
fail 0
-->

## How I tested it

- OS: Windows 11
- Node.js: v22.22.3
- Steps:
  1. Ran the CJK split regression against current `main` and confirmed it fails with a corrupted payload.
  2. Ran `node --test test/hooks-framing.test.cjs` after the fix.
  3. Confirmed all 6 framing regressions pass.
  4. Ran `npm run test:focused`.
  5. Ran `npm run typecheck`.
  6. Ran `npm run build`.
  7. Ran `git diff --check`.

Focused framing result:

```text
tests 6
pass 6
fail 0
```

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` because this change adds no UI.
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`. No art is added by this change.