### PR TITLE
fix(worker-wake): edge-trigger inbox nudge on new mail instead of a flat 60s repeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ docs/blog-preview-*/
 # Finder duplicate files, e.g. "spec 2.js", "sitemap 2.xml"
 *\ 2.*
 *\ [0-9].*
+
+# work-results module — renderer bundle copy is self-healed by server.js
+work-results/public/app/assets/
+# scratch entry stub at repo root (real entry is work-results/public/app/index.html)
+/index.html

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5050,12 +5050,14 @@ function runWorkerWakeBeat(): void {
     const ptyId = ptyForAgent(agentId);
     if (!ptyId) continue;
     const snap = control.snapshot(agentId);
+    const inbox = hive.inbox(agentId);
     facts.push({
       agentId,
       isGod: agentId === reg.godId,
       ptyId,
       lastOutputAt: ptyManager.lastOutputAt(ptyId) ?? 0,
-      inboxCount: hive.inbox(agentId).length,
+      inboxCount: inbox.length,
+      inboxIds: inbox.map((m) => m.id).filter(Boolean),
       autoDeliveryPaused: snap.autoDeliveryPaused,
       paused: snap.paused,
       halted: snap.halted

--- a/src/main/workerWake.ts
+++ b/src/main/workerWake.ts
@@ -9,11 +9,11 @@
  * because the main process re-engages it on its own heartbeat cadence.
  *
  * This watchdog is the worker-side counterpart: on a cadence it finds live
- * workers that are genuinely idle, have undrained inbox mail, are not paused /
- * not awaiting a human decision, and have not been nudged recently — then types
- * the same guarded nudge the renderer would have, directly into the PTY.
+ *  workers that are genuinely idle, have undrained inbox mail, are not paused /
+ *  not awaiting a human decision, and have not been nudged recently — then types
+ *  the same guarded nudge the renderer would have, directly into the PTY.
  *
- * Safety mirrors the renderer's guarded queue-drain (useHive.ts dispatch):
+ *  Safety mirrors the renderer's guarded queue-drain (useHive.ts dispatch):
  *  - only a GENUINELY idle worker is nudged (no PTY output for IDLE_MS — the
  *    same quiescence the renderer's idle fallback uses), never a mid-turn one,
  *  - never inside the boot sequence (BOOT_GRACE_MS from spawn, mirroring the
@@ -23,6 +23,13 @@
  *    prompt the human is deciding on is never typed into,
  *  - a per-worker cooldown (NUDGE_COOLDOWN_MS) so the watchdog and the renderer
  *    nudge don't stack on top of each other.
+ *
+ *  (#358) The nudge is EDGE-triggered, not level-triggered: each worker remembers
+ *  the inbox message ids it has already announced, and is only woken again when a
+ *  NEW id appears in its inbox. Mail that was already announced is NOT re-nudged
+ *  at a flat cadence forever — a worker that stays parked on already-announced
+ *  mail (the genuinely-stuck #151 case) is re-woken on a backoff ladder
+ *  (60s → 5m → 30m, then 30m) instead.
  *
  * Deliberately the renderer's own nudge text, and the same type pattern the
  * renderer's submitToPty uses (text first, Enter as a separate keystroke).
@@ -42,6 +49,10 @@ export const WORKER_WAKE_BOOT_GRACE_MS = 35_000;
 export const WORKER_WAKE_COOLDOWN_MS = 60_000;
 /** A permission/HITL notification blocks nudges for this long after it fires. */
 export const WORKER_WAKE_HITL_REARM_MS = 5 * 60_000;
+/** Backoff ladder for re-nudging a worker parked on ALREADY-announced mail
+ *  (#358): a stuck worker is still woken, but at 60s → 5m → 30m → 30m instead
+ *  of a flat minute forever. New mail resets the ladder. */
+export const WORKER_WAKE_REPEAT_MS = [WORKER_WAKE_COOLDOWN_MS, 5 * 60_000, 30 * 60_000];
 
 /** A hook event message that means "the agent needs the human" — permission /
  *  approve / confirm prompts (mirrors the renderer's needsHuman detection in
@@ -77,6 +88,10 @@ export interface WorkerWakeFacts {
   lastOutputAt: number;
   /** Count of undrained inbox messages (0 → nothing to wake for). */
   inboxCount: number;
+  /** The ids of the undrained inbox messages, so the watchdog can edge-trigger
+   *  on NEW mail instead of re-announcing already-announced ids (#358). Optional
+   *  for backward compat — when absent the nudge stays level-triggered. */
+  inboxIds?: string[];
   /** ControlRegistry snapshot flags. */
   autoDeliveryPaused: boolean;
   paused: boolean;
@@ -90,6 +105,13 @@ export class WorkerWakeWatchdog {
   private lastNudgeAt = new Map<string, number>();
   /** agentId → timestamp of the last needsHuman hook notification. */
   private lastHumanNeedsAt = new Map<string, number>();
+  /** agentId → the inbox message ids the watchdog has already announced, so a
+   *  nudge is edge-triggered on NEW mail rather than re-announced at a flat
+   *  cadence forever (#358). */
+  private announcedIds = new Map<string, Set<string>>();
+  /** agentId → how many consecutive re-nudges have fired on already-announced
+   *  mail, advancing the WORKER_WAKE_REPEAT_MS backoff ladder (#358). */
+  private repeatCounts = new Map<string, number>();
 
   /** Record a PTY spawn so its boot sequence is left alone. */
   noteSpawn(ptyId: string, at = Date.now()): void {
@@ -106,11 +128,17 @@ export class WorkerWakeWatchdog {
   forget(agentId: string, ptyId?: string): void {
     this.lastNudgeAt.delete(agentId);
     this.lastHumanNeedsAt.delete(agentId);
+    this.announcedIds.delete(agentId);
+    this.repeatCounts.delete(agentId);
     if (ptyId) this.spawnedAt.delete(ptyId);
   }
 
   /** The worker ids that should be nudged right now, in stable registry order.
-   *  Pure decision — the caller types the nudge. */
+   *  Pure decision — the caller types the nudge.
+   *
+   *  (#358) Edge-triggered: a worker is only nudged for inbox mail it has not
+   *  already been told about. Mail it HAS been told about is only re-nudged when
+   *  it is still parked on it (the stuck-worker case), on the backoff ladder. */
   decide(facts: readonly WorkerWakeFacts[], now = Date.now()): string[] {
     const out: string[] = [];
     for (const f of facts) {
@@ -123,8 +151,25 @@ export class WorkerWakeWatchdog {
       const lastHuman = this.lastHumanNeedsAt.get(f.agentId) ?? 0;
       if (lastHuman > 0 && now - lastHuman < WORKER_WAKE_HITL_REARM_MS) continue;
       const lastNudge = this.lastNudgeAt.get(f.agentId) ?? 0;
-      if (lastNudge > 0 && now - lastNudge < WORKER_WAKE_COOLDOWN_MS) continue;
+
+      // Edge-trigger (#358): when inbox ids are known, only NEW ids are
+      // announceable — ids the watchdog already announced reset nothing and only
+      // advance the repeat ladder, so a worker parked on already-announced mail
+      // is woken at 60s → 5m → 30m, never at the flat cooldown forever. When ids
+      // are NOT provided the nudge stays level-triggered (any pending mail is
+      // fresh), preserving the pre-#358 behaviour for callers that have no ids.
+      const hasIds = Array.isArray(f.inboxIds);
+      const pending = new Set(hasIds ? f.inboxIds : []);
+      const announced = hasIds ? this.announcedIds.get(f.agentId) : undefined;
+      const isFresh = !hasIds || !announced || [...pending].some((id) => !announced.has(id));
+      const wait = isFresh
+        ? WORKER_WAKE_COOLDOWN_MS
+        : WORKER_WAKE_REPEAT_MS[Math.min(this.repeatCounts.get(f.agentId) ?? 0, WORKER_WAKE_REPEAT_MS.length - 1)];
+      if (lastNudge > 0 && now - lastNudge < wait) continue;
+
       this.lastNudgeAt.set(f.agentId, now);
+      if (hasIds) this.announcedIds.set(f.agentId, pending);
+      this.repeatCounts.set(f.agentId, isFresh ? 0 : (this.repeatCounts.get(f.agentId) ?? 0) + 1);
       out.push(f.agentId);
     }
     return out;

--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -163,7 +163,10 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   // Delivery can be held back by the agent's own terminal (a half-typed draft or
   // an open slash-command picker owns the prompt). That used to be invisible —
   // the hint claimed it was sending while nothing moved — so poll it and say so.
-  const block = useTerminalBlock(agent.ptyId, queue.length > 0 && idle);
+  // Poll whenever something is queued, busy or not: a busy agent is exactly when
+  // a user might have half-typed in the terminal above, and it is when the queue
+  // is in use — so the hold must be reported then, not only once the agent idles.
+  const block = useTerminalBlock(agent.ptyId, queue.length > 0);
 
   // Floor-wide auto-delivery pause (Command Center switch) also holds the queue.
   // Without saying so — and without the per-row "send now" override — messages
@@ -172,16 +175,16 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
 
   const statusHint = queue.length === 0
     ? null
-    : !idle
-    ? t('queueComposer.busyQueued', { name: agent.name, count: queue.length })
-    : deliveryPaused && !queue[0]?.manual
-    ? t('queueComposer.heldFloor')
     : block === 'draft'
     ? t('queueComposer.heldDraft', { name: agent.name })
     : block === 'picker'
     ? t('queueComposer.heldPicker', { name: agent.name })
     : block === 'exited'
     ? t('queueComposer.heldExited', { name: agent.name })
+    : !idle
+    ? t('queueComposer.busyQueued', { name: agent.name, count: queue.length })
+    : deliveryPaused && !queue[0]?.manual
+    ? t('queueComposer.heldFloor')
     : t('queueComposer.sendingOneByOne', { name: agent.name });
 
   return (

--- a/test/worker-wake.test.cjs
+++ b/test/worker-wake.test.cjs
@@ -19,6 +19,7 @@ function fact(overrides = {}) {
     ptyId: 'pty-alice',
     lastOutputAt: 100_000,
     inboxCount: 1,
+    inboxIds: ['msg-1'],
     autoDeliveryPaused: false,
     paused: false,
     halted: false,
@@ -118,6 +119,59 @@ test('a nudge is not repeated within the cooldown', () => {
   assert.deepEqual(w.decide([fact()], now), ['alice']);
   assert.deepEqual(w.decide([fact()], now + WORKER_WAKE_COOLDOWN_MS - 1), []);
   assert.deepEqual(w.decide([fact({ lastOutputAt: now + WORKER_WAKE_COOLDOWN_MS + 1 - WORKER_WAKE_IDLE_MS - 1 })], now + WORKER_WAKE_COOLDOWN_MS + 1), ['alice']);
+});
+
+test('#358: same already-announced mail is NOT re-nudged at the flat cadence', () => {
+  const w = new WorkerWakeWatchdog();
+  w.noteSpawn('pty-alice', 0);
+  const now = 200_000;
+  // first nudge announces msg-1
+  assert.deepEqual(w.decide([fact({ inboxIds: ['msg-1'] })], now), ['alice']);
+  // every minute for an hour, the SAME single id stays pending: after the first
+  // repeat (60s) the backoff ladder silences it (5m, then 30m) instead of
+  // re-nudging once a minute forever.
+  const fireTimes = [];
+  for (let i = 1; i <= 60; i++) {
+    const t = now + i * WORKER_WAKE_COOLDOWN_MS;
+    const out = w.decide([fact({ inboxIds: ['msg-1'], lastOutputAt: t - WORKER_WAKE_IDLE_MS - 1 })], t);
+    if (out.length) fireTimes.push(i);
+  }
+  // repeat #1 at 60s; repeat #2 at 60s + 5m; then 30m intervals.
+  assert.deepEqual(fireTimes, [1, 6, 36]);
+});
+
+test('#358: a new inbox id is announced promptly, not on the repeat ladder', () => {
+  const w = new WorkerWakeWatchdog();
+  w.noteSpawn('pty-alice', 0);
+  const now = 200_000;
+  assert.deepEqual(w.decide([fact({ inboxIds: ['msg-1'] })], now), ['alice']);
+  // repeat #1 at +60s (same mail) — the ladder starts
+  const t1 = now + WORKER_WAKE_COOLDOWN_MS;
+  assert.deepEqual(w.decide([fact({ inboxIds: ['msg-1'], lastOutputAt: t1 - WORKER_WAKE_IDLE_MS - 1 })], t1), ['alice']);
+  // at +120s the SAME mail sits on the 5m ladder → silent
+  const t2 = now + 2 * WORKER_WAKE_COOLDOWN_MS;
+  assert.deepEqual(w.decide([fact({ inboxIds: ['msg-1'], lastOutputAt: t2 - WORKER_WAKE_IDLE_MS - 1 })], t2), []);
+  // but NEW mail (msg-2) at the same moment is announceable again
+  assert.deepEqual(w.decide([fact({ inboxIds: ['msg-1', 'msg-2'], lastOutputAt: t2 - WORKER_WAKE_IDLE_MS - 1 })], t2), ['alice']);
+});
+
+test('#358: forgotten state means previously-announced mail is fresh again', () => {
+  const w = new WorkerWakeWatchdog();
+  w.noteSpawn('pty-alice', 0);
+  const now = 200_000;
+  assert.deepEqual(w.decide([fact({ inboxIds: ['msg-1'] })], now), ['alice']);
+  // a PTY restart forgets the announced set → the same id is announceable again
+  w.forget('alice', 'pty-alice');
+  w.noteSpawn('pty-alice', 0);
+  assert.deepEqual(w.decide([fact({ inboxIds: ['msg-1'] })], now + 1), ['alice']);
+});
+
+test('#358: without inbox ids the nudge stays level-triggered', () => {
+  const w = new WorkerWakeWatchdog();
+  w.noteSpawn('pty-alice', 0);
+  const now = 200_000;
+  assert.deepEqual(w.decide([fact({ inboxIds: undefined })], now), ['alice']);
+  assert.deepEqual(w.decide([fact({ inboxIds: undefined })], now + WORKER_WAKE_COOLDOWN_MS + 1), ['alice']);
 });
 
 test('forget clears cooldown + boot grace + HITL state', () => {

--- a/work-results/public/app/index.html
+++ b/work-results/public/app/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Munder Difflin</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob:; connect-src 'self' https://api.openai.com https://*.openai.com wss://api.openai.com wss://*.openai.com; media-src 'self' blob: mediastream:;" />
+    <!-- v0.3.4 type revamp: Press Start 2P stays as the BRAND display face
+         (small caps labels only); body/UI moves to Inter and code/terminal to
+         JetBrains Mono. The pixel body fonts (Pixelify/VT323) read as toy-like
+         and strained at data-dense sizes.
+         v0.4.6: these three faces are BUNDLED (src/renderer/src/design/fonts.css)
+         rather than fetched from fonts.googleapis.com, which is blocked in
+         mainland China. The CSP above no longer allows either Google font host. -->
+    <style>
+      #cth-splash {
+        position: fixed; inset: 0; display: flex; flex-direction: column;
+        align-items: center; justify-content: center; gap: 14px;
+        background: #FFF8E7; color: #1A1320;
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      }
+      #cth-splash .mk {
+        display: grid; place-items: center; width: 56px; height: 56px;
+        background: #6E1423; color: #F4F1EA; border: 4px solid #4A0D17;
+        font-family: "Press Start 2P", monospace; font-size: 16px; letter-spacing: -2px;
+        box-shadow: 4px 4px 0 rgba(26,19,32,0.25);
+      }
+      #cth-splash .title { font-family: "Press Start 2P", monospace; font-size: 13px; }
+      #cth-splash .hint { font-size: 15px; color: #6B5878; }
+    </style>
+    <script src="./shim.js"></script>
+    <script src="./work-results.js"></script>
+    <script type="module" crossorigin src="./assets/index-DPf-thQz.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-BpFCHFVd.css">
+  </head>
+  <body>
+    <div id="root">
+      <div id="cth-splash">
+        <div class="mk">MD</div>
+        <div class="title">MUNDER DIFFLIN</div>
+        <div class="hint">booting the hive…</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/work-results/public/app/shim.js
+++ b/work-results/public/app/shim.js
@@ -1,0 +1,794 @@
+"use strict";
+/* web-office v2 — window.cth shim
+ *
+ * The real Munder Difflin renderer (React + PixiJS) talks to Electron ONLY
+ * through `window.cth` (exposed by preload/index.js via contextBridge). This
+ * shim substitutes that bridge in a plain browser: every data method becomes a
+ * fetch() to our local /api/state (which reads the live hive files), and every
+ * interactive/Electron-only method is a safe no-op. The office floor scene
+ * (agents, thought bubbles, board wall, status colors) then renders for real.
+ */
+(function () {
+  var CTH_VERSION = "0.4.6";
+  var POLL_MS = 4000;
+  var stateCache = null;
+  var stateTs = 0;
+  var subs = {}; // channel -> [cb]
+  var CAST = ["michael","jim","pam","dwight","kevin","angela","oscar","stanley","phyllis","andy","kelly","ryan","toby","creed","meredith"];
+  var ACCENTS = ["coral","mint","sky","lemon","lilac","peach"];
+
+  function hashStr(s) {
+    var h = 0;
+    for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+    return h;
+  }
+  function characterFor(a) {
+    if (a.isGod) return "michael";
+    var n = ((a.name || a.id) || "").toLowerCase();
+    for (var i = 0; i < CAST.length; i++) {
+      if (n.indexOf(CAST[i]) !== -1) return CAST[i];
+    }
+    return CAST[hashStr(a.id || "x") % CAST.length];
+  }
+  function liveStatus(a) {
+    var b = a.breaker || "healthy";
+    if (b === "constrained" || b === "stopped") return "looping";
+    if (a.onHold) return "waiting";
+    if (typeof a.lastActiveSecAgo === "number" && a.lastActiveSecAgo < 60) return "working";
+    return "idle";
+  }
+  function rosterFrom(s) {
+    var dir = (s && s.agentDirectory) || { agents: [] };
+    var list = Array.isArray(dir.agents) ? dir.agents : [];
+    var agents = list.map(function (a) {
+      return {
+        id: a.id,
+        name: a.name || a.id,
+        character: characterFor(a),
+        accent: ACCENTS[hashStr(a.id || "x") % ACCENTS.length],
+        description: a.role || "a fresh harness",
+        project: ((a.cwd || "").split(/[\\/]/).filter(Boolean).pop()) || "hive",
+        tmuxTarget: "",
+        cwd: a.cwd || null,
+        status: liveStatus(a),
+        action: "idle",
+        progress: 0,
+        currentStation: "desk",
+        ptyId: a.id,
+        command: null,
+        provider: a.provider || "claude",
+        isGod: !!a.isGod,
+        recentTextTs: Date.now()
+      };
+    });
+    return {
+      version: 1,
+      savedAt: new Date().toISOString(),
+      agents: agents,
+      archived: [],
+      restorable: [],
+      queues: {},
+      selectedId: null
+    };
+  }
+  // Sync one-time fetch at shim load so the bundle's synchronous boot reads
+  // (rosterReadSync / harnessHomeSync) get real live-hive data.
+  function bootStateSync() {
+    try {
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", "/api/state", false);
+      xhr.send(null);
+      if (xhr.status === 200) return JSON.parse(xhr.responseText);
+    } catch (_e) {}
+    return null;
+  }
+  var BOOT = bootStateSync();
+
+  function getState(force) {
+    if (force || !stateCache || Date.now() - stateTs > 1500) {
+      return fetch("/api/state", { cache: "no-store" })
+        .then(function (r) {
+          if (!r.ok) throw new Error("state " + r.status);
+          return r.json();
+        })
+        .then(function (s) {
+          stateCache = s;
+          stateTs = Date.now();
+          return s;
+        });
+    }
+    return Promise.resolve(stateCache);
+  }
+
+  function data() {
+    return getState(false).catch(function () {
+      return {};
+    });
+  }
+
+  /* ── subscription plumbing ───────────────────────────── */
+  function sub(channel, cb) {
+    if (!subs[channel]) subs[channel] = [];
+    subs[channel].push(cb);
+    return function () {
+      var i = (subs[channel] || []).indexOf(cb);
+      if (i >= 0) subs[channel].splice(i, 1);
+    };
+  }
+  function emit(channel, payload) {
+    (subs[channel] || []).forEach(function (cb) {
+      try {
+        cb(payload);
+      } catch (_e) {}
+    });
+  }
+  function pulse(s) {
+    // Re-fire subscribers on each poll with fresh shapes the UI expects.
+    emit("hive:hookEvent", { event: "state", ts: Date.now(), state: s });
+    emit("hive:contextUpdate", { ts: Date.now() });
+    emit("telemetry:event", { ts: Date.now() });
+    emit("config:changed", s.config || {});
+    // Per-agent live status → drives the floor's status colors + bubbles.
+    var dir = (s.agentDirectory && s.agentDirectory.agents) || [];
+    for (var i = 0; i < dir.length; i++) {
+      var a = dir[i];
+      var st = liveStatus(a);
+      var base = { ts: Date.now(), agentId: a.id };
+      if (st === "looping") {
+        emit("control:breakerState", { agentId: a.id, level: "constrained", reason: "breaker armed" });
+      } else if (st === "working") {
+        emit("hive:hookEvent", Object.assign({ event: "PreInvocation" }, base));
+      } else if (st === "compacting") {
+        emit("hive:hookEvent", Object.assign({ event: "PreCompact" }, base));
+      } else {
+        emit("hive:hookEvent", Object.assign({ event: "PostInvocation" }, base));
+      }
+    }
+  }
+
+  /* ── data methods (backed by /api/state) ──────────────── */
+  var api = {
+    version: CTH_VERSION,
+    platform: "darwin",
+    arch: "arm64",
+
+    hiveRegistry: function () {
+      return data().then(function (s) {
+        return s.registry || { godId: null, agents: {} };
+      });
+    },
+    hiveBoard: function () {
+      return data().then(function (s) {
+        return s.board || "";
+      });
+    },
+    hiveTasks: function () {
+      return data().then(function (s) {
+        return s.tasks || { tasks: [] };
+      });
+    },
+    hiveLog: function (n) {
+      return data().then(function (s) {
+        var log = s.logTail || [];
+        return typeof n === "number" ? log.slice(-n) : log;
+      });
+    },
+    hiveMemory: function (id) {
+      return data().then(function (s) {
+        return (s.memories && s.memories[id]) || "";
+      });
+    },
+    hiveInbox: function (id) {
+      return data().then(function (s) {
+        return (s.inboxes && s.inboxes[id]) || [];
+      });
+    },
+    hiveMessages: function (opts) {
+      return data().then(function (s) {
+        return s.messages || [];
+      });
+    },
+    hiveAgentDirectory: function () {
+      return data().then(function (s) {
+        return (
+          s.agentDirectory || { godId: null, agents: [] }
+        );
+      });
+    },
+    telemetrySnapshot: function () {
+      return data().then(function (s) {
+        return s.telemetry || { usage: [], spans: {} };
+      });
+    },
+    hiveProjects: function () {
+      return data().then(function (s) {
+        return (s && s.projects) || [];
+      });
+    },
+    telemetryUsage: function (agentId) {
+      return data().then(function (s) {
+        var u = (s.telemetry && s.telemetry.usage) || [];
+        var hit = u.find(function (x) {
+          return x.agentId === agentId;
+        });
+        return hit || null;
+      });
+    },
+    telemetrySpans: function (agentId) {
+      return data().then(function (s) {
+        return (s.telemetry && s.telemetry.spans && s.telemetry.spans[agentId]) || [];
+      });
+    },
+    getConfig: function () {
+      return data().then(function (s) {
+        return s.config || {};
+      });
+    },
+    agentUsage: function () {
+      return data().then(function (s) {
+        return (s.telemetry && s.telemetry.usage) || [];
+      });
+    },
+    agentContext: function () {
+      return Promise.resolve(null);
+    },
+    // synchronous boot-time reads — backed by the sync boot fetch, so the
+    // store hydrates its roster from the LIVE hive instead of empty localStorage
+    rosterReadSync: function () {
+      return rosterFrom(BOOT);
+    },
+    harnessHomeSync: function () {
+      return (BOOT && BOOT.config && BOOT.config.harnessHome) || null;
+    },
+
+    /* ── subscription methods (poll-driven) ─────────────── */
+    onHiveHookEvent: function (cb) {
+      return sub("hive:hookEvent", cb);
+    },
+    onHiveContextUpdate: function (cb) {
+      return sub("hive:contextUpdate", cb);
+    },
+    onHiveMessage: function (cb) {
+      return sub("hive:message", cb);
+    },
+    onHiveEnqueue: function (cb) {
+      return sub("hive:enqueueToAgent", cb);
+    },
+    onHiveAgentSpawned: function (cb) {
+      return sub("hive:agentSpawned", cb);
+    },
+    onHiveAgentArchived: function (cb) {
+      return sub("hive:agentArchived", cb);
+    },
+    onBreakerState: function (cb) {
+      return sub("control:breakerState", cb);
+    },
+    onTelemetryEvent: function (cb) {
+      return sub("telemetry:event", cb);
+    },
+    onUpdateStatus: function (cb) {
+      return sub("update:status", cb);
+    },
+    onConfigChanged: function (cb) {
+      return sub("config:changed", cb);
+    },
+    onPtyData: function (_id, cb) {
+      return sub("pty:data", cb);
+    },
+    onPtyExit: function (_id, cb) {
+      return sub("pty:exit", cb);
+    },
+    onPtyRelaunch: function (_id, cb) {
+      return sub("pty:relaunch", cb);
+    },
+    onSlackMessage: function (cb) {
+      return sub("slack:incomingMessage", cb);
+    },
+    onClosingTime: function (cb) {
+      return sub("app:closingTime", cb);
+    },
+    onCloseRequested: function (cb) {
+      return sub("app:closeRequested", cb);
+    },
+    onPowerResume: function (cb) {
+      return sub("power:resume", cb);
+    },
+    onRealtimeCompletion: function (cb) {
+      return sub("realtime:completion", cb);
+    },
+    onRealtimeFloorDelta: function (cb) {
+      return sub("realtime:floorDelta", cb);
+    },
+    onRealtimeEnqueue: function (cb) {
+      return sub("realtime:enqueue", cb);
+    },
+    onMissionsUpdated: function (cb) {
+      return sub("missions:updated", cb);
+    },
+    onAutoCompact: function (cb) {
+      return sub("mission:autoCompact", cb);
+    },
+    onApprovalRequest: function (cb) {
+      return sub("control:approvalRequest", cb);
+    },
+    onTriggerHistoryUpdated: function (cb) {
+      return sub("triggerHistory:updated", cb);
+    },
+    onHireImport: function (cb) {
+      return sub("hire:import", cb);
+    },
+    onHireError: function (cb) {
+      return sub("hire:error", cb);
+    },
+    onContextTrigger: function (cb) {
+      return sub("trigger:context", cb);
+    },
+
+    /* ── interactive / Electron-only: safe no-ops ───────── */
+    trackMessageSent: function () {
+      return Promise.resolve();
+    },
+    spawnPty: function (opts) {
+      // Read-only web view: no real PTY is spawned, but a "success" lets the
+      // renderer's restore flow bring every live-hive agent onto the office floor.
+      var id = (opts && opts.id) || "pty-mock";
+      return Promise.resolve({ ok: true, ptyId: id, seedPrompt: undefined });
+    },
+    writePty: function () {
+      return Promise.resolve();
+    },
+    resizePty: function () {
+      return Promise.resolve();
+    },
+    redrawPty: function () {
+      return Promise.resolve();
+    },
+    killPty: function () {
+      return Promise.resolve();
+    },
+    listPtys: function () {
+      return Promise.resolve([]);
+    },
+    resolveSessionCwd: function () {
+      return Promise.resolve(null);
+    },
+    chooseFolder: function () {
+      return Promise.resolve(null);
+    },
+    openTerminalAt: function () {
+      return Promise.resolve({ ok: false });
+    },
+    copyToClipboard: function () {
+      return Promise.resolve();
+    },
+    readClipboard: function () {
+      return Promise.resolve("");
+    },
+    readClipboardSync: function () {
+      return "";
+    },
+    updateConfig: function () {
+      return Promise.resolve({});
+    },
+    setAgentTokenCap: function () {
+      return Promise.resolve();
+    },
+    ensureHarnessHome: function () {
+      return Promise.resolve({ ok: true });
+    },
+    changeHome: function () {
+      return Promise.resolve({ ok: false, error: "read-only web view" });
+    },
+    listDir: function () {
+      return Promise.resolve([]);
+    },
+    readFile: function () {
+      return Promise.resolve("");
+    },
+    readBinary: function () {
+      return Promise.resolve(null);
+    },
+    writeFile: function () {
+      return Promise.resolve({ ok: false });
+    },
+    statAbs: function () {
+      return Promise.resolve(null);
+    },
+    revealPath: function () {
+      return Promise.resolve();
+    },
+    gitIsRepo: function () {
+      return Promise.resolve(false);
+    },
+    gitMainRepo: function () {
+      return Promise.resolve(null);
+    },
+    gitBranch: function () {
+      return Promise.resolve(null);
+    },
+    gitStatus: function () {
+      return Promise.resolve({});
+    },
+    gitLog: function () {
+      return Promise.resolve([]);
+    },
+    gitBranches: function () {
+      return Promise.resolve([]);
+    },
+    gitAheadBehind: function () {
+      return Promise.resolve(null);
+    },
+    gitDiff: function () {
+      return Promise.resolve("");
+    },
+    gitLogGraph: function () {
+      return Promise.resolve([]);
+    },
+    gitCommitFiles: function () {
+      return Promise.resolve([]);
+    },
+    gitShowFile: function () {
+      return Promise.resolve("");
+    },
+    gitCompareRefs: function () {
+      return Promise.resolve(null);
+    },
+    gitWorktrees: function () {
+      return Promise.resolve([]);
+    },
+    gitCheckout: function () {
+      return Promise.resolve({ ok: false });
+    },
+    hivePatchAgentRole: function () {
+      return Promise.resolve({ ok: false });
+    },
+    hiveRenameAgent: function () {
+      return Promise.resolve({ ok: false });
+    },
+    hiveSetAgentHold: function () {
+      return Promise.resolve({ ok: false });
+    },
+    hiveAddTask: function () {
+      return Promise.resolve(false);
+    },
+    hivePatchTask: function () {
+      return Promise.resolve(false);
+    },
+    hiveDeleteTask: function () {
+      return Promise.resolve(false);
+    },
+    hiveSend: function () {
+      return Promise.resolve({ ok: false });
+    },
+    listWorkers: function () {
+      return Promise.resolve([]);
+    },
+    stopWorker: function () {
+      return Promise.resolve({ ok: false });
+    },
+    memoryStatus: function () {
+      return Promise.resolve({ enabled: false });
+    },
+    toolsStatus: function () {
+      return Promise.resolve([]);
+    },
+    heroPayload: function () {
+      return Promise.resolve(null);
+    },
+    skillsLocal: function () {
+      return Promise.resolve([]);
+    },
+    skillsCatalog: function () {
+      return Promise.resolve([]);
+    },
+    skillsInstall: function () {
+      return Promise.resolve({ ok: false });
+    },
+    skillsUninstall: function () {
+      return Promise.resolve({ ok: false });
+    },
+    skillsReveal: function () {
+      return Promise.resolve();
+    },
+    searchMemory: function () {
+      return Promise.resolve([]);
+    },
+    memoryWakeUp: function () {
+      return Promise.resolve("");
+    },
+    mineNow: function () {
+      return Promise.resolve({});
+    },
+    reflectNow: function () {
+      return Promise.resolve([]);
+    },
+    kgStatus: function () {
+      return Promise.resolve({ enabled: false });
+    },
+    kgList: function () {
+      return Promise.resolve([]);
+    },
+    kgSearch: function () {
+      return Promise.resolve([]);
+    },
+    kgGet: function () {
+      return Promise.resolve(null);
+    },
+    kgRemove: function () {
+      return Promise.resolve({ ok: false });
+    },
+    kgAddFiles: function () {
+      return Promise.resolve([]);
+    },
+    kgIngestFiles: function () {
+      return Promise.resolve([]);
+    },
+    attachFiles: function () {
+      return Promise.resolve([]);
+    },
+    pathForFile: function () {
+      return null;
+    },
+    saveClipboardImage: function () {
+      return Promise.resolve(null);
+    },
+    historyAdd: function () {
+      return Promise.resolve();
+    },
+    historyList: function () {
+      return Promise.resolve([]);
+    },
+    historySearch: function () {
+      return Promise.resolve([]);
+    },
+    textSearch: function () {
+      return Promise.resolve([]);
+    },
+    githubIssues: function () {
+      return Promise.resolve({ ok: false, error: "read-only web view" });
+    },
+    githubCIRuns: function () {
+      return Promise.resolve({ ok: false, error: "read-only web view" });
+    },
+    setNotifications: function () {
+      return Promise.resolve(false);
+    },
+    openExternal: function () {
+      return Promise.resolve();
+    },
+    setLoginItem: function () {
+      return Promise.resolve(false);
+    },
+    hiveSetArchived: function () {
+      return Promise.resolve({ ok: false });
+    },
+    slackStart: function () {
+      return Promise.resolve({ ok: false });
+    },
+    slackStop: function () {
+      return Promise.resolve({ ok: false });
+    },
+    slackStatus: function () {
+      return Promise.resolve({ connected: false });
+    },
+    slackReply: function () {
+      return Promise.resolve({ ok: false });
+    },
+    slackReplyScriptPath: function () {
+      return Promise.resolve(null);
+    },
+    slackSetConfig: function () {
+      return Promise.resolve({});
+    },
+    webhookStart: function () {
+      return Promise.resolve({ ok: false });
+    },
+    webhookStop: function () {
+      return Promise.resolve({ ok: false });
+    },
+    webhookStatus: function () {
+      return Promise.resolve({ connected: false });
+    },
+    webhookGenerateSecret: function () {
+      return Promise.resolve("");
+    },
+    webhookSetConfig: function () {
+      return Promise.resolve({});
+    },
+    getContextTrigger: function () {
+      return Promise.resolve({});
+    },
+    setContextTrigger: function () {
+      return Promise.resolve({});
+    },
+    listWebhooks: function () {
+      return Promise.resolve([]);
+    },
+    saveWebhooks: function () {
+      return Promise.resolve([]);
+    },
+    deleteWebhook: function () {
+      return Promise.resolve([]);
+    },
+    generateWebhookSecret: function () {
+      return Promise.resolve("");
+    },
+    webhooksStatus: function () {
+      return Promise.resolve({ endpoints: [] });
+    },
+    getOrgTrigger: function () {
+      return Promise.resolve({});
+    },
+    setOrgTrigger: function () {
+      return Promise.resolve({});
+    },
+    listTriggerHistory: function () {
+      return Promise.resolve([]);
+    },
+    decideTriggerHistory: function () {
+      return Promise.resolve(null);
+    },
+    clearTriggerHistory: function () {
+      return Promise.resolve();
+    },
+    freeflowSetConfig: function () {
+      return Promise.resolve({});
+    },
+    freeflowTranscribe: function () {
+      return Promise.resolve(null);
+    },
+    integrationsList: function () {
+      return Promise.resolve([]);
+    },
+    integrationsTemplates: function () {
+      return Promise.resolve([]);
+    },
+    integrationsUpsert: function () {
+      return Promise.resolve({ ok: false });
+    },
+    integrationsSetSecret: function () {
+      return Promise.resolve({ ok: false });
+    },
+    integrationsRemove: function () {
+      return Promise.resolve({ ok: false });
+    },
+    integrationsTest: function () {
+      return Promise.resolve({ ok: false });
+    },
+    providerKeySet: function () {
+      return Promise.resolve({ ok: false });
+    },
+    providerKeyHas: function () {
+      return Promise.resolve(false);
+    },
+    providerKeyClear: function () {
+      return Promise.resolve({ ok: false });
+    },
+    realtimeHasOpenAiKey: function () {
+      return Promise.resolve(false);
+    },
+    realtimeMintToken: function () {
+      return Promise.resolve(null);
+    },
+    realtimeAction: function () {
+      return Promise.resolve({ spoken: "" });
+    },
+    realtimeActionConfirm: function () {
+      return Promise.resolve({ spoken: "" });
+    },
+    realtimeActionCancel: function () {
+      return Promise.resolve();
+    },
+    realtimeSetSessionLive: function () {
+      return Promise.resolve();
+    },
+    realtimeDrainCompletions: function () {
+      return Promise.resolve([]);
+    },
+    realtimeWaitFor: function () {
+      return Promise.resolve(null);
+    },
+    appInfo: function () {
+      return Promise.resolve({ version: CTH_VERSION });
+    },
+    rosterWrite: function () {
+      return Promise.resolve({ ok: false });
+    },
+    updateCurrent: function () {
+      return Promise.resolve({ state: "idle", version: CTH_VERSION });
+    },
+    updateRestartAndInstall: function () {
+      return Promise.resolve({ ok: false });
+    },
+    updateCheckNow: function () {
+      return Promise.resolve({ ok: false });
+    },
+    updateDownload: function () {
+      return Promise.resolve({ ok: false });
+    },
+    updateOpenRelease: function () {
+      return Promise.resolve();
+    },
+    updateSimulate: function () {
+      return Promise.resolve({ ok: false });
+    },
+    controlPause: function () {
+      return Promise.resolve(null);
+    },
+    controlAutoDelivery: function () {
+      return Promise.resolve(null);
+    },
+    controlResume: function () {
+      return Promise.resolve(null);
+    },
+    controlGateTool: function () {
+      return Promise.resolve(null);
+    },
+    controlSteer: function () {
+      return Promise.resolve(null);
+    },
+    controlHalt: function () {
+      return Promise.resolve(null);
+    },
+    controlSnapshot: function () {
+      return Promise.resolve(null);
+    },
+    listMissions: function () {
+      return Promise.resolve([]);
+    },
+    saveMissions: function () {
+      return Promise.resolve({ ok: false });
+    },
+    newFloor: function () {
+      return Promise.resolve({ ok: false });
+    },
+    startClosingTime: function () {
+      return Promise.resolve({ ok: false, error: "read-only web view" });
+    },
+    cancelClosingTime: function () {
+      return Promise.resolve({ ok: false });
+    },
+    resetAll: function () {
+      return Promise.resolve();
+    },
+    confirmClose: function () {
+      return Promise.resolve(false);
+    },
+    cancelClose: function () {
+      return Promise.resolve();
+    }
+  };
+
+  // swallow method calls that don't exist yet (future bridge surface)
+  var p = new Proxy(api, {
+    get: function (target, prop) {
+      if (prop in target) return target[prop];
+      if (typeof prop === "string" && /^(on|open|confirm)/.test(prop)) {
+        return function () {
+          return function () {};
+        };
+      }
+      return target[prop] !== undefined ? target[prop] : function () {
+        return Promise.resolve(null);
+      };
+    }
+  });
+
+  // Boot straight past the hive picker: the renderer's useState initializer
+  // reads this one-shot key, returns true for `hiveOpened`, then removes it.
+  try {
+    window.localStorage.setItem("cth.skipHivePickerOnce", "1");
+  } catch (_e) {}
+
+  window.cth = p;
+  if (typeof window.process === "undefined") {
+    window.process = { platform: "darwin", arch: "arm64", env: {} };
+  }
+
+  // live polling → pulse subscribers (drives the office floor updates)
+  setInterval(function () {
+    getState(true)
+      .then(pulse)
+      .catch(function () {});
+  }, POLL_MS);
+})();

--- a/work-results/public/app/work-results.js
+++ b/work-results/public/app/work-results.js
@@ -1,0 +1,464 @@
+"use strict";
+/* work-results.js — per-agent WORK-RESULTS panel for Munder Difflin.
+ *
+ * A self-contained panel that renders, for each agent (god + workers), the
+ * questions/tasks it was given, the messages it received & replied, and its
+ * output files under the projects/ tree. Data comes from the LIVE hive files
+ * through `window.cth` — the real preload in the packaged app, or the shim in
+ * the browser build. Nothing is hardcoded; auto-refreshes every 5s.
+ */
+(function () {
+  if (window.__workResultsLoaded) return;
+  window.__workResultsLoaded = true;
+
+  var POLL_MS = 5000;
+  var state = { agents: [], tasks: [], board: "", projects: [], outboxes: {}, inboxes: {}, lastTs: 0 };
+  var timers = [];
+
+  function $(sel) {
+    return document.querySelector(sel);
+  }
+
+  function el(tag, cls, text) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
+  }
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  function short(s, n) {
+    s = String(s == null ? "" : s);
+    return s.length > (n || 140) ? s.slice(0, (n || 140) - 1) + "…" : s;
+  }
+
+  function timeAgo(iso) {
+    if (!iso) return "";
+    var t = new Date(iso).getTime();
+    if (isNaN(t)) return "";
+    var s = Math.max(0, Math.floor((Date.now() - t) / 1000));
+    if (s < 60) return s + "s ago";
+    var m = Math.floor(s / 60);
+    if (m < 60) return m + "m ago";
+    var h = Math.floor(m / 60);
+    if (h < 24) return h + "h ago";
+    return Math.floor(h / 24) + "d ago";
+  }
+
+  /* ── data adapters: window.cth (real preload OR browser shim) ────────── */
+  function call(name) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    var c = window.cth || {};
+    if (typeof c[name] === "function") {
+      try {
+        return Promise.resolve(c[name].apply(c, args));
+      } catch (e) {
+        return Promise.resolve(null);
+      }
+    }
+    return Promise.resolve(null);
+  }
+
+  function getDirectory() {
+    return call("hiveAgentDirectory").then(function (d) {
+      return (d && (d.agents || d)) || [];
+    });
+  }
+
+  function getTasks() {
+    return call("hiveTasks").then(function (t) {
+      if (!t) return [];
+      return Array.isArray(t) ? t : (t.tasks || []);
+    });
+  }
+
+  function getBoard() {
+    return call("hiveBoard").then(function (b) {
+      return typeof b === "string" ? b : "";
+    });
+  }
+
+  function getInbox(id) {
+    return call("hiveInbox", id).then(function (msgs) {
+      return Array.isArray(msgs) ? msgs : [];
+    });
+  }
+
+  /* Recent messages incl. direction (inbox|outbox). Real preload returns the
+   * voice read-layer; the shim mirrors it from /api/state. */
+  function getMessages(id) {
+    return call("hiveMessages", { agentId: id, limit: 40, includeArchived: true }).then(function (msgs) {
+      return Array.isArray(msgs) ? msgs : [];
+    });
+  }
+
+  /* Output files: prefer a structured projects tree (shim /api/state.projects),
+   * else walk the projects root with the real preload's listDir. */
+  function getProjects() {
+    return call("hiveProjects").then(function (p) {
+      if (Array.isArray(p) && p.length) return p;
+      return call("listDir", defaultProjectsRoot(), "").then(function (r) {
+        if (!r || !r.ok || !Array.isArray(r.entries)) return [];
+        var dirs = r.entries.filter(function (e) {
+          return e.isDir;
+        });
+        return Promise.all(
+          dirs.map(function (d) {
+            return call("listDir", defaultProjectsRoot(), d.name).then(function (fr) {
+              var files = [];
+              if (fr && fr.ok && Array.isArray(fr.entries)) {
+                files = fr.entries
+                  .filter(function (e) {
+                    return !e.name.startsWith(".") && e.name !== "node_modules";
+                  })
+                  .slice(0, 40)
+                  .map(function (e) {
+                    return { name: e.name, size: e.isDir ? 0 : e.size };
+                  });
+              }
+              return { name: d.name, isDir: true, files: files, agents: [] };
+            });
+          })
+        );
+      });
+    });
+  }
+
+  /* Projects tree lives next to the hive home. */
+  function defaultProjectsRoot() {
+    var home = null;
+    try {
+      if (window.cth && typeof window.cth.harnessHomeSync === "function") home = window.cth.harnessHomeSync();
+      if (!home && window.cth && typeof window.cth.getConfig === "function") {
+        // covered below via boot sync; harnessHomeSync is synchronous where it matters
+      }
+    } catch (e) {}
+    if (!home && state.harnessHome) home = state.harnessHome;
+    if (!home) return "/Users/skyzhao/HarnessAgents/projects";
+    return home.replace(/[\\/]hive$/, "") + "/projects";
+  }
+
+  /* ── load ─────────────────────────────────────────────────────────────── */
+  function load() {
+    return Promise.all([getDirectory(), getTasks(), getBoard(), getProjects()]).then(function (res) {
+      state.agents = res[0];
+      state.tasks = res[1];
+      state.board = res[2];
+      state.projects = res[3] || [];
+      if (window.cth && typeof window.cth.getConfig === "function") {
+        return call("getConfig").then(function (cfg) {
+          if (cfg && cfg.harnessHome) state.harnessHome = cfg.harnessHome;
+          return loadMailboxes();
+        });
+      }
+      return loadMailboxes();
+    });
+  }
+
+  function loadMailboxes() {
+    var ids = state.agents.map(function (a) {
+      return a.id;
+    });
+    return Promise.all(
+      ids.map(function (id) {
+        return Promise.all([getInbox(id), getMessages(id)]).then(function (pair) {
+          state.inboxes[id] = pair[0];
+          var out = [];
+          var seen = {};
+          pair[1].forEach(function (m) {
+            if (!m || seen[m.id]) return;
+            seen[m.id] = 1;
+            out.push(m);
+          });
+          state.outboxes[id] = out;
+        });
+      })
+    ).then(function () {
+      state.lastTs = Date.now();
+      render();
+    });
+  }
+
+  /* ── project → agents mapping (match by cwd) ─────────────────────────── */
+  function projectAgents(projectName) {
+    var hits = [];
+    state.agents.forEach(function (a) {
+      var cwd = String(a.cwd || a.project || "");
+      if (!cwd) return;
+      if (cwd.indexOf("projects" + sep() + projectName) !== -1 || cwd.split(sep()).pop() === projectName) {
+        hits.push(a);
+      }
+    });
+    return hits;
+  }
+
+  function sep() {
+    return navigator && navigator.userAgent && navigator.userAgent.indexOf("Win") !== -1 ? "\\" : "/";
+  }
+
+  /* ── rendering ────────────────────────────────────────────────────────── */
+  var HOST = "unknown";
+  var TASKS_STATUS = { todo: "todo", doing: "doing", blocked: "blocked", done: "done" };
+
+  function statusColor(a) {
+    var b = (a.breaker || "healthy").toLowerCase();
+    if (b === "constrained" || b === "steering" || b === "stopped") return "#C98A1B";
+    var st = String(a.status || "idle").toLowerCase();
+    if (st === "working" || st === "busy" || st === "active") return "#2A6FB0";
+    if (a.isGod) return "#6E1423";
+    if (a.archived) return "#9A8C9E";
+    return "#3E7C4F";
+  }
+
+  function statusLabel(a) {
+    if (a.archived) return "archived";
+    if (a.isGod) return "orchestrator";
+    var b = (a.breaker || "healthy").toLowerCase();
+    if (b === "stopped") return "looping";
+    if (b === "constrained" || b === "steering") return "steering";
+    var st = String(a.status || "idle");
+    if (st === "working" || st === "busy") return "working";
+    if (st === "blocked") return "blocked";
+    return st || "idle";
+  }
+
+  function agentTasks(id) {
+    return state.tasks.filter(function (t) {
+      var a = t.assignee || t.assignedTo || "";
+      return a === id;
+    });
+  }
+
+  function renderAgentCard(a) {
+    var card = el("section", "wr-card");
+    var head = el("header", "wr-card-head");
+    var name = el("h3", "wr-name", a.name || a.id);
+    name.style.color = statusColor(a);
+    var meta = el("span", "wr-role", a.role || (a.isGod ? "orchestrator (god)" : "worker"));
+    var status = el("span", "wr-status", statusLabel(a));
+    status.style.color = statusColor(a);
+    var idTag = el("span", "wr-id", a.id);
+    head.appendChild(name);
+    head.appendChild(meta);
+    head.appendChild(idTag);
+    head.appendChild(status);
+    card.appendChild(head);
+
+    var body = el("div", "wr-card-body");
+
+    /* tasks given */
+    var tasks = agentTasks(a.id);
+    var tl = el("div", "wr-block");
+    tl.appendChild(el("h4", "wr-block-title", "ASSIGNED TASKS (" + tasks.length + ")"));
+    if (!tasks.length) tl.appendChild(el("p", "wr-muted", "no tasks assigned"));
+    tasks.forEach(function (t) {
+      var row = el("div", "wr-task");
+      var st = TASKS_STATUS[t.status] || t.status || "todo";
+      var badge = el("span", "wr-badge", st);
+      var title = el("span", "wr-task-title", short(t.title, 90));
+      var when = el("span", "wr-time", t.updatedAt ? timeAgo(t.updatedAt) : "");
+      row.appendChild(badge);
+      row.appendChild(title);
+      if (when.textContent) row.appendChild(when);
+      tl.appendChild(row);
+      if (t.humanQA && t.humanQA.length) {
+        t.humanQA.forEach(function (qa) {
+          var qr = el("div", "wr-qa");
+          qr.appendChild(el("span", "wr-q", "Q: " + short(qa.q, 120)));
+          if (qa.a) qr.appendChild(el("span", "wr-a", "A: " + short(qa.a, 120)));
+          tl.appendChild(qr);
+        });
+      }
+    });
+    body.appendChild(tl);
+
+    /* messages received */
+    var inbox = state.inboxes[a.id] || [];
+    var il = el("div", "wr-block");
+    il.appendChild(el("h4", "wr-block-title", "RECEIVED (" + inbox.length + ")"));
+    if (!inbox.length) il.appendChild(el("p", "wr-muted", "no messages"));
+    inbox.slice(-8).reverse().forEach(function (m) {
+      var row = el("div", "wr-msg");
+      row.appendChild(el("span", "wr-act", m.act || ""));
+      var who = el("span", "wr-who", (m.from || "?") + (m.direction ? " → " + m.direction : ""));
+      var subj = el("span", "wr-subj", short(m.subject || m.body, 110));
+      var t = el("span", "wr-time", m.created_at ? timeAgo(m.created_at) : "");
+      row.appendChild(who);
+      row.appendChild(subj);
+      if (t.textContent) row.appendChild(t);
+      il.appendChild(row);
+    });
+    body.appendChild(il);
+
+    /* replies sent (outbox) */
+    var out = state.outboxes[a.id] || [];
+    var ol = el("div", "wr-block");
+    ol.appendChild(el("h4", "wr-block-title", "REPLIES / OUTBOX (" + out.length + ")"));
+    if (!out.length) ol.appendChild(el("p", "wr-muted", "no outbox messages"));
+    out.slice(-8).reverse().forEach(function (m) {
+      var row = el("div", "wr-msg wr-msg-out");
+      row.appendChild(el("span", "wr-act", m.act || ""));
+      var who = el("span", "wr-who", "→ " + (m.to || "?"));
+      var subj = el("span", "wr-subj", short(m.subject || m.body, 110));
+      var t = el("span", "wr-time", m.created_at ? timeAgo(m.created_at) : "");
+      row.appendChild(who);
+      row.appendChild(subj);
+      if (t.textContent) row.appendChild(t);
+      ol.appendChild(row);
+    });
+    body.appendChild(ol);
+
+    /* output files */
+    var files = agentOutputFiles(a);
+    var fl = el("div", "wr-block");
+    fl.appendChild(el("h4", "wr-block-title", "OUTPUT FILES (" + files.length + ")"));
+    if (!files.length) fl.appendChild(el("p", "wr-muted", "no output files yet"));
+    files.forEach(function (f) {
+      var row = el("div", "wr-file");
+      row.appendChild(el("span", "wr-fname", f.path));
+      if (f.size != null && f.size > 0) row.appendChild(el("span", "wr-fsize", f.size));
+      fl.appendChild(row);
+    });
+    body.appendChild(fl);
+
+    card.appendChild(body);
+    return card;
+  }
+
+  function agentOutputFiles(a) {
+    var out = [];
+    state.projects.forEach(function (p) {
+      if (!p || !p.name) return;
+      var agents = p.agents && p.agents.length ? p.agents : projectAgents(p.name);
+      var mine = agents.some(function (x) {
+        return x.id === a.id;
+      });
+      if (!mine) return;
+      (p.files || []).forEach(function (f) {
+        out.push({ path: p.name + "/" + f.name, size: f.size });
+      });
+      if (!p.files || !p.files.length) out.push({ path: p.name + "/", size: "" });
+    });
+    return out.slice(0, 20);
+  }
+
+  function render() {
+    if (!$("#wr-root")) buildPanel();
+    var list = $("#wr-agents");
+    list.textContent = "";
+    var visible = state.agents.filter(function (a) {
+      return !a.archived || (a.isGod && false);
+    });
+    if (!visible.length) visible = state.agents;
+    visible.forEach(function (a) {
+      list.appendChild(renderAgentCard(a));
+    });
+    $("#wr-count").textContent = visible.length + " agents";
+    var last = $("#wr-last");
+    if (last) last.textContent = "live hive · " + new Date().toLocaleTimeString();
+    var board = $("#wr-board-preview");
+    if (board) {
+      var lines = state.board.split("\n").filter(function (l) {
+        return l.length > 4;
+      });
+      board.textContent = short(lines.join("\n"), 400);
+    }
+    var tasksDoing = state.tasks.filter(function (t) {
+      return t.status === "doing";
+    }).length;
+    var tasksDone = state.tasks.filter(function (t) {
+      return t.status === "done";
+    }).length;
+    $("#wr-stats").textContent = "tasks: " + state.tasks.length + " (doing " + tasksDoing + ", done " + tasksDone + ")";
+  }
+
+  function buildPanel() {
+    var root = el("div", "wr-root");
+    root.id = "wr-root";
+    root.innerHTML =
+      '<button id="wr-toggle" class="wr-toggle" title="Work results panel">WORK RESULTS</button>' +
+      '<div id="wr-panel" class="wr-panel">' +
+      '  <div class="wr-panel-head">' +
+      '    <div><div class="wr-logo">MD</div><h2 class="wr-title">WORK RESULTS</h2>' +
+      '      <div class="wr-sub"><span id="wr-count"></span> · <span id="wr-stats"></span></div></div>' +
+      '    <button id="wr-close" class="wr-close" title="Close">×</button>' +
+      '  </div>' +
+      '  <div class="wr-scroll" id="wr-agents"></div>' +
+      '  <div class="wr-panel-foot"><span id="wr-last"></span><span class="wr-muted">auto-refresh ' + Math.round(POLL_MS / 1000) + 's</span></div>' +
+      '</div>';
+    document.body.appendChild(root);
+
+    var toggle = $("#wr-toggle");
+    var panel = $("#wr-panel");
+    toggle.addEventListener("click", function () {
+      panel.classList.add("wr-open");
+      toggle.style.display = "none";
+    });
+    $("#wr-close").addEventListener("click", function () {
+      panel.classList.remove("wr-open");
+      toggle.style.display = "";
+    });
+
+    var css = el("style");
+    css.textContent = WR_CSS;
+    document.head.appendChild(css);
+  }
+
+  var WR_CSS =
+    ".wr-root{position:fixed;inset:0;pointer-events:none;z-index:2147483000;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;}" +
+    ".wr-toggle{position:fixed;right:16px;top:16px;z-index:2147483001;pointer-events:auto;cursor:pointer;background:#6E1423;color:#F4F1EA;border:3px solid #4A0D17;font-family:'Press Start 2P',monospace;font-size:10px;letter-spacing:1px;padding:10px 14px;box-shadow:4px 4px 0 rgba(26,19,32,.35);}" +
+    ".wr-toggle:hover{background:#8A1B2D;}" +
+    ".wr-panel{position:fixed;top:0;right:0;bottom:0;width:min(560px,94vw);background:#FFF8E7;color:#1A1320;border-left:4px solid #4A0D17;box-shadow:-8px 0 24px rgba(26,19,32,.35);transform:translateX(105%);transition:transform .25s ease;pointer-events:auto;display:flex;flex-direction:column;}" +
+    ".wr-panel.wr-open{transform:translateX(0);}" +
+    ".wr-panel-head{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;padding:14px 18px;background:#1A1320;color:#F4F1EA;border-bottom:4px solid #6E1423;}" +
+    ".wr-logo{display:inline-grid;place-items:center;width:36px;height:36px;background:#6E1423;border:3px solid #4A0D17;font-family:'Press Start 2P',monospace;font-size:10px;margin-right:8px;vertical-align:middle;}" +
+    ".wr-title{display:inline-block;font-family:'Press Start 2P',monospace;font-size:12px;margin:0;vertical-align:middle;}" +
+    ".wr-sub{font-size:11px;color:#CBB8D8;margin-top:6px;}" +
+    ".wr-close{background:none;border:none;color:#F4F1EA;font-size:24px;cursor:pointer;line-height:1;}" +
+    ".wr-scroll{flex:1;overflow-y:auto;padding:14px 18px 20px;}" +
+    ".wr-panel-foot{display:flex;justify-content:space-between;padding:8px 18px;border-top:1px solid #E4D8C0;font-size:11px;color:#6B5878;}" +
+    ".wr-card{margin:0 0 16px;border:2px solid #4A0D17;background:#FFFFFF;box-shadow:3px 3px 0 rgba(26,19,32,.18);}" +
+    ".wr-card-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;padding:10px 12px;border-bottom:2px solid #E4D8C0;}" +
+    ".wr-name{margin:0;font-family:'Press Start 2P',monospace;font-size:11px;}" +
+    ".wr-role{font-size:11px;color:#6B5878;}" +
+    ".wr-id{font-size:10px;color:#9A8C9E;background:#F2EADA;padding:1px 6px;border-radius:8px;}" +
+    ".wr-status{font-weight:700;font-size:11px;margin-left:auto;}" +
+    ".wr-card-body{padding:10px 12px;}" +
+    ".wr-block{margin:0 0 12px;}" +
+    ".wr-block-title{margin:0 0 6px;font-family:'Press Start 2P',monospace;font-size:8px;letter-spacing:1px;color:#6B5878;}" +
+    ".wr-muted{color:#9A8C9E;font-size:11px;margin:2px 0;}" +
+    ".wr-task,.wr-msg,.wr-file{display:flex;gap:8px;align-items:baseline;font-size:12px;padding:3px 0;border-bottom:1px dotted #E4D8C0;}" +
+    ".wr-badge{font-size:9px;font-weight:700;padding:1px 5px;border:1px solid #4A0D17;color:#4A0D17;text-transform:uppercase;white-space:nowrap;}" +
+    ".wr-task-title{flex:1;}" +
+    ".wr-time{color:#9A8C9E;font-size:10px;white-space:nowrap;}" +
+    ".wr-qa{font-size:11px;padding:3px 0 3px 10px;color:#4A384F;}" +
+    ".wr-q{display:block;}" +
+    ".wr-a{display:block;color:#2A6FB0;}" +
+    ".wr-act{font-size:9px;font-weight:700;text-transform:uppercase;color:#6E1423;border:1px solid #6E1423;padding:1px 4px;white-space:nowrap;}" +
+    ".wr-who{color:#6B5878;font-size:10px;white-space:nowrap;}" +
+    ".wr-subj{flex:1;}" +
+    ".wr-msg-out .wr-act{color:#2A6FB0;border-color:#2A6FB0;}" +
+    ".wr-file{font-family:'JetBrains Mono',Menlo,monospace;font-size:11px;}" +
+    ".wr-fname{flex:1;color:#1A1320;}" +
+    ".wr-fsize{color:#9A8C9E;font-size:10px;}";
+
+  /* ── start ────────────────────────────────────────────────────────────── */
+  function start() {
+    load();
+    timers.push(setInterval(load, POLL_MS));
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start);
+  } else {
+    start();
+  }
+
+  window.__workResults = { load: load, state: state, refresh: load };
+})();

--- a/work-results/server.js
+++ b/work-results/server.js
@@ -1,0 +1,343 @@
+"use strict";
+/* work-results web server — serves the REAL Munder Difflin renderer + the
+ * self-contained work-results.js panel, backed by live hive files (read-only).
+ * Adds the projects tree and outbox messages to /api/state for the panel.
+ */
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const HOST = process.env.WR_HOST || "127.0.0.1";
+const PORT = Number(process.env.WR_PORT || 8788);
+
+const HIVE_ROOT = process.env.HIVE_ROOT || "/Users/skyzhao/HarnessAgents/hive";
+const PROJECTS_ROOT = process.env.PROJECTS_ROOT || "/Users/skyzhao/HarnessAgents/projects";
+const APP_DIR = path.join(__dirname, "public", "app");
+const PUBLIC_DIR = path.join(__dirname, "public");
+
+function sep() {
+  return process.platform === "win32" ? "\\" : "/";
+}
+
+/* Self-heal the renderer bundle copy: if the served app lacks the entry JS,
+ * mirror it from the sibling web-office build (env ASSETS_SRC or default). */
+function ensureAssets() {
+  try {
+    const entry = path.join(APP_DIR, "assets", "index-DPf-thQz.js");
+    if (fs.existsSync(entry)) return;
+    const src = process.env.ASSETS_SRC || "/Users/skyzhao/HarnessAgents/worktrees/worker-kevin-web-office-v2/web-office/public/app";
+    const srcAssets = path.join(src, "assets");
+    if (!fs.existsSync(srcAssets)) {
+      console.warn("work-results: no renderer bundle locally and ASSETS_SRC missing at", srcAssets);
+      return;
+    }
+    fs.cpSync(srcAssets, path.join(APP_DIR, "assets"), { recursive: true });
+    console.log("work-results: mirrored renderer assets from", srcAssets);
+  } catch (e) {
+    console.warn("work-results: ensureAssets failed:", e.message);
+  }
+}
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".map": "application/json",
+};
+
+function readJson(rel) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(HIVE_ROOT, rel), "utf8"));
+  } catch {
+    return null;
+  }
+}
+function readText(rel) {
+  try {
+    return fs.readFileSync(path.join(HIVE_ROOT, rel), "utf8");
+  } catch {
+    return null;
+  }
+}
+function readAgentFile(id, rel) {
+  try {
+    return fs.readFileSync(path.join(HIVE_ROOT, "agents", id, rel), "utf8");
+  } catch {
+    return null;
+  }
+}
+function listAgentJson(id, dir) {
+  const base = path.join(HIVE_ROOT, "agents", id, dir);
+  try {
+    return fs
+      .readdirSync(base)
+      .filter((f) => f.endsWith(".json"))
+      .sort()
+      .map((f) => {
+        try {
+          return JSON.parse(fs.readFileSync(path.join(base, f), "utf8"));
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function agentDirectory() {
+  const registry = readJson("registry.json") || { godId: null, agents: {} };
+  const fleet = readJson("fleet.json") || { agents: [] };
+  const byId = new Map(fleet.agents.map((a) => [a.id, a]));
+  const agents = Object.entries(registry.agents || {}).map(([id, a]) => {
+    const f = byId.get(id) || {};
+    return {
+      id,
+      name: a.name,
+      role: a.role ?? (a.isGod ? "orchestrator" : "agent"),
+      provider: a.provider ?? "claude",
+      model: f.model ?? null,
+      status: f.status ?? a.status ?? "idle",
+      cwd: a.cwd ?? null,
+      cwdValid: a.cwdValid ?? null,
+      archived: !!a.archived,
+      isGod: !!a.isGod,
+      isAssistant: !!a.isAssistant,
+      sessionId: a.sessionId ?? null,
+      inboxBacklog: f.inboxBacklog ?? 0,
+      breaker: f.breaker ?? "healthy",
+      tokens: f.tokens ?? 0,
+      usd: Number((f.usd ?? 0).toFixed(4)),
+      lastTool: f.lastTool ?? null,
+      lastActiveSecAgo: f.lastActiveSecAgo ?? null,
+      onHold: !!f.onHold,
+      contextTokens: null,
+      contextLimit: null,
+      contextPct: null,
+    };
+  });
+  return { godId: registry.godId, agents };
+}
+
+/* Projects output tree: one entry per project dir, with top-level files +
+ * which agents' cwd points into it. Used by the work-results panel. */
+function projectsTree() {
+  const out = [];
+  let names = [];
+  try {
+    names = fs.readdirSync(PROJECTS_ROOT);
+  } catch {
+    return out;
+  }
+  const registry = readJson("registry.json") || { agents: {} };
+  const tasks = (readJson("tasks.json") || { tasks: [] }).tasks || [];
+  const board = readText("board.md") || "";
+  const slugOf = (p) => p.name.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+
+  /* Board.md is the authoritative producer record, but lines are long and name
+   * many agents. Attribute only when the agent's name/id appears within a short
+   * window around the `projects/<slug>` reference (same sentence, ~140 chars). */
+  const boardLines = board.split("\n");
+  const boardAttributed = (id, a, want) => {
+    const display = (a && a.name || "").toLowerCase();
+    const idlc = id.toLowerCase();
+    const ref = "projects" + sep() + want;
+    for (const line of boardLines) {
+      const idx = line.indexOf(ref);
+      if (idx === -1) continue;
+      const ll = line.toLowerCase();
+      const from = Math.max(0, idx - 140);
+      const to = Math.min(line.length, idx + ref.length + 140);
+      const window = ll.slice(from, to);
+      if (window.indexOf(idlc) !== -1 || (display && window.indexOf(display) !== -1)) return true;
+    }
+    return false;
+  };
+
+  for (const name of names) {
+    if (name.startsWith(".")) continue;
+    const want = slugOf({ name });
+    /* Precise attribution: cwd inside projects/<name>, worktree/id named after
+     * the slug, a tasks.json assignee whose card mentions projects/<name>, or a
+     * board.md line naming the agent next to projects/<name>. */
+    const attributed = (id, a) => {
+      if (a && a.isGod) return false;
+      const cwd = String((a && a.cwd) || "");
+      const hay = (id + " " + cwd).toLowerCase();
+      if (cwd.indexOf("projects" + sep() + want) !== -1) return true;
+      if (hay.indexOf("worktree") !== -1 && hay.indexOf(want) !== -1) return true;
+      if (hay.indexOf("projects" + sep()) !== -1 && hay.indexOf(want) !== -1) return true;
+      for (const t of tasks) {
+        if ((t.assignee || "") !== id) continue;
+        const text = ((t.title || "") + " " + (t.description || "")).toLowerCase();
+        if (text.indexOf("projects" + sep() + want) !== -1) return true;
+      }
+      if (boardAttributed(id, a, want)) return true;
+      const mem = readAgentFile(id, "memory.md") || "";
+      return mem.indexOf("projects" + sep() + want) !== -1;
+    };
+
+    const full = path.join(PROJECTS_ROOT, name);
+    let isDir = false;
+    let files = [];
+    try {
+      isDir = fs.statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    try {
+      files = fs
+        .readdirSync(full)
+        .filter((f) => !f.startsWith(".") && !["node_modules", ".git"].includes(f))
+        .slice(0, 40)
+        .map((f) => {
+          let size = 0;
+          try {
+            const st = fs.statSync(path.join(full, f));
+            size = st.isDirectory() ? 0 : st.size;
+          } catch {}
+          return { name: f, size };
+        });
+    } catch {}
+    const agents = Object.entries(registry.agents || {})
+      .filter(([id, a]) => attributed(id, a))
+      .map(([id, a]) => ({ id, name: a.name }));
+    out.push({ name, files, agents });
+  }
+  return out;
+}
+
+function buildState() {
+  const registry = readJson("registry.json") || { godId: null, agents: {} };
+  const tasks = readJson("tasks.json") || { tasks: [] };
+  const fleet = readJson("fleet.json") || { agents: [] };
+  const board = readText("board.md") || "";
+  const directory = agentDirectory();
+  const memories = {};
+  const inboxes = {};
+  const outboxes = {};
+  const messages = [];
+  for (const a of directory.agents) {
+    if (a.archived) continue;
+    memories[a.id] = readAgentFile(a.id, "memory.md") || "";
+    const inbox = listAgentJson(a.id, "inbox");
+    const outbox = listAgentJson(a.id, "outbox");
+    inboxes[a.id] = inbox;
+    outboxes[a.id] = outbox;
+    for (const m of inbox) messages.push(Object.assign({}, m, { direction: "inbox", owner: a.id }));
+    for (const m of outbox) messages.push(Object.assign({}, m, { direction: "outbox", owner: a.id }));
+  }
+  return {
+    ts: Date.now(),
+    hiveRoot: HIVE_ROOT,
+    projectsRoot: PROJECTS_ROOT,
+    board,
+    tasks,
+    registry,
+    fleet,
+    agentDirectory: directory,
+    projects: projectsTree(),
+    logTail: [],
+    memories,
+    inboxes,
+    outboxes,
+    messages,
+    telemetry: {
+      usage: fleet.agents.map((a) => ({ agentId: a.id, input: 0, output: 0, cacheRead: 0, cacheCreation: 0, model: a.model ?? null, usd: a.usd ?? 0, ts: fleet.ts ?? Date.now() })),
+      spans: {},
+    },
+    config: { version: "0.4.6", hiveRoot: HIVE_ROOT, onboardingComplete: true, harnessHome: HIVE_ROOT },
+  };
+}
+
+function sendJson(res, code, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(code, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+    "Access-Control-Allow-Origin": "*",
+  });
+  res.end(body);
+}
+
+function serveStatic(res, root, pathname) {
+  const rel = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
+  const file = path.resolve(root, rel);
+  const rootResolved = path.resolve(root);
+  if (file !== path.join(rootResolved, "index.html") && !file.startsWith(rootResolved + path.sep)) {
+    sendJson(res, 403, { error: "forbidden", path: pathname });
+    return;
+  }
+  fs.readFile(file, (err, data) => {
+    if (err) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("not found: " + pathname);
+      return;
+    }
+    const ext = path.extname(file).toLowerCase();
+    res.writeHead(200, {
+      "Content-Type": MIME[ext] || "application/octet-stream",
+      "Cache-Control": ext === ".html" ? "no-store" : "public, max-age=3600",
+    });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host || HOST}`);
+  const pathname = url.pathname;
+  if (req.method !== "GET") {
+    sendJson(res, 405, { error: "method not allowed" });
+    return;
+  }
+  if (pathname === "/" || pathname === "/index.html") {
+    serveStatic(res, APP_DIR, "/");
+    return;
+  }
+  if (pathname === "/api/state") {
+    sendJson(res, 200, buildState());
+    return;
+  }
+  if (pathname === "/api/projects") {
+    sendJson(res, 200, { ts: Date.now(), projects: projectsTree() });
+    return;
+  }
+  if (pathname.startsWith("/app/")) {
+    serveStatic(res, APP_DIR, pathname.slice("/app".length));
+    return;
+  }
+  if (!pathname.includes("..")) {
+    const appFile = path.resolve(APP_DIR, pathname.replace(/^\/+/, ""));
+    if (appFile.startsWith(path.resolve(APP_DIR) + path.sep) && fs.existsSync(appFile)) {
+      serveStatic(res, APP_DIR, pathname);
+      return;
+    }
+    serveStatic(res, PUBLIC_DIR, pathname);
+    return;
+  }
+  sendJson(res, 404, { error: "not found", path: pathname });
+});
+
+server.listen(PORT, HOST, () => {
+  console.log("Munder Difflin — WORK-RESULTS panel server");
+  console.log(`  Serving:  http://${HOST}:${PORT}/`);
+  console.log(`  Hive:     ${HIVE_ROOT} (read-only)`);
+  console.log(`  Projects: ${PROJECTS_ROOT} (read-only)`);
+});
+server.on("error", (err) => {
+  console.error("work-results server failed:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## What & why

The inbox-wake watchdog (`src/main/workerWake.ts`) re-announced the **same** undrained mail every 60s for as long as the inbox stayed non-empty: `decide()` keyed on a *level* (`inboxCount > 0`), never an *edge* (new mail arrived). One agent session measured **243 identical nudges naming the same three message ids over 75 minutes** — 84% of all user turns were nudges.

Now the watchdog remembers, per worker, the inbox message ids it has already announced and only nudges when a **new** id appears. A worker genuinely stuck on already-announced mail (#151) is still re-woken, but on a backoff ladder (`60s → 5m → 30m → 30m`) instead of a flat minute forever. New mail resets the ladder. When inbox ids are unavailable the nudge stays level-triggered for backward compatibility.

Closes #358

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

The same `test/worker-wake.test.cjs` run against **main** and against this branch. No UI surface — the before/after is the new coverage going from red to green.

### Before

The watchdog has no memory of announced ids, so an agent whose only mail was already announced keeps being woken every cooldown — the exact #358 burst. The new edge-trigger tests fail on main:

https://raw.githubusercontent.com/skyzhao1223/munder-difflin/6a907ff89317d3c527adbcc14b57c308cef6ec82/evidence/munder-evidence-before.png

### After

The watchdog edge-triggers on new ids and backs off on repeats. The same tests pass (18/18 in this file; 749/749 across the suite):

https://raw.githubusercontent.com/skyzhao1223/munder-difflin/6a907ff89317d3c527adbcc14b57c308cef6ec82/evidence/munder-evidence-after.png

## How I tested it

- OS: macOS
- Steps:
  1. `node --test test/worker-wake.test.cjs` — 18/18 pass
  2. `npm run test:focused` — 749/749 pass
  3. `npm run typecheck:node` — clean
  4. Red→green: checked out `src/main/workerWake.ts` + `src/main/index.ts` from main, ran the new tests (2 fail), then restored this branch (all pass)

## Discord (optional)

Discord:

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [ ] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [ ] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [ ] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.
