### PR TITLE
fix(hive): stop git's auto-gc from outliving the commit that triggered it

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -2493,8 +2493,26 @@ export class HiveManager {
   }
 
   // — git (single committer, retry + stale-lock recovery) —
+  //
+  // `gc.autoDetach=false` is what makes this call actually synchronous.
+  //
+  // A commit runs `gc --auto`, and git detaches that into a BACKGROUND process
+  // by default. `spawnSync` returns when `git commit` exits, so the caller
+  // believes the hive is quiescent while a gc it cannot see is still writing
+  // into `.git/objects/`. Anything that touches the hive directory right after
+  // a commit races that process: removing a hive home throws ENOTEMPTY, and a
+  // read can catch a half-written pack.
+  //
+  // It reproduces on its own — create a HiveManager on a fresh temp home, call
+  // ensureAgent, then remove the home: ~3.5% of iterations throw ENOTEMPTY,
+  // and the leftover is always `.git/objects/`, sometimes still holding a
+  // `bitmap-ref-tips_*` temp file that vanishes a fraction of a second later.
+  // With this flag, gc runs inline and 200 iterations pass clean.
+  //
+  // The gc still happens — this only stops it from outliving the command that
+  // triggered it, which is what "single committer" was supposed to mean.
   private git(args: string[], cwd: string): { ok: boolean; out: string; err: string } {
-    const res = spawnSync('git', ['-c', 'commit.gpgsign=false', '-c', 'user.name=Hive', '-c', 'user.email=hive@local', ...args], {
+    const res = spawnSync('git', ['-c', 'commit.gpgsign=false', '-c', 'gc.autoDetach=false', '-c', 'user.name=Hive', '-c', 'user.email=hive@local', ...args], {
       cwd, encoding: 'utf8', timeout: 8000
     });
     return { ok: res.status === 0, out: res.stdout ?? '', err: res.stderr ?? '' };


### PR DESCRIPTION
## What & why

`HiveManager.git()` runs git through `spawnSync`, so every caller is written
as if the hive is quiescent the moment the call returns. It isn't. A commit runs
`gc --auto`, and git detaches that into a background process by default
(`gc.autoDetach` is true unless you say otherwise), so the gc goes on writing
into `.git/objects/` after `git commit` has exited and `spawnSync` has
returned.

Anything that touches the hive directory right after a commit races that
invisible process. Removing a hive home throws `ENOTEMPTY`; a read can catch a
half-written pack.

Passing `-c gc.autoDetach=false` makes the gc run inline, so `spawnSync`
returns only once every write is done. The gc still happens — it just no longer
outlives the command that triggered it, which is what "single committer" was
supposed to mean.

**How I found it.** `test/` is where it shows up: several suites build a hive
on a temp home and remove it in an `after` hook, and those fail intermittently
with `ENOTEMPTY` / `EEXIST`. Three steps narrowed it down:

1. Ruled out `fs.rmSync` itself — plain `mkdtemp` + recursive `rmSync`
   under I/O load, 3000 iterations, zero failures.
2. Reproduced without the test runner — `new HiveManager` → `ensureAgent` →
   `rmSync`, nothing else, no concurrency between files. Fails ~2.5-3.5% of
   iterations.
3. Listed the leftovers at the moment of the throw — always `.git/objects/`,
   once still holding a `bitmap-ref-tips_*` temp file that vanished a fraction
   of a second later. That named it.

Worth noting this is invisible to CI today: `ci.yml` runs typecheck and build,
not `test:focused`, so nothing has been exercising this path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

The repro, run 200 times on each side. Same machine, same script, same
iteration count — the only difference is the flag.

```js
// repro.cjs — build a hive on a fresh temp home, then remove that home.
const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hive-repro-'));
const hive = new HiveManager(() => home);
await hive.ensureAgent({ id: 'god-1', name: 'Michael', provider: 'claude', cwd: home, isGod: true },
                       { semanticMemory: true, knowledgeGraph: true });
fs.rmSync(home, { recursive: true, force: true });   // <- throws ENOTEMPTY
```

### Before

On `main`: 5 of 200 removals throw `ENOTEMPTY`.

![200 removals on main — 195 clean, 5 ENOTEMPTY](https://raw.githubusercontent.com/vicenteliu/munder-difflin-scrappy/pr-evidence/hive-gc-autodetach/before-enotempty-on-main.png)

### After

With `gc.autoDetach=false`: 200 of 200 clean.

![200 removals with the fix — 200 clean, 0 ENOTEMPTY](https://raw.githubusercontent.com/vicenteliu/munder-difflin-scrappy/pr-evidence/hive-gc-autodetach/after-clean-with-fix.png)

## How I tested it

- OS: macOS 15 (Apple Silicon)
- Steps:
  1. The repro above, 200 iterations on `main` and 200 on this branch — the
     two screenshots.
  2. `npm run typecheck` — passes (node + web).
  3. `npm run test:focused` — 745 tests, 745 pass, 0 fail.
  4. `npm run build` — succeeds.

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts. (No UI change.)
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`. (No new art.)
