### PR TITLE
test(windows): make platform fixtures deterministic

### DIFF
--- a/test/cli-install-ladder.test.cjs
+++ b/test/cli-install-ladder.test.cjs
@@ -14,7 +14,9 @@ const loadTs = require('./load-ts.cjs');
 const { chooseInstallRung, buildMissingCliScript } = loadTs('src/main/cliInstall.ts');
 const { installInfoForProvider } = loadTs('src/shared/agentProvider.ts');
 
-const script = (provider, npmAvailable, platform) =>
+// Most assertions below exercise the multi-line POSIX script. Keep them
+// deterministic on every host; the dedicated Windows test passes win32 itself.
+const script = (provider, npmAvailable, platform = 'linux') =>
   buildMissingCliScript(provider, provider, npmAvailable, platform);
 
 test('with npm present the ladder is unchanged — npm install, for every provider', () => {
@@ -68,7 +70,7 @@ test('the no-node script explains the real problem instead of failing at it', ()
 test('the native rung actually runs, and says why it differs', () => {
   const out = script('claude', false);
   assert.match(out, /no Node needed/);
-  const native = installInfoForProvider('claude').nativeCommand;
+  const native = installInfoForProvider('claude', 'linux').nativeCommand;
   assert.ok(out.split('\n').includes(native), 'the installer must be an executed line, not only echoed');
 });
 
@@ -94,7 +96,7 @@ test('the Windows script stays a single quote-free cmd.exe line', () => {
 
 test('a hostile binary name cannot inject a command into the banner', () => {
   const out = script('claude', true).split('\n');
-  const evil = buildMissingCliScript("x'; rm -rf /; echo '", 'claude', true).split('\n');
+  const evil = buildMissingCliScript("x'; rm -rf /; echo '", 'claude', true, 'linux').split('\n');
   assert.equal(evil.length, out.length, 'no extra statements');
   assert.ok(evil.some((l) => l.includes('xrm-rf')), 'sanitized to a bare identifier');
   assert.ok(!evil.some((l) => /rm -rf \//.test(l)));

--- a/test/codex-remote.test.cjs
+++ b/test/codex-remote.test.cjs
@@ -13,7 +13,9 @@ const {
   CODEX_REMOTE_SOCKET_RELATIVE
 } = loadTs('src/shared/codexRemote.ts');
 
-test('Codex remote uses a short stable per-agent home alias', () => {
+test('Codex remote uses a short stable per-agent home alias', {
+  skip: process.platform === 'win32' ? 'Codex remote uses Unix sockets and is disabled on Windows' : false
+}, () => {
   const first = codexRemoteAliasPath('/very/long/hive/agent/.codex', 'dev-1', '/tmp');
   const again = codexRemoteAliasPath('/very/long/hive/agent/.codex', 'dev-1', '/tmp');
   const other = codexRemoteAliasPath('/very/long/hive/agent/.codex', 'dev-2', '/tmp');

--- a/test/transcript-project-dir.test.cjs
+++ b/test/transcript-project-dir.test.cjs
@@ -3,9 +3,6 @@
 // Originally contributed by Vyapak Goyal (@gts-47) in #123, extended here with
 // the dotted-path cases that the first version's dot-free fixtures could not
 // catch.
-//
-// POSIX-only: projectDir() resolves against os.homedir(), which these cases
-// redirect via $HOME — a knob Windows does not honour.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -16,12 +13,13 @@ const loadTs = require('./load-ts.cjs');
 
 const { projectDir } = loadTs('src/main/transcript.ts');
 
-/** projectDir() resolves against os.homedir(), which POSIX reads from $HOME — so
- *  each case gets a throwaway home and never touches the real ~/.claude. */
+/** Give projectDir() a throwaway home so no case touches the real ~/.claude.
+ *  os.homedir() reads HOME on POSIX and USERPROFILE on Windows. */
 function withHome(run) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-transcript-'));
-  const prev = process.env.HOME;
-  process.env.HOME = home;
+  const homeEnv = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
+  const prev = process.env[homeEnv];
+  process.env[homeEnv] = home;
   try {
     return run(home, (key) => {
       const dir = path.join(home, '.claude/projects', key);
@@ -29,11 +27,15 @@ function withHome(run) {
       return dir;
     });
   } finally {
-    if (prev === undefined) delete process.env.HOME;
-    else process.env.HOME = prev;
+    if (prev === undefined) delete process.env[homeEnv];
+    else process.env[homeEnv] = prev;
     fs.rmSync(home, { recursive: true, force: true });
   }
 }
+
+const posixLegacyOnly = {
+  skip: process.platform === 'win32' ? 'the pre-2026 legacy key existed only on POSIX' : false
+};
 
 test('an unseen cwd resolves to the CURRENT key, leading slash dashed', () => {
   withHome(() => {
@@ -90,14 +92,14 @@ test('the dotted legacy twin loses to the dotted current spelling', () => {
   });
 });
 
-test('a legacy-only install still resolves, so old transcripts stay readable', () => {
+test('a legacy-only install still resolves, so old transcripts stay readable', posixLegacyOnly, () => {
   withHome((_home, mkProject) => {
     const legacy = mkProject('Users-me-app');
     assert.equal(projectDir('/Users/me/app'), legacy);
   });
 });
 
-test('a legacy-only install with dots resolves to its undashed twin', () => {
+test('a legacy-only install with dots resolves to its undashed twin', posixLegacyOnly, () => {
   withHome((_home, mkProject) => {
     // The legacy key kept dots, so the fallback has to keep them too — deriving
     // it from the new key by stripping the leading dash would look for


### PR DESCRIPTION
## What & why

Current `main` still has 7 of the Windows-only failures reported in #253. The affected tests either let the host OS choose syntax for assertions that specifically inspect POSIX output, redirect only `HOME` even though Windows `os.homedir()` reads `USERPROFILE`, or exercise POSIX-only behavior that production explicitly disables on Windows.

This makes the POSIX fixtures deterministic, redirects the transcript sandbox through the correct platform home variable, and skips only the three assertions whose production behavior is genuinely Unix-only. Production code is unchanged.

Closes #253

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

<img width="1200" alt="Windows targeted tests before: 27 pass, 7 fail" src="https://raw.githubusercontent.com/oleg-ai-dev/munder-difflin/issue-253-evidence/.github/pr-evidence/253-before.png">

### After

<img width="1200" alt="Windows targeted tests after: 31 pass, 0 fail, 3 justified skips" src="https://raw.githubusercontent.com/oleg-ai-dev/munder-difflin/issue-253-evidence/.github/pr-evidence/253-after.png">

## How I tested it

- OS: Windows 11
- `node --test test/cli-install-ladder.test.cjs test/codex-remote.test.cjs test/expand-tilde.test.cjs test/transcript-project-dir.test.cjs` — 31 passed, 0 failed, 3 skipped (the Unix-only cases)
- `tsc --noEmit -p tsconfig.node.json` — passed
- `tsc --noEmit -p tsconfig.web.json` — passed
- `electron-vite build` plus `tools/copy-main-assets.cjs` — passed
- Full `test/*.test.cjs` baseline comparison on the same checkout and dependency tree:
  - untouched `main`: 742 tests, 725 passed, 15 failed, 2 skipped
  - this branch: 742 tests, 729 passed, 8 failed, 5 skipped
  - all 8 remaining failures are pre-existing and outside the three files changed here; this patch removes all 7 issue-specific failures without adding a new failure

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes. The branch removes all 7 in-scope failures; 8 newer pre-existing failures elsewhere remain, as detailed above.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no UI changed.
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md` — no art added.