### PR TITLE
feat(cast): let a character be added without editing the built-in cast

### DIFF
--- a/src/renderer/src/scene/office/cast.ts
+++ b/src/renderer/src/scene/office/cast.ts
@@ -1,5 +1,9 @@
 // The Office cast — roster metadata + sprite frames.
 //
+// The built-in cast is closed (BuiltinCharacterName); the *selectable* cast is
+// open. Call `registerCastMember` to add one — see it and OfficeCharacterName
+// below for why the type is widened rather than the array being replaced.
+//
 // Both the static portraits (cards / picker) and the in-scene walking sprites are
 // now fully custom-drawn from the same per-character recipes in portraitArt.ts:
 // the scene sprite reuses the portrait's exact head/face/clothing and adds legs,
@@ -7,12 +11,26 @@
 // sheets are no longer used for the cast. See assets/ATTRIBUTION.md.
 
 import { Texture } from 'pixi.js';
-import { paintPortrait, sceneFrameBufs, SCENE_W, SCENE_H } from './portraitArt';
+import { paintPortrait, registerRecipe, sceneFrameBufs, SCENE_W, SCENE_H, type Recipe } from './portraitArt';
 
-export type OfficeCharacterName =
+/** The cast that ships with the app. Closed on purpose: portraitArt's RECIPES
+ *  is keyed on this, so adding a name here fails the build until its recipe
+ *  exists — which is exactly the check you want for the built-ins. */
+export type BuiltinCharacterName =
   | 'michael' | 'jim' | 'pam' | 'dwight' | 'kevin' | 'angela'
   | 'oscar' | 'stanley' | 'phyllis' | 'andy' | 'kelly' | 'ryan'
   | 'toby' | 'creed' | 'meredith';
+
+/** Any character name — built-in, or one added through `registerCastMember`.
+ *
+ *  `(string & {})` keeps the built-in names as editor autocomplete while still
+ *  admitting registered ones. The scene already tolerates a name it does not
+ *  know (OfficeFloor falls back to the theme's default character, and
+ *  portraitArt falls back to a stand-in recipe), so widening this costs no
+ *  runtime safety — it only stops the type from being the thing that makes a
+ *  custom character impossible. */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type OfficeCharacterName = BuiltinCharacterName | (string & {});
 
 export interface CastMember {
   name: OfficeCharacterName;
@@ -23,7 +41,9 @@ export interface CastMember {
   blurb: string;
 }
 
-/** Selectable roster, in display order. */
+/** Selectable roster, in display order. Registered members are appended
+ *  by `registerCastMember`, so every picker that maps over this array picks
+ *  them up without knowing the registry exists. */
 export const OFFICE_CAST: CastMember[] = [
   { name: 'michael',  displayName: 'Michael',  shirt: '#5a6b8c', blurb: "World's best boss" },
   { name: 'jim',      displayName: 'Jim',      shirt: '#6fa8dc', blurb: 'Salesman, prankster' },
@@ -42,17 +62,43 @@ export const OFFICE_CAST: CastMember[] = [
   { name: 'meredith', displayName: 'Meredith', shirt: '#b5544a', blurb: 'Supplier relations' },
 ];
 
-export const CAST_BY_NAME: Record<OfficeCharacterName, CastMember> =
-  Object.fromEntries(OFFICE_CAST.map((c) => [c.name, c])) as Record<OfficeCharacterName, CastMember>;
+export const CAST_BY_NAME: Record<string, CastMember> =
+  Object.fromEntries(OFFICE_CAST.map((c) => [c.name, c]));
 
 export const DEFAULT_CHARACTER: OfficeCharacterName = 'jim';
+
+/** Rendered scene frames, keyed by character. Declared here rather than beside
+ *  `getCastFrames` below so `registerCastMember` can invalidate it without a
+ *  forward reference. */
+const frameCache = new Map<OfficeCharacterName, Texture[][]>();
+
+/**
+ * Add a character to the selectable cast at runtime.
+ *
+ * Both `OFFICE_CAST` and `CAST_BY_NAME` are mutated in place rather than
+ * rebuilt: every consumer holds the same array/object reference (the pickers
+ * map over OFFICE_CAST, the theme registry hands CAST_BY_NAME to the floor),
+ * so replacing them would leave those references pointing at a stale snapshot.
+ *
+ * Call this at module scope, before the first render.
+ *
+ * @param member  Roster entry — name, display name, accent color, blurb.
+ * @param recipe  How to draw them. Same shape the built-ins use.
+ */
+export function registerCastMember(member: CastMember, recipe: Recipe): void {
+  const existing = OFFICE_CAST.findIndex((c) => c.name === member.name);
+  if (existing >= 0) OFFICE_CAST[existing] = member;
+  else OFFICE_CAST.push(member);
+  CAST_BY_NAME[member.name] = member;
+  registerRecipe(member.name, recipe);
+  frameCache.delete(member.name);
+}
 
 export function hexToNumber(hex: string): number {
   return parseInt(hex.replace('#', ''), 16);
 }
 
 // ─── scene frames ────────────────────────────────────────────────────────────
-const frameCache = new Map<OfficeCharacterName, Texture[][]>();
 
 function bufToTexture(buf: Uint8ClampedArray): Texture {
   const canvas = document.createElement('canvas');

--- a/src/renderer/src/scene/office/portraitArt.ts
+++ b/src/renderer/src/scene/office/portraitArt.ts
@@ -7,7 +7,7 @@
 // the specific show character. The in-scene walking sprites still use the LimeZu
 // recolor in cast.ts; this module only powers the static portraits in the UI.
 
-import type { OfficeCharacterName } from './cast';
+import type { BuiltinCharacterName, OfficeCharacterName } from './cast';
 
 export const PORTRAIT_W = 18;
 export const PORTRAIT_H = 28;
@@ -17,7 +17,7 @@ export const SCENE_H = 32;
 const OUTLINE: RGB = [38, 34, 46];
 const HX0 = 4, HX1 = 13; // head skin columns
 
-type RGB = [number, number, number];
+export type RGB = [number, number, number];
 type Buf = Uint8ClampedArray;
 
 // Current canvas dims — set per compose() so the same drawing primitives serve
@@ -77,8 +77,8 @@ function drawHead(buf: Buf, skin: string): void {
   rect(buf, 7, 17, 10, 18, s.sh); rect(buf, 7, 17, 9, 17, s.base);
 }
 
-type Brow = 'flat' | 'angry' | 'raised' | 'soft';
-type Mouth = 'neutral' | 'smile' | 'frown' | 'grin';
+export type Brow = 'flat' | 'angry' | 'raised' | 'soft';
+export type Mouth = 'neutral' | 'smile' | 'frown' | 'grin';
 function drawFace(buf: Buf, skin: string, brow: Brow, mouth: Mouth, blush: boolean, lashes = false): void {
   const s = SKIN[skin];
   const white: RGB = [250, 248, 244], pup: RGB = [46, 38, 42];
@@ -110,7 +110,7 @@ function drawFace(buf: Buf, skin: string, brow: Brow, mouth: Mouth, blush: boole
 }
 
 // ─── hairstyles ──────────────────────────────────────────────────────────────
-interface HairArgs { part?: 'L' | 'R'; recede?: number; length?: number; vol?: number; }
+export interface HairArgs { part?: 'L' | 'R'; recede?: number; length?: number; vol?: number; }
 type HairFn = (buf: Buf, color: RGB, skinBase: RGB, a: HairArgs) => void;
 
 const styleShort: HairFn = (buf, color, skinBase, a) => {
@@ -244,10 +244,10 @@ const styleBald: HairFn = (buf, color, skinBase, a) => {
 };
 
 const HAIR_FNS = { styleShort, styleFloppy, styleFrame, styleBun, styleCurly, styleMessy, styleRecede, styleSpiky, styleBald };
-type HairStyle = keyof typeof HAIR_FNS;
+export type HairStyle = keyof typeof HAIR_FNS;
 
 // ─── facial hair ─────────────────────────────────────────────────────────────
-type Facial = 'mustache' | 'mustacheSm' | 'stubble' | 'goatee';
+export type Facial = 'mustache' | 'mustacheSm' | 'stubble' | 'goatee';
 function drawFacial(buf: Buf, kind: Facial, color: RGB): void {
   const [, base, sh] = shades(color);
   if (kind === 'mustache') {
@@ -288,7 +288,7 @@ function drawGlasses(buf: Buf): void {
 }
 
 // ─── clothing ────────────────────────────────────────────────────────────────
-type Cloth = 'suit' | 'dressshirt' | 'polo' | 'blouse' | 'cardigan' | 'sweater';
+export type Cloth = 'suit' | 'dressshirt' | 'polo' | 'blouse' | 'cardigan' | 'sweater';
 function bodyShape(buf: Buf, col: RGB, heavy = false): void {
   const [, base, sh] = shades(col);
   const rows: [number, number, number][] = heavy
@@ -464,7 +464,7 @@ function outlinePass(buf: Buf): void {
 }
 
 // ─── recipes ─────────────────────────────────────────────────────────────────
-interface Recipe {
+export interface Recipe {
   skin: string; hairc: RGB; hair: HairStyle; hairargs?: HairArgs;
   cloth: Cloth; c1: RGB; c2?: RGB; tie?: RGB; pants?: RGB;
   brow?: Brow; mouth?: Mouth; blush?: boolean; facial?: Facial; glasses?: boolean;
@@ -490,7 +490,7 @@ function drawHeavyFace(buf: Buf, skin: string): void {
   set(buf, 7, 17, s.sh); set(buf, 10, 17, s.sh); // crease shadow between chin + roll
 }
 
-const RECIPES: Record<OfficeCharacterName, Recipe> = {
+const RECIPES: Record<BuiltinCharacterName, Recipe> = {
   michael:  { skin: 'light', hairc: [58, 42, 28],   hair: 'styleShort',  hairargs: { part: 'L' }, cloth: 'suit', c1: [58, 63, 74], tie: [170, 58, 58], brow: 'flat', mouth: 'smile' },
   jim:      { skin: 'light', hairc: [92, 60, 34],   hair: 'styleFloppy', cloth: 'dressshirt', c1: [172, 196, 224], tie: [120, 130, 150], brow: 'flat', mouth: 'smile' },
   pam:      { skin: 'light', hairc: [120, 76, 42],  hair: 'styleFrame',  hairargs: { length: 18, vol: 2 }, cloth: 'cardigan', c1: [236, 174, 192], c2: [244, 242, 238], brow: 'soft', mouth: 'smile', blush: true, lashes: true },
@@ -546,6 +546,29 @@ function composeScene(r: Recipe, phase: number, back: boolean): Buf {
   return buf;
 }
 
+// ─── recipe registry ─────────────────────────────────────────────────────────
+//
+// RECIPES above is the built-in cast and stays exhaustive over
+// BuiltinCharacterName, so adding a name to that union still fails the build
+// until its recipe exists. Characters registered at runtime live here instead.
+
+const extraRecipes = new Map<string, Recipe>();
+
+/** Register a portrait recipe for a character added via `registerCastMember`.
+ *  Registering the same name twice replaces the recipe and clears its caches,
+ *  so a hot reload picks up an edited recipe instead of serving a stale bust. */
+export function registerRecipe(name: string, recipe: Recipe): void {
+  extraRecipes.set(name, recipe);
+  bufCache.delete(name);
+  sceneCache.delete(name);
+}
+
+/** Built-in first, then registered, then Jim as the last-resort stand-in —
+ *  an unknown name renders as somebody rather than crashing the floor. */
+function recipeFor(name: OfficeCharacterName): Recipe {
+  return (RECIPES as Record<string, Recipe>)[name] ?? extraRecipes.get(name) ?? RECIPES.jim;
+}
+
 // ─── public render ───────────────────────────────────────────────────────────
 const bufCache = new Map<OfficeCharacterName, Buf>();
 const sceneCache = new Map<OfficeCharacterName, SceneFrames>();
@@ -553,7 +576,7 @@ const sceneCache = new Map<OfficeCharacterName, SceneFrames>();
 function getBuf(name: OfficeCharacterName): Buf {
   let buf = bufCache.get(name);
   if (!buf) {
-    buf = compose(RECIPES[name] ?? RECIPES.jim);
+    buf = compose(recipeFor(name));
     bufCache.set(name, buf);
   }
   return buf;
@@ -565,7 +588,7 @@ export interface SceneFrames { front: Buf[]; back: Buf[]; }
 export function sceneFrameBufs(name: OfficeCharacterName): SceneFrames {
   let frames = sceneCache.get(name);
   if (!frames) {
-    const r = RECIPES[name] ?? RECIPES.jim;
+    const r = recipeFor(name);
     frames = {
       front: [composeScene(r, 0, false), composeScene(r, 1, false), composeScene(r, 2, false)],
       back: [composeScene(r, 0, true), composeScene(r, 1, true), composeScene(r, 2, true)],


### PR DESCRIPTION
## What & why

Adding one character to the office means editing three places across two files
that the built-in cast owns: the `OfficeCharacterName` union, the
`OFFICE_CAST` literal, and `portraitArt`'s `RECIPES` record keyed on that
union. There is no way to add one from outside those files.

Most of the machinery for this already exists. `ThemeCast.byName` is keyed by
`string`, `OfficeFloor` already falls back to the theme's default character
for a name it doesn't recognise, and `portraitArt` already fell back to a
stand-in recipe. Only the types and the two literals stood in the way, so this
opens that last inch rather than reworking anything.

- `BuiltinCharacterName` — the fifteen shipped names. Still closed, and
  `RECIPES` is still exhaustive over it, so adding a built-in name keeps
  failing the build until its recipe exists.
- `OfficeCharacterName` — now `BuiltinCharacterName | (string & {})`. The
  built-in names keep their editor autocomplete; a registered name is admitted.
- `registerCastMember(member, recipe)` — appends to `OFFICE_CAST`,
  `CAST_BY_NAME` and a recipe registry, and drops that character's render
  caches so a re-registration doesn't serve a stale bust.

`OFFICE_CAST` and `CAST_BY_NAME` are mutated in place rather than rebuilt:
the pickers map over that array and the theme registry hands that object to the
floor, so replacing either would leave live references pointing at a stale
snapshot. `Recipe` and the types it is built from are exported so a caller can
author one.

No behaviour change for the shipped cast — the fifteen recipes, the picker order
and the default character are all untouched.

I noticed `themeRegistry.ts` describes this as Phase 0 of the TV-show-offices
work, with five more themes to come. This is meant to compose with that rather
than get in front of it: a future theme can register its own people through the
same entry point. Happy to reshape or park it if it cuts across what you have
planned for `cast.ts`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

The character picker, rendered from the real `OFFICE_CAST` and the real
`SpritePortrait`. Same view, same window size, same theme.

### Before

The fifteen built-in characters, on `main`.

![Character picker on main — 15 selectable](https://raw.githubusercontent.com/vicenteliu/munder-difflin-scrappy/pr-evidence/cast-registry/before-15-builtin-cast.png)

### After

The same fifteen, unchanged and in the same order, plus one added through
`registerCastMember` — "Holly" here, registered from a scratch file that is
**not** part of this diff, purely to show the entry point working.

![Character picker with the registry — 16 selectable, Holly added](https://raw.githubusercontent.com/vicenteliu/munder-difflin-scrappy/pr-evidence/cast-registry/after-16-registered-cast.png)

## How I tested it

- OS: macOS 15 (Apple Silicon)
- Steps:
  1. `npm run typecheck` — passes (node + web).
  2. `npm run test:focused` — 745 tests, 745 pass, 0 fail.
  3. `npm run build` — succeeds.
  4. Ran the renderer and opened the character picker on `main` and on this
     branch: the fifteen built-ins render identically. Registered one extra
     character from a scratch file and confirmed it appears in the picker with
     its portrait drawn from the recipe it was registered with (the two shots
     above).

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts. (No new UI: this changes types and two literals.)
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`. (No new art.)
