### PR TITLE
fix(slack): Stop now persists slackEnabled:false so boot does not re-arm

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3988,7 +3988,24 @@ ipcMain.handle('app:setLoginItem', (_evt, enabled: unknown) => {
 
 // ─── IPC: Slack integration ─────────────────────────────────────────────────
 ipcMain.handle('slack:start', () => startSlackServer());
-ipcMain.handle('slack:stop', () => { stopSlackServer(); return { ok: true }; });
+/** Stop must survive a restart. Boot re-arms from `slackEnabled`, so stopping
+ *  without clearing it silently brought the server back on the next launch —
+ *  the user pressed Stop and Slack was live again.
+ *
+ *  Persist BEFORE tearing down. If the write throws (read-only volume, ENOSPC)
+ *  the server is still up and the UI stays truthful; the other order leaves a
+ *  dead server that still reads as Connected with the flag set, which is this
+ *  same bug again with no error to show for it.
+ *
+ *  Only this handler clears the flag. changeHome / quit / reset call
+ *  `stopSlackServer()` directly and must not: they are lifecycle, not a user
+ *  turning the integration off. (Start persists the flag from the renderer, in
+ *  `SettingsModal.startSlack`, not here.) */
+ipcMain.handle('slack:stop', () => {
+  writeConfig({ slackEnabled: false });
+  stopSlackServer();
+  return { ok: true };
+});
 /** Current connection state + last Request URL — lets Settings hydrate the
  *  "Connected" badge and re-show the persisted tunnel URL on reopen. */
 ipcMain.handle('slack:status', () => ({ running: slackServer != null, url: lastSlackUrl }));

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -634,7 +634,9 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
   const stopSlack = async () => {
     setSlackBusy(true); setSlackNote('');
     // Keep the last Request URL visible (greyed) after Stop.
-    try { await window.cth.slackStop(); setRunning(false); setSlackNote('stopped'); }
+    // Mirror startSlack: main persists slackEnabled:false, this keeps the pill
+    // honest without waiting for a Settings reopen.
+    try { await window.cth.slackStop(); setRunning(false); setSlackEnabled(false); setSlackNote('stopped'); }
     catch (e) { setSlackNote(e instanceof Error ? e.message : String(e)); }
     finally { setSlackBusy(false); }
   };

--- a/test/slack-stop-persist.test.cjs
+++ b/test/slack-stop-persist.test.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Slack Stop is a user decision and must survive a restart.
+ *
+ * Boot re-arms the server from `slackEnabled` (src/main/index.ts, the
+ * `slackCfg.slackEnabled && slackCfg.slackSigningSecret` gate), so a Stop that
+ * only tears down the running server leaves the flag true and Slack silently
+ * comes back on the next launch.
+ *
+ * `index.ts` imports electron, so it cannot be require()d here — this reads it as
+ * source, the same approach test/update-applied.test.cjs uses for updater.ts.
+ * The scan is deliberately TWO-SIDED: the user-facing handler must clear the
+ * flag, and the lifecycle teardowns (changeHome / quit / reset) must not. Pinning
+ * only the first half would let a "fix" that clears the flag on quit pass.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.log(`  ✗ ${name}\n     ${err.message}`);
+  }
+}
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'src/main/index.ts'), 'utf8');
+
+/** The body of the `slack:stop` IPC handler, from the handle() call to the
+ *  matching `});` that closes it. */
+function slackStopHandler() {
+  const start = src.indexOf("ipcMain.handle('slack:stop'");
+  assert.notStrictEqual(start, -1, "no slack:stop handler found in src/main/index.ts");
+  const end = src.indexOf('\n});', start);
+  assert.notStrictEqual(end, -1, "could not find the end of the slack:stop handler");
+  return src.slice(start, end);
+}
+
+test('slack:stop persists slackEnabled:false, so boot does not re-arm', () => {
+  const body = slackStopHandler();
+  assert.ok(
+    /writeConfig\(\{[^}]*slackEnabled:\s*false|disableSlack\(\)/.test(body),
+    'slack:stop tears the server down but never clears slackEnabled — the next ' +
+    'launch will re-arm it and Slack comes back after the user pressed Stop'
+  );
+});
+
+test('slack:stop still actually stops the running server', () => {
+  assert.ok(/stopSlackServer\(\)/.test(slackStopHandler()), 'slack:stop no longer stops the server');
+});
+
+test('the lifecycle teardowns do not clear the flag', () => {
+  // changeHome / quit / reset call stopSlackServer() directly. They are lifecycle,
+  // not the user disabling the integration, so an enabled Slack must still be
+  // enabled after a restart — the issue calls this out explicitly.
+  //
+  // Assert against the teardown lines themselves, not a count across the file: a
+  // file-wide count both fails a legitimate second clear elsewhere (e.g. clearing
+  // the flag when the signing secret is emptied) and passes a teardown that
+  // disables via a helper, which is the regression this is here to catch.
+  for (const tag of ['changeHome', 'quit', 'reset']) {
+    const re = new RegExp(`^.*console\\.error\\('\\[${tag}\\] slack\\.stop:.*$`, 'm');
+    const line = src.match(re);
+    assert.ok(line, `could not find the ${tag} slack teardown line — has it been renamed?`);
+    assert.ok(
+      !/writeConfig|slackEnabled|disableSlack/.test(line[0]),
+      `the ${tag} teardown now writes config — lifecycle must not disable Slack behind the user`
+    );
+  }
+});
+
+if (failures > 0) {
+  console.log(`\n${failures} test(s) failed`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What & why

Closes #395.

Stop tore down the running Slack server but never persisted `slackEnabled: false`. Boot re-arms from `slackEnabled && slackSigningSecret`, so quitting after an explicit Stop brought Slack straight back on the next launch — and the Settings pill kept reading ON with the token/secret fields open until the modal was closed and reopened.

Start already persists the flag (from the renderer, in `startSlack`), so this is the missing half of that pair; the two functions now read as inverses.

Two notes on the implementation:

**It persists *before* tearing down**, which is the one deviation from the fix suggested in the issue. If the write throws — read-only volume, ENOSPC — the server is still up and the UI stays truthful. Stopping first and then failing the write leaves a dead server that still reads as Connected with the flag set, which is this same bug again with nothing to show for it.

**Only the user-initiated handler clears the flag.** `changeHome`, `quit` and `reset` call `stopSlackServer()` directly and deliberately do not, exactly as the issue calls out — they are lifecycle, not a user turning the integration off.

One consequence worth naming: because `slackEnabled` also gates the config panel, Stop now collapses it, which is what the issue asks for (steps 3 and 5 list the fields staying visible as a symptom). The side effect is that the greyed "last Request URL" block, which was written for a stopped-but-still-enabled state, is no longer reachable after a Stop. Happy to restore it behind a widened condition if you'd rather keep it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

`index.ts` imports electron and cannot be `require()`d, so the guard is a source-scan test in the style `test/update-applied.test.cjs` already uses for `updater.ts`. Evidence is the suite going red on the bug and green on the fix.

### Before

![Before](https://raw.githubusercontent.com/ketan0095/munder-difflin/pr-evidence/slack-before.png)

_Rendered from the real test run; the same output is pasted below so it is searchable._

The unfixed handler (`stopSlackServer()` only, no write), against the new test:

```console
$ node --test test/slack-stop-persist.test.cjs
  ✗ slack:stop persists slackEnabled:false, so boot does not re-arm
     slack:stop tears the server down but never clears slackEnabled — the next
     launch will re-arm it and Slack comes back after the user pressed Stop
exit=1
```

### After

![After](https://raw.githubusercontent.com/ketan0095/munder-difflin/pr-evidence/slack-after.png)

_Rendered from the real test run; the same output is pasted below so it is searchable._

```console
$ node --test test/slack-stop-persist.test.cjs
  ✓ slack:stop persists slackEnabled:false, so boot does not re-arm
  ✓ slack:stop still actually stops the running server
  ✓ the lifecycle teardowns do not clear the flag
exit=0

$ npm run typecheck   # exit 0
$ npm run test:focused
ℹ tests 746
ℹ pass 746
ℹ fail 0
```

## How I tested it

- OS: macOS (Darwin 25.5.0), Apple Silicon
- Steps:
  - `npm run typecheck` — clean, node + web.
  - `npm run test:focused` — 746 pass, 0 fail.
  - Mutation-tested the guards one at a time, including the cases a naive version of this test gets wrong:
    - restoring the original bug → red on the persistence guard;
    - a teardown that disables Slack via a helper (`disableSlack()` called from `quit`) → red on the lifecycle guard;
    - a behaviour-identical helper extraction with no bug → **green**;
    - a legitimate second `slackEnabled: false` elsewhere (clearing the flag when the signing secret is emptied) → **green**.
  - The last two are why the lifecycle guard anchors on the three teardown lines instead of counting occurrences across the file: a file-wide count fails honest changes and passes the helper-based regression it exists to catch.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
