### PR TITLE
feat(opencode): list live CLI models in the Add-Agent picker

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { homedir } from 'node:os';
 import { request as httpsRequest } from 'node:https';
 import { PtyManager, type SpawnOptions } from './pty';
 import { resolveCommand as resolveCliCommand, isSafeCommandName } from './shellEnv';
+import { listOpenCodeModels } from './openCodeModels';
 import { initAutoUpdater, abortPendingRestart } from './updater';
 import { RealtimeFloorWatcher } from './realtimeFloorWatcher';
 import {
@@ -3103,6 +3104,14 @@ ipcMain.handle('integrations:test', async (_evt, payload: unknown) => {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 });
+
+// ─── IPC: OpenCode model discovery ──────────────────────────────────────────
+// The Add-Agent picker asks the OpenCode CLI for its live model list (`opencode
+// models`) so a user sees the slugs they can actually reach, not just the static
+// curated catalog. Best-effort: returns [] when the CLI is absent or the probe
+// fails, and the renderer falls back to the shipped list. Provider-specific by
+// design — only OpenCode advertises its catalog this way.
+ipcMain.handle('opencode:listModels', (): string[] => listOpenCodeModels());
 
 // ─── IPC: config ────────────────────────────────────────────────────────────
 ipcMain.handle('config:get', (): HarnessConfig => readConfig());

--- a/src/main/openCodeModels.ts
+++ b/src/main/openCodeModels.ts
@@ -1,0 +1,78 @@
+// Runtime model discovery for the OpenCode CLI.
+//
+// The Add-Agent model picker ships a small CURATED list of OpenCode slugs
+// (src/shared/modelCatalog.json) because models.dev drifts and a hardcoded list
+// goes stale. `opencode models` is the CLI's own source of truth — it prints the
+// live catalog the user can actually reach (their authenticated providers plus
+// models.dev), one `provider/model` slug per line. This module runs it once and
+// parses those slugs so the renderer can merge them into the picker.
+//
+// Everything here is best-effort and provider-neutral in spirit: any failure
+// (CLI absent, offline, non-zero exit, junk output) returns an EMPTY list, and
+// the caller falls back to the static catalog. Discovery never blocks a hire.
+
+import { spawnSync } from 'node:child_process';
+import { resolveCommand, userShellPath } from './shellEnv';
+
+/** Longest we let `opencode models` run before giving up. It hits models.dev on
+ *  a cold run, so this is generous — but bounded, because it executes on the
+ *  main process and a hang would freeze every window. */
+const OPENCODE_MODELS_TIMEOUT_MS = 8000;
+
+/** Cache the parsed list for the process lifetime. The catalog does not change
+ *  mid-session, and each call boots a subprocess (and possibly a network round
+ *  trip), so the picker should pay that cost at most once. Only a SUCCESSFUL,
+ *  non-empty read is cached; an empty result stays retryable (the user may have
+ *  just installed the CLI or authenticated a provider). */
+let cached: string[] | null = null;
+
+/** A plausible `provider/model` slug as printed by `opencode models`: at least
+ *  one `provider/` segment, no whitespace, printable. Guards against rc-file
+ *  chatter or an error banner sneaking into the list as if it were a model. */
+function looksLikeSlug(line: string): boolean {
+  return /^[A-Za-z0-9._-]+\/[A-Za-z0-9./:_-]+$/.test(line);
+}
+
+/** Parse the raw stdout of `opencode models` into a de-duplicated slug list,
+ *  preserving the CLI's own ordering (opencode/* first, then per provider).
+ *  Exported so it can be unit-tested without spawning a process. */
+export function parseOpenCodeModels(stdout: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || !looksLikeSlug(line) || seen.has(line)) continue;
+    seen.add(line);
+    out.push(line);
+  }
+  return out;
+}
+
+/** Run `opencode models` and return the live slug list, or [] on any failure.
+ *
+ *  Uses the shared PATH/binary resolution (shellEnv) so it finds `opencode` in a
+ *  packaged app the same way agent spawns do — Electron on macOS starts without
+ *  the login-shell PATH, so a bare `opencode` would ENOENT. */
+export function listOpenCodeModels(): string[] {
+  if (cached !== null) return cached;
+
+  const bin = resolveCommand('opencode');
+  try {
+    const res = spawnSync(bin, ['models'], {
+      encoding: 'utf8',
+      timeout: OPENCODE_MODELS_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      // Give the child the user's real PATH so any tools opencode shells out to
+      // resolve too, matching the environment an agent spawn would see.
+      env: { ...process.env, PATH: userShellPath() }
+    });
+    // A non-zero exit, a signal (timeout kill), or a spawn error all mean "we
+    // could not read the live list" — return empty and let the caller fall back.
+    if (res.status !== 0 || res.error) return [];
+    const models = parseOpenCodeModels(res.stdout ?? '');
+    if (models.length > 0) cached = models;
+    return models;
+  } catch {
+    return [];
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -652,6 +652,13 @@ const api = {
     try { return ipcRenderer.sendSync('app:readClipboardSync') ?? ''; } catch { return ''; }
   },
 
+  // ─── OpenCode model discovery ──────────────────────────────────────────────
+  /** The live `provider/model` slugs reported by the OpenCode CLI (`opencode
+   *  models`), for the Add-Agent picker. Best-effort: resolves to [] when the CLI
+   *  is absent or the probe fails, and the picker falls back to the static list. */
+  listOpenCodeModels: (): Promise<string[]> =>
+    ipcRenderer.invoke('opencode:listModels'),
+
   // ─── Config ──────────────────────────────────────────────────────────────
   getConfig: (): Promise<HarnessConfig> =>
     ipcRenderer.invoke('config:get'),

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -205,6 +205,21 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   const [description, setDescription] = useState(pendingHire?.description ?? 'a fresh harness');
   const [hireMeta, setHireMeta] = useState<HireManifest | null>(pendingHire);
 
+  // Live model slugs from the OpenCode CLI (`opencode models`), merged into the
+  // picker below alongside the static curated catalog. Empty until loaded and
+  // for every other provider — the fetch runs only when OpenCode is selected,
+  // and any failure leaves this [] so the picker just shows the shipped list.
+  const [opencodeModels, setOpencodeModels] = useState<string[]>([]);
+  useEffect(() => {
+    if (provider !== 'opencode') { setOpencodeModels([]); return; }
+    let alive = true;
+    window.cth
+      .listOpenCodeModels()
+      .then((slugs) => { if (alive) setOpencodeModels(slugs); })
+      .catch(() => { /* best-effort: fall back to the static catalog */ });
+    return () => { alive = false; };
+  }, [provider]);
+
   // Picking a model rebuilds the command; the command field stays editable for
   // power users (it's the source of truth for the actual spawn).
   const pickModel = (id?: string) => {
@@ -917,9 +932,22 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                           // selected card instead of leaving the picker looking unset —
                           // the command field already carries it either way.
                           const known = modelsForProvider(provider);
-                          return model && !known.some((m) => m.id === model)
-                            ? [...known, { id: model, label: tr('addAgent.fromHire', { model }) }]
-                            : known;
+                          // For OpenCode, fold in the live slugs from `opencode
+                          // models` (fetched above) that the static catalog does
+                          // not already list, deduped by id. The id-less "CLI
+                          // default" entry never matches a real slug, so it stays.
+                          const withDiscovered =
+                            provider === 'opencode' && opencodeModels.length > 0
+                              ? [
+                                  ...known,
+                                  ...opencodeModels
+                                    .filter((slug) => !known.some((m) => m.id === slug))
+                                    .map((slug) => ({ id: slug, label: slug }))
+                                ]
+                              : known;
+                          return model && !withDiscovered.some((m) => m.id === model)
+                            ? [...withDiscovered, { id: model, label: tr('addAgent.fromHire', { model }) }]
+                            : withDiscovered;
                         })().map((m) => {
                           const active = (model ?? '') === (m.id ?? '');
                           return (

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -219,11 +219,13 @@ interface ModelCatalog {
  *    follow the CLI instead of pinning preview model ids that drift.
  *  - qwen: qwen-code (`qwen`), the proxy-bridge CLI driving an OpenAI-compatible
  *    endpoint. Starting suggestions only. // TODO-verify the live list.
- *  - opencode: `--model` takes a `provider/model` slug; curated BYOK suggestions
- *    (`opencode models` / models.dev is the source of truth). `CLI default` is the
+ *  - opencode: `--model` takes a `provider/model` slug. These curated BYOK
+ *    entries are the OFFLINE fallback; the Add-Agent picker also queries the CLI
+ *    at runtime (`opencode models`, via window.cth.listOpenCodeModels) and merges
+ *    the live slugs in, so the drift the // TODO-verify used to warn about is now
+ *    self-correcting when the CLI is installed. `CLI default` stays the
  *    PRESELECTED entry, because a BYOK slug the user holds no key for fails
  *    silently — see the recommendedOrchestratorModel note in agentProvider.ts.
- *    // TODO-verify exact live slugs (they drift).
  *  - crush: `--model` takes a `provider/model-id` slug; free-text editable (Crush
  *    accepts arbitrary slugs). The local pick is an OpenAI-wire slug so traffic
  *    routes through the proxy (the harness overrides the `openai` provider's


### PR DESCRIPTION
## Summary

When an agent's provider is **OpenCode**, the Add-Agent model picker now queries the OpenCode CLI at runtime (`opencode models`) and merges the live `provider/model` slugs into the picker, instead of offering only the small curated catalog. If the CLI is missing or the probe fails, the picker silently falls back to the shipped static list, so nothing regresses for users without OpenCode installed.

## Why

The curated OpenCode list in `modelCatalog.json` was a fixed set of BYOK suggestions carrying a standing `// TODO-verify` because the real catalog drifts. `opencode models` is the CLI's own source of truth (the user's authenticated providers plus models.dev), so this wires it in and the picker shows models the user can actually reach.

## What changed

- **`src/main/openCodeModels.ts`** (new) — `listOpenCodeModels()` runs `opencode models` via `spawnSync`, reusing the existing `shellEnv` helpers (`resolveCommand` + `userShellPath`) so the binary resolves in a packaged app despite the macOS GUI-PATH issue. Parses newline-delimited slugs, dedupes, caches a successful non-empty read, and returns `[]` on any failure. `parseOpenCodeModels` is split out for unit testing.
- **`src/main/index.ts`** — registers `ipcMain.handle('opencode:listModels', …)`.
- **`src/preload/index.ts`** — exposes `listOpenCodeModels(): Promise<string[]>` on `window.cth` (type auto-flows via `CthApi = typeof api`).
- **`src/renderer/src/components/AddAgentModal.tsx`** — fetches only when OpenCode is selected (effect keyed on `provider`, unmount-guarded) and merges discovered slugs into the picker, deduped by id, keeping the preselected id-less "CLI default" entry.
- **`src/renderer/src/store/config.ts`** — updated the stale doc comment (dropped the `// TODO-verify`).

Stays provider-neutral: only the OpenCode arm calls the CLI; every other provider is unaffected.

## How tested (macOS, Node 20)

- `npm run typecheck` — green (node + web)
- `npm run test:focused` — 745/745 pass
- `npm run build` — succeeds
- Manual: verified `opencode models` output live (52 slugs on this machine) and confirmed they render in the picker.

## Before

<img width="800" height="692" alt="image" src="https://github.com/user-attachments/assets/b8a7e388-7189-426a-a27e-f503e820f4b9" />

## After

<img width="1994" height="1726" alt="image" src="https://github.com/user-attachments/assets/1e338e04-9eff-4932-b6e1-9ad02a716353" />

