### PR TITLE
fix(queue): surface a terminal draft hold while the agent is busy

### DIFF
--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -163,7 +163,10 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   // Delivery can be held back by the agent's own terminal (a half-typed draft or
   // an open slash-command picker owns the prompt). That used to be invisible —
   // the hint claimed it was sending while nothing moved — so poll it and say so.
-  const block = useTerminalBlock(agent.ptyId, queue.length > 0 && idle);
+  // Poll whenever something is queued, busy or not: a busy agent is exactly when
+  // a user might have half-typed in the terminal above, and it is when the queue
+  // is in use — so the hold must be reported then, not only once the agent idles.
+  const block = useTerminalBlock(agent.ptyId, queue.length > 0);
 
   // Floor-wide auto-delivery pause (Command Center switch) also holds the queue.
   // Without saying so — and without the per-row "send now" override — messages
@@ -172,16 +175,16 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
 
   const statusHint = queue.length === 0
     ? null
-    : !idle
-    ? t('queueComposer.busyQueued', { name: agent.name, count: queue.length })
-    : deliveryPaused && !queue[0]?.manual
-    ? t('queueComposer.heldFloor')
     : block === 'draft'
     ? t('queueComposer.heldDraft', { name: agent.name })
     : block === 'picker'
     ? t('queueComposer.heldPicker', { name: agent.name })
     : block === 'exited'
     ? t('queueComposer.heldExited', { name: agent.name })
+    : !idle
+    ? t('queueComposer.busyQueued', { name: agent.name, count: queue.length })
+    : deliveryPaused && !queue[0]?.manual
+    ? t('queueComposer.heldFloor')
     : t('queueComposer.sendingOneByOne', { name: agent.name });
 
   return (


### PR DESCRIPTION
## What

Fixes #379: a half-typed draft left in an agent's terminal pane silently holds every message queued in the composer below, but the 'held' hint only appeared once the agent went idle — so while it was busy, queued messages looked stuck with no explanation.

## Changes (one file: src/renderer/src/components/MessageQueueComposer.tsx, +8/-5)

- Dropped `&& idle` from the terminal-block gate: the terminal-automation block is now polled whenever anything is queued, busy or not.
- Reordered `statusHint` so the block branches (draft/picker/exited) outrank the `!idle` 'busy' branch — the 'held — <name>'s terminal has unsent text' hint + recover/close button now appear while the agent is still busy.
- Deliberately left out the issue's optional items (link-label copy, expiry-fusion, blur-vs-abandon) to keep the PR minimal. Existing translation keys reused.

## Verification

- `npm run typecheck` — PASS
- `npm run test:focused` — 745/745 PASS
- `npm run build` — PASS

## Evidence

An agent that is busy with a half-typed draft in its terminal, with a message queued in the composer. Before the fix the composer claims it is just busy and offers no escape; after the fix it names the actual hold and offers the recover button.

### Before

![Before](https://raw.githubusercontent.com/skyzhao1223/munder-difflin/pr-evidence/docs/evidence/379-before.png)

### After

![After](https://raw.githubusercontent.com/skyzhao1223/munder-difflin/pr-evidence/docs/evidence/379-after.png)
