### PR TITLE
fix(codex): recommended orchestrator model is not a codex CLI id

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -543,6 +543,24 @@ let triggersMigrationRan = false;
  * Wrapped end-to-end in a try/catch: a config that is corrupt in some unrelated
  * way must still boot the app, and a migration is never worth a failed launch.
  */
+/** Repair a stored `godModel` that the codex CLI cannot accept.
+ *
+ *  `gpt-5-codex` is a real OpenAI *API* model id, so it looked right, but it is
+ *  not in the codex CLI's model catalog and the CLI answers `404 Model not
+ *  found`. Onboarding and the Command Center both persisted it into `godModel`
+ *  when Codex was chosen, and `godModel` wins over the preset everywhere it is
+ *  read — so correcting the preset alone leaves every existing install spawning
+ *  an orchestrator that never answers.
+ *
+ *  No latch: the value never worked, so a stored one is always a bug and never a
+ *  preference, and the repair is idempotent. SET rather than delete — `readConfig`
+ *  merges DEFAULTS, whose `godModel` is a Claude id, which would quietly hand a
+ *  Claude model to a codex spawn. */
+function repairUnusableGodModel(cfg: HarnessConfig): HarnessConfig {
+  if (cfg.godModel !== 'gpt-5-codex') return cfg;
+  return { ...cfg, godModel: providerPreset('codex').recommendedOrchestratorModel };
+}
+
 function migrateTriggersV1(cfg: HarnessConfig): HarnessConfig {
   if (cfg.triggersMigratedV1 || triggersMigrationRan) return cfg;
   triggersMigrationRan = true;
@@ -592,7 +610,9 @@ export function readConfig(): HarnessConfig {
   try {
     const raw = readFileSync(p, 'utf8');
     const parsed = JSON.parse(raw);
-    return normalizeStoredHomes(migrateTriggersV1(withTriggerDefaults({ ...DEFAULTS, ...parsed })));
+    return repairUnusableGodModel(
+      normalizeStoredHomes(migrateTriggersV1(withTriggerDefaults({ ...DEFAULTS, ...parsed })))
+    );
   } catch {
     return withTriggerDefaults({ ...DEFAULTS });
   }

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -103,7 +103,7 @@ Return EXACTLY this shape (omit optional fields you don't need; keep the spec st
 }
 
 Rules:
-- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5.6-sol, "Gemini 3.1 Pro (High)").
+- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. cursor: gpt-5.6-luna-high, claude: claude-opus-4-8[1m], codex: gpt-5.6-sol, antigravity: "Gemini 3.1 Pro (High)").
 - Do NOT include shell commands or any flags beyond these fields.
 - Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
 

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -103,7 +103,7 @@ Return EXACTLY this shape (omit optional fields you don't need; keep the spec st
 }
 
 Rules:
-- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
+- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5.6-sol, "Gemini 3.1 Pro (High)").
 - Do NOT include shell commands or any flags beyond these fields.
 - Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
 

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -232,9 +232,13 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     canReceiveInbox: true,
     initialPromptFlag: undefined,
     positionalInitialPrompt: true,
-    // Codex's long-context coding model for the orchestrator role. // TODO-verify
-    // the exact codex CLI model id (couldn't install the codex CLI to confirm).
-    recommendedOrchestratorModel: 'gpt-5-codex',
+    // `gpt-5-codex` is a real OpenAI *API* model id, which is why it looked right,
+    // but it is absent from the codex CLI's own catalog: `codex debug models
+    // --bundled` on 0.149.1 lists 8 models and none of them is it, and a run with
+    // it returns `404 Not Found: Model not found gpt-5-codex`. `gpt-5.6-sol` is the
+    // priority-1, list-visible entry in that same bundled catalog.
+    // The catalog refreshes from the server, so re-verify this on a CLI bump.
+    recommendedOrchestratorModel: 'gpt-5.6-sol',
     // Codex resumes via a SUBCOMMAND, not a flag: `codex resume [OPTIONS]
     // [SESSION_ID]`. A `--resume <id>` flag does not exist, which is why restarts
     // used to silently start a brand-new session instead of continuing.

--- a/test/agent-provider.test.cjs
+++ b/test/agent-provider.test.cjs
@@ -93,6 +93,18 @@ test('codex preset still resolves (no regression)', () => {
   assert.strictEqual(ap.providerPreset('codex').defaultCommand, 'codex');
 });
 
+// `gpt-5-codex` is a real OpenAI *API* model id, which is why it looked right, but
+// the codex CLI rejects it with `404 Model not found`. It reached users through the
+// UI: onboarding and the Command Center both persist this preset value into
+// `config.godModel`, which then wins everywhere the spawn model is read. (The
+// `?? recommendedOrchestratorModel` arm in modelForRole is not the carrier — DEFAULTS
+// always supplies a godModel, so that arm never runs.) Pin the CLI-accepted id.
+test('codex orchestrator model is a codex-CLI id, not an API-only one', () => {
+  const model = ap.providerPreset('codex').recommendedOrchestratorModel;
+  assert.notStrictEqual(model, 'gpt-5-codex');
+  assert.strictEqual(model, 'gpt-5.6-sol');
+});
+
 if (failures > 0) {
   console.log(`\n${failures} test(s) failed`);
   process.exit(1);

--- a/test/god-model-repair.test.cjs
+++ b/test/god-model-repair.test.cjs
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * A stored `godModel` of `gpt-5-codex` must not survive a read.
+ *
+ * The id is a real OpenAI *API* model but is absent from the codex CLI's catalog,
+ * so the CLI answers `404 Model not found`. Onboarding and the Command Center
+ * persisted it into `godModel` when Codex was picked, and `godModel` wins over the
+ * provider preset wherever the spawn model is read — so correcting the preset alone
+ * would leave every existing install spawning an orchestrator that never answers.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+// config.ts resolves its file through Electron's app.getPath(); point that one
+// dependency at a throwaway root so this never touches the real config.
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'md-god-model-repair-'));
+const electron = require.resolve('electron');
+require.cache[electron] = {
+  id: electron, filename: electron, loaded: true,
+  exports: { app: { getPath: () => userData } }
+};
+
+const { writeConfig, readConfig } = loadTs('src/main/config.ts');
+const { providerPreset } = loadTs('src/shared/agentProvider.ts');
+
+test.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+
+// Settle the one-shot trigger migration first, as a real app start would.
+writeConfig({});
+readConfig();
+
+test('a stored gpt-5-codex godModel is repaired on read', () => {
+  writeConfig({ godProvider: 'codex', godModel: 'gpt-5-codex' });
+  assert.equal(readConfig().godModel, providerPreset('codex').recommendedOrchestratorModel);
+});
+
+test('the repair SETS the id — a codex god must never inherit the Claude default', () => {
+  // Deleting the key instead would let readConfig's DEFAULTS merge supply
+  // `claude-opus-4-8`, quietly handing a Claude model to a codex spawn.
+  writeConfig({ godProvider: 'codex', godModel: 'gpt-5-codex' });
+  const model = readConfig().godModel;
+  assert.notEqual(model, 'claude-opus-4-8');
+  assert.match(model, /^gpt-/);
+});
+
+test('any other stored godModel is left untouched', () => {
+  for (const keep of ['claude-opus-4-8', 'gpt-5.6-terra', 'some-future-id']) {
+    writeConfig({ godModel: keep });
+    assert.equal(readConfig().godModel, keep, `${keep} should not be rewritten`);
+  }
+});


### PR DESCRIPTION
## What & why

The codex preset recommends `gpt-5-codex` as the orchestrator model. That is a real OpenAI **API** model id, which is why it looked right, but it is absent from the codex CLI's own catalog and the CLI rejects it — so a Codex orchestrator 404s on every turn while the floor shows it ready. The preset carried a `// TODO-verify` saying the codex CLI could not be installed to confirm the id; this discharges it.

It reached users as a **stored** value, not through the preset fallback. `OnboardingWizard` and `CommandCenterPanel` both persist the recommendation into `config.godModel`, and `godModel` wins wherever the spawn model is read (`useHive` builds the command straight from it). Correcting the preset alone would leave every existing install broken, so `readConfig` also repairs a stored `gpt-5-codex`. It **sets** rather than deletes: `readConfig` merges `DEFAULTS`, whose `godModel` is a Claude id, so deleting the key would quietly hand a Claude model to a codex spawn.

`AddAgentModal`'s hire prompt also offered the broken id to the model as an example of "a real model id for that provider".

Refs #104 — the "fix a bug in an existing integration" half.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

![Before](https://raw.githubusercontent.com/ketan0095/munder-difflin/pr-evidence/codex-before.png)

_Rendered from the real terminal session; the same output is pasted below so it is searchable._

The pinned id, against the real CLI (`codex-cli 0.149.1`):

```console
$ codex exec -m gpt-5-codex "reply with the single word OK"
ERROR: unexpected status 404 Not Found: Model not found gpt-5-codex,
       url: https://api.openai.com/v1/responses, cf-ray: a3432d2ecb03d70f-BNE
```

And it is not in the catalog compiled into the binary, which is identical for every install:

```console
$ codex debug models --bundled | jq -r '.models[].slug'
gpt-5.6-sol
gpt-5.6-terra
gpt-5.6-luna
gpt-5.5
gpt-5.4
gpt-5.4-mini
gpt-5.2
codex-auto-review
```

The new tests, run against the unfixed code — the suite is red:

```console
$ node --test test/god-model-repair.test.cjs
✖ a stored gpt-5-codex godModel is repaired on read
  exit=1  pass 2  fail 1
```

### After

![After](https://raw.githubusercontent.com/ketan0095/munder-difflin/pr-evidence/codex-after.png)

_Rendered from the real terminal session; the same output is pasted below so it is searchable._

The replacement, same command, same machine:

```console
$ codex exec -m gpt-5.6-sol "reply with the single word OK"
OK
```

`gpt-5.6-sol` is the `priority: 1`, `visibility: "list"`, `supported_in_api: true` entry in that same bundled catalog. The catalog refreshes from the server, so the comment records that it needs re-verifying on a CLI bump.

Suite green:

```console
$ npm run typecheck   # exit 0
$ npm run test:focused
ℹ tests 748
ℹ pass 748
ℹ fail 0
```

## How I tested it

- OS: macOS (Darwin 25.5.0), Apple Silicon; `codex-cli 0.149.1`
- Steps:
  - Ran the failing and passing model ids through `codex exec` as above, with the working id as a control so the probe itself is proven able to succeed.
  - Confirmed the id is absent from `codex debug models --bundled` (8 models).
  - `npm run typecheck` — clean, node + web.
  - `npm run test:focused` — 748 pass, 0 fail.
  - Mutation-tested the new repair one guard at a time: unwiring it from `readConfig` (the shipped bug) fails, deleting the key instead of setting it fails, and widening it to rewrite every model fails. Restored source is green.

Note: my `~/.codex/auth.json` holds an `OPENAI_API_KEY`, so the 404 above is the API-key path. The bundled-catalog check is auth-independent and covers both.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
