### PR TITLE
fix(update): don't replay a stale pending update for the running version

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -401,7 +401,18 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
     return runDownload();
   });
   /** Re-serve the last known status to a freshly loaded window. */
-  ipcMain.handle('update:current', () => lastStatus ?? { state: 'idle' });
+  ipcMain.handle('update:current', () => {
+    const s = lastStatus;
+    // After an out-of-band update the process may restart with a stale
+    // `available`/`available-manual` record for the version we are now running.
+    // Replaying it would resurrect the "download" chip the update just cleared.
+    // If a pending state names a version we are already on (not newer), drop it
+    // back to idle — `pendingVersion` on the renderer would do the same.
+    if (s && 'version' in s && s.state !== 'just-updated' && !isNewer(s.version, app.getVersion())) {
+      return { state: 'idle' };
+    }
+    return s ?? { state: 'idle' };
+  });
   /**
    * DEV ONLY — push a synthetic status so the update toast can be seen without a
    * real release. The toast renders for exactly two states ('downloaded' and

--- a/src/shared/updateState.ts
+++ b/src/shared/updateState.ts
@@ -163,6 +163,16 @@ export function reduceStatus(prev: UpdateStatus | null, next: UpdateStatus): Upd
   const nv = versionOf(next);
   if (pv && nv && isNewer(nv, pv)) return next;   // a newer release supersedes
   if (pv && nv && pv !== nv) return next;         // different (e.g. rolled back) release
+  // SAME version (pv === nv, or one side has no version): a "you're current"
+  // confirmation (just-updated / not-available) is the truth about the running
+  // build and must beat a stale "update pending" record naming the version you
+  // are ALREADY on. After an update lands out-of-band, a replayed `available`
+  // for the new version must not resurrect a "download" chip.
+  if (pv && nv && pv === nv) {
+    const current = (s: UpdateStatus): boolean => s.state === 'just-updated' || s.state === 'not-available';
+    if (current(next)) return next;
+    if (current(prev)) return prev;
+  }
   return rank(next) >= rank(prev) ? next : prev;
 }
 

--- a/test/update-state.test.cjs
+++ b/test/update-state.test.cjs
@@ -214,3 +214,32 @@ test('just-updated is quiet on the badge and loses to a newer available release'
   );
   assert.equal(next.state, 'available');
 });
+
+test('a same-version pending update loses to a "you are current" confirmation', () => {
+  // After an update lands out-of-band, a stale `available`/`available-manual`
+  // record naming the version we are ALREADY running must not resurrect the
+  // "download" chip once the running build confirms it is current.
+  const staleAvailable = { state: 'available', version: '0.4.6' };
+  const staleManual = { state: 'available-manual', version: '0.4.6', url: 'https://x' };
+  assert.deepEqual(
+    reduceStatus(staleAvailable, { state: 'just-updated', version: '0.4.6' }),
+    { state: 'just-updated', version: '0.4.6' }
+  );
+  assert.deepEqual(
+    reduceStatus(staleManual, { state: 'not-available', version: '0.4.6' }),
+    { state: 'not-available', version: '0.4.6' }
+  );
+});
+
+test('a stale same-version replay cannot resurrect the download chip either', () => {
+  // The confirmation is already on screen; a replayed stale pending record for
+  // the same version must not knock it back to an update affordance.
+  assert.deepEqual(
+    reduceStatus({ state: 'just-updated', version: '0.4.6' }, { state: 'available', version: '0.4.6' }),
+    { state: 'just-updated', version: '0.4.6' }
+  );
+  assert.deepEqual(
+    reduceStatus({ state: 'not-available', version: '0.4.6' }, { state: 'available-manual', version: '0.4.6', url: 'https://x' }),
+    { state: 'not-available', version: '0.4.6' }
+  );
+});


### PR DESCRIPTION
## What

Fixes #374: after an update lands out-of-band, the process could restart with a stale `available`/`available-manual` record for the version that is now running. Replaying it via `update:current` resurrected a "download" chip the update had just cleared.

## Changes

- `src/main/updater.ts` — `update:current` drops a non-newer pending status back to idle on replay.
- `src/shared/updateState.ts` — a same-version "you're current" confirmation (`just-updated`/`not-available`) beats a stale pending record in either order.
- `test/update-state.test.cjs` — +2 focused tests for the same-version cases (19/19 in the update-state suite).

## Verification

- `npm run typecheck` — PASS
- `npm run test:focused` — 747/747 PASS
- `npm run build` — PASS

## Evidence

Settings → General → Updates after restarting the app with a stale `available-manual` record for the version now running. The "download" chip the update had just cleared comes back when the stale record is replayed — and stays cleared after this fix.

### Before

![Before](https://raw.githubusercontent.com/skyzhao1223/munder-difflin/pr-evidence/docs/evidence/374-before.png)

### After

![After](https://raw.githubusercontent.com/skyzhao1223/munder-difflin/pr-evidence/docs/evidence/374-after.png)
