### PR TITLE
l10n: Chinese translation of source comments + terminal CJK/duplicate/flash fixes

### DIFF
--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -1,156 +1,156 @@
 /**
- * Product analytics (PostHog) — anonymous, allowlisted, opt-out.
+ * 产品分析（PostHog）——匿名、白名单、默认退出（opt-out）。
  *
- * This is the OUTBOUND product-usage counterpart to telemetry.ts (which is the
- * loopback-only OTel collector and never leaves the machine). Everything here
- * is governed by TELEMETRY.md — the public contract. Keep the two in lockstep:
- * an event or property that isn't in TELEMETRY.md must not be added here, and
- * vice versa.
+ * 这是 telemetry.ts 的对外产品使用量对应物（telemetry.ts 是仅回环的本机
+ * OTel 采集器，永远不会离开机器）。这里的一切都受 TELEMETRY.md——公共
+ * 契约约束。两者必须保持同步：TELEMETRY.md 中不存在的事件或属性绝不能
+ * 在这里添加，
+ * 反之亦然。
  *
- * 🔒 Anonymity is BY CONSTRUCTION, same philosophy as telemetry.ts:
- *   - Every event carries `$process_person_profile: false` → PostHog stores it
- *     as an anonymous event and never creates a person profile.
- *   - The distinct id is a RANDOM UUID minted at first run and stored in
- *     userData (`telemetry-install-id`) — not a machine id, not derivable from
- *     anything, gone when the app's data dir is deleted.
- *   - `track()` enforces a per-event property ALLOWLIST (EVENTS below), so a
- *     future call site cannot leak a new property by accident: unknown events
- *     and unknown keys are dropped, never sent.
- *   - No prompts, transcripts, file paths, repo names, hostnames, or agent
- *     output — nothing free-form crosses this seam.
+ * 🔒 匿名性「按构造（BY CONSTRUCTION）」保证，与 telemetry.ts 理念一致：
+ *   - 每个事件都携带 `$process_person_profile: false` → PostHog 将其存储为
+ *     匿名事件，且绝不创建人物画像。
+ *   - distinct id 是在首次运行时铸造的随机 UUID，存储于 userData
+ *     （`telemetry-install-id`）——不是机器 id，不可由任何东西推导，应用数据目录
+ *     被删除即随之消失。
+ *   - `track()` 强制按事件属性白名单（见下方 EVENTS），因此未来的
+ *     调用点不会意外泄露新属性：未知事件和未知键都会被丢弃，
+ *     绝不发送。
+ *   - 不含任何提示词、对话记录、文件路径、仓库名、主机名或 agent 输出——
+ *     没有任何自由格式内容越过这条界线。
  *
- * Sending is gated on ALL of (checked in this order):
- *   1. A build-time key (__POSTHOG_KEY__, injected from the POSTHOG_KEY env in
- *      release CI). Dev builds and forks compile with '' → this whole module is
- *      a silent no-op for them.
- *   2. The DO_NOT_TRACK env convention (any value except '' / '0') — respected
- *      unconditionally, checked at every send so it can't be raced.
- *   3. The user's `telemetryEnabled` config (Settings → Privacy; default ON,
- *      i.e. opt-out — flipped live via setEnabled()).
+ * 发送受以下所有条件门控（按此顺序检查）：
+ *   1. 构建期密钥（__POSTHOG_KEY__，在发布 CI 中从 POSTHOG_KEY 环境变量
+ *      注入）。开发构建和 fork 编译为 '' → 对它们而言整个模块
+ *      是静默 no-op。
+ *   2. DO_NOT_TRACK 环境变量约定（除 '' / '0' 之外的任何值）——无条件遵守，
+ *      在每次发送时检查，因此不会被竞态绕过。
+ *   3. 用户的 `telemetryEnabled` 配置（设置 → 隐私；默认为开启，即 opt-out
+ *      ——可通过 setEnabled() 实时切换）。
  *
- * Deliberately free of any `electron` import (paths/version are injected via
- * init) so it can be smoke-tested as a plain Node module, like telemetry.ts.
+ * 刻意不引入任何 `electron` 导入（路径/版本经 init 注入），因此可以像 telemetry.ts
+ * 一样作为纯 Node 模块做冒烟测试。
  */
 import { closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync, readSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { PostHog } from 'posthog-node';
 
-// Injected by electron-vite `define` (electron.vite.config.ts) from the
-// POSTHOG_KEY / POSTHOG_HOST env at BUILD time. Empty in dev/fork builds.
+// 由 electron-vite `define`（electron.vite.config.ts）在构建时从
+// POSTHOG_KEY / POSTHOG_HOST 环境变量注入。开发/fork 构建中为空。
 declare const __POSTHOG_KEY__: string;
 declare const __POSTHOG_HOST__: string;
 
-/** The complete event → allowed-property-keys contract. Mirrors TELEMETRY.md
- *  exactly; `track()` refuses anything outside it. Common props (`app_version`,
- *  `os`, `arch`) are stamped centrally and are not listed per event. */
+/** 完整的事件 → 允许属性键契约。与 TELEMETRY.md 精确对应；`track()` 会拒绝
+ *  契约之外的任何内容。通用属性（`app_version`、`os`、`arch`）在中心统一
+ *  打上，不逐事件列出。 */
 const EVENTS: Record<string, ReadonlySet<string>> = {
-  /** Once per install, when the install id is first minted. */
+  /** 每次安装仅一次，当安装 id 首次铸造时触发。 */
   first_run: new Set<string>(),
-  /** Every app start. The DAU/retention backbone. */
+  /** 每次应用启动时触发。DAU/留存（retention）的支柱。 */
   app_launched: new Set<string>(),
-  /** Once per version change, on the first run after the version moved. Both
-   *  values are version strings of the same shape as the `app_version` every
-   *  event already carries; `from_version` is `unknown` for an install that
-   *  predates version stamping (i.e. anything upgrading INTO the first release
-   *  that ships this event). `via` is a fixed three-value enum saying whether
-   *  OUR updater moved the version or something else did. */
+  /** 每次版本变化一次，在版本变动后的首次运行时触发。两个值都是
+   *  与每个事件已携带的 `app_version` 同形态的版本字符串；对早于
+   *  版本打点（version stamping）的安装，`from_version` 为
+   *  `unknown`（即任何升级到首个携带该事件的版本的安装）。
+   *  `via` 是固定的三值枚举，说明是我们的更新器还是其他东西
+   *  移动了版本。 */
   update_applied: new Set<string>(['from_version', 'to_version', 'via']),
-  /** An agent PTY spawned. `provider` is the CLI engine name only. */
+  /** 一个 agent PTY 已产生。`provider` 仅是 CLI 引擎名。 */
   agent_spawned: new Set<string>(['provider']),
-  /** ── The activation funnel (v0.4.6): app_launched → onboarding_completed →
+  /** ── 激活漏斗（v0.4.6）：app_launched → onboarding_completed →
    *  agent_spawn_attempted → {agent_spawned | agent_spawn_failed |
-   *  agent_install_started → agent_install_finished}. Every added property is a
-   *  closed enum or a closed CLI name — nothing free-form, same allowlist rule. */
-  /** Onboarding wizard finished (the install crossed onboardingComplete
-   *  false→true). `provider` is the engine chosen, a closed CLI name. The top of
-   *  the funnel: what share of installs finish setup, and which engine they pick. */
+   *  agent_install_started → agent_install_finished}。每个新增属性都是
+   *  封闭枚举或封闭的 CLI 名——不含自由格式内容，与白名单规则一致。 */
+  /** 引导向导完成（安装使 onboardingComplete 从 false→true）。`provider` 是
+   *  所选引擎，一个封闭的 CLI 名。漏斗顶端：多少比例的安装完成设置，以及他们
+   *  选择哪个引擎。 */
   onboarding_completed: new Set<string>(['provider']),
-  /** A spawn was REQUESTED — every path through spawnAgentCore. Mirrors
-   *  agent_spawned; (attempted − spawned) is the activation fallout. */
+  /** 已请求一次 spawn——经过 spawnAgentCore 的每条路径。与
+   *  agent_spawned 对应；(attempted − spawned) 即激活漏斗的流失。 */
   agent_spawn_attempted: new Set<string>(['provider']),
-  /** A spawn did NOT produce a running agent. `reason` is a fixed enum (see
-   *  SpawnFailReason): `cli_missing` (engine absent and no auto-installer, manual
-   *  only), `cwd_missing`, `already_running`, `spawn_error`. */
+  /** 一次 spawn 未产生运行中的 agent。`reason` 是固定枚举（见
+   *  SpawnFailReason）：`cli_missing`（引擎缺失且无自动安装器，仅可手动）、
+   *  `cwd_missing`、`already_running`、`spawn_error`。 */
   agent_spawn_failed: new Set<string>(['provider', 'reason']),
-  /** The engine CLI was absent, so the auto-installer PTY started. `rung` is a
-   *  fixed enum (see InstallRung): `npm`, `node-then-npm`, `native`. */
+  /** 引擎 CLI 缺失，因此自动安装器 PTY 启动。`rung` 是固定枚举（见
+   *  InstallRung）：`npm`、`node-then-npm`、`native`。 */
   agent_install_started: new Set<string>(['provider', 'rung']),
-  /** The auto-installer PTY exited. `outcome` is a fixed enum (see
-   *  InstallOutcome): `agent_launched` (clean exit, the agent is relaunching) or
-   *  `install_failed` (non-zero exit — e.g. an installer that cannot complete
-   *  unattended). This is the signal that a first agent never actually started. */
+  /** 自动安装器 PTY 已退出。`outcome` 是固定枚举（见
+   *  InstallOutcome）：`agent_launched`（干净退出，agent 正在重新启动）或
+   *  `install_failed`（非零退出——例如无法无人值守完成的安装器）。这是
+   *  首个 agent 从未真正启动的信号。 */
   agent_install_finished: new Set<string>(['provider', 'rung', 'outcome']),
-  /** ── The end of the activation funnel (v0.4.6): a HUMAN sent a message to an
-   *  agent. Counted at the SUBMIT boundary, never per keystroke — see
-   *  MESSAGE_SURFACES for the four places a person can send one. Carries a COUNT
-   *  and nothing else: no text, no length, no hash. `surface` is a closed enum. */
+  /** ── 激活漏斗的末端（v0.4.6）：一个「人」向 agent 发送了消息。在提交
+   *  （SUBMIT）边界计数，绝不按每次击键——可发送消息的四个位置见
+   *  MESSAGE_SURFACES。只携带一个计数，别无其他：没有文本、没有长度、没有哈希。
+   *  `surface` 是封闭枚举。 */
   message_sent: new Set<string>(['surface']),
-  /** Coarse feature adoption; `feature` is a fixed enum (see FEATURES), fired
-   *  at most once per feature per app session. */
+  /** 粗粒度的功能采纳情况；`feature` 是固定枚举（见 FEATURES），每个功能在每个
+   *  应用会话内至多触发一次。 */
   feature_used: new Set<string>(['feature']),
-  /** Fired on quit. `duration_bucket` is a coarse label, never raw ms. */
+  /** 退出时触发。`duration_bucket` 是粗粒度标签，绝不是原始毫秒数。 */
   session_ended: new Set<string>(['duration_bucket'])
 };
 
-/** The only values `feature_used.feature` may take. */
+/** `feature_used.feature` 唯一可取的值。 */
 export type AnalyticsFeature =
   | 'slack_trigger'
   | 'webhook_trigger'
   | 'hire_install'
   | 'voice_dictation';
 
-/** The only values `agent_spawn_failed.reason` may take. A closed enum so the
- *  "why didn't the agent start" split can never carry a free-form message. */
+/** `agent_spawn_failed.reason` 唯一可取的值。封闭枚举，因此「agent 为何未启动」
+ *  的拆分永远不会携带自由格式消息。 */
 export type SpawnFailReason = 'cli_missing' | 'cwd_missing' | 'already_running' | 'spawn_error';
 
-/** The only values the install events' `rung` may take. Mirrors
- *  cliInstall.InstallRungKind minus `manual` — a manual rung spawns no installer,
- *  so it never reaches agent_install_started; it is an agent_spawn_failed:cli_missing. */
+/** 安装事件的 `rung` 唯一可取的值。对应
+ *  cliInstall.InstallRungKind 减去 `manual`——manual 这一级不产生安装器，
+ *  因此它永远不会到达 agent_install_started；它会成为 agent_spawn_failed:cli_missing。 */
 export type InstallRung = 'npm' | 'node-then-npm' | 'native';
 
-/** The only values `agent_install_finished.outcome` may take. */
+/** `agent_install_finished.outcome` 唯一可取的值。 */
 export type InstallOutcome = 'agent_launched' | 'install_failed';
 
-/** The only values `message_sent.surface` may take — the four places a HUMAN can
- *  send a message to an agent:
+/** `message_sent.surface` 唯一可取的值——人（HUMAN）可以向 agent 发送消息的
+ *  四个位置：
  *
- *   - `terminal` — typed straight into the agent's terminal and submitted with
- *     Enter (terminalPool's submit boundary, NOT `pty:write`, which fires on
- *     every keystroke and would count typing, not messages).
- *   - `composer` — the per-agent message queue composer.
- *   - `steer`    — the steer box on the agent control strip.
- *   - `hive`     — a hive message sent by the human (Command Center dispatch,
- *     a thread reply, an ASK ME answer). Agent-to-agent hive traffic is NOT
- *     counted: `hive:send` carries a `from` and only `'human'` qualifies.
+ *   - `terminal` — 直接键入 agent 的终端并按 Enter 提交（terminalPool 的
+ *     提交边界，不是 `pty:write`——后者每次击键都会触发，统计的是打字而非
+ *     消息）。
+ *   - `composer` — 每个 agent 的消息队列编辑器（composer）。
+ *   - `steer`    — agent 控制条上的 steer 输入框。
+ *   - `hive`     — 由人发送的 hive 消息（Command Center 派发、线程回复、
+ *     ASK ME 回答）。agent 之间的 hive 流量不计入：`hive:send` 携带 `from`，
+ *     只有 `'human'` 才符合条件。
  *
- *  Closed enum, same rule as every other property here. */
+ *  封闭枚举，与这里每个其他属性规则相同。 */
 export const MESSAGE_SURFACES = ['terminal', 'composer', 'steer', 'hive'] as const;
 export type MessageSurface = typeof MESSAGE_SURFACES[number];
 
-/** The subset of MESSAGE_SURFACES the RENDERER is allowed to name over IPC.
+/** 渲染进程（RENDERER）被允许通过 IPC 命名的 MESSAGE_SURFACES 子集。
  *
- *  `steer` and `hive` are counted in main, at the IPC handlers that already
- *  receive them, so the renderer must not be able to name those two — otherwise
- *  a future renderer call site could double-count a message main has already
- *  counted. `terminal` and `composer` are the only submits main cannot see for
- *  itself, so they are the only ones that cross the bridge. */
+ *  `steer` 和 `hive` 在 main 进程中、在已经接收它们的 IPC 处理器处计数，
+ *  因此渲染进程绝不能命名这两个——否则未来某个渲染进程调用点会把
+ *  main 已经计过数的消息重复计数。`terminal` 和 `composer` 是
+ *  main 无法自行看到的仅有的两个提交，
+ *  因此它们也是仅有的跨桥（bridge）传输的。 */
 const RENDERER_MESSAGE_SURFACES: ReadonlySet<string> = new Set<string>(['terminal', 'composer']);
 
-/** Validate a surface arriving from the renderer. Everything crossing that seam
- *  is untrusted input, and `track()`'s allowlist filters property KEYS but not
- *  property VALUES — so without this an unrecognised string would ride along as
- *  a free-form value, exactly what TELEMETRY.md promises never happens. */
+/** 校验来自渲染进程的 surface。任何越过该界线的输入都不可信，而 `track()` 的
+ *  白名单只过滤属性键（KEYS）而不过滤属性值（VALUES）——因此若没有此校验，
+ *  无法识别的字符串会作为自由格式值随行，这正是 TELEMETRY.md 承诺绝不会发生的
+ *  事。 */
 export function isRendererMessageSurface(v: unknown): v is MessageSurface {
   return typeof v === 'string' && RENDERER_MESSAGE_SURFACES.has(v);
 }
 
 export interface AnalyticsInitOptions {
-  /** Directory for the install-id file (userData). Created if missing. */
+  /** 安装 id 文件所在目录（userData）。若不存在则创建。 */
   stateDir: string;
-  /** App version stamped on every event. */
+  /** 打在每个事件上的应用版本。 */
   appVersion: string;
-  /** The user's `telemetryEnabled` config at boot (default true = opt-out). */
+  /** 启动时用户的 `telemetryEnabled` 配置（默认 true = opt-out）。 */
   enabled: boolean;
 }
 
@@ -159,27 +159,27 @@ function dntSet(): boolean {
   return v !== undefined && v !== '' && v !== '0';
 }
 
-/** Exported for the unit test only — index.ts uses the `analytics` singleton
- *  below. Constructing a fresh one is the only way to exercise the once-per-
- *  install paths (first_run, update_applied) more than once in a process. */
+/** 仅为单元测试导出——index.ts 使用下方 `analytics` 单例。构造全新实例是
+ *  在单个进程中多次演练每次安装只发生一次的路径（first_run、update_applied）
+ *  的唯一方式。 */
 export class Analytics {
   private client: PostHog | null = null;
   private distinctId = '';
   private enabled = false;
   private firstRun = false;
-  /** False when the state dir was unwritable and loadOrMintInstallId fell back
-   *  to an ephemeral id. Such an install cannot be recognised across boots, so
-   *  it must never report a version transition — it would report one on EVERY
-   *  boot and inflate the exact number update_applied exists to produce. */
+  /** 当状态目录不可写、loadOrMintInstallId 回退到临时 id 时为 false。这样
+   *  的安装无法在多次启动之间被识别，因此绝不能上报版本变迁——否则它会在
+   *  每次启动时都上报一次，虚增 update_applied 恰恰要统计的那个数字，
+   *  这个数字正是它存在的目的。 */
   private idPersisted = false;
   private startedAt = 0;
   private sessionEnded = false;
-  /** Session-scoped dedup for feature_used. */
+  /** 针对 feature_used 的会话级去重。 */
   private readonly featuresSeen = new Set<string>();
   private common: Record<string, string> = {};
 
-  /** Boot the client (no-op without a build-time key / with DNT set). Returns
-   *  whether this boot minted a fresh install id (first run ever). */
+  /** 启动客户端（没有构建期密钥 / 设置了 DNT 时为 no-op）。返回
+   *  本次启动是否铸造了全新的安装 id（首次运行）。 */
   init(opts: AnalyticsInitOptions): void {
     this.enabled = opts.enabled;
     this.startedAt = Date.now();
@@ -188,19 +188,19 @@ export class Analytics {
       os: process.platform,
       arch: process.arch
     };
-    if (!__POSTHOG_KEY__ || dntSet()) return; // stay dark: no client, no id file
+    if (!__POSTHOG_KEY__ || dntSet()) return; // 保持静默：无客户端、无 id 文件
     try {
       this.distinctId = this.loadOrMintInstallId(opts.stateDir);
       this.client = new PostHog(__POSTHOG_KEY__, {
         host: __POSTHOG_HOST__ || 'https://us.i.posthog.com',
-        // Events are rare (a handful per session) — send immediately so quit
-        // loses at most the final session_ended, never a whole batch.
+        // 事件很少（每个会话只有几个）——立即发送，这样退出时最多丢失最后的
+        // session_ended，绝不会丢失整批。
         flushAt: 1,
         flushInterval: 10_000,
-        // GeoIP stays OFF (posthog-node default). It was explicitly re-enabled
-        // here for country-level numbers, but nothing in this codebase ever read
-        // a country, and enabling it made PostHog derive city, postal code and
-        // lat/long as well — far past the country TELEMETRY.md describes.
+        // GeoIP 保持关闭（posthog-node 默认）。此前曾在此为获取国家级别数字
+        // 而显式重新启用，但本代码库从未读取过国家，而且启用它会让 PostHog
+        // 同时推导城市、邮政编码和经纬度——远超 TELEMETRY.md 所述的
+        // 国家范围。
         disableGeoip: true
       });
     } catch (e) {
@@ -208,16 +208,16 @@ export class Analytics {
       this.client = null;
       return;
     }
-    // Version-change detection. Read BEFORE the stamp is refreshed, and stamp
-    // BEFORE sending: at-most-once beats at-least-once here, because a
-    // duplicated update_applied would corrupt the very count it exists to
-    // produce, while a lost one costs a single install out of thousands. The
-    // stamp is refreshed for a user who opted out IN THE APP — we record
-    // locally and let track() decide whether anything leaves the machine, so
-    // turning it back on never back-fills a transition from the dark period.
-    // It is NOT refreshed under DO_NOT_TRACK or without a build key, because
-    // init() returns above before anything here runs: those installs write no
-    // file at all, and a DNT user who later unsets it reports 'unknown' once.
+    // 版本变迁检测。在刷新打点之前读取，在发送之前打点：此处「至多一次」
+    // （at-most-once）优于「至少一次」（at-least-once），因为重复的
+    // update_applied 会破坏它本要统计的那个数字，而丢失一次只是成千上万
+    // 次安装中损失一次。
+    // 对在应用内（IN THE APP）选择退出的用户，打点仍会刷新——我们只在本地
+    // 记录，由 track() 决定是否有内容离开机器，因此重新开启后绝不会从
+    // 静默期回补一次变迁。
+    // 在 DO_NOT_TRACK 或无构建密钥的情况下打点不会被刷新，因为 init() 早在
+    // 任何代码运行前就返回了：这些安装根本不写文件，而一个之后取消 DNT 的
+    // 用户只会上报一次 'unknown'。
     let transition: VersionTransition | null = null;
     if (this.idPersisted) {
       const previous = readVersionStamp(opts.stateDir);
@@ -233,24 +233,24 @@ export class Analytics {
     this.track('app_launched');
   }
 
-  /** Live opt-in/out from Settings. Turning off stops sends instantly; nothing
-   *  needs recreating to turn back on. */
+  /** 从设置中实时选择加入/退出。关闭会立即停止发送；重新开启无需重建
+   *  任何东西。 */
   setEnabled(on: boolean): void {
     this.enabled = on;
   }
 
-  /** Capture one allowlisted event. Silently drops anything not in EVENTS. */
+  /** 捕获一个白名单内的事件。不在 EVENTS 中的内容被静默丢弃。 */
   track(event: string, props: Record<string, string> = {}): void {
     if (!this.client || !this.enabled || dntSet() || this.sessionEnded) return;
     const allowed = EVENTS[event];
     if (!allowed) return;
     const properties: Record<string, unknown> = {
       ...this.common,
-      $process_person_profile: false, // anonymous event — no person profile
-      // PostHog fills $ip from the connection ONLY when the event does not
-      // carry one, so sending it explicitly as null is the one client-side way
-      // to stop the IP being stored. Belt and braces with the project-level
-      // discard setting: this alone protects every event we send from here.
+      $process_person_profile: false, // 匿名事件——不创建人物画像
+      // 仅当事件未携带 $ip 时，PostHog 才会从连接中填充 $ip，因此显式
+      // 将其发送为 null 是阻止 IP 被存储的唯一的客户端方式。与项目级
+      // 丢弃（discard）设置双保险：仅此一项就保护了从这里发送的每个
+      // 事件。
       $ip: null
     };
     for (const [k, v] of Object.entries(props)) {
@@ -263,23 +263,23 @@ export class Analytics {
     }
   }
 
-  /** One human-sent message. NOT deduped — unlike trackFeature this IS a usage
-   *  meter, and the count is the whole point. Re-checks the enum at runtime
-   *  because the `terminal`/`composer` surfaces originate in the renderer. */
+  /** 一条人类发送的消息。不去重——与 trackFeature 不同，这是一个用量表
+   *  （usage meter），计数正是其意义所在。在运行时重新检查该枚举，
+   *  因为 `terminal`/`composer` 这两个 surface 源于渲染进程。 */
   trackMessageSent(surface: MessageSurface): void {
     if (!(MESSAGE_SURFACES as readonly string[]).includes(surface)) return;
     this.track('message_sent', { surface });
   }
 
-  /** feature_used with per-session dedup (adoption signal, not a usage meter). */
+  /** feature_used，带会话级去重（采纳信号，而非用量表）。 */
   trackFeature(feature: AnalyticsFeature): void {
     if (this.featuresSeen.has(feature)) return;
     this.featuresSeen.add(feature);
     this.track('feature_used', { feature });
   }
 
-  /** Fire session_ended and flush. Bounded by the caller (will-quit races this
-   *  against a timeout) — never assume it completes. Idempotent. */
+  /** 触发 session_ended 并刷新。由调用方限定时间（will-quit 会把它与超时
+   *  竞争）——绝不要假设它会完成。幂等。 */
   async endSession(): Promise<void> {
     if (!this.client || this.sessionEnded) return;
     this.track('session_ended', { duration_bucket: durationBucket(Date.now() - this.startedAt) });
@@ -309,51 +309,51 @@ export class Analytics {
       this.idPersisted = true;
       return id;
     } catch (e) {
-      // Unwritable state dir: use an ephemeral id for this session rather than
-      // failing closed on analytics (still anonymous, just not stable).
+      // 状态目录不可写：为本次会话使用临时 id，而不是在 analytics 上失败关闭
+      // （仍然匿名，只是不稳定）。
       console.error('[analytics] install-id persist failed (ephemeral id):', e);
       return randomUUID();
     }
   }
 }
 
-/** The version this install last ran, kept beside the install id in userData.
- *  Deleting the app's data dir clears it exactly like the install id. */
+/** 该安装上次运行的版本，与安装 id 一起保存在 userData 中。
+ *  删除应用数据目录会像清除安装 id 一样清除它。 */
 const VERSION_STAMP_FILE = 'telemetry-last-version';
 
-/** Semver-shaped and nothing else. The stamp is an ordinary file in userData
- *  that a user can edit, so it is re-validated on the way out — that keeps
- *  `from_version` provably closed-form and honours TELEMETRY.md's "nothing
- *  free-form" promise even against a hand-edited state dir. */
+/** 只要求符合 Semver 形态，别无其他。打点是 userData 中一个用户可以编辑的
+ *  普通文件，因此输出时会重新校验——即使面对手工编辑过的状态目录，也能保证
+ *  `from_version` 可证明是封闭形式，并兑现 TELEMETRY.md「不含自由格式内容」
+ *  的承诺。 */
 const VERSION_RE = /^[0-9]{1,6}\.[0-9]{1,6}\.[0-9]{1,6}(?:-[0-9A-Za-z.]{1,32})?$/;
 
-/** A type alias, NOT an interface: `track()` takes `Record<string, string>` and
- *  TypeScript only gives object *type aliases* an implicit index signature. */
+/** 这是一个类型别名，不是 interface：`track()` 接收 `Record<string, string>`，
+ *  而 TypeScript 只会给对象 *类型别名* 隐式索引签名。 */
 export type VersionTransition = {
   from_version: string;
   to_version: string;
 };
 
-/** The single place that decides whether a boot is a version change.
+/** 判断一次启动是否为版本变迁的唯一位置。
  *
- *  - `firstRun` (the install id was just minted) → a brand-new install, never
- *    an update. This is what keeps update_applied and first_run disjoint.
- *  - no stamp on an install that already had an id → the install predates
- *    version stamping, so it arrived here from SOME earlier version:
- *    `from_version: 'unknown'`. This is what makes the very first release
- *    carrying the event measurable, instead of silent for one whole cycle.
- *  - stamp !== current → a version change (a downgrade reports honestly, with
- *    from > to).
- *  - stamp === current → an ordinary relaunch. Nothing.
+ *  - `firstRun`（安装 id 刚刚铸造）→ 全新安装，绝不是更新。这正
+ *    是保持 update_applied 与 first_run 不相交的原因。
+ *  - 已有 id 的安装却没有打点 → 该安装早于版本打点功能，因此
+ *    它是从某个更早的版本来到这里的：`from_version: 'unknown'`。
+ *    这使首个携带该事件的版本可被度量，而不是沉默
+ *    整整一个周期。
+ *  - 打点 !== 当前 → 版本变迁（降级也会如实上报，
+ *    即 from > to）。
+ *  - 打点 === 当前 → 普通重新启动。无事发生。
  *
- *  Pure and exported so the decision can be unit-tested without PostHog. */
+ *  纯函数并导出，因此可以在不依赖 PostHog 的情况下对决策做单元测试。 */
 export function updateTransition(
   previous: string | null,
   current: string,
   firstRun: boolean
 ): VersionTransition | null {
   if (firstRun) return null;
-  if (!VERSION_RE.test(current)) return null; // can't name where we landed
+  if (!VERSION_RE.test(current)) return null; // 无法命名我们落到的版本
   if (previous === current) return null;
   return {
     from_version: previous && VERSION_RE.test(previous) ? previous : 'unknown',
@@ -361,7 +361,7 @@ export function updateTransition(
   };
 }
 
-/** Raw stamp, or null when absent/unreadable. Never throws. */
+/** 原始打点，缺失或不可读时为 null。绝不抛异常。 */
 export function readVersionStamp(stateDir: string): string | null {
   try {
     const file = join(stateDir, VERSION_STAMP_FILE);
@@ -372,8 +372,8 @@ export function readVersionStamp(stateDir: string): string | null {
   }
 }
 
-/** Best-effort. A failed stamp just means the transition may be reported again
- *  next boot; it must never take the app down. */
+/** 尽力而为。打点失败只意味着下次启动可能再次上报该变迁；绝不能让
+ *  应用崩溃。 */
 export function writeVersionStamp(stateDir: string, version: string): void {
   try {
     mkdirSync(stateDir, { recursive: true });
@@ -383,96 +383,96 @@ export function writeVersionStamp(stateDir: string, version: string): void {
   }
 }
 
-/** ── Was it OUR updater, or did the user reinstall by hand? ──────────────────
+/** ── 是我们的更新器，还是用户手动重装？──────────────────────
  *
- *  `update_applied` on its own says the version moved; it cannot say what moved
- *  it, because an auto-update and a manual re-download both keep userData, keep
- *  the install id, and advance the version. The obvious fix is a marker written
- *  by the OLD process when the user clicks restart-to-install — but the old
- *  process is a build already in the wild, so a marker added now would be
- *  useless for exactly the release we need to watch and would only start
- *  telling the truth one cycle later.
+ *  `update_applied` 单独只能说明版本移动了；它无法说明
+ *  是什么移动了它，因为自动更新和手动重新下载都会保留
+ *  userData、保留安装 id，并推进版本。显而易见的修法是在
+ *  用户点击 restart-to-install 时由旧进程写入一个标记——但旧
+ *  进程是已发布在外的构建，所以现在添加的标记恰恰对我们需要
+ *  关注的版本毫无用处，只会在一个周期之后才开始说
+ *  真话。
  *
- *  It turns out we do not need a new marker: `updater.ts` has appended one to
- *  `updater.log` since v0.3.7, and both lines below are byte-identical in the
- *  shipped v0.4.3 and v0.4.4 builds. An auto-update leaves this ordered pair:
+ *  事实上我们并不需要新标记：`updater.ts` 自 v0.3.7 起就向 `updater.log`
+ *  追加了一行，且下面两行在已发布的 v0.4.3 和 v0.4.4 构建中是逐字节相同的。
+ *  一次自动更新会留下这一有序对：
  *
  *      update downloaded: <version> — waiting for the user to restart
  *      quitAndInstall requested by the user
  *
- *  Matching on the version is what makes it trustworthy: a leftover pair from a
- *  PREVIOUS upgrade names that older version, so it cannot be mistaken for this
- *  one. The pair is necessary but not sufficient, because `quitAndInstall()`
- *  can return without installing anything — so a launch that names a different
- *  version after the request, or a refused quit warning, takes it back to
- *  `manual`. That correction matters more from 0.4.5 on than it did before it:
- *  the title-bar badge is now the MANUAL download, so the user whose automatic
- *  install quietly did nothing is exactly the user who then reaches for manual,
- *  and crediting that install to `auto` would flatter the path that failed.
- *  The log is read only to derive the closed enum below — no line, path or
- *  message from it is ever sent, and updater.ts is not modified to support this
- *  (`test/update-applied.test.cjs` asserts the two literals still match, so a
- *  future reword fails the suite instead of silently degrading the metric).
+ *  按版本匹配正是其可信之处：来自上一次升级遗留的
+ *  有序对指向那个更老的版本，因此不会被误认为本次。
+ *  该有序对是必要条件但不充分，因为 `quitAndInstall()`
+ *  可能在未安装任何东西的情况下就返回——所以请求之后
+ *  启动时命名的版本不同，或退出警告被拒绝，都会被归回
+ *  `manual`。这一修正从 0.4.5 起比之前更重要：标题栏徽章
+ *  现在是手动下载，因此自动安装悄悄什么都没做的用户，
+ *  正是随后会去手动下载的用户，而把那次安装记成 `auto`
+ *  会美化那条失败的路径。
+ *  读取日志仅仅是为了推导下面的封闭枚举——其中的任何行、路径或消息都
+ *  绝不会被发送，且 updater.ts 并未被修改来支持此功能
+ *  （`test/update-applied.test.cjs` 断言这两个字面量仍然匹配，因此未来
+ *  改词会让测试套件失败，而不是悄悄劣化该指标）。
  */
 const LOG_FILE = 'updater.log';
 const LOG_DOWNLOADED = 'update downloaded: ';
 const LOG_QUIT_REQUESTED = 'quitAndInstall requested by the user';
 const LOG_QUIT_FAILED = 'quitAndInstall failed:';
-/** Written once per packaged launch, naming the version that launched — in
- *  v0.4.3 and v0.4.4 as shipped, so it is readable for the 0.4.5 hop. */
+/** 每次打包启动时写一次，指明启动的版本——在已发布的 v0.4.3 和 v0.4.4 中
+ *  已存在，因此 0.4.5 一跳时可读。 */
 const LOG_READY = /native updater ready \(current v([^)\s]+)\)/;
-/** Only in 0.4.5 and later, so it starts paying off for the 0.4.6 hop. */
+/** 仅 0.4.5 及之后才有，因此它从 0.4.6 一跳开始产生价值。 */
 const LOG_QUIT_CANCELLED = 'quitAndInstall cancelled by the user at the quit warning';
-/** The log grows by a line or two per update, never on a routine check, so this
- *  is years of history — but it is a user-writable file, so the read is bounded
- *  rather than trusting. */
+/** 日志每次更新只增长一两行，例行检查时从不增长，因此这里可能有数年历史
+ *  ——但它是用户可写的文件，所以读取是有界（bounded）的，而不是完全
+ *  信任。 */
 const LOG_TAIL_BYTES = 128 * 1024;
 
-/** `auto` our updater installed it, `manual` something else moved the version,
- *  `unknown` there is no log to read (and therefore no evidence either way). */
+/** `auto` 表示我们的更新器安装了它，`manual` 表示其他东西移动了版本，
+ *  `unknown` 表示没有可读的日志（因此也没有任何一方的证据）。 */
 export type UpdateVia = 'auto' | 'manual' | 'unknown';
 
-/** Pure: the whole decision, given the log text and where we landed. */
+/** 纯函数：给定日志文本与我们所处的版本，给出完整判断。 */
 export function updateVia(logText: string | null, toVersion: string): UpdateVia {
   if (logText === null) return 'unknown';
   const lines = logText.split('\n');
-  // The lookahead excludes every character a version can CONTINUE with, so
-  // `0.4.5` matches neither `0.4.55` nor the prerelease `0.4.5-beta.1` — both
-  // are different builds, and a download of one is no evidence about the other.
+  // 前向断言排除了版本可以继续匹配的每个字符，因此 `0.4.5` 既不会匹配
+  // `0.4.55` 也不会匹配预发布版 `0.4.5-beta.1`——两者都是不同的构建，
+  // 下载其中一个并不能作为另一个的证据。
   const downloaded = new RegExp(
     `${LOG_DOWNLOADED}${toVersion.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&')}(?![0-9.\\-])`
   );
 
-  // The LAST download of THIS version — anything earlier belongs to a previous
-  // upgrade and would name a different version anyway.
+  // 该版本的最后一次下载——更早的都属于之前的升级，反正会命名不同
+  // 的版本。
   let i = -1;
   for (let n = 0; n < lines.length; n++) if (downloaded.test(lines[n])) i = n;
   if (i < 0) return 'manual';
 
-  // A restart request that came AFTER that download. The log is append-only, so
-  // file order is time order.
+  // 在该下载之后出现的重启请求。日志只追加，因此文件顺序即
+  // 时间顺序。
   let j = -1;
   for (let n = i + 1; n < lines.length; n++) if (lines[n].includes(LOG_QUIT_REQUESTED)) j = n;
   if (j < 0) return 'manual';
 
-  // updater.ts logs the failure from the catch immediately after the request, so
-  // an attempt that threw is the very next line — the app never quit, and
-  // whatever moved the version afterwards was not us.
+  // updater.ts 会在请求之后紧接的 catch 中记录失败，因此抛异常的
+  // 尝试正好是下一行——应用从未退出，之后无论什么移动了版本都
+  // 不是我们。
   if (lines[j + 1]?.includes(LOG_QUIT_FAILED)) return 'manual';
 
-  // A request that threw is the easy case. The one that matters is the request
-  // that returned cleanly and still did not install: `quitAndInstall()` reports
-  // no outcome (updater.ts says so in its own header), so a silent no-op and a
-  // successful install are the same line. The log tells them apart anyway,
-  // because the app that runs NEXT identifies itself:
+  // 抛异常的请求是简单情形。真正要紧的是干净返回却仍未安装的请求：
+  // `quitAndInstall()` 不报告任何结果（updater.ts 在其自身的头部注释里
+  // 也这么说），因此静默的 no-op 与成功安装是同一行。日志无论如何都能
+  // 将它们区分开，因为随后运行的 NEXT 应用会表明
+  // 自己的身份：
   //
-  //  - a launch naming any version other than the one we landed on means a
-  //    build that is not the target ran after the restart was asked for, so
-  //    that restart did not install this version;
-  //  - the user refusing the quit warning says the same thing outright.
+  //  - 启动时命名的版本不是我们所处的版本，意味着在请求重启之后
+  //    运行的是非目标构建，
+  //    因此那次重启并未安装本版本；
+  //  - 用户拒绝退出警告也直截了当地说明了同样的事。
   //
-  // Both are disproof only. Their absence is not evidence of success, so this
-  // still cannot see an install that failed with nothing running afterwards.
+  // 两者都只能作为反证。它们的不存在并不是成功的证据，因此这里仍然无法
+  // 发现那种安装失败且之后没有任何东西运行的场景。
   for (let n = j + 1; n < lines.length; n++) {
     if (lines[n].includes(LOG_QUIT_CANCELLED)) return 'manual';
     const launched = LOG_READY.exec(lines[n]);
@@ -481,8 +481,8 @@ export function updateVia(logText: string | null, toVersion: string): UpdateVia 
   return 'auto';
 }
 
-/** Last LOG_TAIL_BYTES of updater.log, or null when there is none to read.
- *  Never throws — a missing log is an answer ('unknown'), not a failure. */
+/** updater.log 的最后 LOG_TAIL_BYTES 字节，没有可读内容时为 null。
+ *  绝不抛异常——日志缺失本身就是一个答案（'unknown'），而非失败。 */
 export function readUpdaterLogTail(stateDir: string): string | null {
   let fd: number | null = null;
   try {
@@ -498,11 +498,11 @@ export function readUpdaterLogTail(stateDir: string): string | null {
   } catch {
     return null;
   } finally {
-    if (fd !== null) { try { closeSync(fd); } catch { /* nothing left to do */ } }
+    if (fd !== null) { try { closeSync(fd); } catch { /* 无事可做 */ } }
   }
 }
 
-/** Coarse, non-identifying session-length label. */
+/** 粗粒度、不可识别的会话时长标签。 */
 function durationBucket(ms: number): string {
   const m = ms / 60_000;
   if (m < 5) return '<5m';
@@ -512,5 +512,5 @@ function durationBucket(ms: number): string {
   return '8h+';
 }
 
-/** The process-wide singleton, mirroring how index.ts owns other services. */
+/** 进程级单例，与 index.ts 拥有其他服务的方式一致。 */
 export const analytics = new Analytics();

--- a/src/main/breaker.ts
+++ b/src/main/breaker.ts
@@ -1,34 +1,32 @@
 /**
- * Circuit breaker — runaway/cost guardrail policy (Lane A #6.6b).
+ * 熔断器 —— 失控/成本护栏策略（Lane A #6.6b）。
  *
- * Claude Code exposes `--max-turns` but NO dollar ceiling, so we enforce one
- * ourselves. This module owns the POLICY only — trip conditions + the
- * steer → constrain → stop escalation ladder. It has no side effects: it reads
- * signals and returns decisions; the caller (the heartbeat beat in index.ts)
- * performs the enforcement (send a corrective message, notify, kill+archive) and
- * emits BreakerState on the separate `control:breakerState` channel (Seam 2 with
- * Oscar/#7, whose avatar adapter gives breaker level precedence over hook status).
+ * Claude Code 暴露了 `--max-turns`，但没有美元上限，因此我们自行强制实施。
+ * 本模块只负责 POLICY —— 触发条件 + steer → constrain → stop 升级阶梯。
+ * 它没有副作用：读取信号并返回决策；由调用方（index.ts 中的心跳 beat）
+ * 执行强制手段（发送纠正消息、通知、kill+archive），并在独立的
+ * `control:breakerState` 通道上发出 BreakerState（Seam 2，与
+ * Oscar/#7 协作，其 avatar 适配器让熔断等级优先于 hook 状态）。
  *
- * Inputs aggregate three sources:
- *   (a) Oscar's usage samples via UsageProvider [Seam 1] — for cost + token velocity;
- *   (b) hook events (repeated identical tool calls, api_error storms) — fed in by
- *       HookServer through recordToolUse/recordError;
- *   (c) file-mtime no-progress — passed per-agent by the beat as `progressing`.
+ * 输入聚合三个来源：
+ *   (a) Oscar 经 UsageProvider [Seam 1] 的用量采样 —— 用于成本与 token 速率;
+ *   (b) hook 事件（重复的相同工具调用、api_error 风暴）—— 由
+ *       HookServer 通过 recordToolUse/recordError 喂入;
+ *   (c) 文件 mtime 无进展 —— 由 beat 以 `progressing` 形式逐 agent 传入。
  *
- * Velocity is the DIFF of consecutive cumulative samples (Δoutput/Δt), never a
- * single sample treated as an increment.
+ * 速率是相邻累计采样的 DIFF（Δoutput/Δt），绝不会把单个采样当作增量。
  *
- * Safe by construction: steer-first, one level per beat (never jump to a kill),
- * de-escalates a level per healthy beat (recovery), and `hardStop` is OFF by
- * default — without it the ladder caps at `constrained` and never kills.
+ * 结构上安全：先 steer、每个 beat 只升一级（绝不直接跳到 kill）、
+ * 每个健康 beat 降一级（恢复），且 `hardStop` 默认 OFF ——
+ * 没有它，阶梯最高只到 `constrained`，永远不会 kill。
  */
 import type { CircuitBreakerConfig } from './config';
 import type { AgentUsageSample } from './usage';
 
 export type BreakerLevel = 'healthy' | 'steering' | 'constrained' | 'stopped';
 
-/** Emitted on control:breakerState (Seam 2). One per agent per beat so Oscar's
- *  dashboard/avatars stay live; `level` takes precedence over hook-derived status. */
+/** 在 control:breakerState（Seam 2）上发出。每个 beat 每个 agent 一条，让 Oscar 的
+ *  仪表盘/头像保持实时；`level` 优先于由 hook 推导的状态。 */
 export interface BreakerState {
   agentId: string;
   level: BreakerLevel;
@@ -36,23 +34,23 @@ export interface BreakerState {
   ts: number;
 }
 
-/** What the beat should do this tick for one agent. `action` fires only when the
- *  level ESCALATES (so a durable steer message isn't re-sent every beat). */
+/** 本 tick 中 beat 应对单个 agent 采取的动作。仅当等级 ESCALATES（升级）时
+ *  `action` 才会触发（这样持久化的 steer 消息不会每个 beat 都重发）。 */
 export type BreakerAction = 'none' | 'steer' | 'constrain' | 'stop';
 
 export interface BreakerDecision {
   state: BreakerState;
   action: BreakerAction;
-  /** True when level changed since the previous beat (escalation OR recovery). */
+  /** 自上一 beat 以来等级是否发生变化（升级或恢复均为 true）。 */
   changed: boolean;
 }
 
-/** Per-agent input for one beat. */
+/** 单个 beat 中每个 agent 的输入。 */
 export interface BreakerInput {
   agentId: string;
-  /** Cumulative usage snapshot, or null when unknown (skips cost/velocity trips). */
+  /** 累计用量快照，未知时为 null（此时跳过成本/速率触发）。 */
   sample: AgentUsageSample | null;
-  /** Did the agent make coordination progress recently (file-mtime signal)? */
+  /** 该 agent 近期是否取得了协调进展（文件 mtime 信号）？ */
   progressing: boolean;
 }
 
@@ -61,7 +59,7 @@ const rank = (l: BreakerLevel): number => LEVELS.indexOf(l);
 const actionFor = (l: BreakerLevel): BreakerAction =>
   l === 'steering' ? 'steer' : l === 'constrained' ? 'constrain' : l === 'stopped' ? 'stop' : 'none';
 
-/** Total tokens in a cumulative sample (all kinds), 0 when unknown. */
+/** 累计采样中的 token 总数（含所有类型），未知时为 0。 */
 const tokensOf = (s: AgentUsageSample | null): number =>
   s ? s.input + s.output + s.cacheRead + s.cacheCreation : 0;
 
@@ -70,41 +68,40 @@ const DEFAULTS = {
   hardStop: false,
   repeatedToolLimit: 8,
   errorStormLimit: 5,
-  tokenVelocityPerMin: 60_000 // output tokens/min — coarse backstop, deliberately high
+  tokenVelocityPerMin: 60_000 // 输出 token/分钟 —— 粗粒度兜底，刻意定得较高
 };
 
-/** Safety cap on the PreCompact exemption: if PostCompact never arrives (crash,
- *  or a Claude build that doesn't emit it), the Δoutput trips re-arm on their own. */
+/** PreCompact 豁免的安全上限：若 PostCompact 永不出现（崩溃，
+ *  或某个不发出该事件的 Claude 构建），Δoutput 触发会自动重新武装。 */
 const COMPACT_GRACE_MS = 5 * 60_000;
-/** Trailing grace after PostCompact: the compaction burst lands in the NEXT
- *  beat's cumulative diff, so the exemption must outlive the compaction itself. */
+/** PostCompact 之后的尾随宽限期：压缩突增会落入下一 beat 的累计 diff 中，
+ *  因此豁免必须比压缩本身活得更久。 */
 const POST_COMPACT_GRACE_MS = 90_000;
-/** How recent a DISTINCT tool call must be to count as progress for the
- *  no-progress arm. Mirrors the beat's file-mtime progress window (300s). */
+/** 一个 DISTINCT 工具调用必须多近才能算作 no-progress 分支的进展。
+ *  与 beat 的文件 mtime 进展窗口（300s）保持一致。 */
 const PROGRESS_TOOL_WINDOW_MS = 300_000;
-/** Consecutive tripping beats the no-progress arm needs before it fires — a
- *  one-beat blip (inbox ack, statusline burst) never steers on its own. */
+/** no-progress 分支触发前需要的连续触发 beat 数 —— 单 beat 的瞬时毛刺
+ *  （inbox 确认、状态行突增）绝不会单独触发 steer。 */
 const NO_PROGRESS_BEATS = 2;
 
 interface AgentBreakerState {
   level: BreakerLevel;
   reason: string;
   lastSample: AgentUsageSample | null;
-  /** Consecutive identical tool calls (same name+input). */
+  /** 连续相同工具调用（相同 name+input）对应的键。 */
   repeatKey: string | null;
   repeatCount: number;
-  /** Consecutive api_error / retry events with no intervening progress. */
+  /** 连续发生的 api_error / retry 事件数（期间没有任何进展）。 */
   errorCount: number;
-  /** Δoutput-based trips are exempt until this instant (compaction in flight,
-   *  set on PreCompact; PostCompact shortens it to a trailing grace). */
+  /** 在此时间点之前，基于 Δoutput 的触发被豁免（压缩进行中时设置于
+   *  PreCompact；PostCompact 会把它缩短为一段尾随宽限）。 */
   compactingUntil: number;
-  /** When the last DISTINCT (name+input) tool call ran. A varied tool stream is
-   *  work — background workflows / interactive sessions whose output lands
-   *  outside the hive files (git, Jira) must not read as "no progress". A true
-   *  single-call loop never refreshes this; an alternating loop that would is
-   *  still backstopped by the velocity trip. */
+  /** 最近一次 DISTINCT（name+input）工具调用的时间。多样化的工具流就是
+   *  工作 —— 输出落在 hive 文件之外的（git、Jira 等）后台工作流/交互式会话
+   *  不能被读成"no progress"。真正的单调用循环永远不会刷新它；即使是
+   *  会刷新它的交替循环，也仍然有速率触发兜底。 */
   lastDistinctToolAt: number;
-  /** Consecutive beats the no-progress condition held (debounce counter). */
+  /** no-progress 条件持续成立的连续 beat 数（防抖计数器）。 */
   noProgressBeats: number;
 }
 
@@ -139,21 +136,21 @@ export class CircuitBreaker {
     return s;
   }
 
-  /** Drop all state for an agent (call on archive/kill so it can't leak/zombie). */
+  /** 清空某 agent 的全部状态（在 archive/kill 时调用，避免泄漏/残留）。 */
   forget(agentId: string): void {
     this.agents.delete(agentId);
   }
 
-  /** Current breaker level for an agent (for the live fleet snapshot). */
+  /** 某 agent 当前的熔断等级（用于实时 fleet 快照）。 */
   levelFor(agentId: string): BreakerLevel {
     return this.agents.get(agentId)?.level ?? 'healthy';
   }
 
-  // ── event-driven inputs (fed by HookServer) ──────────────────────────────
+  // ── 事件驱动输入（由 HookServer 喂入） ──────────────────────────────────
 
-  /** A tool call ran. A NEW (name+input) key counts as forward progress (resets
-   *  the repeat + error counters and stamps the distinct-tool clock the
-   *  no-progress arm reads); the SAME key in a row is the loop signal. */
+  /** 一次工具调用已执行。NEW（name+input）键计为正向进展（重置
+   *  repeat 与 error 计数器，并更新 no-progress 分支读取的 distinct 工具时钟）；
+   *  连续出现 SAME 键则是循环信号。 */
   recordToolUse(agentId: string, toolName: string | undefined, toolInput: unknown, now = Date.now()): void {
     const s = this.get(agentId);
     const key = this.toolKey(toolName, toolInput);
@@ -162,41 +159,39 @@ export class CircuitBreaker {
     } else {
       s.repeatKey = key;
       s.repeatCount = 1;
-      s.errorCount = 0; // a distinct tool call = progress; clear the error storm
+      s.errorCount = 0; // 一次 distinct 工具调用即进展；清除错误风暴
       s.lastDistinctToolAt = now;
     }
   }
 
-  /** An api_error / retry occurred (no forward progress). */
+  /** 发生了 api_error / retry（无正向进展）。 */
   recordError(agentId: string): void {
     this.get(agentId).errorCount += 1;
   }
 
-  /** Compaction started (PreCompact hook). Exempt the Δoutput-based trips —
-   *  compaction burns output tokens while touching no coordination file, which
-   *  is exactly the false-positive shape of upstream issue #109 (the harness's
-   *  own auto-compact mission tripping its own breaker on idle agents). */
+  /** 压缩已开始（PreCompact hook）。豁免基于 Δoutput 的触发 ——
+   *  压缩会消耗输出 token 却不触碰任何协调文件，这正是上游 issue #109
+   *  的误报形态（harness 自身的 auto-compact 任务在空闲 agent 上
+   *  触发自己的熔断器）。 */
   recordCompactStart(agentId: string, now = Date.now()): void {
     this.get(agentId).compactingUntil = now + COMPACT_GRACE_MS;
   }
 
-  /** Compaction finished (PostCompact, or any SessionStart). Shortens the
-   *  exemption to a trailing grace — the burst still lands in the next beat's
-   *  cumulative diff. A no-op when no compaction is in flight, so a plain
-   *  session start never grants an exemption. */
+  /** 压缩已结束（PostCompact 或任意 SessionStart）。把豁免缩短为
+   *  一段尾随宽限 —— 突增仍会落入下一 beat 的累计 diff。
+   *  当没有压缩在进行时这是空操作，因此普通的会话开始绝不会授予豁免。 */
   recordCompactEnd(agentId: string, now = Date.now()): void {
     const s = this.get(agentId);
     if (s.compactingUntil > now) s.compactingUntil = now + POST_COMPACT_GRACE_MS;
   }
 
   private toolKey(toolName: string | undefined, toolInput: unknown): string {
-    // Truncating replacer: a Write/Edit tool_input carries the whole file body
-    // (up to MBs), and this runs synchronously inside the hook reply path on
-    // EVERY PostToolUse — serializing it all only to keep 200 chars was a
-    // multi-MB transient allocation per large write. Capping each string field
-    // bounds the work while keeping the key semantics (a repeat of the same
-    // call still yields the same key; distinct calls still differ within the
-    // first 200 chars far more often than full serialization ever mattered).
+    // 截断式 replacer：Write/Edit 的 tool_input 携带整个文件内容
+    // （可到数 MB），而这里会在每次 PostToolUse 的 hook 应答路径中同步执行
+    // —— 只为了保留 200 字符就把全部内容序列化，每次大写入都会产生
+    // 数 MB 的瞬时分配。给每个字符串字段设上限在限制工作量的同时
+    // 保持键的语义（相同调用的重复仍产生相同键；distinct 调用在前 200
+    // 字符内不同的概率远高于完整序列化的价值）。
     let inp = '';
     try {
       inp = JSON.stringify(toolInput, (_k, v) =>
@@ -205,16 +200,15 @@ export class CircuitBreaker {
     return `${toolName ?? '?'}:${inp.slice(0, 200)}`;
   }
 
-  // ── periodic evaluation (called by the heartbeat beat) ────────────────────
+  // ── 周期性评估（由心跳 beat 调用） ──────────────────────────────────────
 
-  /** Evaluate every agent for this beat and return a decision per agent. The
-   *  caller emits each state (keeps the dashboard live) and enforces `action`
-   *  when present. */
+  /** 为本 beat 评估每个 agent，并返回每个 agent 的决策。调用方
+   *  发出每个状态（保持仪表盘实时）并在有 `action` 时强制执行。 */
   tick(inputs: BreakerInput[], nowMs: number): BreakerDecision[] {
     const cfg = this.cfg();
     const decisions: BreakerDecision[] = [];
     if (!cfg.enabled) {
-      // Breaker off: report healthy for everyone, take no action.
+      // 熔断器关闭：所有人都报告 healthy，不采取任何动作。
       for (const { agentId } of inputs) {
         const s = this.get(agentId);
         const changed = s.level !== 'healthy';
@@ -224,8 +218,8 @@ export class CircuitBreaker {
       return decisions;
     }
 
-    // Cost cap is floor-wide: sum cumulative usd, blame the single biggest spender
-    // so one runaway doesn't trip the whole floor.
+    // 成本上限是全场（floor）级别的：汇总累计 usd，归咎于单个最大开支者，
+    // 这样单个失控者不会触发整个 floor 熔断。
     let topSpender: string | null = null;
     if (typeof cfg.costCapUsd === 'number' && cfg.costCapUsd > 0) {
       let total = 0; let max = -1;
@@ -234,10 +228,10 @@ export class CircuitBreaker {
         total += usd;
         if (usd > max) { max = usd; topSpender = i.agentId; }
       }
-      if (total <= cfg.costCapUsd) topSpender = null; // under cap — nobody blamed
+      if (total <= cfg.costCapUsd) topSpender = null; // 未超上限 —— 无人被归咎
     }
 
-    // Token cap (the user-facing budget): same floor-wide logic on total tokens.
+    // Token 上限（面向用户的预算）：对总 token 数采用同样的全场逻辑。
     let topTokenSpender: string | null = null;
     if (typeof cfg.costCapTokens === 'number' && cfg.costCapTokens > 0) {
       let total = 0; let max = -1;
@@ -246,7 +240,7 @@ export class CircuitBreaker {
         total += tok;
         if (tok > max) { max = tok; topTokenSpender = i.agentId; }
       }
-      if (total <= cfg.costCapTokens) topTokenSpender = null; // under cap
+      if (total <= cfg.costCapTokens) topTokenSpender = null; // 未超上限
     }
 
     for (const input of inputs) {
@@ -256,7 +250,7 @@ export class CircuitBreaker {
         input.agentId === topSpender, cfg.costCapUsd,
         input.agentId === topTokenSpender, cfg.costCapTokens
       );
-      // remember the cumulative baseline for next beat's velocity diff
+      // 记住累计基线，供下一 beat 的速率 diff 使用
       if (input.sample) s.lastSample = input.sample;
 
       const ceiling: BreakerLevel = cfg.hardStop ? 'stopped' : 'constrained';
@@ -264,7 +258,7 @@ export class CircuitBreaker {
       if (trip.tripping) {
         target = LEVELS[Math.min(rank(s.level) + 1, rank(ceiling))];
       } else {
-        target = LEVELS[Math.max(rank(s.level) - 1, 0)]; // recover one level
+        target = LEVELS[Math.max(rank(s.level) - 1, 0)]; // 恢复一级
       }
       const changed = target !== s.level;
       const escalated = rank(target) > rank(s.level);
@@ -280,7 +274,7 @@ export class CircuitBreaker {
     return decisions;
   }
 
-  /** Pure trip evaluation for one agent given its signals + remembered baseline. */
+  /** 给定信号与记忆的基线，对单个 agent 做纯触发评估。 */
   private evaluate(
     input: BreakerInput,
     s: AgentBreakerState,
@@ -291,32 +285,31 @@ export class CircuitBreaker {
     isTopTokenSpender: boolean,
     costCapTokens: number | undefined
   ): { tripping: boolean; reason: string } {
-    // (b) repeated identical tool calls
+    // (b) 重复的相同工具调用
     if (s.repeatCount >= cfg.repeatedToolLimit) {
-      return { tripping: true, reason: `looping: ${s.repeatCount}× identical tool call (${s.repeatKey?.split(':')[0] ?? '?'})` };
+      return { tripping: true, reason: `循环：${s.repeatCount}× 相同的工具调用（${s.repeatKey?.split(':')[0] ?? '?'}）` };
     }
-    // (b) api_error storm
+    // (b) api_error 风暴
     if (s.errorCount >= cfg.errorStormLimit) {
-      return { tripping: true, reason: `error storm: ${s.errorCount} consecutive api errors/retries` };
+      return { tripping: true, reason: `错误风暴：${s.errorCount} 次连续的 API 错误/重试` };
     }
-    // (a) per-agent token limit — this agent's own total over its configured cap
+    // (a) 单 agent token 上限 —— 该 agent 自身总量超过其配置上限
     const perAgentCap = cfg.agentTokenCaps?.[input.agentId];
     if (typeof perAgentCap === 'number' && perAgentCap > 0 && tokensOf(input.sample) > perAgentCap) {
-      return { tripping: true, reason: `token limit: ${tokensOf(input.sample).toLocaleString()} over the agent cap of ${perAgentCap.toLocaleString()}` };
+      return { tripping: true, reason: `token 超限：${tokensOf(input.sample).toLocaleString()}，超过该 agent 上限 ${perAgentCap.toLocaleString()}` };
     }
-    // (a) cost cap — floor total over cap, this agent is the biggest spender
+    // (a) 成本上限 —— floor 总量超过上限，且该 agent 是最大开支者
     if (isTopSpender && typeof costCapUsd === 'number') {
-      return { tripping: true, reason: `cost cap: floor total over $${costCapUsd} (top spender $${(input.sample?.usd ?? 0).toFixed(2)})` };
+      return { tripping: true, reason: `成本超限：楼层总额超过 $${costCapUsd}（最高支出者 $${(input.sample?.usd ?? 0).toFixed(2)}）` };
     }
-    // (a) token cap — floor total tokens over cap, this agent is the biggest spender
+    // (a) token 上限 —— floor 总 token 数超过上限，且该 agent 是最大开支者
     if (isTopTokenSpender && typeof costCapTokens === 'number') {
       return { tripping: true, reason: `token cap: floor total over ${costCapTokens.toLocaleString()} tokens (top spender ${tokensOf(input.sample).toLocaleString()})` };
     }
-    // (a) token-velocity spike — diff cumulative output across consecutive beats.
-    // Skipped entirely while a compaction is in flight (+ trailing grace): a
-    // /compact burns output tokens with no coordination writes, which is the
-    // false-positive shape of issue #109 — the auto-compact mission tripping
-    // the breaker on idle agents.
+    // (a) token 速率尖峰 —— 连续 beat 之间累计输出的差分。
+    // 压缩进行期间（+ 尾随宽限）完全跳过：/compact 消耗输出 token 却没有任何
+    // 协调写入，这正是 issue #109 的误报形态 —— auto-compact 任务在空闲
+    // agent 上触发熔断器。
     if (input.sample && s.lastSample && nowMs >= s.compactingUntil) {
       const dOut = input.sample.output - s.lastSample.output;
       const dMin = (input.sample.ts - s.lastSample.ts) / 60_000;
@@ -325,12 +318,11 @@ export class CircuitBreaker {
         if (velocity > cfg.tokenVelocityPerMin) {
           return { tripping: true, reason: `token velocity ${Math.round(velocity)}/min > ${cfg.tokenVelocityPerMin}/min` };
         }
-        // (c) no-progress: burning output tokens while not coordinating. A recent
-        // DISTINCT tool call counts as progress too — background workflows and
-        // interactive sessions do real work that never touches the hive files
-        // (a single-call loop never refreshes that clock, and the loop/velocity
-        // arms above still backstop). Debounced: fires only after
-        // NO_PROGRESS_BEATS consecutive beats, so a one-beat blip never steers.
+        // (c) 无进展：在未协调的情况下消耗输出 token。最近的
+        // DISTINCT 工具调用也算进展 —— 后台工作流和交互式会话做的实际工作
+        // 从不触碰 hive 文件（单调用循环永远不会刷新该时钟，且上面的
+        // 循环/速率分支仍会兜底）。经过防抖：只有在连续
+        // NO_PROGRESS_BEATS 个 beat 后才触发，因此单 beat 的毛刺绝不会 steer。
         const toolActive = nowMs - s.lastDistinctToolAt < PROGRESS_TOOL_WINDOW_MS;
         if (!input.progressing && !toolActive) {
           s.noProgressBeats += 1;

--- a/src/main/cliInstall.ts
+++ b/src/main/cliInstall.ts
@@ -1,9 +1,9 @@
 /**
- * The missing-engine-CLI install ladder.
+ * 缺失引擎 CLI 的安装阶梯（install ladder）。
  *
- * Split out of index.ts deliberately: it imports NOTHING from electron, so the
- * decision ("which installer can actually succeed on this machine?") and the
- * script it emits are both testable without booting an app.
+ * 特意从 index.ts 中拆出：它不 import electron 的任何内容，因此“哪种安装器
+ * 在这台机器上确实能装成功？”这一决策，以及它生成的脚本，都可以在不启动
+ * 应用的情况下测试。
  */
 import type { AgentProvider, ProviderInstallInfo } from '../shared/agentProvider';
 import { installInfoForProvider } from '../shared/agentProvider';
@@ -12,27 +12,26 @@ import { buildNodeInstallScript } from './nodeInstall';
 
 export type InstallRungKind = 'npm' | 'node-then-npm' | 'native' | 'manual';
 
-/** Pick which rung of the install ladder to run, given what this machine has.
+/** 根据这台机器已具备的条件，选择安装阶梯的哪一级来执行。
  *
- *  Every provider's `installCommand` is `npm install -g …`, which needs npm,
- *  which needs node. On a machine with no node the banner used to print that
- *  command anyway and run it — so the user watched `npm: command not found`
- *  scroll past and concluded the app was broken. Classify first:
+ *  每个 provider 的 `installCommand` 都是 `npm install -g …`，这需要 npm，
+ *  而 npm 又需要 node。在没有 node 的机器上，启动横幅过去照样会打印这条
+ *  命令并执行它——于是用户看着 `npm: command not found` 滚动过去，认定应用
+ *  坏了。先做分类：
  *
- *    npm usable                        → npm install (unchanged; the common case)
- *    npm absent, Node installer found  → install real Node + npm, THEN npm install
- *    npm absent, native installer      → the vendor's self-contained installer
- *    neither                           → manual only. Do NOT run a doomed command.
+ *    npm 可用                          → npm install（不变；常见情况）
+ *    npm 缺失、找到 Node 安装器        → 先装真正的 Node + npm，再 npm install
+ *    npm 缺失、有原生安装器            → 厂商自带的独立安装器
+ *    两者都没有                        → 仅手动处理。不要运行注定失败的命令。
  *
- *  Founder decision (2026-08-07) put `node-then-npm` ABOVE `native`, reversing the
- *  earlier "never auto-install a system Node" rule: a user who only ever gets the
- *  node-free Claude installer still has no runtime for MCP servers, hooks, or any
- *  other provider — so the default is to fix the machine, not to route around it.
- *  `native` survives as the fallback for when no installer could be resolved
- *  (offline, or a platform nodejs.org ships no package for).
+ *  创始人决策（2026-08-07）把 `node-then-npm` 排在 `native` 之上，推翻了早先
+ *  “绝不自动安装系统级 Node”的规则：只拿到不含 node 的 Claude 安装器的用户，
+ *  依然没有可运行 MCP 服务器、hooks 或其他 provider 的运行时——因此默认做法
+ *  是修好机器，而不是绕开它。`native` 保留为无法解析出任何安装器时的回退
+ *  （离线，或平台 nodejs.org 没有提供对应包）。
  *
- *  `npmAvailable` means npm is present AND its Node is new enough (see
- *  nodeInstall.NODE_FLOOR_MAJOR) — an ancient Node routes into the upgrade rung. */
+ *  `npmAvailable` 表示 npm 存在且其 Node 版本足够新（见
+ *  nodeInstall.NODE_FLOOR_MAJOR）——过旧的 Node 会走升级那一级。 */
 export function chooseInstallRung(
   info: ProviderInstallInfo,
   npmAvailable: boolean,
@@ -44,14 +43,12 @@ export function chooseInstallRung(
   return { kind: 'manual', nodeMissing: !npmAvailable };
 }
 
-/** Build the shell script the missing-CLI auto-install path runs IN PLACE of a
- *  missing engine CLI. When a rung of the ladder above is runnable it prints a
- *  banner then RUNS it visibly (so the user can watch + finish any sign-in);
- *  otherwise it prints a manual instruction only and runs nothing. The script is
- *  emitted in the target platform's shell syntax ($SHELL on unix, cmd.exe on
- *  Windows) — `platform` is a parameter only so the Windows branch is reachable
- *  from a test on macOS. The only user-derived value (the missing binary name) is
- *  sanitized to a safe identifier; the install commands are trusted constants. */
+/** 生成缺失 CLI 自动安装路径“顶替”缺失引擎 CLI 时运行的 shell 脚本。当上面的
+ *  某一级可以执行时，它先打印横幅再显式运行（让用户能看着并完成任何登录）；
+ *  否则只打印一条手动操作说明，不运行任何东西。脚本以目标平台的 shell 语法
+ *  输出（unix 上是 $SHELL，Windows 上是 cmd.exe）——`platform` 只是参数，
+ *  这样 Windows 分支也能在 macOS 上的测试里触达。唯一由用户派生出的值
+ *  （缺失的二进制名）会清洗成安全标识符；安装命令是可信常量。 */
 export function buildMissingCliScript(
   bin: string,
   provider: AgentProvider,
@@ -62,36 +59,36 @@ export function buildMissingCliScript(
   const info: ProviderInstallInfo = installInfoForProvider(provider, platform);
   const safeBin = (bin || provider).replace(/[^A-Za-z0-9._-]/g, '') || provider;
   const rung = chooseInstallRung(info, npmAvailable, nodeInstaller);
-  // Only the rung that actually needs it gets the Node install spliced in.
+  // 只有确实需要的那一级才会拼入 Node 安装步骤。
   const nodeSteps = rung.kind === 'node-then-npm' && nodeInstaller
     ? buildNodeInstallScript(nodeInstaller, platform)
     : null;
-  const cmd = rung.command; // trusted constant, or undefined → manual hint only
+  const cmd = rung.command; // 可信常量；若为 undefined → 仅提示手动操作
   const label = info.label;
   const docs = info.docsUrl;
   const rule = '------------------------------------------------------------';
 
   if (platform === 'win32') {
-    // ONE cmd.exe line: `&` chains steps, `^&` prints a literal ampersand, and the
-    // script carries NO double-quotes (it is wrapped verbatim in `/d /s /c "..."`).
-    // We avoid `if errorlevel` branching (untestable here) — a combined success/
-    // failure hint after the install is robust and satisfies the manual-fallback DoD.
-    const parts: string[] = ['echo.', `echo ${rule}`, `echo   Engine CLI not found:  ${safeBin}`, 'echo.'];
+    // 单条 cmd.exe 命令：`&` 串联各步骤，`^&` 打印字面量 & 字符，并且
+    // 脚本不含双引号（它会原样包在 `/d /s /c "..."` 里）。
+    // 我们避免 `if errorlevel` 分支（此处无法测试）——一条合并的成功/
+    // 失败提示在安装之后给出，稳健且满足手动回退的完成定义（DoD）。
+    const parts: string[] = ['echo.', `echo ${rule}`, `echo   找不到引擎 CLI：${safeBin}`, 'echo.'];
     if (nodeSteps && nodeInstaller) {
       parts.push(
-        'echo   Node.js is not installed on this machine, so the usual npm',
-        `echo   installer cannot run yet. Installing Node ${nodeInstaller.version} ^(+ npm^) first,`,
-        'echo   straight from nodejs.org, checksum-verified.',
+        'echo   此机器未安装 Node.js，所以通常的 npm',
+        `echo   安装器暂时无法运行。先从 nodejs.org 安装 Node ${nodeInstaller.version} ^(+ npm^)，`,
+        'echo   校验和已验证。',
         'echo.',
         ...nodeSteps,
         'echo.'
       );
     } else if (rung.nodeMissing) {
-      parts.push('echo   Node.js is not installed on this machine, so the usual', 'echo   npm installer cannot run here.', 'echo.');
+      parts.push('echo   此机器未安装 Node.js，所以通常', 'echo   npm 安装器无法在此运行。', 'echo.');
     }
     if (cmd) {
-      if (rung.kind === 'native') parts.push(`echo   Using the self-contained ${label} installer instead ^(no Node needed^):`);
-      else parts.push(`echo   Installing the ${label} CLI now so you can watch:`);
+      if (rung.kind === 'native') parts.push(`echo   改用自包含的 ${label} 安装器 ^(无需 Node^)：`);
+      else parts.push(`echo   现在安装 ${label} CLI，你可以观看：`);
       parts.push(
         'echo.',
         `echo     ${cmd}`,
@@ -99,20 +96,20 @@ export function buildMissingCliScript(
         'echo.',
         cmd,
         'echo.',
-        'echo   [done] If it succeeded, the agent launches automatically.',
-        'echo   If it failed, run the command above manually, then restart the agent.'
+        'echo   [完成] 如果成功，agent 会自动启动。',
+        'echo   如果失败，请手动运行上面的命令，然后重启 agent。'
       );
     } else {
       if (rung.nodeMissing) {
         parts.push(
-          `echo   Install Node.js ^(nodejs.org^), then the ${label} CLI:`,
+          `echo   安装 Node.js ^(nodejs.org^)，然后是 ${label} CLI：`,
           `echo     ${info.command ?? ''}`,
-          'echo   …or install the CLI by whatever method its docs recommend.'
+          'echo   …或按其文档推荐的方式安装该 CLI。'
         );
       } else {
         parts.push(
-          `echo   No bundled installer for the ${label} provider.`,
-          'echo   Install it manually, then restart the agent to launch it.'
+          `echo   没有针对 ${label} provider 的捆绑安装器。`,
+          'echo   请手动安装，然后重启 agent 以启动它。'
         );
       }
       if (docs) parts.push(`echo   Docs: ${docs}`);
@@ -121,41 +118,41 @@ export function buildMissingCliScript(
     return parts.join(' & ');
   }
 
-  // unix ($SHELL -lc <script>): one statement per line, single-quoted echo text so
-  // no shell metacharacter expands. We avoid `!` so any shell with history
-  // expansion never fires. npm is found via the interactive PATH spawn() injects.
+  // unix（$SHELL -lc <script>）：每行一条语句，echo 文本用单引号包裹，这样
+  // 就不会有 shell 元字符被展开。我们避开 `!`，免得带历史扩展
+  // 的 shell 触发误展开。npm 是通过 spawn() 注入的交互式 PATH 找到的。
   const lines: string[] = [
     `echo ''`,
     `echo '${rule}'`,
-    `echo '  Engine CLI not found:  ${safeBin}'`,
+    `echo '  找不到引擎 CLI：${safeBin}'`,
     `echo ''`
   ];
   if (nodeSteps && nodeInstaller) {
-    // The default path on a bare machine: fix the runtime, then use it. Every
-    // step aborts the whole script on failure, so the npm install below only
-    // ever runs against a Node that actually landed.
+    // 裸机上的默认路径：先修好运行时，再使用它。每个
+    // 步骤失败都会中止整个脚本，因此下面的 npm install 只
+    // 会在真实安装成功的 Node 上运行。
     lines.push(
-      `echo '  Node.js is not installed on this machine, so the usual npm'`,
-      `echo '  installer cannot run yet. Installing Node ${nodeInstaller.version} (+ npm) first,'`,
-      `echo '  straight from nodejs.org, checksum-verified.'`,
+      `echo '  此机器未安装 Node.js，所以通常的 npm'`,
+      `echo '  安装器暂时无法运行。先从 nodejs.org 安装 Node ${nodeInstaller.version} (+ npm)，'`,
+      `echo '  校验和已验证。'`,
       `echo ''`,
       ...nodeSteps,
       `echo ''`
     );
   } else if (rung.nodeMissing) {
     lines.push(
-      `echo '  Node.js is not installed on this machine, so the usual npm'`,
-      `echo '  installer cannot run here.'`,
+      `echo '  此机器未安装 Node.js，所以通常的 npm'`,
+      `echo '  安装器无法在此运行。'`,
       `echo ''`
     );
   }
   if (cmd) {
     lines.push(
       ...(rung.kind === 'native'
-        ? [`echo '  Using the self-contained ${label} installer instead (no Node needed) —'`,
-           `echo '  finish any sign-in it prompts for, then come back to this terminal.'`]
-        : [`echo '  Installing the ${label} CLI now so you can watch — finish any'`,
-           `echo '  sign-in it prompts for, then come back to this terminal.'`]),
+        ? [`echo '  改用自包含的 ${label} 安装器（无需 Node）——'`,
+           `echo '  完成它提示的任何登录，然后回到此终端。'`]
+        : [`echo '  现在安装 ${label} CLI，你可以观看——完成任何'`,
+           `echo '  它提示的登录，然后回到此终端。'`]),
       `echo ''`,
       `echo '    ${cmd}'`,
       `echo '${rule}'`,
@@ -164,28 +161,28 @@ export function buildMissingCliScript(
       `__clirc=$?`,
       `echo ''`,
       `if [ $__clirc -eq 0 ]; then`,
-      `  echo '  [done] Installed — launching the agent…'`,
+      `  echo '  [完成] 已安装——正在启动 agent…'`,
       `else`,
-      `  echo "  [x] Install exited with code $__clirc — finish it manually:"`,
+      `  echo "  [x] 安装以代码 $__clirc 退出——请手动完成："`,
       `  echo '    ${cmd}'`,
       ...(docs ? [`  echo '    Docs: ${docs}'`] : []),
-      `  echo '  Then restart the agent to launch it.'`,
+      `  echo '  然后重启 agent 以启动它。'`,
       `fi`
     );
   } else if (rung.nodeMissing) {
-    // The honest dead end: no node, and this vendor ships no node-free installer.
-    // Say what is actually missing instead of running a command that cannot work.
+    // 坦诚的死胡同：没有 node，且该厂商没有随附无 node 的安装器。
+    // 直接说明到底缺什么，而不是运行一条注定无法成功的命令。
     lines.push(
-      `echo '  Install Node.js (nodejs.org), then the ${label} CLI:'`,
+      `echo '  安装 Node.js (nodejs.org)，然后是 ${label} CLI：'`,
       ...(info.command ? [`echo '    ${info.command}'`] : []),
-      `echo '  …or install the CLI by whatever method its docs recommend.'`,
+      `echo '  …或按其文档推荐的方式安装该 CLI。'`,
       ...(docs ? [`echo '  Docs: ${docs}'`] : []),
       `echo '${rule}'`
     );
   } else {
     lines.push(
-      `echo '  No bundled installer for the ${label} provider.'`,
-      `echo '  Install it manually, then restart the agent to launch it.'`,
+      `echo '  没有针对 ${label} provider 的捆绑安装器。'`,
+      `echo '  请手动安装，然后重启 agent 以启动它。'`,
       ...(docs ? [`echo '  Docs: ${docs}'`] : []),
       `echo '${rule}'`
     );

--- a/src/main/closingTime.ts
+++ b/src/main/closingTime.ts
@@ -1,27 +1,23 @@
 /**
- * Closing Time — the graceful, data-loss-free shutdown protocol.
+ * Closing Time —— 优雅、零数据丢失的关闭协议。
  *
- * Killing the PTYs mid-thought loses whatever the agents were holding in
- * working memory: uncommitted WIP, unrecorded decisions, half-updated
- * memory.md files. "Closing time" closes the floor the way a real office
- * does: the human announces it, every worker packs up and confirms, the
- * manager locks the door.
+ * 在 agent 思考中途杀掉 PTY，会丢失它们工作内存里的一切：未提交的 WIP、
+ * 未记录的决定、写到一半的 memory.md 文件。“打烊时间（closing time）”像真实
+ * 办公室那样收尾：人类宣布打烊，每位员工收拾好并确认，经理锁门。
  *
- *   1. The human clicks "closing time" in the quit dialog.
- *   2. We mail the god agent a shutdown brief: broadcast closing time to the
- *      team; every worker commits/parks WIP, appends state + next steps to
- *      its memory.md, then replies with subject CLOSING-TIME-ACK.
- *   3. The god waits for every ACK (the harness shows live progress by
- *      watching the same inbox traffic), saves its own memory, and sends a
- *      message with subject CLOSING-TIME-COMPLETE.
- *   4. The router observer spots that message → the app tears down and quits.
+ *   1. 人类在退出对话框里点击“closing time”。
+ *   2. 我们给 god agent 发送一份关闭简报：向团队广播 closing time；每个
+ *      worker 提交/暂存 WIP，把状态 + 后续步骤追加到自己的 memory.md，
+ *      然后以主题 CLOSING-TIME-ACK 回复。
+ *   3. god 等待每个 ACK（harness 通过观察同一份 inbox 流量显示实时进度）、
+ *      保存自己的记忆，并发送主题为 CLOSING-TIME-COMPLETE 的消息。
+ *   4. 路由器观察者发现那条消息 → 应用拆除并退出。
  *
- * Everything rides the existing hive rails: inbox delivery, the idle
- * inbox-wake nudge, and Stop-hook draining already guarantee the messages
- * get acted on. This module only injects the kickoff mail and watches the
- * routed traffic — it never types into terminals.
+ * 一切都搭乘现有的 hive 轨道：inbox 投递、空闲时 inbox-wake 轻推，以及
+ * Stop-hook 排空，已经保证消息会被处理。本模块只注入启动邮件并观察
+ * 被路由的流量——它从不向终端输入文字。
  *
- * Runs in the Electron main process.
+ * 运行在 Electron 主进程。
  */
 import type { WebContents } from 'electron';
 import type { HiveManager, HiveMessage } from './hive';
@@ -32,22 +28,22 @@ export type ClosingTimePhase =
 
 export interface ClosingTimeEvent {
   phase: ClosingTimePhase;
-  /** Workers that have ACKed so far / total workers being waited on. */
+  /** 目前已经 ACK 的 worker 数 / 正在等待的 worker 总数。 */
   acked: number;
   total: number;
 }
 
-/** Subject markers. Deliberately forgiving (case, -/_/space) — agents write
- *  these by hand, so "Closing Time Ack" must count as well as the canonical
- *  CLOSING-TIME-ACK the brief asks for. */
+/** 主题标记。刻意放宽匹配（大小写、-/ _/空格）——agent 是手写的，
+ *  因此 “Closing Time Ack” 也要算数，和简报要求的规范写法
+ *  CLOSING-TIME-ACK 一样生效。 */
 const ACK_RE = /CLOSING[-_\s]*TIME[-_\s]*ACK/i;
 const COMPLETE_RE = /CLOSING[-_\s]*TIME[-_\s]*COMPLETE/i;
 
-/** How long to wait before surfacing "this is taking long — force quit?".
- *  Compaction or a long tool call can easily hold an ACK for a few minutes. */
+/** 在提示“耗时过长——强制退出？”之前等待多久。
+ *  压缩或一次很长的工具调用很容易让 ACK 拖上几分钟。 */
 const TIMEOUT_MS = 6 * 60_000;
-/** Grace after COMPLETE before tearing down, so the god's final commit/log
- *  writes land on disk and the floor visibly concludes. */
+/** COMPLETE 之后、拆除之前的宽限期，让 god 最后的提交/日志写入
+ *  落到磁盘上，工作区也能可见地收尾。 */
 const TEARDOWN_GRACE_MS = 2_500;
 
 export class ClosingTimeController {
@@ -60,17 +56,16 @@ export class ClosingTimeController {
 
   constructor(
     private hive: HiveManager,
-    /** Agent ids that have a LIVE PTY right now. The hive registry alone is
-     *  not enough: agents that died with the app (hard quit, crash) keep
-     *  their registry record without ever being flagged `archived`, so a
-     *  registry-based roster waits on ghosts that can never ACK. */
+    /** 当前拥有 LIVE PTY 的 agent id。仅靠 hive 注册表是不够的：随应用一起
+     *  死亡的 agent（硬退出、崩溃）会保留注册记录，却从未被标记为
+     *  `archived`，因此基于注册表的名册会一直等待永远无法 ACK 的幽灵。 */
     private getLiveAgentIds: () => string[],
     private getWebContents: () => WebContents | null,
-    /** Called once the god concluded — runs the real teardown + app.quit(). */
+    /** 一旦 god 结束时调用——执行真正的拆除 + app.quit()。 */
     private onConcluded: () => void,
-    /** Mid-run steering (#7C.2): lets closing time reach DEEPLY BUSY agents at
-     *  their next hook boundary instead of waiting for the Stop-hook inbox
-     *  drain — the graceful interrupt. Optional so tests can omit it. */
+    /** 运行中的 steering（#7C.2）：让 closing time 能在深度忙碌（DEEP BUSY）的
+     *  agent 到达下一个 hook 边界时触达它，而不是等待 Stop-hook 的 inbox
+     *  排空——这就是优雅中断。可选参数，测试可以省略它。 */
     private control?: ControlRegistry
   ) {}
 
@@ -78,11 +73,11 @@ export class ClosingTimeController {
     return this.active;
   }
 
-  /** Kick off the protocol. Returns an error string when the floor cannot run
-   *  it (no live god agent) so the UI can fall back to the hard quit. */
+  /** 启动协议。当工作区无法运行时（没有在线的 god agent）返回错误字符串，
+   *  这样 UI 可以回退到硬退出。 */
   start(): { ok: boolean; error?: string } {
     if (this.active) {
-      // Re-pressed while running (e.g. from the timeout view): keep waiting.
+      // 运行中被再次按下（例如从超时视图）：继续等待。
       this.armTimeout();
       this.emitState('progress');
       return { ok: true };
@@ -91,11 +86,11 @@ export class ClosingTimeController {
     this.godId = reg.godId ?? 'god';
     const live = new Set(this.getLiveAgentIds());
     if (!reg.agents[this.godId] || !live.has(this.godId)) {
-      return { ok: false, error: 'No orchestrator is running — closing time needs the god agent to collect the reports.' };
+      return { ok: false, error: '没有编排器在运行——关闭流程需要 god agent 来收集报告。' };
     }
 
-    // Only agents with a live terminal are waited on — the registry is just
-    // metadata here (names + god/assistant flags), never the roster source.
+    // 只有拥有在线终端的 agent 才会被等待——注册表在这里只是
+    // 元数据（名字 + god/assistant 标志），绝不是名册来源。
     this.workers = new Set(
       [...live].filter((id) => {
         const a = reg.agents[id];
@@ -112,34 +107,34 @@ export class ClosingTimeController {
     this.hive.send({
       to: 'god',
       act: 'request',
-      subject: 'CLOSING TIME — run the shutdown protocol now',
+      subject: 'CLOSING TIME —— 现在执行关闭协议',
       body: [
-        'The human pressed "closing time": the harness will close as soon as you confirm the floor is safe. Run this protocol now, before anything else:',
+        '人类按下了「closing time」：只要你确认楼层安全，整个框架就会关闭。现在立刻执行本协议，先于任何其他事项：',
         '',
-        `1. BROADCAST closing time to the team (message with "to":"broadcast"). Current workers: ${names}.`,
-        '   Tell each worker to immediately: park or commit any work-in-progress safely, append its current state + concrete next steps to its memory.md, and then reply to you with a message whose subject is exactly "CLOSING-TIME-ACK".',
-        '2. WAIT and keep draining your inbox until EVERY worker above has sent its CLOSING-TIME-ACK. Nudge stragglers once if needed.',
-        '3. Save your own state: update board.md and append your shift summary to your memory.md.',
-        `4. CONCLUDE by sending a message with "to":"human" and the subject exactly "CLOSING-TIME-COMPLETE" — the harness watches for it and closes the app. Do not send it before every worker has acked: the harness independently verifies the ACKs and will reject a premature conclusion.`,
+        `1. 向团队 BROADCAST closing time（消息里带 "to":"broadcast"）。当前成员：${names}。`,
+        '   告诉每个成员立刻：安全地暂存或提交手头未完成的工作，把当前状态 + 具体下一步追到其 memory.md，然后回复你一条 subject 恰好为 "CLOSING-TIME-ACK" 的消息。',
+        '2. 等待并持续清空收件箱，直到上面每一个成员都发来了它的 CLOSING-TIME-ACK。必要时催促一次掉队的。',
+        '3. 保存你自己的状态：更新 board.md，并把本轮小结追到你的 memory.md。',
+        `4. 收尾：发送一条带 "to":"human" 且 subject 恰好为 "CLOSING-TIME-COMPLETE" 的消息——框架会盯住它并关闭应用。在所有成员确认之前不要发送：框架会独立核验 ACK，并拒绝过早的结论。`,
         '',
         this.workers.size === 0
-          ? 'There are no workers on the floor right now — do steps 3 and 4 immediately.'
-          : 'The prep assistant saves its own memory separately — do NOT wait for it and do not message it.',
-        'This is a shutdown: do not start new work and do not accept new tasks.'
+          ? '现在楼上一个成员都没有——立即执行第 3、4 步。'
+          : '预备助理会单独保存自己的记忆——不要等它，也不要给它发消息。',
+        '这是一次关闭：不要开始新工作，也不要接受新任务。'
       ].join('\n')
     }, 'human');
 
-    // Graceful interrupt for the deeply busy (#7C.2): the inbox brief above
-    // only lands when an agent next STOPS — a worker hours into a task would
-    // hold the whole shutdown. A steer note rides the next hook boundary
-    // (PostToolUse/UserPromptSubmit) instead, so every live agent learns about
-    // closing time within one tool call. Idle agents are covered by the
-    // inbox-wake nudge; busy ones by the steer — both rails, no PTY typing.
+    // 针对深度忙碌的优雅中断（#7C.2）：上面的 inbox 简报
+    // 只在 agent 下一次 STOP 时才落地——一个任务做到一半的 worker 会
+    // 拖住整个关闭流程。改由一条 steer 通知搭乘下一个 hook 边界
+    // （PostToolUse/UserPromptSubmit），因此每个在线 agent 都会
+    // 在一次工具调用内得知 closing time。空闲 agent 由
+    // inbox-wake 轻推覆盖；忙碌的由 steer 覆盖——双轨并行，无需向 PTY 打字。
     this.control?.steer(this.godId,
-      'CLOSING TIME was pressed by the human: pause your current work at the next sensible point and drain your inbox NOW — a shutdown brief is waiting there. Coordinate the floor shutdown before anything else.');
+      '人类按下了 CLOSING TIME：在下一个合适的位置暂停当前工作，现在立即清空收件箱——里面有份关闭简报等着你。先协调楼层的关闭，再做别的。');
     for (const id of this.workers) {
       this.control?.steer(id,
-        'CLOSING TIME — the office is shutting down. Finish your current step but do NOT start new work. Park or commit your work-in-progress safely, append your current state + concrete next steps to your memory.md, then reply to god with a message whose subject is exactly "CLOSING-TIME-ACK".');
+        'CLOSING TIME —— 办公室正在关闭。完成当前这一步，但不要开始新工作。安全地暂存或提交未完成的工作，把当前状态 + 具体下一步追到你的 memory.md，然后回复 god 一条 subject 恰好为 "CLOSING-TIME-ACK" 的消息。');
     }
 
     this.armTimeout();
@@ -147,13 +142,13 @@ export class ClosingTimeController {
     return { ok: true };
   }
 
-  /** Human changed their mind — stand the floor back up. */
+  /** 人类改变了主意——把工作区重新立起来。 */
   cancel(): void {
     if (!this.active) return;
     this.cleanup();
-    // Drop closing-time steers that no hook boundary has consumed yet, so a
-    // busy agent doesn't get told to shut down AFTER the human cancelled.
-    // Agents that already saw the note get corrected via the god (below).
+    // 丢弃尚无任何 hook 边界消费的 closing-time steer，这样在人类取消之后，
+    // 忙碌的 agent 不会才被告知要关闭。
+    // 已经看到通知的 agent 会通过 god 纠正（见下）。
     this.control?.clearSteers(this.godId);
     for (const id of this.workers) this.control?.clearSteers(id);
     this.emitState('cancelled');
@@ -161,17 +156,17 @@ export class ClosingTimeController {
       this.hive.send({
         to: 'god',
         act: 'inform',
-        subject: 'CLOSING TIME CANCELLED',
-        body: 'The human cancelled the shutdown — disregard the closing-time protocol and resume normal operation. Any memory saves already done are a bonus, not a problem.'
+        subject: 'CLOSING TIME 已取消',
+        body: '人类取消了关闭——忽略关闭协议，恢复正常运作。已经完成的记忆保存是额外收获，不是问题。'
       }, 'human');
-    } catch { /* best-effort */ }
+    } catch { /* 尽力而为 */ }
   }
 
-  /** Router observer — called by the hive for every routed message. */
+  /** 路由器观察者——hive 对每条被路由的消息都会调用它。 */
   onRouted(msg: HiveMessage, targets: string[]): void {
     if (!this.active) return;
-    // A worker reporting in. Counted only for known workers, and only when the
-    // ACK actually reached the god (not e.g. a stray broadcast echo).
+    // 一个 worker 在报到。只有已知 worker、且 ACK 确实到达 god 时才计数
+    //（而不是例如误入的广播回显）。
     if (ACK_RE.test(msg.subject) && this.workers.has(msg.from) && targets.includes(this.godId)) {
       if (!this.acked.has(msg.from)) {
         this.acked.add(msg.from);
@@ -179,14 +174,14 @@ export class ClosingTimeController {
       }
       return;
     }
-    // The god concluding. COMPLETE is only honored from the god itself — a
-    // worker can't (accidentally or otherwise) shut down the whole floor.
+    // god 在收尾。只有 god 自己发出的 COMPLETE 才被认可——worker
+    // 不能（有意或无意地）关闭整个工作区。
     if (COMPLETE_RE.test(msg.subject) && msg.from === this.godId) {
-      // Trust but VERIFY: the god is told to wait for every ACK, but the
-      // whole point of closing time is that no worker loses unsaved state —
-      // so a premature COMPLETE must not close the floor. Workers whose
-      // terminal died mid-protocol (tab closed, crash) are excused: their
-      // ACK can never arrive and their session is gone either way.
+      // 信任但要验证：god 被要求等待每个 ACK，但
+      // closing time 的全部意义在于不让任何 worker 丢失未保存的状态——
+      // 因此过早的 COMPLETE 绝不能关闭工作区。协议中途
+      // 终端死掉的 worker（标签页关闭、崩溃）可以豁免：他们的
+      // ACK 永远不会到达，而且无论怎样会话都已消失。
       const reg = this.hive.registry();
       const liveNow = new Set(this.getLiveAgentIds());
       const pending = [...this.workers].filter(
@@ -197,18 +192,18 @@ export class ClosingTimeController {
         this.hive.send({
           to: 'god',
           act: 'refuse',
-          subject: 'CLOSING TIME — conclusion rejected, workers still missing',
+          subject: 'CLOSING TIME —— 结论被拒绝，仍有成员未确认',
           body: [
-            `The harness is still missing a CLOSING-TIME-ACK from: ${names}.`,
-            'The app stays open until every worker has confirmed its memory is saved.',
-            'Chase the stragglers (re-send the closing-time instruction to each), wait for their ACKs, then send CLOSING-TIME-COMPLETE again.'
+            `框架仍然缺少来自以下成员的 CLOSING-TIME-ACK：${names}。`,
+            '应用会保持打开，直到每个成员都确认其记忆已保存。',
+            '催促掉队的成员（向每个人重发关闭指令），等他们的 ACK，然后再次发送 CLOSING-TIME-COMPLETE。'
           ].join('\n')
         }, 'human');
         this.emitState('progress');
         return;
       }
       this.cleanup();
-      this.active = true; // stays "active" through the grace so the UI holds
+      this.active = true; // 宽限期内保持 "active"，这样 UI 就能保持
       this.emitState('complete');
       this.teardownTimer = setTimeout(() => {
         this.active = false;
@@ -232,6 +227,6 @@ export class ClosingTimeController {
 
   private emitState(phase: ClosingTimePhase): void {
     const ev: ClosingTimeEvent = { phase, acked: this.acked.size, total: this.workers.size };
-    try { this.getWebContents()?.send('app:closingTime', ev); } catch { /* window tore down */ }
+    try { this.getWebContents()?.send('app:closingTime', ev); } catch { /* 窗口已拆除 */ }
   }
 }

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -23,110 +23,97 @@ import {
   type WebhookTrigger
 } from '../shared/triggers';
 
-/** A recurring auto-dispatched mission fired on an interval by the scheduler. */
+/** 由调度器按间隔自动派发的周期性任务。 */
 export interface ScheduledMission {
   id: string;
   label: string;
   intervalMs: number;
-  /** Day-of-week + time-of-day schedule. When present and valid this REPLACES
-   *  `intervalMs` — an interval cannot say "weekday mornings", because it drifts
-   *  against the clock and a 24h one started at 15:00 fires at 15:00 forever.
-   *  `intervalMs` is deliberately left on the record so switching back restores
-   *  the cadence the user had. See shared/weeklySchedule.ts. */
+  /** 星期几 + 一天中时刻的排程。当其存在且有效时，将完全取代 `intervalMs`——
+   *  间隔无法表达"工作日上午"，因为它会随时间漂移：例如 15:00 启动的 24 小时
+   *  间隔会永远在 15:00 触发。`intervalMs` 有意保留在记录中，这样切换回来即可
+   *  恢复用户原先的节奏。参见 shared/weeklySchedule.ts。 */
   weekly?: { days: number[]; minute: number };
   to: string;
   body: string;
   enabled: boolean;
-  /** When true, the scheduler asks the renderer to compact live terminals when
-   *  this mission fires — but only agents whose context has filled past the bar
-   *  in `contextTrigger.compact` (60% by default, 40% on ~1M-token windows), so
-   *  small/idle sessions are left alone instead of compacting on every tick.
+  /** 为 true 时，调度器会在该任务触发时要求渲染器压缩活动的终端——但只压缩
+   *  上下文已填满超过 `contextTrigger.compact` 中阈值（默认 60%，约 1M token
+   *  窗口为 40%）的代理，因此小/空闲会话会被放过，而不是每次触发都压缩。
    *
-   *  This gate used to be described here but was never actually implemented: every
-   *  live agent was compacted on every tick. It is real now, and the bars live in
-   *  `ContextTriggerConfig` where the operator can edit them, so do not restate
-   *  the numbers anywhere else — they will drift. */
+   *  这个闸门过去只在这里被描述、从未真正实现：每个活动代理每次触发都会被
+   *  压缩。现在它是真实生效的，阈值位于 `ContextTriggerConfig` 中，操作者可
+   *  自行编辑，所以不要在别处重复这些数字——它们会漂移。 */
   autoCompact?: boolean;
   lastFiredAt?: number;
-  /** Mission flavor. Absent ⇒ 'dispatch' (the classic interval-dispatch mission,
-   *  e.g. the ops standup). 'heartbeat' (Lane A #1) is a context-aware beat: it
-   *  observes live floor state, re-engages a quiet god, and ticks the circuit
-   *  breaker — armed with an adaptive cadence, not a fixed setInterval. */
+  /** 任务风味。缺省 ⇒ 'dispatch'（经典的间隔派发任务，如运维站会）。
+   *  'heartbeat'（Lane A #1）是一种感知上下文的节拍：它观察实时楼层状态，
+   *  重新接洽安静的 god，并拨动熔断器——采用自适应节奏，而非固定的
+   *  setInterval。 */
   kind?: 'dispatch' | 'heartbeat' | 'compact';
-  /** Heartbeat only: a floor is "quiet" when no tracked signal (log.jsonl mtime,
-   *  inbox/outbox mtimes, any PTY output) has moved in this many ms. Default
-   *  ~5 min. NOT derived from registry.status (which never transitions in main). */
+  /** 仅 heartbeat：当所有被追踪的信号（log.jsonl 的 mtime、inbox/outbox 的
+   *  mtime、任何 PTY 输出）在此毫秒数内都没有变动时，楼层即为"安静"。
+   *  默认约 5 分钟。不取自 registry.status（它在 main 中从不变化）。 */
   quietThresholdMs?: number;
 }
 
-/** The built-in hourly ops standup: god reviews who's doing what + whether tasks
- *  are on track and agents are running, and every terminal's context is compacted.
- *  Shipped enabled by default; users can toggle it off in the Command Center. */
+/** 内置的每小时运维站会：god 检查谁在做什么 + 任务是否按计划推进、代理是否
+ *  在运行，并压缩每个终端的上下文。默认启用；用户可在 Command Center 中
+ *  关闭它。 */
 export const OPS_STANDUP_MISSION: ScheduledMission = {
   id: 'ops-standup',
-  label: 'Hourly ops standup',
+  label: '每小时运维站会',
   intervalMs: 3_600_000,
   to: 'god',
   body:
-    'Hourly ops standup. Review every agent: who is doing what, and confirm each ' +
-    'is still running (not stalled or idle-stale). Check the task board — are ' +
-    'in-flight tasks on track, and is anything blocked or unowned? Flag stale ' +
-    'agents and at-risk tasks, and keep the board accurate. (As part of this ' +
-    "standup each working agent is asked to summarise its current task and the " +
-    'next step, then compact and resume from the same point — so terminal ' +
-    'contexts stay bounded without losing work. The compaction is queued and ' +
-    'runs when an agent is idle, so it never interrupts work mid-step.)',
+    '每小时运维站会。逐一检查每个代理：谁在做什么，并确认每个代理 ' +
+    '仍在正常运行（未卡死、未闲置过久）。查看任务看板——进行中的任务是否 ' +
+    '按计划推进，是否有被阻塞或无主的任务？标记停滞的代理和风险任务，并 ' +
+    '保持看板准确。（作为站会的一部分，每个工作中的代理都被要求总结其当前 ' +
+    '任务和下一步，然后压缩并从同一位置继续——这样终端上下文保持有限而不会 ' +
+    '丢失工作。压缩会被排队，在代理空闲时执行，绝不会打断进行中的工作。）',
   enabled: true
-  // NO autoCompact. Compaction belongs to contextTrigger.compact and nothing else.
-  // This flag used to live here as well, which meant a default install asked for
-  // compaction on TWO cadences — hourly from this standup and 2-hourly from the
-  // trigger — the exact "two controls that disagree" the maint-1 retirement below
-  // was written to end. The standup's own prose still describes compaction, and
-  // that stays true: the trigger does it, just not on this mission's clock.
+  // 没有 autoCompact。压缩只属于 contextTrigger.compact，别无其他。
+  // 这个标志过去也住在这里，意味着默认安装会在两个节奏上要求压缩——本站会
+  // 每小时一次、触发器每两小时一次——这正是下方 maint-1 退役要终结的
+  // "两个互不一致的控制"。站会自己的文案仍然描述压缩，这一点依然成立：
+  // 由触发器来做，只是不在该任务的时钟上。
 };
 
-/** The built-in heartbeat (Lane A #1). A context-aware beat that, each tick,
- *  observes live floor state and — only when the floor has gone quiet — drops a
- *  digest into god's inbox and (if god's PTY is genuinely idle) nudges it to
- *  re-engage anyone stalled. The same beat ticks the circuit breaker.
+/** 内置的心跳任务（Lane A #1）。一种感知上下文的节拍，每次跳动都会观察实时
+ *  楼层状态，并且——仅在楼层安静下来时——向 god 的收件箱投放摘要，并在
+ *  god 的 PTY 确实空闲时轻推它去重新接洽任何停滞者。同一节拍也拨动熔断器。
  *
- *  Shipped DISABLED by default (opt-in): unlike the standup, which only sends a
- *  hive message, the heartbeat types into god's PTY, so the user turns it on
- *  explicitly in the Command Center once they want active re-engagement.
- *  `intervalMs` is the normal-cadence base; the scheduler derives a tighter beat
- *  when an agent looks stuck and a slower one right after a re-engage. */
+ *  默认以 DISABLED 状态发货（选择启用）：与仅发送 hive 消息的站会不同，
+ *  心跳会向 god 的 PTY 键入内容，因此用户想主动重新接洽时，会在 Command
+ *  Center 中显式开启。`intervalMs` 是正常节奏的基础；当代理看起来卡住时，
+ *  调度器会推导出更紧凑的节拍，而在重新接洽之后则使用较慢的节拍。 */
 export const HEARTBEAT_MISSION: ScheduledMission = {
   id: 'heartbeat',
-  label: 'Floor heartbeat',
+  label: '楼层心跳',
   intervalMs: 120_000,
   to: 'god',
   body:
-    'Floor heartbeat: the team has gone quiet. Review the digest in your inbox, ' +
-    're-engage anyone stalled or blocked, and keep the board accurate — or rest ' +
-    'if the work is genuinely done.',
+    '楼层心跳：团队已安静下来。请查看收件箱中的摘要，重新接洽任何停滞或 ' +
+    '被阻塞的成员，并保持看板准确——如果工作确实完成了，就休息吧。',
   enabled: false,
   kind: 'heartbeat',
   quietThresholdMs: 300_000
 };
 
-/** The dedicated auto-compact MAINTENANCE schedule (maint-1). DECOUPLED from the
- *  ops standup so editing/replacing a standup can never silently disable
- *  compaction again (the bug this fixes). It fires ONLY the auto-compact signal —
- *  `kind:'compact'` makes syncMissions skip the hive.send dispatch (empty to/body).
- *  Shipped DISABLED (v0.3.4 founder decision): scheduled compaction is opt-in.
- *  Turn it on in Settings → General or the Schedules tab; the Schedules warning
- *  panel explains the risk of leaving it off for long-running agents. It is the
- *  SINGLE source of truth for compaction, and it's persistent: deleting it makes
- *  it reappear DISABLED.
- *  Existing installs keep whatever enabled state the user already has
- *  (compactMaintenanceSeeded guards re-seeding). */
+/** 专用的自动压缩 MAINTENANCE 排程（maint-1）。与运维站会解耦，这样编辑或
+ *  替换站会再也不会悄悄禁用压缩（这正是本修复要解决的 bug）。它只触发
+ *  auto-compact 信号——`kind:'compact'` 让 syncMissions 跳过 hive.send 派发
+ *  （to/body 为空）。默认以 DISABLED 发货（v0.3.4 创始人决定）：定时压缩为
+ *  选择启用。可在 Settings → General 或 Schedules 标签页中开启；Schedules
+ *  警告面板解释了长期运行代理不开启压缩的风险。它是压缩的唯一事实来源，且
+ *  具有持久性：删除它会让它以 DISABLED 状态重新出现。
+ *  现有安装保留用户已有的 enabled 状态（compactMaintenanceSeeded 防止重新播种）。 */
 export const COMPACT_MAINTENANCE_MISSION: ScheduledMission = {
   id: 'compact-maintenance',
-  label: 'Auto-compact (maintenance)',
-  // 2h, matching DEFAULT_CONTEXT_TRIGGER.compact.everyMs. The two cadences must
-  // agree: this mission is the schedule half of the same behaviour the context
-  // trigger now owns, and a 1h seed here would keep interrupting agents on the
-  // old rhythm no matter what the trigger says.
+  label: '自动压缩（维护）',
+  // 2 小时，与 DEFAULT_CONTEXT_TRIGGER.compact.everyMs 一致。两个节奏必须
+  // 相同：该任务是上下文触发器现在所拥有的同一行为的排程一半，这里若播种
+  // 1 小时，无论触发器怎么说都会以旧节奏不断打断代理。
   intervalMs: 7_200_000,
   to: '',
   body: '',
@@ -135,285 +122,264 @@ export const COMPACT_MAINTENANCE_MISSION: ScheduledMission = {
   kind: 'compact'
 };
 
-/** The 1h cadence `compact-maintenance` was seeded with before Triggers doubled
- *  it. `migrateTriggersV1` bumps only missions still sitting on this EXACT value,
- *  so an interval the user tuned by hand is left exactly where they put it. */
+/** `compact-maintenance` 在 Triggers 将其加倍之前播种的 1 小时节奏。
+ *  `migrateTriggersV1` 只升级仍停留在这个精确值上的任务，因此用户手动调整的
+ *  间隔会原样保留在他们设定的位置。 */
 const LEGACY_COMPACT_MAINTENANCE_INTERVAL_MS = 3_600_000;
 
-/** Circuit-breaker thresholds (Lane A #6.6b). The breaker runs inside the
- *  heartbeat beat, so it only ticks when the heartbeat is enabled. Trip
- *  conditions are behavioral by default; `costCapUsd` is the only $-based one and
- *  is unset by default (a hardcoded dollar default would be arbitrary). Defaults
- *  are deliberately conservative and steer-first — `hardStop` is OFF unless the
- *  user opts in, so the breaker never auto-kills a healthy long-runner. */
+/** 熔断器阈值（Lane A #6.6b）。熔断器运行在心跳节拍内部，因此只有心跳启用时
+ *  它才会拨动。触发条件默认基于行为；`costCapUsd` 是唯一以 $ 计量的，默认不
+ *  设置（硬编码的美元默认值将是任意的）。默认值刻意保守且以引导优先——
+ *  `hardStop` 默认关闭，除非用户选择启用，因此熔断器绝不会自动杀死健康的
+ *  长期运行者。 */
 export interface CircuitBreakerConfig {
-  /** Master switch for breaker evaluation within the beat. Default true. */
+  /** 节拍内熔断器评估的主开关。默认 true。 */
   enabled?: boolean;
-  /** Allow the top of the ladder (kill PTY + archive). Default false = the
-   *  breaker may steer/constrain but never hard-stops until the user opts in. */
+  /** 允许阶梯顶端（杀死 PTY + 归档）。默认 false = 熔断器可以引导/约束，但在用户选择启用之前绝不硬停。 */
   hardStop?: boolean;
-  /** Consecutive identical tool calls (same name+input) before tripping. */
+  /** 触发前允许的连续相同工具调用（同名+同输入）。 */
   repeatedToolLimit?: number;
-  /** Consecutive api_error / retry events before tripping. */
+  /** 触发前允许的连续 api_error / retry 事件。 */
   errorStormLimit?: number;
-  /** Output-token velocity (tokens/min, diffed across beats) before tripping. */
+  /** 触发前的输出 token 速率（token/分钟，跨节拍差分）。 */
   tokenVelocityPerMin?: number;
 }
 
-/** Enterprise Knowledge Graph (multimodal context store + agent access tool).
- *  The user ingests their own documents/images/PDFs; agents query them on demand
- *  via the `kg` CLI. Opt-in like the heartbeat/Slack features — `enabled` gates
- *  everything (no env injected, no prompt line, no store touched when off). See
- *  docs/design/knowledge-graph.md. */
+/** Enterprise Knowledge Graph（多模态上下文存储 + 代理访问工具）。
+ *  用户摄入自己的文档/图片/PDF；代理按需通过 `kg` CLI 查询它们。与
+ *  heartbeat/Slack 功能一样为选择启用——`enabled` 门控一切（关闭时不注入
+ *  env、不加提示行、不触碰存储）。参见 docs/design/knowledge-graph.md。 */
 export interface KnowledgeGraphConfig {
-  /** Master switch. Default false = zero behaviour change (the feature is dark). */
+  /** 主开关。默认 false = 零行为变化（该功能保持暗置）。 */
   enabled?: boolean;
-  /** Override the store location. Unset = <userData>/knowledge. */
+  /** 覆盖存储位置。未设置 = <userData>/knowledge。 */
   rootPath?: string;
 }
 
 export interface HarnessConfig {
-  /** Has the user completed the first-run onboarding? */
+  /** 用户是否已完成首次运行引导？ */
   onboardingComplete: boolean;
-  /** Self-identified audience picked on the first onboarding screen. Drives the
-   *  copy register everywhere onboarding explains itself: 'technical' shows CLI /
-   *  flag lingo, 'non-technical' explains each concept in plain language. Unset =
-   *  not yet chosen (treated as technical for any incidental copy). */
+  /** 用户在首次引导界面自选的受众类型。驱动引导文案的所有措辞：'technical'
+   *  显示 CLI / 参数术语，'non-technical' 用平实语言解释每个概念。未设置 =
+   *  尚未选择（任何附带文案按 technical 处理）。 */
   audience?: 'technical' | 'non-technical';
-  /** Folder where the harness keeps its own state (agent metadata, logs). */
+  /** harness 保存自身状态的文件夹（代理元数据、日志）。 */
   harnessHome: string | null;
-  /** Recently-opened hive home folders (most-recent first), surfaced by the
-   *  launch-time hive picker. Maintained by writeConfig whenever harnessHome is
-   *  set (onboarding finish, changeHome). Capped to a handful. */
+  /** 最近打开的 hive home 文件夹（最近的在前），由启动时的 hive 选择器展示。
+   *  每当 harnessHome 被设置（引导完成、changeHome）时由 writeConfig 维护。
+   *  上限为少量几个。 */
   recentHives?: string[];
-  /** Folders the user registered during onboarding (used as quick-picks). */
+  /** 用户在引导期间注册的文件夹（用作快速选择）。 */
   registeredRepos: string[];
-  /** When true, new agents are spawned with --permission-mode bypassPermissions. */
+  /** 为 true 时，新代理以 --permission-mode bypassPermissions 派生。 */
   autoMode: boolean;
-  /** May the orchestrator ("Michael") spin up agents on its own?
+  /** 编排器（"Michael"）能否自行派生代理？
    *
-   *  Default FALSE. Spawning an agent is a SPEND decision, so it should not
-   *  happen unprompted. The ability itself shipped in v0.4.4 with no gate at all,
-   *  so this closes an existing default-on behaviour rather than gating a new
-   *  feature: an operator who wants it must now say so.
+   *  默认 FALSE。派生一个代理是花费（SPEND）决策，因此不应在未被提示时发生。
+   *  该能力本身在 v0.4.4 中毫无门控地发货，所以这里关闭的是一个已有的默认
+   *  开启行为，而非给新功能加门控：想要它的操作者现在必须明确表态。
    *
-   *  Off does not FAIL a queued spawn request, it declines to consume one. The
-   *  request sits in HIVE_ROOT/spawn-requests until the toggle is turned on. */
+   *  关闭并不会使排队的派生请求失败，而是拒绝消费它。请求停留在
+   *  HIVE_ROOT/spawn-requests 中，直到该开关被打开。 */
   orchestratorMaySpawn: boolean;
-  /** The command we run when spawning a new agent. */
+  /** 派生新代理时运行的命令。 */
   defaultCommand: string;
-  /** Default model for newly spawned agents (e.g. 'claude-sonnet-4-6[1m]'); unset = CLI default. */
+  /** 新派生代理的默认模型（如 'claude-sonnet-4-6[1m]'）；未设置 = CLI 默认。 */
   defaultModel?: string;
-  /** Which provider powers the GOD orchestrator ("Michael"). The persona is
-   *  constant; only its engine is selectable. Default 'claude'. Eligible providers
-   *  are those that can receive inbox (claude/codex/antigravity/qwen). */
+  /** 哪个 provider 驱动 GOD 编排器（"Michael"）。人设恒定；只有其引擎可选。
+   *  默认 'claude'。合格的 provider 是那些能接收 inbox 的
+   *  （claude/codex/antigravity/qwen）。 */
   godProvider?: AgentProvider;
-  /** The model GOD runs on. Unset falls back to the provider preset's
-   *  `recommendedOrchestratorModel`, then MODEL_GOD. Default 'claude-opus-4-8'. */
+  /** GOD 运行的模型。未设置时回退到 provider 预设的
+   *  `recommendedOrchestratorModel`，然后是 MODEL_GOD。默认 'claude-opus-4-8'。 */
   godModel?: string;
-  /** Per-server consent state for the default MCP bundle, keyed by catalog id.
-   *  Seeded from MCP_CATALOG (safe-readonly ON, write/secret OFF); the user flips
-   *  these in Settings. A server is wired into an agent only when enabled here. */
+  /** 默认 MCP 套件的按服务器同意状态，以 catalog id 为键。从 MCP_CATALOG
+   *  播种（safe-readonly ON，write/secret OFF）；用户可在 Settings 中切换。
+   *  只有当此处启用时，服务器才会被接入代理。 */
   mcpDefaults?: { [id: string]: { enabled: boolean } };
-  /** Enable semantic memory (MemPalace CLI). No-op if mempalace isn't installed. */
+  /** 启用语义记忆（MemPalace CLI）。若未安装 mempalace 则为空操作。 */
   semanticMemory: boolean;
-  /** Embedding model for the palace: lightweight 'minilm' or multilingual 'embeddinggemma'. */
+  /** 宫殿的 embedding 模型：轻量 'minilm' 或多语言 'embeddinggemma'。 */
   embeddingModel: 'minilm' | 'embeddinggemma';
-  /** Recurring auto-dispatch missions handled by the scheduler. */
+  /** 由调度器处理的周期性自动派发任务。 */
   missions?: ScheduledMission[];
-  /** One-time guard: has the built-in hourly ops standup been seeded into an
-   *  existing install's missions? Prevents re-adding it after a user deletes it. */
+  /** 一次性守卫：内置的每小时运维站会是否已被播种进现有安装的任务中？
+   *  防止用户在删除它之后被重新添加。 */
   opsStandupSeeded?: boolean;
-  /** One-time guard for the built-in heartbeat mission (mirrors opsStandupSeeded
-   *  so a user who deletes the heartbeat doesn't get it re-added every boot). */
+  /** 内置心跳任务的一次性守卫（镜像 opsStandupSeeded，这样删除心跳的用户
+   *  不会每次启动都看到它被重新添加）。 */
   heartbeatSeeded?: boolean;
-  /** maint-1 guard for the dedicated auto-compact maintenance mission. UNLIKE the
-   *  two above, this does NOT suppress re-add forever: once seeded (flag set), a
-   *  later delete makes the mission reappear DISABLED on next boot (compaction is
-   *  required, so it's never silently lost — only user-disabled). */
+  /** 专用自动压缩维护任务的 maint-1 守卫。与上面两个不同，它不会永远抑制
+   *  重新添加：一旦播种（标志已设置），之后删除会让任务在下一次启动时以
+   *  DISABLED 状态重新出现（压缩是必需的，因此它绝不会被悄悄丢失——只会被
+   *  用户禁用）。 */
   compactMaintenanceSeeded?: boolean;
-  /** DEPRECATED (v0.3.4): config-file only, no UI anywhere. Hard dollar ceiling
-   *  across all active agents. Still enforced if present so legacy configs keep
-   *  their guard, but the token cap (costCapTokens) is the real budget —
-   *  scheduled for removal next release. */
+  /** DEPRECATED (v0.3.4)：仅存在于配置文件中，任何地方都没有 UI。所有活动
+   *  代理的硬性美元上限。若存在仍会强制执行，以便旧配置保留其守卫，但 token
+   *  上限（costCapTokens）才是真正的预算——计划在下个版本移除。 */
   costCapUsd?: number;
-  /** Hard TOKEN ceiling (total tokens across all active agents) before the
-   *  breaker trips. The user-facing budget — set in Settings. Opt-in like the
-   *  $-cap; total = input + output + cacheRead + cacheCreation, summed across the
-   *  floor (the biggest token spender is blamed). */
+  /** 熔断器触发前的硬性 TOKEN 上限（所有活动代理的总 token）。面向用户的
+   *  预算——在 Settings 中设置。与 $ 上限一样为选择启用；total = input +
+   *  output + cacheRead + cacheCreation，跨整个楼层求和（最大的 token
+   *  消耗者会被问责）。 */
   costCapTokens?: number;
-  /** Per-agent total-token ceiling, keyed by agent id. When an agent's own total
-   *  tokens exceed its cap the breaker trips that agent alone (independent of the
-   *  floor budget). Set from each agent's card in the Command Center. */
+  /** 按代理的 total-token 上限，以 agent id 为键。当某个代理自身的总 token
+   *  超过其上限时，熔断器单独触发该代理（独立于楼层预算）。在 Command Center
+   *  中从每个代理的卡片设置。 */
   agentTokenCaps?: Record<string, number>;
-  /** Agent ids whose automatic inbox/queue delivery is paused. Pending messages
-   *  stay durable until the operator explicitly resumes delivery. */
+  /** 暂停了自动 inbox/队列投递的代理 id。待处理消息保持持久，直到操作者显式
+   *  恢复投递。 */
   autoDeliveryPausedAgents?: string[];
-  /** Passed to every spawned agent as `--max-turns <n>` when set; unset = no cap
-   *  (Claude Code's default). A coarse runaway guard independent of the breaker. */
+  /** 设置时以 `--max-turns <n>` 传给每个派生代理；未设置 = 无上限（Claude
+   *  Code 的默认）。一个独立于熔断器的粗略失控守卫。 */
   maxTurns?: number;
-  /** Max concurrent god-triggered ephemeral Slack workers; extra spawn-requests
-   *  wait in the queue (natural backpressure, a resource backstop). Default 4. */
+  /** god 触发的临时 Slack worker 的最大并发数；多余的 spawn-requests 在队列中
+   *  等待（天然背压，作为资源后盾）。默认 4。 */
   maxConcurrentWorkers?: number;
-  /** Minutes an ephemeral worker may produce NO output before the reaper kills it
-   *  — idle-based, never wall-clock, so an actively-working worker is never reaped.
-   *  Default 20. */
+  /** 临时 worker 在收割者杀死它之前可以零输出的分钟数——基于空闲而非墙钟，
+   *  因此正在活跃工作的 worker 绝不会被收割。默认 20。 */
   workerIdleTimeoutMinutes?: number;
-  /** Registered integrations (Phase 2) — labeled REST endpoints workers reach through
-   *  the loopback secret broker. METADATA ONLY: each record carries a `secretRef`
-   *  handle, never the secret value (secrets live encrypted in a separate file via
-   *  Electron safeStorage — see src/main/integrations.ts). Default []. */
+  /** 已注册的 integrations（Phase 2）——worker 通过回环 secret broker 访问的
+   *  带标签 REST 端点。仅元数据：每条记录携带 `secretRef` 句柄，绝不携带
+   *  secret 值（secret 通过 Electron safeStorage 加密保存在单独文件中——见
+   *  src/main/integrations.ts）。默认 []。 */
   integrations?: IntegrationRecord[];
-  /** Default per-worker TOTAL-token cap (input+output+cache) applied to every
-   *  god-triggered ephemeral worker; a worker's own spawn-request `tokenCap`
-   *  overrides it. When the effective cap is exceeded the worker is reaped (its
-   *  committed work preserved) and god is informed. This is PLUMBING for a later
-   *  budget feature: per the human directive there is NO per-worker cap today, so
-   *  the default is 0 = UNLIMITED — the mechanism is wired but never throttles
-   *  unless someone explicitly sets a positive cap (per request or here). */
+  /** 应用于每个 god 触发的临时 worker 的默认单 worker TOTAL-token 上限
+   *  （input+output+cache）；worker 自身 spawn-request 的 `tokenCap` 会覆盖
+   *  它。当有效上限被超出时，worker 被收割（其已提交的工作得以保留）并通知
+   *  god。这是为后续预算功能铺设的管线（PLUMBING）：根据人工指令，目前没有
+   *  单 worker 上限，因此默认 0 = UNLIMITED——机制已接线但不会限流，除非某人
+   *  显式设置正数上限（按请求或在此处）。 */
   defaultWorkerTokenCap?: number;
-  /** Circuit-breaker thresholds (Lane A #6.6b). Unset = conservative defaults. */
+  /** 熔断器阈值（Lane A #6.6b）。未设置 = 保守默认值。 */
   circuitBreaker?: CircuitBreakerConfig;
-  /** Enterprise Knowledge Graph (multimodal context for agents). Default OFF. */
+  /** Enterprise Knowledge Graph（面向代理的多模态上下文）。默认 OFF。 */
   knowledgeGraph?: KnowledgeGraphConfig;
-  /** Fire native desktop notifications on agent lifecycle events (idle finish / waiting for input). */
+  /** 在代理生命周期事件（空闲完成 / 等待输入）时触发原生桌面通知。 */
   notifications?: boolean;
-  /** Opt-in "strong keep-alive": while ≥1 agent PTY is live, escalate the power
-   *  blocker from 'prevent-app-suspension' to 'prevent-display-sleep', which on
-   *  macOS also blocks TRUE system sleep (lid-close/idle) so scheduled missions
-   *  and terminals keep firing ON TIME while away — at a battery cost (best on
-   *  AC). Default OFF: the honest default is "survive sleep + catch up once on
-   *  resume" (see the powerMonitor 'resume' handler), not "stay awake". */
+  /** 选择启用的"强保活"：当 ≥1 个代理 PTY 活跃时，将电源阻止器从
+   *  'prevent-app-suspension' 升级为 'prevent-display-sleep'，在 macOS 上还会
+   *  阻止真正的系统睡眠（合盖/空闲），从而在离开期间定时任务和终端仍能准时
+   *  触发——代价是耗电（最好接电源）。默认 OFF：诚实的默认是"经受睡眠 +
+   *  恢复后一次性追赶"（见 powerMonitor 'resume' 处理器），而非"保持清醒"。 */
   strongKeepalive?: boolean;
-  /** Auto-update from GitHub releases (v0.3.4). Default ON. Packaged builds
-   *  check on boot + every ~6h, download in the background, and show a
-   *  "restart to update" toast — installation is always user-initiated. OFF
-   *  disables checking entirely. (Mirrored in preload + renderer config.) */
+  /** 从 GitHub releases 自动更新（v0.3.4）。默认 ON。打包构建在启动时 + 每
+   *  ~6 小时检查一次，后台下载，并显示"重启以更新"提示——安装始终由用户
+   *  发起。OFF 完全禁用检查。（在 preload + renderer 配置中镜像。） */
   autoUpdate?: boolean;
-  /** Multi-window "floors": expose a New Floor action that opens additional
-   *  windows, each an independent office with isolated renderer state (its own
-   *  session partition) and per-window PTY routing. ON by default (v0.3.4: code
-   *  and comment disagreed; the shipped behavior — enabled — wins) —
-   *  the window/PTY-ownership plumbing is always active and single-window-safe,
-   *  but the New Floor entry points (app menu item + IPC) only appear when on.
-   *  The on-disk hive (god orchestration under harnessHome) stays process-global;
-   *  floors share it. */
+  /** 多窗口"楼层"：暴露一个 New Floor 操作，打开额外窗口，每个窗口是独立的
+   *  办公室，拥有隔离的 renderer 状态（各自的 session partition）和按窗口的
+   *  PTY 路由。默认 ON（v0.3.4：代码与注释不一致；已发货行为——启用——胜出）——
+   *  窗口/PTY 归属管线始终激活且单窗口安全，但 New Floor 入口（应用菜单项 +
+   *  IPC）只在开启时出现。磁盘上的 hive（harnessHome 下的 god 编排）保持进程
+   *  全局；各楼层共享它。 */
   multiWindow?: boolean;
-  /** Terminal theme — mirrored into each agent's per-session Claude settings
-   *  ("theme" key) at spawn so the TUI's truecolor palette matches. Scoped to
-   *  harness agents only; the user's global Claude theme is never touched. */
+  /** 终端主题——派生时镜像到每个代理的每会话 Claude 设置（"theme" 键），使
+   *  TUI 的 truecolor 调色板一致。仅作用于 harness 代理；用户的全局 Claude
+   *  主题绝不被触碰。 */
   terminalTheme?: 'light' | 'dark';
-  /** Anonymous product analytics (PostHog) — the exact events/properties are
-   *  documented in TELEMETRY.md. Default ON (opt-out, like autoUpdate); builds
-   *  without an injected key and environments with DO_NOT_TRACK set never send
-   *  regardless of this flag. (Mirrored in preload + renderer config.) */
+  /** 匿名产品分析（PostHog）——确切的事件/属性记录在 TELEMETRY.md 中。默认
+   *  ON（选择退出，如同 autoUpdate）；没有注入 key 的构建以及设置了
+   *  DO_NOT_TRACK 的环境无论此标志如何都绝不发送。（在 preload + renderer
+   *  配置中镜像。） */
   telemetryEnabled?: boolean;
-  /** Master flag for the TV-show office themes feature (Settings theme picker +
-   *  destructive switch flow). Default false = the picker is hidden and the
-   *  office renders as today (zero behavior change). */
+  /** 电视剧办公室主题功能的 master 标志（Settings 主题选择器 + 破坏性切换
+   *  流程）。默认 false = 选择器隐藏，办公室按现状渲染（零行为变化）。 */
   tvShowOffices?: boolean;
-  /** Which office map/cast theme the pixel office renders. Only honored when
-   *  `tvShowOffices` is on; otherwise the office theme is used. Unbuilt show
-   *  themes fall back to 'office' in the loader. */
+  /** 像素办公室渲染哪个办公室地图/卡司主题。仅当 `tvShowOffices` 开启时生效；
+   *  否则使用 office 主题。未构建的剧集主题在 loader 中回退到 'office'。 */
   officeTheme?: 'office' | 'friends' | 'brooklyn99' | 'siliconvalley' | 'got' | 'hogwarts';
-  /** Per-CLI-provider local/self-hosted base URL (Ollama/LM Studio/vLLM, …) for the
-   *  OpenCode/Crush/pi/qwen engines; applied at spawn (config-injection or proxy
-   *  upstream). API KEYS are NOT stored here — they live write-only in the secret
-   *  broker (integrations.ts), read MAIN-ONLY at spawn. */
+  /** OpenCode/Crush/pi/qwen 引擎的按 CLI provider 的本地/自托管 base URL
+   *  （Ollama/LM Studio/vLLM, …）；在派生时应用（配置注入或代理上游）。
+   *  API KEYS 不存储在此——它们只写存在于 secret broker（integrations.ts）
+   *  中，派生时仅 MAIN 读取。 */
   providerBaseUrls?: Partial<Record<AgentProvider, string>>;
-  /** Per-CLI-provider default model slug, used to pre-fill the model picker. */
+  /** 按 CLI provider 的默认模型 slug，用于预填模型选择器。 */
   providerDefaultModels?: Partial<Record<AgentProvider, string>>;
-  /** Master toggle for the Slack → Michael's-queue integration. */
+  /** Slack → Michael 队列集成的 master 开关。 */
   slackEnabled?: boolean;
-  /** Slack app signing secret (Basic Information → Signing Secret). Never logged. */
+  /** Slack 应用签名密钥（Basic Information → Signing Secret）。绝不记录。 */
   slackSigningSecret?: string;
-  /** Bot token (xoxb-…) — only needed if the bot ever replies; optional for now. */
+  /** Bot token（xoxb-…）——仅当 bot 需要回复时才需要；目前可选。 */
   slackBotToken?: string;
-  /** Restrict ingestion to one channel id; empty/undefined = any channel. */
+  /** 将摄取限制为单个 channel id；空/undefined = 任意频道。 */
   slackChannelId?: string;
-  /** Local HTTP port the webhook server binds to (default 3847). */
+  /** webhook 服务器绑定的本地 HTTP 端口（默认 3847）。 */
   slackPort?: number;
-  /** Opt-in: allow APP/VOICE-INITIATED proactive posting into Slack (e.g. the
-   *  renderer's "queued" acknowledgement). DEFAULT OFF per the human directive
-   *  "stop posting into Slack by default". This does NOT gate the Slack-ORIGIN
-   *  done-reply round-trip (a user @-mention → task → result posted back to that
-   *  thread) or an agent's own direct in-thread reply — those always stay on. */
+  /** 选择启用：允许由 APP/语音发起的主动 Slack 发帖（例如 renderer 的
+   *  "queued" 确认）。按人工指令"默认停止向 Slack 发帖"默认 OFF。这不会门控
+   *  Slack 来源的完成回复往返（用户 @提及 → 任务 → 结果回帖到该线程）或代理
+   *  自己在线程内的直接回复——这些始终开启。 */
   slackProactivePosting?: boolean;
 
-  // ─── Free Flow (voice dictation → message queue) ───────────────────────────
-  /** Master toggle for Free Flow push-to-talk dictation. Default OFF: with it off
-   *  the composer shows no mic button, no getUserMedia runs, and no Groq call is
-   *  ever made (zero behavior change). */
+  // ─── Free Flow（语音听写 → 消息队列）───────────────────────────
+  /** Free Flow 按键通话听写的 master 开关。默认 OFF：关闭时 composer 不显示
+   *  麦克风按钮，不运行 getUserMedia，也绝不发起任何 Groq 调用（零行为
+   *  变化）。 */
   freeflowEnabled?: boolean;
-  /** User-pasted Groq API key (the user supplies their own free key). Used ONLY in
-   *  the main process for the Groq STT call; NEVER logged, and never crosses IPC
-   *  for the request. Treated like `slackBotToken`. */
+  /** 用户粘贴的 Groq API key（用户自备免费 key）。仅在主进程用于 Groq STT
+   *  调用；绝不记录，也绝不为请求跨 IPC。与 `slackBotToken` 同等对待。 */
   groqApiKey?: string;
-  /** Groq Whisper model id. Default 'whisper-large-v3-turbo' (fast, multilingual). */
+  /** Groq Whisper 模型 id。默认 'whisper-large-v3-turbo'（快速、多语言）。 */
   freeflowModel?: string;
 
-  // ─── Realtime Michael (premium speech-to-speech voice orchestrator) ─────────
-  /** True ONLY while a Realtime Michael voice session is live: the renderer
-   *  session flips this on at start() (before getUserMedia) and off at stop().
-   *  The main-process mic permission gate reads it so the Electron media
-   *  permission is open EXACTLY while the voice loop holds the mic — never just
-   *  because an OpenAI key exists (that key is shared with the CLI engines).
-   *  Default off; absence ⇒ mic denied, mirroring `freeflowEnabled`. */
+  // ─── Realtime Michael（高级语音对语音语音编排器）─────────────────
+  /** 仅在 Realtime Michael 语音会话活跃时为 true：renderer 会话在 start() 时
+   *  打开它（getUserMedia 之前），在 stop() 时关闭。主进程的麦克风权限闸门
+   *  读取它，使 Electron 媒体权限恰好只在语音循环持有麦克风时开放——绝不会
+   *  仅仅因为有 OpenAI key 就开放（该 key 与 CLI 引擎共享）。
+   *  默认关闭；缺省 ⇒ 麦克风被拒，与 `freeflowEnabled` 一致。 */
   realtimeVoiceEnabled?: boolean;
-  /** How long (ms) a realtime voice session may sit with no voice activity before
-   *  it auto-disconnects (the rt-9 idle guard). Default 180000 (3 min). 0 = never
-   *  auto-disconnect on idle — the spend cap remains the runaway guard. The user
-   *  tunes this in Settings → Realtime Michael. */
+  /** 实时语音会话在自动断开前可静置多久（ms）（rt-9 空闲守卫）。默认
+   *  180000（3 分钟）。0 = 空闲时永不自动断开——花费上限仍是失控守卫。用户
+   *  在 Settings → Realtime Michael 中调整。 */
   realtimeIdleDisconnectMs?: number;
 
-  // ─── Generic inbound webhook + status API (LEGACY, single-endpoint) ─────────
-  // Superseded by `webhookTriggers`, which allows many endpoints over one server
-  // and one tunnel. These three are kept because they are the MIGRATION SOURCE
-  // (`migrateTriggersV1` folds them into a `WebhookTrigger`) and because the main
-  // process still reads them until the server is rewired onto the new list.
-  // Nothing new should be written here.
-  /** @deprecated Use `webhookTriggers[].enabled`. */
+  // ─── 通用入站 webhook + 状态 API（LEGACY，单端点）────────────────────────
+  // 已被 `webhookTriggers` 取代，后者允许一个服务器和一个隧道承载多个端点。
+  // 这三个被保留，因为它们是迁移来源（MIGRATION SOURCE）（`migrateTriggersV1`
+  // 将它们折叠进一个 `WebhookTrigger`），也因为 main 进程在服务器被重新接线到
+  // 新列表之前仍会读取它们。这里不应再写任何新内容。
+  /** @deprecated 使用 `webhookTriggers[].enabled`。 */
   webhookEnabled?: boolean;
-  /** App-generated shared secret callers echo in `x-md-webhook-secret`. Never
-   *  logged, and never forwarded into the routed message/card/response.
-   *  @deprecated Use `webhookTriggers[].secret` (one secret per endpoint, so
-   *  revoking one caller never disturbs the others). */
+  /** 应用生成的共享密钥，调用方在 `x-md-webhook-secret` 中回显。绝不记录，
+   *  也绝不转发到被路由的消息/卡片/响应中。
+   *  @deprecated 使用 `webhookTriggers[].secret`（每个端点一个密钥，这样撤销
+   *  一个调用方绝不会影响其他调用方）。 */
   webhookSecret?: string;
-  /** Local HTTP port the generic webhook server binds to (default 3849).
-   *  @deprecated The port is a property of the shared server, not of any one
-   *  trigger; `webhookTriggers` are multiplexed over it by id. */
+  /** 通用 webhook 服务器绑定的本地 HTTP 端口（默认 3849）。
+   *  @deprecated 端口是共享服务器的属性，而非任何一个 trigger 的属性；
+   *  `webhookTriggers` 通过 id 在其上多路复用。 */
   webhookPort?: number;
 
-  // ─── Triggers (src/shared/triggers.ts owns every type here) ────────────────
-  /** Auto-compaction / auto-clearing of agent terminal context. Both halves ship
-   *  in DEFAULT_CONTEXT_TRIGGER; `readConfig` deep-fills them, because the
-   *  top-level merge below is one level deep and a half-written sub-object would
-   *  otherwise reach consumers with `undefined` thresholds. */
+  // ─── Triggers（此处每个类型都由 src/shared/triggers.ts 拥有）──────────────
+  /** 代理终端上下文的自动压缩 / 自动清理。两个半部都随
+   *  DEFAULT_CONTEXT_TRIGGER 发货；`readConfig` 深度填充它们，因为下面的顶层
+   *  合并只有一层深，否则半写入的子对象会以 `undefined` 阈值到达消费者。 */
   contextTrigger?: ContextTriggerConfig;
-  /** Inbound HTTP endpoints, one entry per caller. Replaces the legacy single
-   *  webhook above; several coexist on one port, told apart by `id` in the path. */
+  /** 入站 HTTP 端点，每个调用方一个条目。取代上面遗留的单个 webhook；多个
+   *  可共存于一个端口，通过路径中的 `id` 区分。 */
   webhookTriggers?: WebhookTrigger[];
-  /** Peer messaging between teammates' clone nodes. Persistence + UI only today —
-   *  no transport service reads `apiKey` yet. */
+  /** 队友克隆节点之间的对等消息。目前仅有持久化 + UI——尚无传输服务读取
+   *  `apiKey`。 */
   orgTrigger?: OrgTriggerConfig;
-  /** One-time guard for `migrateTriggersV1` (legacy webhook → webhookTriggers,
-   *  1h → 2h compact cadence). Set once the migration has run to completion. */
+  /** `migrateTriggersV1` 的一次性守卫（legacy webhook → webhookTriggers、
+   *  1h → 2h 压缩节奏）。迁移完整运行完毕后设置。 */
   triggersMigratedV1?: boolean;
 
-  // ─── Memory reflection (the janitor's condense half) ───────────────────────
-  /** Master toggle for the in-process MemoryReflector. Default on. */
+  // ─── Memory reflection（清洁工的压缩半部）───────────────────────
+  /** 进程内 MemoryReflector 的 master 开关。默认开启。 */
   reflectEnabled?: boolean;
-  /** How often to scan agent memory.md files for condensing (default 30 min). */
+  /** 多久扫描一次代理的 memory.md 文件以进行压缩（默认 30 分钟）。 */
   reflectIntervalMs?: number;
-  /** Condense when bytes exceed this percent of the 128 KB budget (matches the
-   *  janitor's TRIGGER_PCT). DECIDED: 50. */
+  /** 当字节数超过 128 KB 预算的这个百分比时进行压缩（与清洁工的 TRIGGER_PCT
+   *  一致）。DECIDED: 50。 */
   reflectByteTriggerPct?: number;
-  /** ...OR when `## ` section count exceeds this (AND bytes > floor). DECIDED: 50. */
+  /** ...或当 `## ` 节数超过此值（且字节数 > 下限）时。DECIDED: 50。 */
   reflectSectionTrigger?: number;
-  /** Newest K verbatim `## ` sections kept untouched on each condense. */
+  /** 每次压缩时保留最新 K 个逐字的 `## ` 节原封不动。 */
   reflectRecentKeep?: number;
-  /** Never condense a file smaller than this; also the section-trigger byte floor.
-   *  DECIDED: 16 KB. */
+  /** 绝不压缩小于此值的文件；同时也是节触发器的字节下限。DECIDED: 16 KB。 */
   reflectMinBytes?: number;
 }
 
@@ -427,17 +393,17 @@ const DEFAULTS: HarnessConfig = {
   defaultCommand: 'claude',
   godProvider: 'claude',
   godModel: 'claude-opus-4-8',
-  // Global default model for every agent that hasn't picked one explicitly — wins
-  // over the role-based tiers (modelForRole) in the spawn handler, so all agents
-  // (incl. god) default to Fable 5. A per-agent model choice still overrides it.
+  // 每个未显式选择模型的代理的全局默认模型——在派生处理器中胜过基于角色的
+  // 分级（modelForRole），因此所有代理（含 god）都默认使用 Fable 5。
+  // 单代理的模型选择仍然覆盖它。
   defaultModel: 'claude-fable-5',
-  // Seeded from the MCP catalog so the consent defaults never drift from it
-  // (safe-readonly ON, write/secret OFF).
+  // 从 MCP catalog 播种，这样同意默认值绝不会与其漂移
+  // （safe-readonly ON，write/secret OFF）。
   mcpDefaults: defaultMcpDefaults(),
   maxConcurrentWorkers: 4,
   workerIdleTimeoutMinutes: 20,
   integrations: [],
-  defaultWorkerTokenCap: 0, // 0 = unlimited (human directive: NO per-worker cap)
+  defaultWorkerTokenCap: 0, // 0 = 无上限（人工指令：无单 worker 上限）
   semanticMemory: true,
   embeddingModel: 'minilm',
   missions: [OPS_STANDUP_MISSION],
@@ -462,26 +428,25 @@ const DEFAULTS: HarnessConfig = {
   webhookEnabled: false,
   webhookSecret: undefined,
   webhookPort: undefined,
-  // Triggers. These three are the ONLY object/array defaults that get handed
-  // straight back out of `readConfig` for a config that never persisted them, so
-  // `withTriggerDefaults` re-copies them on every read — see the note there.
+  // Triggers。这三个是唯一会被 `readConfig` 原样交还的对象/数组默认值
+  // （针对从未持久化它们的配置），因此 `withTriggerDefaults` 在每次读取时
+  // 重新复制它们——参见那里的注释。
   contextTrigger: DEFAULT_CONTEXT_TRIGGER,
   webhookTriggers: [],
   orgTrigger: DEFAULT_ORG_TRIGGER,
   triggersMigratedV1: false,
-  // Memory reflection — preventive; nobody is over threshold today, so it sits
-  // dark until an agent's memory crosses one of these (the verify gate is the
-  // safety for the LLM step). Thresholds DECIDED by god 2026-06-06.
+  // Memory reflection——预防性的；目前没人超阈值，因此它保持暗置，直到某个
+  // 代理的记忆越过其中一个（verify gate 是 LLM 步骤的安全保障）。阈值于
+  // 2026-06-06 由 god DECIDED。
   reflectEnabled: true,
   reflectIntervalMs: 1_800_000,
   reflectByteTriggerPct: 50,
   reflectSectionTrigger: 50,
   reflectRecentKeep: 12,
   reflectMinBytes: 16_384,
-  // Enterprise Knowledge Graph — opt-in; dark until the user enables it.
-  // v0.3.4 fix: default OFF, matching the field's own documentation ("Default
-  // OFF / dark until enabled") — the true default contradicted it. Existing
-  // installs keep their persisted value.
+  // Enterprise Knowledge Graph——选择启用；在用户启用前保持暗置。
+  // v0.3.4 修复：默认 OFF，与该字段自身的文档（"Default OFF / dark until
+  // enabled"）一致——真实默认值之前与之矛盾。现有安装保留其持久化的值。
   knowledgeGraph: { enabled: false }
 };
 
@@ -490,19 +455,17 @@ function configPath(): string {
 }
 
 /**
- * Deep-fill the trigger sub-objects, and hand back copies of them.
+ * 深度填充 trigger 子对象，并返回它们的副本。
  *
- * TWO problems, one fix. First, the merge in `readConfig` is one level deep, so a
- * `contextTrigger` persisted by an older build (or by a `writeConfig` that
- * patched only `compact`) arrives missing sub-keys that DEFAULTS would have
- * supplied — the consumer then reads `undefined` where it expects a number and
- * the rule never fires. Second, that same shallow merge hands the literal
- * DEFAULT_CONTEXT_TRIGGER / DEFAULT_ORG_TRIGGER instances to every config that
- * didn't persist them, so one caller mutating what it read would rewrite the
- * defaults for the whole process — and for every config read afterwards.
+ * 一个修复解决两个问题。其一，`readConfig` 中的合并只有一层深，因此旧构建
+ * 持久化的 `contextTrigger`（或只修补了 `compact` 的 `writeConfig`）到达时
+ * 缺少 DEFAULTS 本应提供的子键——消费者于是在期望数字的地方读到
+ * `undefined`，规则永远不触发。其二，同样的浅合并把字面的
+ * DEFAULT_CONTEXT_TRIGGER / DEFAULT_ORG_TRIGGER 实例交给每个未持久化它们的
+ * 配置，因此某个调用方修改它读取到的内容，就会重写整个进程的默认值——以及
+ * 之后读取的每一个配置。
  *
- * Every branch below therefore constructs a fresh object, including the
- * "nothing persisted" branch.
+ * 因此下面的每个分支都构造一个全新对象，包括"未持久化"分支。
  */
 function withTriggerDefaults(cfg: HarnessConfig): HarnessConfig {
   return {
@@ -518,30 +481,28 @@ function withTriggerDefaults(cfg: HarnessConfig): HarnessConfig {
   };
 }
 
-/** Set once `migrateTriggersV1` has run in THIS process. `writeConfig` reads
- *  before it writes, so without an in-memory latch the migration's own persist
- *  would re-enter `readConfig` and run the migration a second time before
- *  `triggersMigratedV1: true` ever reached disk. */
+/** 一旦 `migrateTriggersV1` 在当前进程中运行过即被设置。`writeConfig` 在写入
+ *  前会先读取，因此没有内存锁存器的话，迁移自身的 persist 会在
+ *  `triggersMigratedV1: true` 到达磁盘之前重新进入 `readConfig` 并再次运行
+ *  迁移。 */
 let triggersMigrationRan = false;
 
 /**
- * Fold the pre-Triggers config shape forward, exactly once per install.
+ * 将 pre-Triggers 的配置形态向前折叠，每个安装恰好一次。
  *
- * Runs from `readConfig`, so it is complete before any consumer can observe the
- * config — there is no boot ordering to get wrong and no window in which half
- * the app sees the old shape. Two things move:
+ * 从 `readConfig` 运行，因此在任何消费者能观察到配置之前就已完整——不存在
+ * 会弄错的启动顺序，也不存在半个应用看到旧形态的窗口。两件事会被迁移：
  *
- *   1. The single legacy webhook (`webhookEnabled`/`webhookSecret`) becomes one
- *      `WebhookTrigger` with the stable id `legacy`, so the caller that already
- *      holds that secret keeps working across the upgrade. Skipped when
- *      `webhookTriggers` is already populated — the user has moved on, and
- *      re-adding a synthesised entry would resurrect a revoked endpoint.
- *   2. The seeded `compact-maintenance` mission moves from the old 1h cadence to
- *      2h, but ONLY if it still reads exactly 1h. A user-chosen interval is a
- *      decision, not a stale default, and is left alone.
+ *   1. 单个遗留 webhook（`webhookEnabled`/`webhookSecret`）变成一个 id 稳定的
+ *      `WebhookTrigger`（`legacy`），这样已持有该密钥的调用方在升级后仍能工作。
+ *      当 `webhookTriggers` 已被填充时跳过——用户已经前进，重新添加一个合成
+ *      条目会复活已撤销的端点。
+ *   2. 已播种的 `compact-maintenance` 任务从旧的 1 小时节奏移到 2 小时，但
+ *      仅当它仍精确读取为 1 小时时。用户选择的间隔是一种决定，而非过时的
+ *      默认值，会被原样保留。
  *
- * Wrapped end-to-end in a try/catch: a config that is corrupt in some unrelated
- * way must still boot the app, and a migration is never worth a failed launch.
+ * 整体包裹在 try/catch 中：以某种无关方式损坏的配置也必须能让应用启动，
+ * 迁移绝不值得一次失败的启动。
  */
 function migrateTriggersV1(cfg: HarnessConfig): HarnessConfig {
   if (cfg.triggersMigratedV1 || triggersMigrationRan) return cfg;
@@ -577,17 +538,16 @@ function migrateTriggersV1(cfg: HarnessConfig): HarnessConfig {
     persistConfig(next);
     return next;
   } catch {
-    // Leave the config exactly as read. The latch above stays set, so a failing
-    // migration retries on the next launch rather than on every single read.
+    // 将配置原样保留为读取到的状态。上面的锁存器保持已设置，因此失败的迁移
+    // 会在下一次启动时重试，而不是在每次读取时都重试。
     return cfg;
   }
 }
 
 export function readConfig(): HarnessConfig {
   const p = configPath();
-  // No file yet = a first run with nothing to migrate; the defaults ARE the
-  // post-migration shape. Deliberately does not persist — a bare read must not
-  // conjure a config.json before onboarding has written one.
+  // 尚无文件 = 首次运行、无需迁移；默认值就是迁移后的形态。刻意不持久化——
+  // 裸读取绝不能在引导写入 config.json 之前凭空变出一个。
   if (!existsSync(p)) return withTriggerDefaults({ ...DEFAULTS });
   try {
     const raw = readFileSync(p, 'utf8');
@@ -598,15 +558,13 @@ export function readConfig(): HarnessConfig {
   }
 }
 
-/** (#140, the upgrade path) A config.json persisted BEFORE `writeConfig`
- *  learned to expand `~` still holds literal `~/…` strings in `harnessHome` /
- *  `recentHives`, and nothing rewrites the file until the next write — so the
- *  hive picker renders the raw `~` string and feeds it straight back into
- *  `config:changeHome`, which lands on `resolve()` → `<cwd>/~/…`, a real
- *  directory named "~". `normalizeHiveHome` only cleans values on the way IN;
- *  this cleans them on the way OUT, so no consumer can see a `~` path
- *  regardless of the file's vintage. Expanded duplicates collapse (a stale
- *  "~/X" next to its absolute twin becomes one entry). */
+/** (#140，升级路径) 在 `writeConfig` 学会展开 `~` 之前持久化的 config.json，
+ *  `harnessHome` / `recentHives` 中仍持有字面的 `~/…` 字符串，且在下一次写入
+ *  之前没有任何东西会重写该文件——因此 hive 选择器会渲染原始的 `~` 字符串，
+ *  并直接把它喂回 `config:changeHome`，落在 `resolve()` → `<cwd>/~/…` 上，
+ *  即一个真实命名为 "~" 的目录。`normalizeHiveHome` 只在进入时清理值；
+ *  这个函数在离开时清理，因此无论文件年代如何，任何消费者都看不到 `~` 路径。
+ *  展开后的重复项会合并（过时的 "~/X" 与其绝对双胞胎相邻时会变成一个条目）。 */
 function normalizeStoredHomes(cfg: HarnessConfig): HarnessConfig {
   if (typeof cfg.harnessHome === 'string' && cfg.harnessHome.trim()) {
     cfg.harnessHome = expandTilde(cfg.harnessHome);
@@ -621,11 +579,11 @@ function normalizeStoredHomes(cfg: HarnessConfig): HarnessConfig {
   return cfg;
 }
 
-/** Announces every saved setting, so a screen showing one can update.
+/** 广播每次保存的设置，以便展示它的界面可以更新。
  *
- *  Settings, Slack, voice and notifications each save by their own route, and
- *  all of them end up writing the file below — so one subscription here covers
- *  every setting rather than the ones anybody remembered to wire up. */
+ *  Settings、Slack、voice 和 notifications 各自通过自己的路径保存，而它们最终
+ *  都会写入下面的文件——因此这里的一个订阅覆盖所有设置，而不只是那些有人
+ *  记得接线的设置。 */
 type ConfigWriteListener = (next: HarnessConfig) => void;
 const configWriteListeners = new Set<ConfigWriteListener>();
 
@@ -638,15 +596,14 @@ function persistConfig(next: HarnessConfig): HarnessConfig {
   const p = configPath();
   mkdirSync(dirname(p), { recursive: true });
   writeFileSync(p, JSON.stringify(next, null, 2), 'utf8');
-  // Saving one setting stores only that setting, so fill the rest back in first:
-  // subscribers must see the same complete config a read gives them, never a
-  // half-filled one. Skip the migration — it saves in its own right, and has
-  // already run against what this change was built on.
+  // 保存一个设置只存储那一个设置，所以先把其余部分填回来：订阅者必须看到
+  // 与读取一致、完整而非半填充的配置。跳过迁移——它会自行保存，并且已经针对
+  // 本次更改所基于的内容运行过了。
   const view = normalizeStoredHomes(withTriggerDefaults({ ...DEFAULTS, ...next }));
-  // The change is already saved, so one failed subscriber must not fail the save
-  // for its caller, nor stop the subscribers after it.
+  // 更改已经保存，因此一个失败的订阅者不能让其调用方的保存失败，也不能
+  // 阻止其后的订阅者。
   for (const listener of configWriteListeners) {
-    try { listener(view); } catch { /* a broken listener is not a failed save */ }
+    try { listener(view); } catch { /* 一个损坏的 listener 不等于一次失败的保存 */ }
   }
   return next;
 }
@@ -654,26 +611,25 @@ function persistConfig(next: HarnessConfig): HarnessConfig {
 export function writeConfig(patch: Partial<HarnessConfig>): HarnessConfig {
   const current = readConfig();
   const next: HarnessConfig = { ...current, ...patch };
-  // Project INGESTION — a registered repo is typed by hand ("~/dev/foo") as often
-  // as it is picked from the folder dialog. Expand `~` here so the persisted list
-  // (and therefore every agent's default cwd) is ABSOLUTE; Node's fs/spawn treat
-  // `~` as a literal directory name and the spawn dies with `cwd does not exist`.
+  // 项目摄入（INGESTION）——注册的 repo 常常是手打的（"~/dev/foo"），与从
+  // 文件夹对话框选择一样常见。在此处展开 `~`，使持久化的列表（因此也是每个
+  // 代理的默认 cwd）是 ABSOLUTE；Node 的 fs/spawn 会把 `~` 当作字面的目录名，
+  // 派生会因 `cwd does not exist` 而死掉。
   if (Array.isArray(patch.registeredRepos)) {
     const seen = new Set<string>();
     next.registeredRepos = patch.registeredRepos
       .map((r) => expandTilde(r))
       .filter((r) => r && !seen.has(r) && (seen.add(r), true));
   }
-  // The HIVE HOME needs the exact same treatment as registeredRepos above, and for
-  // years it did not get it (#140). Onboarding SUGGESTS `~/HarnessAgents` and the
-  // field is free text, so the common path — accept the default, press Finish —
-  // persisted a literal `~`. The first thing the finish step does is create the
-  // directory, and Node's mkdir has no idea what `~` means: it tried to make a
-  // folder actually named "~", which fails as
+  // HIVE HOME 需要与上面 registeredRepos 完全相同的处理，多年来它都没有得到
+  // 这一处理（#140）。引导程序 SUGGESTS `~/HarnessAgents`，而该字段是自由
+  // 文本，因此常见路径——接受默认值、按 Finish——持久化了字面的 `~`。
+  // finish 步骤做的第一件事是创建目录，而 Node 的 mkdir 不知道 `~` 是什么：
+  // 它试图创建一个实际名为 "~" 的文件夹，结果以
   //   ENOENT: no such file or directory, mkdir '~/HarnessAgents'
-  // and left the wizard wedged on its last step with no way forward. Expand BEFORE
-  // the value is persisted or copied into recentHives, so every downstream reader
-  // (mkdir, the hive root, the launch picker) sees one absolute path.
+  // 失败，把向导卡在最后一步、无路可走。要在值被持久化或复制进 recentHives
+  // 之前展开，这样每个下游读取方（mkdir、hive 根、启动选择器）都看到同一个
+  // 绝对路径。
   if (typeof patch.harnessHome === 'string' && patch.harnessHome) {
     const { home, recentHives } = normalizeHiveHome(patch.harnessHome, current.recentHives ?? []);
     next.harnessHome = home;
@@ -682,13 +638,12 @@ export function writeConfig(patch: Partial<HarnessConfig>): HarnessConfig {
   return persistConfig(next);
 }
 
-/** Set or clear one agent's token ceiling against the latest config on disk.
+/** 针对磁盘上最新的配置设置或清除单个代理的 token 上限。
  *
- * Renderer config objects are snapshots. Replacing `agentTokenCaps` from one of
- * those snapshots loses caps written since the snapshot was read (most visibly
- * while reviewing a batch of imported hires). Keep the read-modify-write in the
- * synchronous main process so each call merges with the result of the previous
- * one before returning the updated config to the renderer. */
+ * renderer 的配置对象是快照。从某个快照替换 `agentTokenCaps` 会丢失自快照
+ * 读取之后写入的上限（在审核一批导入的 hires 时最为明显）。将读-改-写保留在
+ * 同步的 main 进程中，这样每次调用都会在把更新后的配置返回给 renderer 之前
+ * 与上一次的结果合并。 */
 export function setAgentTokenCap(agentId: unknown, tokenCap: unknown): HarnessConfig {
   if (typeof agentId !== 'string' || agentId.trim().length === 0) {
     throw new Error('invalid agent token cap');
@@ -713,44 +668,43 @@ export function setAgentTokenCap(agentId: unknown, tokenCap: unknown): HarnessCo
   });
 }
 
-/** Wipe the persisted config back to first-run defaults so the app boots into
- *  onboarding again. Used by the "reset & start over" flow. */
+/** 把持久化的配置擦除回首次运行的默认值，让应用再次引导进入 onboarding。
+ *  由"reset & start over"流程使用。 */
 export function resetConfig(): HarnessConfig {
-  // Saved like any other change, so a reset announces itself too.
+  // 与任何其他更改一样被保存，因此重置也会自我广播。
   persistConfig({ ...DEFAULTS });
-  // Drop the migration latch too: the file on disk is back to `triggersMigratedV1:
-  // false`, and a latch left set would keep the flag from ever being written again
-  // in this process. The migration itself is a no-op on defaults either way.
+  // 同时丢弃迁移锁存器：磁盘上的文件已回到 `triggersMigratedV1: false`，
+  // 若锁存器保持已设置，该标志将永远不会在本进程中再次被写入。迁移本身对
+  // 默认值来说无论如何都是空操作。
   triggersMigrationRan = false;
   return withTriggerDefaults({ ...DEFAULTS });
 }
 
-/** Model ids by tier (Lane A #6.4). Kept in sync with AGENT_MODELS in
- *  src/renderer/src/store/config.ts. */
-const MODEL_GOD = 'claude-opus-4-8';                  // orchestration — highest capability
-const MODEL_WORKER = 'claude-sonnet-4-6';             // general execution
-const MODEL_HELPER = 'claude-haiku-4-5-20251001';     // narrow, cheap helpers
+/** 按层级的模型 id（Lane A #6.4）。与 src/renderer/src/store/config.ts 中的
+ *  AGENT_MODELS 保持同步。 */
+const MODEL_GOD = 'claude-opus-4-8';                  // 编排——最高能力
+const MODEL_WORKER = 'claude-sonnet-4-6';             // 通用执行
+const MODEL_HELPER = 'claude-haiku-4-5-20251001';     // 狭窄、廉价的辅助
 
-/** Minimal structural shape for tiering — a subset of AgentMeta so config.ts
- *  stays free of a hive.ts import. */
+/** 分层所需的最小结构形态——AgentMeta 的一个子集，这样 config.ts 无需引入
+ *  hive.ts。 */
 export interface RoleHint {
   isGod?: boolean;
   role?: string;
   capabilities?: string[];
 }
 
-/** Default model for an agent given its role (Lane A #6.4): Opus for the god,
- *  Haiku for narrow helpers (triage / routing / verification / formatting),
- *  Sonnet for general workers. Returns a model id (matching AGENT_MODELS) or
- *  undefined to fall back to the CLI default. This is only a DEFAULT — an
- *  explicit per-agent model selection always wins. */
+/** 根据代理角色给出的默认模型（Lane A #6.4）：god 用 Opus，狭窄辅助（triage /
+ *  routing / verification / formatting）用 Haiku，通用 worker 用 Sonnet。
+ *  返回模型 id（与 AGENT_MODELS 一致）或 undefined 以回退到 CLI 默认。
+ *  这只是 DEFAULT——显式的单代理模型选择始终优先。 */
 export function modelForRole(
   meta: RoleHint,
   config?: Pick<HarnessConfig, 'godProvider' | 'godModel'>
 ): string | undefined {
   if (meta.isGod) {
-    // GOD engine is selectable: an explicit godModel wins, else the chosen
-    // provider's recommended orchestrator model, else the legacy Opus default.
+    // GOD 引擎可选：显式的 godModel 优先，否则用所选 provider 推荐的
+    // 编排器模型，否则用遗留的 Opus 默认。
     const preset = providerPreset(config?.godProvider ?? 'claude');
     return config?.godModel ?? preset.recommendedOrchestratorModel ?? MODEL_GOD;
   }
@@ -759,19 +713,17 @@ export function modelForRole(
   return MODEL_WORKER;
 }
 
-/** Ensure harnessHome exists on disk. Expands `~` first — the onboarding wizard
- *  lets the user type the path, and mkdir treats a literal `~` as a plain
- *  directory name (issue #140's `ENOENT: mkdir '~/HarnessAgents'`). */
+/** 确保 harnessHome 在磁盘上存在。先展开 `~`——引导向导允许用户输入路径，
+ *  而 mkdir 会把字面的 `~` 当作普通目录名（issue #140 的
+ *  `ENOENT: mkdir '~/HarnessAgents'`）。 */
 export function ensureHarnessHome(path: string): { ok: boolean; error?: string } {
   try {
-    // Expand HERE too, not only at the config write (#140). This runs FIRST —
-    // onboarding calls it before updateConfig — so normalizing only at the write
-    // boundary left the actual mkdir still receiving a literal `~`. Depending on
-    // the process cwd that either fails outright or, worse, quietly succeeds by
-    // creating a directory genuinely named "~" somewhere nobody will look, and
-    // the hive then lives at a path the user cannot find. This is the
-    // "defense-in-depth at the consumers" the expandTilde doc calls for: the
-    // ingestion point normalizes, and the consumer refuses to trust that it did.
+    // 在这里也展开，而不仅仅在写入配置时（#140）。它最先运行——onboarding
+    // 在 updateConfig 之前调用它——因此只在写入边界规范化会让真正的 mkdir
+    // 仍然收到字面的 `~`。取决于进程 cwd，这要么直接失败，要么更糟：悄悄成功
+    // 地在某个没人会看的地方创建了一个真实名为 "~" 的目录，hive 于是住在一个
+    // 用户找不到的路径上。这正是 expandTilde 文档要求的"在消费者端纵深防御"：
+    // 摄入点规范化，消费者拒绝盲目信任它已规范化。
     mkdirSync(expandTilde(path), { recursive: true });
     return { ok: true };
   } catch (e) {
@@ -779,22 +731,21 @@ export function ensureHarnessHome(path: string): { ok: boolean; error?: string }
   }
 }
 
-/** Idempotently pre-accept Claude Code's first-run prompts so agents spawned with
- *  `--permission-mode bypassPermissions` start cleanly. Without this, a fresh
- *  install shows an interactive "WARNING: Bypass Permissions mode … 1. No, exit /
- *  2. Yes, I accept" prompt that the PTY can't answer in time, so the agent exits
- *  code 1 on its own (reported by multiple users).
+/** 幂等地预先接受 Claude Code 的首次运行提示，让以 `--permission-mode
+ *  bypassPermissions` 派生的代理干净启动。没有它，全新安装会显示一个交互式
+ *  "WARNING: Bypass Permissions mode … 1. No, exit / 2. Yes, I accept" 提示，
+ *  PTY 无法及时回答，代理于是自行以 code 1 退出（多位用户反馈）。
  *
- *  Two separate gates, written only when they aren't already satisfied (so we
- *  rarely touch files a running `claude` also writes):
+ *  两个独立的门，仅在它们尚未满足时才写入（因此我们极少触碰正在运行的
+ *  `claude` 也会写的文件）：
  *   1. `~/.claude/settings.json` → `skipDangerousModePermissionPrompt` +
- *      `skipAutoPermissionPrompt` — these gate the bypass-mode warning (global).
- *   2. `~/.claude.json` → `projects[cwd].hasTrustDialogAccepted` — the per-folder
- *      "do you trust the files in this folder?" dialog. */
+ *      `skipAutoPermissionPrompt`——它们门控绕过模式警告（全局）。
+ *   2. `~/.claude.json` → `projects[cwd].hasTrustDialogAccepted`——逐文件夹的
+ *      "你信任此文件夹中的文件吗？"对话框。 */
 export function ensureClaudePermissionsAccepted(cwd?: string): void {
   const home = homedir();
   if (!home) return;
-  // 1) Global bypass-mode warning gate.
+  // 1) 全局绕过模式警告门。
   try {
     const dir = join(home, '.claude');
     const p = join(dir, 'settings.json');
@@ -808,8 +759,8 @@ export function ensureClaudePermissionsAccepted(cwd?: string): void {
       mkdirSync(dir, { recursive: true });
       writeFileSync(p, JSON.stringify(s, null, 2), 'utf8');
     }
-  } catch { /* best-effort; never block a spawn */ }
-  // 2) Per-folder trust dialog gate (only when this cwd isn't already trusted).
+  } catch { /* 尽力而为；绝不阻塞派生 */ }
+  // 2) 逐文件夹信任对话框门（仅当该 cwd 尚未被信任时）。
   if (cwd) {
     try {
       const p = join(home, '.claude.json');
@@ -822,6 +773,6 @@ export function ensureClaudePermissionsAccepted(cwd?: string): void {
         c.projects[cwd] = { ...(c.projects[cwd] ?? {}), hasTrustDialogAccepted: true };
         writeFileSync(p, JSON.stringify(c, null, 2), 'utf8');
       }
-    } catch { /* best-effort */ }
+    } catch { /* 尽力而为 */ }
   }
 }

--- a/src/main/control.ts
+++ b/src/main/control.ts
@@ -1,27 +1,26 @@
 /**
- * ControlRegistry — operator control over running agents (#7C.1–7C.3).
+ * ControlRegistry —— 对运行中 agent 的操作员控制（#7C.1–7C.3）。
  *
- * Holds per-agent control state that the HookServer reads when deciding what to
- * return from a hook. This is how the floor exerts control WITHOUT typing into
- * the PTY: the decision rides Claude Code's own hook-return protocol.
+ * 保存每个 agent 的控制状态，HookServer 在决定 hook 返回什么时读取它。这就是
+ * 工作区“无需向 PTY 输入文字”也能施加控制的方式：决策搭乘 Claude Code
+ * 自己的 hook 返回协议。
  *
- *   - pause / gateTool (#7C.1) → PreToolUse returns permissionDecision:'deny'
- *     (race-free, immediate — no renderer round-trip, so it can't hit the shim
- *     timeout). Slow human APPROVAL deliberately rides Claude's native prompt
- *     instead, per the spec's latency mitigation.
- *   - steer (#7C.2) → the next UserPromptSubmit/PostToolUse returns
- *     additionalContext, injecting guidance into the agent's context once.
- *   - halt (#7C.3) → the next hook boundary returns { continue:false } so the
- *     agent stops CLEANLY (vs killing the PTY). Overrides the inbox-drain.
+ *   - pause / gateTool（#7C.1）→ PreToolUse 返回 permissionDecision:'deny'
+ *     （无竞态、即时——不经过渲染进程往返，因此不会撞上 shim 超时）。缓慢的
+ *     人工 APPROVAL 则刻意走 Claude 的原生提示，符合规范的延迟缓解要求。
+ *   - steer（#7C.2）→ 下一个 UserPromptSubmit/PostToolUse 返回
+ *     additionalContext，把指导一次性注入 agent 的上下文。
+ *   - halt（#7C.3）→ 下一个 hook 边界返回 { continue:false }，让 agent
+ *     “干净地”停下（而不是杀掉 PTY）。覆盖 inbox 排空。
  *
- * Runs in the Electron main process; no electron import (unit-testable).
+ * 运行在 Electron 主进程；不 import electron（可单元测试）。
  */
 
-/** Max steer notes queued per agent before the OLDEST is dropped. Each note
- *  rides the next hook's additionalContext; a stalled/halted agent never drains
- *  the queue, so without a cap a burst of steers (closing-time loop, a stuck
- *  caller) would grow memory forever. The latest instruction wins: when full we
- *  drop from the front (FIFO) so a busy agent still hears the most recent note. */
+/** 每个 agent 排队中的 steer 通知上限，超出后丢弃最旧的一条。每条通知
+ *  搭乘下一个 hook 的 additionalContext；停滞/已暂停的 agent 永远不会排空
+ *  队列，因此没有上限的话，一阵 steer 突发（closing-time 循环、卡住的
+ *  调用方）会让内存无限增长。最新的指令优先：队列满时我们从队首丢弃
+ *  （FIFO），这样忙碌的 agent 仍能听到最近的通知。 */
 const MAX_PENDING_STEERS = 20;
 
 export interface AgentControlSnapshot {
@@ -58,7 +57,7 @@ export class ControlRegistry {
     return c;
   }
 
-  // ─── Operator actions (wired to IPC) ───────────────────────────────────────
+  // ─── 操作员动作（接到 IPC）──────────────────────────────────────────────────
 
   pause(id: string, on: boolean): void { this.ensure(id).paused = on; }
   pauseAutoDelivery(id: string, on: boolean): void {
@@ -80,39 +79,39 @@ export class ControlRegistry {
     if (!t) return;
     const q = this.ensure(id).steerQueue;
     if (q.length >= MAX_PENDING_STEERS) {
-      // Drop the oldest so the newest instruction still reaches the next hook
-      // boundary. Log a breadcrumb so a note silently falling off the front is
-      // diagnosable — a full queue means the agent has been unreachable for a long time.
+      // 丢弃最旧的，让最新指令仍能到达下一个 hook
+      // 边界。记录一条面包屑，让悄悄从队首掉落的通知可被诊断——
+      // 队列满了意味着该 agent 已经很久无法联系到。
       console.warn(`[control] ${id}: steer queue full (${MAX_PENDING_STEERS}) — dropping oldest note`);
-      q.shift(); // keep the newest note, drop the oldest
+      q.shift(); // 保留最新通知，丢弃最旧的
     }
-    q.push(t.slice(0, 10000)); // hook additionalContext cap
+    q.push(t.slice(0, 10000)); // hook additionalContext 上限
   }
-  /** Request a graceful stop at the next hook boundary. */
+  /** 请求在下一个 hook 边界处优雅停止。 */
   halt(id: string): void { this.ensure(id).halted = true; }
-  /** Drop all queued-but-undelivered steer notes (e.g. closing time cancelled
-   *  before a busy agent's next hook boundary consumed the instruction). */
+  /** 丢弃所有已排队但尚未送达的 steer 通知（例如：忙碌 agent 的下一个 hook
+   *  边界还没来得及消化指令，closing time 就被取消了）。 */
   clearSteers(id: string): void { const c = this.map.get(id); if (c) c.steerQueue.length = 0; }
-  /** Clear pause + halt (lets a paused/halted agent run again). Keeps gates. */
+  /** 清除 pause + halt（让已暂停/已停止的 agent 重新运行）。保留门控。 */
   resume(id: string): void { const c = this.ensure(id); c.paused = false; c.halted = false; }
 
-  // ─── Reads (used by HookServer) ────────────────────────────────────────────
+  // ─── 读取（供 HookServer 使用）────────────────────────────────────────────
 
   shouldHalt(id: string): boolean { return this.map.get(id)?.halted ?? false; }
   isAutoDeliveryPaused(id: string): boolean {
     return this.map.get(id)?.autoDeliveryPaused ?? false;
   }
 
-  /** Whether a tool call should be denied (paused agent, or this tool gated). */
+  /** 工具调用是否应被拒绝（agent 已暂停，或该工具被门控）。 */
   toolDecision(id: string, tool: string): { deny: boolean; reason?: string } {
     const c = this.map.get(id);
     if (!c) return { deny: false };
-    if (c.paused) return { deny: true, reason: 'Paused by operator — resume from the floor to continue.' };
-    if (tool && c.gatedTools.has(tool)) return { deny: true, reason: `Tool ${tool} is gated by the operator.` };
+    if (c.paused) return { deny: true, reason: '已被操作员暂停——回到楼层以恢复。' };
+    if (tool && c.gatedTools.has(tool)) return { deny: true, reason: `工具 ${tool} 已被操作员门控。` };
     return { deny: false };
   }
 
-  /** Dequeue one pending steer note for delivery, or undefined. */
+  /** 弹出一条待投递的 steer 通知，若无则返回 undefined。 */
   takeSteer(id: string): string | undefined { return this.map.get(id)?.steerQueue.shift(); }
 
   snapshot(id: string): AgentControlSnapshot {

--- a/src/main/costLifetime.ts
+++ b/src/main/costLifetime.ts
@@ -1,96 +1,91 @@
 /**
- * Lifetime cost, recovered from `cost-ledger.jsonl`.
+ * 终身成本，从 `cost-ledger.jsonl` 中恢复。
  *
- * WHY THIS EXISTS
- * ───────────────
- * `AgentUsageSample.usd` is a CUMULATIVE-SINCE-PROCESS-START counter, not a
- * lifetime one. `TelemetryCollector` accumulates into in-memory maps
- * (`sessions` / `agentSessions`), so an app restart rebuilds them empty and the
- * counter restarts at ~0 under the SAME `session_id` (the agent resumes; only
- * our accumulator forgot). Every consumer that reads the LAST value therefore
- * understates spend for any agent that has been through a restart.
+ * 为什么存在
+ * ───────────
+ * `AgentUsageSample.usd` 是“自进程启动以来累积”的计数器，而不是终身值。
+ * `TelemetryCollector` 累积到内存映射（`sessions` / `agentSessions`）里，
+ * 所以应用重启后会重建为空、计数器在同一个 `session_id` 下从 ~0 重新开始
+ * （代理恢复了，只是我们的累加器忘了）。任何只读最后一个值的消费者，
+ * 都会低估经历过重启的代理的开销。
  *
- * Measured on a live ledger with dozens of such resets, the last value hid
- * 59% of real spend. The shortfall scales with how often the app is restarted,
- * so a long-running floor is affected worse than a fresh one.
+ * 在带几十次这类重置的实盘账本上实测，最后的值掩盖了 59% 的真实开销。
+ * 缺口随应用重启频率增长，所以长期运行的楼层比新建的受影响更大。
  *
- * THE RECOVERY
- * ────────────
- * The ledger keeps every line, so the pre-reset peaks are still on disk. Within
- * one (agent, session) the counter only ever climbs, so a DECREASE is the reset
- * signature and nothing else. Lifetime is then:
+ * 恢复方案
+ * ────────
+ * 账本保留每一行，所以重置前的峰值仍留在磁盘上。在同一个 (agent, session)
+ * 内计数器只会上升，因此“下降”就是重置的签名，不会是别的。终身值于是为：
  *
- *     sum(peak of each closed segment) + peak of the open segment
+ *     sum(每个已关闭区段的峰值) + 打开区段的峰值
  *
- * Any decrease counts, with only a float-noise epsilon. A dollar threshold was
- * considered and rejected: real restarts routinely drop from well under a
- * dollar straight to zero, so any threshold big enough to be worth having
- * silently misses them. A cumulative counter has no legitimate reason to go
- * down, so the magic number bought nothing and cost coverage.
+ * 任何下降都计入，只留一个浮点噪声的 epsilon。曾考虑过美元阈值并否决：
+ * 真实重启常常从远低于一美元直接掉到零，任何大得值得用的阈值都会悄悄漏掉
+ * 它们。累积计数器没有正当理由下降，所以那个魔法数买不到任何东西，
+ * 反而损失覆盖率。
  *
- * COST / SHAPE
- * ────────────
- * The ledger is append-only and grows without bound, so on an established
- * floor a full fold takes long enough that it must NOT land on the Electron
- * main thread. Folding is therefore async and INCREMENTAL: each pass reads only
- * the bytes appended since the last one and keeps the running segment state.
- * Steady-state cost per pass is a few hundred bytes regardless of ledger size.
+ * 成本 / 形态
+ * ───────────
+ * 账本只追加、无界增长，所以在成熟楼层上完整折叠一次耗时太长，
+ * 绝不能落在 Electron 主线程上。因此折叠是异步且增量的：每轮只读取
+ * 自上一轮以来追加的字节，并保留运行中的区段状态。稳态下每轮成本
+ * 只有几百字节，与账本大小无关。
  *
- * Read-only: this module never writes to the ledger.
+ * 只读：本模块从不写账本。
  */
 
 import { createReadStream, statSync } from 'fs';
 
-/** Per (agent, session) fold state: closed segments plus the open one. */
+/** 每个 (agent, session) 的折叠状态：已关闭区段加当前打开区段。 */
 interface Segment {
-  /** Sum of the peaks of every segment already closed by a reset. */
+  /** 已被一次重置关闭的所有区段峰值之和。 */
   committed: number;
-  /** High-water mark of the segment currently open. */
+  /** 当前打开区段的最高水位。 */
   peak: number;
 }
 
-/** Float noise guard. Real resets drop by cents at minimum, so anything below
- *  this is arithmetic dust rather than a restart. */
+/** 浮点噪声防护。真实重置至少会掉几美分，所以任何低于此值的
+ *  都只是运算尘埃，而非一次重启。 */
 const EPS = 1e-9;
 
-/** Cap per pass so a cold start cannot stall behind one enormous read. The
- *  fold simply resumes on the next call. */
+/** 每轮的上限，避免冷启动被一次超大读取卡住。
+ *  折叠只是在下一次调用时继续。 */
 const MAX_BYTES_PER_PASS = 8 * 1024 * 1024;
 
 export class CostLedgerTotals {
-  /** Bytes of the ledger already folded. */
+  /** 账本已折叠的字节数。 */
   private offset = 0;
-  /** Trailing partial line, kept as BYTES so a multi-byte character split
-   *  across a read boundary is never decoded in half. */
+  /** 末尾不完整的一行，以 BYTES 保存，这样跨读取边界被切开的多字节
+   *  字符绝不会被半截解码。 */
   private tail: Buffer = Buffer.alloc(0);
-  /** `agentId \t sessionId` → fold state. */
+  /** `agentId \t sessionId` → 折叠状态。 */
   private readonly seg = new Map<string, Segment>();
-  /** agentId → lifetime usd. Recomputed after each pass. */
+  /** agentId → 终身 usd。每轮之后重新计算。 */
   private totals = new Map<string, number>();
-  /** One pass at a time; a timer must never stack folds on itself. */
+  /** 同一时间只进行一轮；定时器绝不能让自己叠加折叠。 */
   private folding = false;
-  /** True once a full pass has completed, so callers can tell "no spend" from
-   *  "not read yet" instead of reporting a confident $0. */
+  /** 一旦某轮完整完成即为 true，这样调用者能区分“零开销”与“尚未读取”，
+   *  而不会自信地报出 $0。 */
   private warm = false;
 
-  /** Lifetime usd for one agent, or null when the ledger has not been folded
-   *  yet. Null rather than 0 so a caller never publishes a cold zero as fact. */
+  /** 单个代理的终身 usd，账本尚未折叠时返回 null。用 null 而非 0，
+   *  这样调用者绝不会把冷启动的 0 当作事实发布。 */
   usdFor(agentId: string): number | null {
     if (!this.warm) return null;
     return this.totals.get(agentId) ?? 0;
   }
 
-  /** Every agent's lifetime usd. Empty until the first pass completes. */
+  /** 每个代理的终身 usd。首轮完成前为空。 */
   all(): Map<string, number> {
     return new Map(this.totals);
   }
 
-  /** Has at least one full pass completed? */
+  /** 是否已至少完成一轮完整折叠？ */
   get ready(): boolean {
     return this.warm;
   }
 
-  /** True lifetime spend across every agent in the ledger. */
+  /** 账本中所有代理的真实终身开销。 */
   floorTotal(): number {
     let t = 0;
     for (const v of this.totals.values()) t += v;
@@ -98,21 +93,20 @@ export class CostLedgerTotals {
   }
 
   /**
-   * Fold whatever has been appended since the last pass. Returns immediately;
-   * the work happens off the caller's stack. Safe to call from a timer and
-   * never throws (a ledger we cannot read just leaves the last good totals in
-   * place, same contract as the other best-effort writers here).
+   * 折叠自上一轮以来追加的内容。立即返回；实际工作在调用者的栈之外完成。
+   * 可安全地从定时器调用，且从不抛出（读不到的账本只是保留最后的好总量，
+   * 与本处其他尽力而为的写入者契约一致）。
    */
   refresh(ledgerPath: string): Promise<void> {
     if (this.folding) return Promise.resolve();
     this.folding = true;
     return this.fold(ledgerPath)
-      .catch(() => { /* keep last good totals */ })
+      .catch(() => { /* 保留最后的好总量 */ })
       .finally(() => { this.folding = false; });
   }
 
-  /** Fold repeatedly until caught up to EOF. Convenience for callers that want
-   *  the number now rather than over the next few timer ticks. */
+  /** 反复折叠直到追上 EOF。方便那些现在就想要数字、而不是等几个定时器
+   *  滴答的调用者。 */
   async refreshFully(ledgerPath: string): Promise<void> {
     for (let i = 0; i < 4096; i++) {
       await this.refresh(ledgerPath);
@@ -124,8 +118,8 @@ export class CostLedgerTotals {
     let size: number;
     try { size = statSync(ledgerPath).size; } catch { return; }
 
-    // Truncated or rotated underneath us: the offset now points past the end,
-    // so every segment we hold is suspect. Start clean.
+    // 底下发生了截断或轮换：偏移现在指向末尾之后，所以保存的每个区段
+    // 都不可信。从头开始。
     if (size < this.offset) this.reset();
     if (size === this.offset) { this.warm = true; return; }
 
@@ -144,11 +138,11 @@ export class CostLedgerTotals {
 
     this.offset = end + 1;
     this.recompute();
-    // Only "warm" once we have caught up to EOF; a capped pass is still behind.
+    // 只有追上 EOF 才算“warm”；被上限截断的一轮仍落后于文件。
     if (this.offset >= size) this.warm = true;
   }
 
-  /** Fold one buffer, holding back any incomplete trailing line. */
+  /** 折叠一个缓冲区，暂存任何不完整的末尾行。 */
   private consume(chunk: Buffer): void {
     const buf = this.tail.length ? Buffer.concat([this.tail, chunk]) : chunk;
     const cut = buf.lastIndexOf(0x0a); // '\n'
@@ -161,7 +155,7 @@ export class CostLedgerTotals {
 
   private foldLine(line: string): void {
     let row: { agent_id?: string; session_id?: string; usd?: number };
-    try { row = JSON.parse(line); } catch { return; } // half-written tail line
+    try { row = JSON.parse(line); } catch { return; } // 写了一半的尾部行
     if (!row || typeof row.agent_id !== 'string') return;
     const usd = typeof row.usd === 'number' && Number.isFinite(row.usd) ? row.usd : 0;
 
@@ -170,7 +164,7 @@ export class CostLedgerTotals {
     if (!s) { s = { committed: 0, peak: 0 }; this.seg.set(key, s); }
 
     if (usd < s.peak - EPS) {
-      // Counter went backwards: the previous segment ended at its peak.
+      // 计数器回退：上一个区段在其峰值处结束。
       s.committed += s.peak;
       s.peak = usd;
     } else if (usd > s.peak) {
@@ -197,12 +191,12 @@ export class CostLedgerTotals {
 }
 
 /**
- * One-shot fold of a ledger already in memory. Used by tests and by any caller
- * that wants the number without holding an incremental reader.
+ * 对已在内存中的账本做一次性折叠。供测试以及任何想直接拿到数字、
+ * 而不持有增量读取器的调用者使用。
  */
 export function lifetimeUsdFromLedger(text: string): Map<string, number> {
   const t = new CostLedgerTotals();
-  // Reuse the exact same fold path so the two can never disagree.
+  // 复用完全相同的折叠路径，保证二者永不一致。
   (t as unknown as { consume(b: Buffer): void }).consume(Buffer.from(text.endsWith('\n') ? text : `${text}\n`));
   (t as unknown as { recompute(): void }).recompute();
   return t.all();

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -1,25 +1,24 @@
 /**
- * PersistStore — durable harness state in SQLite (better-sqlite3, synchronous).
+ * PersistStore —— 基于 SQLite 的持久化 harness 状态（better-sqlite3，同步）。
  *
- * Phase A scope (the rest of the renderer state stays in localStorage for now):
- *   - kv:               scalar app state. Today: the main window's bounds.
- *   - command_history:  NET-NEW — every prompt the user submits to an agent.
+ * Phase A 范围（其余渲染进程状态暂时仍放在 localStorage）：
+ *   - kv:               标量应用状态。目前：主窗口的 bounds。
+ *   - command_history:  全新——用户向 agent 提交的每一条提示词。
  *
- * Lives in the Electron MAIN process (better-sqlite3 is native + synchronous);
- * the renderer reaches it over IPC. The DB file sits next to config.json under
- * app.getPath('userData'). WAL mode so reads never block the single writer.
+ * 位于 Electron 主进程（better-sqlite3 是原生 + 同步的）；渲染进程通过 IPC
+ * 访问。DB 文件与 config.json 相邻，位于 app.getPath('userData') 下。使用
+ * WAL 模式，读取不阻塞唯一的写入者。
  *
- * Schema evolves via PRAGMA user_version migrations: an ordered array where
- * migration N runs when user_version < N+1, then bumps it. NEVER edit a shipped
- * migration — only append. Phases B/C (agents + message_queue mirror) and the
- * cross-lane cost_ledger are reserved as future additive migrations (see below);
- * they are deliberately NOT built in v1.
+ * Schema 通过 PRAGMA user_version 迁移演进：一个有序数组，当 user_version
+ * < N+1 时运行迁移 N，然后递增版本。绝不要修改已发布的迁移——只能追加。
+ * Phase B/C（agents + message_queue 镜像）以及跨通道 cost_ledger 保留为
+ * 未来的增量迁移（见下）；它们刻意不在 v1 中构建。
  */
 import Database from 'better-sqlite3';
 import { app } from 'electron';
 import { join } from 'node:path';
 
-/** A captured user prompt, as returned to the renderer (camelCase columns). */
+/** 一条捕获的用户提示词，按返回给渲染进程的形式（camelCase 列）。 */
 export interface CommandHistoryRow {
   id: number;
   agentId: string;
@@ -29,25 +28,23 @@ export interface CommandHistoryRow {
 }
 
 /**
- * Ordered, append-only migrations. Index N takes the DB from user_version N to
- * N+1. To evolve the schema, APPEND a new function — never edit an existing one
- * (shipped DBs have already run it).
+ * 有序、只追加的迁移。索引 N 把 DB 从 user_version N 带到 N+1。要演进 schema，
+ * 请追加新函数——绝不修改已存在的函数（已发布的 DB 已经运行过它）。
  *
- * FUTURE (do NOT build in v1 — reserved so the array isn't painted into a corner):
- *   - Phase B: `agents` + `message_queue` mirror of the renderer roster/queues
- *     (dual-write), enabling the eventual authority flip off localStorage.
- *   - Cross-lane (Lane A #6): migrate Jim's cost ledger onto this DB so his
- *     circuit-breaker can move off transcript-polling. Column names match his
- *     <harnessHome>/hive/cost-ledger.jsonl keys 1:1 for a straight INSERT…SELECT
- *     (coordinated w/ jim-mq290qkn 2026-06-06):
+ * FUTURE（不要在 v1 中构建——预留出来，免得这个数组被逼进死角）：
+ *   - Phase B：渲染进程 roster/队列的 `agents` + `message_queue` 镜像
+ *     （双写），为最终摆脱 localStorage 的权威翻转做准备。
+ *   - 跨通道（Lane A #6）：把 Jim 的成本账本迁移到本 DB，让他的熔断器可以
+ *     不再轮询 transcript。列名与他 <harnessHome>/hive/cost-ledger.jsonl 的
+ *     key 一一对应，便于直接 INSERT…SELECT（与 jim-mq290qkn 于 2026-06-06
+ *     协调）：
  *       cost_ledger(id, agent_id, session_id TEXT, ts, input, output,
  *                   cache_read, cache_creation, model TEXT, usd REAL)
- *     Rows are CUMULATIVE snapshots (one per agent per heartbeat beat) — diff
- *     consecutive rows for velocity; index (agent_id, session_id, ts). Additive;
- *     lands as a later migration.
+ *     行是累计快照（每个 agent 每次心跳一行）——用相邻行做差得到速率；
+ *     索引 (agent_id, session_id, ts)。加法迁移，作为后续迁移落地。
  */
 const MIGRATIONS: Array<(db: Database.Database) => void> = [
-  // → user_version 1 (Phase A): scalar kv + net-new command history.
+  // → user_version 1（Phase A）：标量 kv + 全新的命令历史。
   (db) => {
     db.exec(`
       CREATE TABLE IF NOT EXISTS kv (
@@ -70,12 +67,12 @@ const MIGRATIONS: Array<(db: Database.Database) => void> = [
 export class PersistStore {
   private db: Database.Database | null = null;
 
-  /** @param dbPath  Override the DB location (tests). Defaults to userData/harness.db. */
+  /** @param dbPath  覆盖 DB 位置（测试用）。默认为 userData/harness.db。 */
   constructor(private dbPath?: string) {}
 
-  /** Open (creating if needed) and migrate the DB. Idempotent — a second call is
-   *  a no-op. Throws if the native module fails to load or the file is unusable;
-   *  callers should guard so a DB failure can't crash app startup. */
+  /** 打开（必要时创建）并迁移 DB。幂等——第二次调用是空操作。若原生模块
+   *  加载失败或文件不可用则抛错；调用方应加防护，避免 DB 故障导致应用
+   *  启动崩溃。 */
   open(): void {
     if (this.db) return;
     const path = this.dbPath ?? join(app.getPath('userData'), 'harness.db');
@@ -91,8 +88,8 @@ export class PersistStore {
   private migrate(db: Database.Database): void {
     const version = db.pragma('user_version', { simple: true }) as number;
     for (let i = version; i < MIGRATIONS.length; i++) {
-      // Each migration + its version bump run in one transaction so a crash
-      // mid-migration never leaves a half-applied schema at the wrong version.
+      // 每个迁移及其版本递增都在同一事务中执行，这样迁移中途崩溃
+      // 绝不会在错误的版本上留下只应用了一半的 schema。
       const run = db.transaction(() => {
         MIGRATIONS[i](db);
         db.pragma(`user_version = ${i + 1}`);
@@ -101,17 +98,17 @@ export class PersistStore {
     }
   }
 
-  /** Close the handle (checkpoints WAL). Safe to call when already closed. */
+  /** 关闭句柄（对 WAL 做 checkpoint）。已关闭时调用也安全。 */
   close(): void {
-    try { this.db?.close(); } catch { /* best-effort on shutdown */ }
+    try { this.db?.close(); } catch { /* 关闭时尽力而为 */ }
     this.db = null;
   }
 
   get isOpen(): boolean { return this.db !== null; }
 
-  // ─── kv (scalar app state) ─────────────────────────────────────────────────
+  // ─── kv（标量应用状态）─────────────────────────────────────────────────────
 
-  /** Read a JSON-decoded scalar, or undefined if absent/unparseable. */
+  /** 读取一个 JSON 解码的标量；不存在或无法解析时返回 undefined。 */
   getKv<T = unknown>(key: string): T | undefined {
     if (!this.db) return undefined;
     const row = this.db.prepare('SELECT value FROM kv WHERE key = ?').get(key) as { value: string } | undefined;
@@ -119,7 +116,7 @@ export class PersistStore {
     try { return JSON.parse(row.value) as T; } catch { return undefined; }
   }
 
-  /** Upsert a JSON-encoded scalar. */
+  /** 写入（upsert）一个 JSON 编码的标量。 */
   setKv(key: string, value: unknown): void {
     if (!this.db) return;
     this.db.prepare(
@@ -128,9 +125,9 @@ export class PersistStore {
     ).run(key, JSON.stringify(value), Date.now());
   }
 
-  // ─── command history (net-new) ─────────────────────────────────────────────
+  // ─── 命令历史（全新）───────────────────────────────────────────────────────
 
-  /** Record one submitted prompt. Empty text or missing agent id are ignored. */
+  /** 记录一条已提交的提示词。空文本或缺少 agent id 会被忽略。 */
   addHistory(entry: { agentId: string; cwd?: string | null; text: string }): void {
     if (!this.db) return;
     const text = (entry.text ?? '').trim();
@@ -139,7 +136,7 @@ export class PersistStore {
       .run(entry.agentId, entry.cwd ?? null, text, Date.now());
   }
 
-  /** Most-recent-first history, optionally scoped to one agent. */
+  /** 最近优先的历史，可选地限定到某个 agent。 */
   listHistory(agentId?: string, limit = 100): CommandHistoryRow[] {
     if (!this.db) return [];
     const lim = clampLimit(limit, 100);
@@ -153,13 +150,13 @@ export class PersistStore {
     return rows as CommandHistoryRow[];
   }
 
-  /** Substring search over prompt text, most-recent-first. */
+  /** 对提示词文本做子串搜索，最近优先。 */
   searchHistory(query: string, limit = 50): CommandHistoryRow[] {
     if (!this.db) return [];
     const q = (query ?? '').trim();
     if (!q) return [];
     const lim = clampLimit(limit, 50);
-    // Escape LIKE wildcards so a literal % or _ in the query isn't a metachar.
+    // 转义 LIKE 通配符，让查询中的字面量 % 或 _ 不再是元字符。
     const needle = `%${q.replace(/[\\%_]/g, '\\$&')}%`;
     return this.db.prepare(
       "SELECT id, agent_id AS agentId, cwd, text, ts FROM command_history WHERE text LIKE ? ESCAPE '\\' ORDER BY ts DESC, id DESC LIMIT ?"
@@ -167,7 +164,7 @@ export class PersistStore {
   }
 }
 
-/** Coerce an untrusted limit into [1, 1000] with a sane fallback. */
+/** 把不可信的 limit 收敛到 [1, 1000]，带合理的回退。 */
 function clampLimit(n: number, fallback: number): number {
   const v = Math.floor(Number(n));
   if (!Number.isFinite(v) || v <= 0) return fallback;

--- a/src/main/fetchText.ts
+++ b/src/main/fetchText.ts
@@ -1,13 +1,11 @@
 /**
- * One place that fetches text over https.
+ * 通过 https 抓取文本的唯一入口。
  *
- * Extracted from skills.ts when the hero payload needed the same thing: two
- * copies of redirect-following, timeout and status handling would drift, and the
- * one that drifted would be the one nobody was looking at.
+ * 当 hero 负载也需要同样的能力时，从 skills.ts 中拆出：重定向跟随、超时和
+ * 状态处理若存在两份拷贝就会逐渐分叉，而分叉的那份往往是没人盯着的那份。
  *
- * https only, by construction — every caller fetches from raw.githubusercontent
- * or a repo URL, and an http: fallback would silently downgrade content the app
- * then renders.
+ * 只走 https，这是刻意为之——所有调用方都从 raw.githubusercontent 或仓库
+ * URL 抓取，如果回退到 http: 会悄悄降级应用随后渲染的内容。
  */
 import { request as httpsRequest } from 'node:https';
 
@@ -15,8 +13,8 @@ export function getText(url: string, opts: { timeoutMs?: number } = {}): Promise
   const timeoutMs = opts.timeoutMs ?? 12000;
   return new Promise((resolve, reject) => {
     const req = httpsRequest(url, { method: 'GET', headers: { 'user-agent': 'munder-difflin' } }, (res) => {
-      // Follow a redirect once per hop; raw.githubusercontent does this for
-      // branch aliases and the request just fails without it.
+      // 每一跳跟随一次重定向；raw.githubusercontent 对
+      // 分支别名需要这样，缺少它会直接请求失败。
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         res.resume();
         getText(res.headers.location, opts).then(resolve, reject);

--- a/src/main/freeflow.ts
+++ b/src/main/freeflow.ts
@@ -1,45 +1,44 @@
 /**
- * Free Flow — Groq Whisper speech-to-text, run from the Electron MAIN process.
+ * Free Flow —— Groq Whisper 语音转文字，在 Electron 主进程中运行。
  *
- * The renderer captures mic audio (getUserMedia → MediaRecorder) and hands the
- * raw bytes here over IPC; this module does the multipart upload to Groq's
- * OpenAI-compatible transcription endpoint and returns the transcript. Doing the
- * HTTP call in main (like `slack.ts` / `webhook.ts`) keeps the user's Groq key out
- * of the renderer and dodges CORS.
+ * 渲染进程采集麦克风音频（getUserMedia → MediaRecorder），通过 IPC 把原始
+ * 字节交到这里；本模块向 Groq 的 OpenAI 兼容转录端点做 multipart 上传并返回
+ * 转录文本。在主进程做这个 HTTP 调用（与 `slack.ts` / `webhook.ts` 相同），
+ * 用户的 Groq key 就不会进渲染进程，也避开了 CORS。
  *
- * Electron 32 bundles Node 20, so the global `fetch` + `FormData` + `Blob`
- * (undici) are available here — no extra dependency and no hand-rolled multipart.
+ * Electron 32 内置 Node 20，因此这里的全局 `fetch` + `FormData` + `Blob`
+ * （undici）都可用——无需额外依赖，也无需手写 multipart。
  *
- * The API key is passed in by the caller (it lives in main's config), is used
- * ONLY for the Authorization header, and is NEVER logged.
+ * API key 由调用方传入（它存放在主进程的 config 中），仅用于
+ * Authorization 头，绝不记录日志。
  *
- * Deliberately free of any `electron` import so it can be unit-/smoke-tested as a
- * plain Node module.
+ * 刻意不 import 任何 `electron`，因此它可以作为普通 Node 模块做
+ * 单元/冒烟测试。
  */
 
-/** Groq's OpenAI-compatible transcription endpoint. */
+/** Groq 的 OpenAI 兼容转录端点。 */
 const GROQ_TRANSCRIBE_URL = 'https://api.groq.com/openai/v1/audio/transcriptions';
-/** Default model — fast, multilingual; ~216× real-time. The other option is the
- *  higher-accuracy `whisper-large-v3`. */
+/** 默认模型——快速、多语言；约 216 倍实时。另一个选项是
+ *  更高精度的 `whisper-large-v3`。 */
 export const DEFAULT_GROQ_MODEL = 'whisper-large-v3-turbo';
-/** Groq free-tier upload cap is 25 MB; reject larger payloads before we spend a
- *  network round-trip (our clips are seconds long / tens of KB in practice). */
+/** Groq 免费层上传上限是 25 MB；在浪费一次网络往返之前先拒绝更大的
+ *  负载（我们的片段实际只有几秒长 / 几十 KB）。 */
 const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
-/** Don't let a hung request wedge the feature — bound the call. */
+/** 别让挂起的请求卡死该功能——给调用设上限。 */
 const REQUEST_TIMEOUT_MS = 60_000;
 
 export interface TranscribeOptions {
-  /** User's Groq API key. Used only for the Authorization header; never logged. */
+  /** 用户的 Groq API key。仅用于 Authorization 头；绝不记录日志。 */
   apiKey: string;
-  /** Raw audio bytes captured in the renderer (e.g. webm/opus). */
+  /** 渲染进程捕获的原始音频字节（例如 webm/opus）。 */
   audio: ArrayBuffer | Uint8Array | Buffer;
-  /** MIME type of `audio` (e.g. 'audio/webm'). Defaults to 'audio/webm'. */
+  /** `audio` 的 MIME 类型（例如 'audio/webm'）。默认为 'audio/webm'。 */
   mimeType?: string;
-  /** Upload filename (Groq infers format from the extension). Defaults to a webm name. */
+  /** 上传文件名（Groq 从扩展名推断格式）。默认为一个 webm 名称。 */
   filename?: string;
-  /** Groq model id. Defaults to DEFAULT_GROQ_MODEL. */
+  /** Groq 模型 id。默认为 DEFAULT_GROQ_MODEL。 */
   model?: string;
-  /** Optional ISO-639-1 language hint to improve accuracy/latency. */
+  /** 可选的 ISO-639-1 语言提示，用于提升准确率/延迟。 */
   language?: string;
 }
 
@@ -50,8 +49,8 @@ export interface TranscribeResult {
 }
 
 /**
- * Transcribe a single audio clip via Groq Whisper. Resolves `{ ok, text }` on
- * success or `{ ok: false, error }` otherwise. Never throws; never logs the key.
+ * 通过 Groq Whisper 转录单个音频片段。成功时 resolve `{ ok, text }`，
+ * 否则 resolve `{ ok: false, error }`。从不抛错；从不记录 key。
  */
 export async function transcribeWithGroq(opts: TranscribeOptions): Promise<TranscribeResult> {
   if (!opts.apiKey) return { ok: false, error: 'missing Groq API key' };
@@ -68,8 +67,8 @@ export async function transcribeWithGroq(opts: TranscribeOptions): Promise<Trans
 
   const form = new FormData();
   form.append('model', model);
-  // `response_format=text` returns the bare transcript, but JSON is more robust to
-  // parse defensively; we ask for json and read `.text`.
+  // `response_format=text` 返回裸转录文本，但 JSON 更稳健——
+  // 我们请求 json，并用防御性的方式读取 `.text`。
   form.append('response_format', 'json');
   if (opts.language) form.append('language', opts.language);
   form.append('file', new Blob([toArrayBuffer(bytes)], { type: mimeType }), filename);
@@ -85,8 +84,8 @@ export async function transcribeWithGroq(opts: TranscribeOptions): Promise<Trans
     });
     const raw = await res.text();
     if (!res.ok) {
-      // Surface Groq's error message (NOT the key) — e.g. 401 invalid_api_key,
-      // 413 too large, 429 rate limited. Keep it short.
+      // 透出 Groq 的错误信息（不是 key）——例如 401 invalid_api_key、
+      // 413 太大、429 被限流。保持简短。
       return { ok: false, error: `Groq ${res.status}: ${extractError(raw) || res.statusText}` };
     }
     let text = '';
@@ -94,7 +93,7 @@ export async function transcribeWithGroq(opts: TranscribeOptions): Promise<Trans
       const json = JSON.parse(raw) as { text?: unknown };
       text = typeof json.text === 'string' ? json.text.trim() : '';
     } catch {
-      // response_format fallback: a bare-text body.
+      // response_format 回退：纯文本响应体。
       text = raw.trim();
     }
     if (!text) return { ok: false, error: 'no speech detected' };
@@ -107,22 +106,22 @@ export async function transcribeWithGroq(opts: TranscribeOptions): Promise<Trans
   }
 }
 
-/** Pull a human-readable message out of Groq's JSON error envelope, if present. */
+/** 若存在，从 Groq 的 JSON 错误信封中取出可读的消息。 */
 function extractError(raw: string): string {
   try {
     const j = JSON.parse(raw) as { error?: { message?: string } | string };
     if (typeof j.error === 'string') return j.error;
     if (j.error && typeof j.error.message === 'string') return j.error.message;
-  } catch { /* not json */ }
+  } catch { /* 不是 json */ }
   return '';
 }
 
 function toUint8Array(audio: ArrayBuffer | Uint8Array | Buffer): Uint8Array {
-  if (audio instanceof Uint8Array) return audio; // Buffer is a Uint8Array subclass
+  if (audio instanceof Uint8Array) return audio; // Buffer 是 Uint8Array 的子类
   return new Uint8Array(audio);
 }
 
-/** Blob wants an ArrayBuffer-backed view; copy out a clean ArrayBuffer slice. */
+/** Blob 需要 ArrayBuffer 支撑的视图；拷贝出一份干净的 ArrayBuffer 切片。 */
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }

--- a/src/main/fs.ts
+++ b/src/main/fs.ts
@@ -4,12 +4,12 @@ import { homedir } from 'node:os';
 import { imageMimeForPath } from '../shared/imageTypes';
 
 /**
- * Confines `path` inside `root` to prevent path-traversal escapes.
- * Returns the resolved absolute path on success, or null on violation.
+ * 把 `path` 限制在 `root` 之内，防止路径穿越（path-traversal）逃逸。
+ * 成功时返回解析后的绝对路径，违规时返回 null。
  *
- * Exported so other main-process modules (e.g. git.ts) validate caller-supplied
- * relative paths against a workspace root with the SAME guard — there is exactly
- * one path-escape policy in the app and it lives here.
+ * 导出它，是为了让其他主进程模块（例如 git.ts）能用“同一个”守卫来校验
+ * 调用方提供的相对路径是否位于工作区根目录内——应用里只有一条路径逃逸
+ * 策略，而且就在这里。
  */
 export function safeJoin(root: string, rel: string): string | null {
   const absRoot = resolve(root);
@@ -30,7 +30,7 @@ export async function listDir(root: string, rel: string): Promise<{
   ok: true; entries: DirEntry[]; path: string;
 } | { ok: false; error: string }> {
   const abs = safeJoin(root, rel);
-  if (!abs) return { ok: false, error: 'path escapes root' };
+  if (!abs) return { ok: false, error: '路径超出根目录' };
   try {
     const names = await readdir(abs);
     const entries = await Promise.all(names.map(async (name): Promise<DirEntry> => {
@@ -57,15 +57,15 @@ export async function readFileText(root: string, rel: string): Promise<{
   ok: true; content: string; path: string; size: number;
 } | { ok: false; error: string }> {
   const abs = safeJoin(root, rel);
-  if (!abs) return { ok: false, error: 'path escapes root' };
+  if (!abs) return { ok: false, error: '路径超出根目录' };
   try {
     const s = await stat(abs);
     if (s.size > MAX_READ_BYTES) {
-      return { ok: false, error: `file too large (${(s.size / 1024 / 1024).toFixed(1)} MB)` };
+      return { ok: false, error: `文件过大（${(s.size / 1024 / 1024).toFixed(1)} MB）` };
     }
     const buf = await readFile(abs);
-    // Reject obvious binary files based on null-byte sniff
-    if (buf.includes(0)) return { ok: false, error: 'binary file (not displayable)' };
+    // 通过空字节嗅探拒绝明显的二进制文件
+    if (buf.includes(0)) return { ok: false, error: '二进制文件（无法显示）' };
     return { ok: true, content: buf.toString('utf8'), path: abs, size: s.size };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
@@ -73,58 +73,53 @@ export async function readFileText(root: string, rel: string): Promise<{
 }
 
 /**
- * Ceiling for the BINARY read. Deliberately larger than MAX_READ_BYTES (2 MB):
- * that cap exists to stop Monaco choking on a huge text buffer, and applying it
- * to images would reject the exact files people want to look at — a retina
- * screenshot of a full 5K display is routinely 3–6 MB. 10 MB covers real
- * screenshots and design assets while still refusing to hand the renderer a
- * video-sized payload over structured clone.
+ * 二进制读取的上限。刻意大于 MAX_READ_BYTES（2 MB）：那个上限是为了防止
+ * Monaco 被巨大的文本缓冲卡死；把它套到图片上会拒绝掉人们正想看的文件——
+ * 整块 5K 显示器的视网膜截图通常就有 3–6 MB。10 MB 既能覆盖真实截图和
+ * 设计素材，又仍然拒绝通过 structured clone 把视频大小的负载交给渲染进程。
  */
 const MAX_BINARY_READ_BYTES = 10 * 1024 * 1024; // 10 MB
 
 /**
- * Read a file as raw BYTES, confined to `root` by the same `safeJoin` guard as
- * every other fs entry point here.
+ * 以原始字节读取文件，并用与这里其他 fs 入口相同的 `safeJoin` 守卫把读取
+ * 限制在 `root` 内。
  *
- * Exists because the text path deliberately refuses binary content (the
- * null-byte sniff in readFileText), which meant a PNG in an agent's workspace
- * was completely unviewable inside the app — the IDE opened a tab that said
- * "binary file (not displayable)" and stopped there. The renderer cannot reach
- * the file itself: the CSP is `default-src 'self'` with no `file:` source and
- * there is no registered file protocol, so `<img src="file://…">` silently
- * fails. Bytes therefore have to travel over IPC, and the renderer turns them
- * into a `blob:` URL (already allowed by `img-src`).
+ * 它的存在是因为文本路径刻意拒绝二进制内容（readFileText 里的空字节嗅探），
+ * 这意味着 agent 工作区里的 PNG 在应用内完全无法查看——IDE 打开一个写着
+ * "binary file (not displayable)" 的标签页就止步了。渲染进程自己也够不到
+ * 这个文件：CSP 是 `default-src 'self'`，没有 `file:` 源，也没有注册任何
+ * file 协议，所以 `<img src="file://…">` 会静默失败。因此字节必须走 IPC
+ * 传输，渲染进程再把它们变成 `blob:` URL（`img-src` 已经允许）。
  *
- * NEVER reads unbounded: the size is checked from stat BEFORE opening, and
- * re-checked against the bytes actually read so a file that grows between the
- * two calls can't slip past the cap.
+ * 绝不做无界读取：打开前先从 stat 检查大小，再与实际读到的字节数复核，
+ * 这样两次调用之间变大的文件也不可能溜过上限。
  */
 export async function readFileBinary(root: string, rel: string, maxBytes = MAX_BINARY_READ_BYTES): Promise<{
   ok: true; bytes: Uint8Array<ArrayBuffer>; mime: string; path: string; size: number;
 } | { ok: false; error: string }> {
   const abs = safeJoin(root, rel);
-  if (!abs) return { ok: false, error: 'path escapes root' };
+  if (!abs) return { ok: false, error: '路径超出根目录' };
   try {
     const s = await stat(abs);
-    // Directories and FIFOs are the trap here: readFile on a directory throws
-    // (fine) but on a FIFO it BLOCKS forever with no size to check against, which
-    // would hang the IPC call and, with it, the renderer's loading state.
-    if (!s.isFile()) return { ok: false, error: 'not a regular file' };
+    // 目录和 FIFO 是这里的陷阱：对目录 readFile 会抛错
+    //（没问题），但对 FIFO 会永久阻塞，且没有大小可核对，这会
+    // 挂住 IPC 调用，连带挂住渲染进程的加载状态。
+    if (!s.isFile()) return { ok: false, error: '不是常规文件' };
     if (s.size > maxBytes) {
-      return { ok: false, error: `file too large (${(s.size / 1024 / 1024).toFixed(1)} MB)` };
+      return { ok: false, error: `文件过大（${(s.size / 1024 / 1024).toFixed(1)} MB）` };
     }
     const buf = await readFile(abs);
     if (buf.byteLength > maxBytes) {
-      // The file grew between stat and read. Rare, but the cap is a memory
-      // guarantee for the renderer, not an advisory.
-      return { ok: false, error: 'file grew past the size limit while reading' };
+      // 文件在 stat 与 read 之间变大了。罕见，但上限是给渲染进程的
+      // 内存保证，不是建议。
+      return { ok: false, error: '读取时文件超过大小限制' };
     }
-    // COPY into a freshly-allocated Uint8Array instead of forwarding the Buffer.
-    // Node serves small reads out of a shared 8 KB Buffer pool, so a pooled
-    // Buffer is a VIEW onto memory that also holds unrelated recently-read
-    // bytes; structured-clone carries the whole backing ArrayBuffer across the
-    // IPC boundary, not just the view. Copying keeps the renderer's payload
-    // exactly the file and nothing else.
+    // 拷贝进一个全新分配的 Uint8Array，而不是直接转发 Buffer。
+    // Node 的小读取来自共享的 8 KB Buffer 池，因此池化的
+    // Buffer 是内存的一块“视图”，里面还装着无关的最近读到的
+    // 字节；structured-clone 会跨 IPC 边界搬运整个底层 ArrayBuffer，
+    // 而不仅是视图。拷贝能让渲染进程的负载
+    // 恰好是文件本身，不多不少。
     const bytes = new Uint8Array(buf.byteLength);
     bytes.set(buf);
     return {
@@ -143,7 +138,7 @@ export async function writeFileText(root: string, rel: string, content: string):
   ok: true; path: string;
 } | { ok: false; error: string }> {
   const abs = safeJoin(root, rel);
-  if (!abs) return { ok: false, error: 'path escapes root' };
+  if (!abs) return { ok: false, error: '路径超出根目录' };
   try {
     await writeFile(abs, content, 'utf8');
     return { ok: true, path: abs };
@@ -153,21 +148,18 @@ export async function writeFileText(root: string, rel: string, content: string):
 }
 
 /**
- * Expand a leading `~` to the user's home dir and return an absolute, normalized
- * path. SYNC on purpose — every consumer (spawn guards, cwd validation, config
- * writes) is synchronous.
+ * 把开头的 `~` 展开为用户主目录，并返回绝对、规范化的路径。刻意用同步
+ * 实现——每个消费方（spawn 守卫、cwd 校验、config 写入）都是同步的。
  *
- * Only a SHELL expands `~`; Node's `fs`/`child_process` treat it as a literal
- * directory name, so a user-typed `~/dev/foo` fails every existsSync/statSync and
- * dies with `cwd does not exist`. This is applied at INGESTION (project add,
- * `pty:spawn`) so the registry only ever stores an ABSOLUTE cwd, with
- * defense-in-depth at the consumers.
+ * 只有 SHELL 才会展开 `~`；Node 的 `fs`/`child_process` 把它当作字面量
+ * 目录名，所以用户输入的 `~/dev/foo` 会失败于每一个 existsSync/statSync，
+ * 并以 `cwd does not exist` 告终。它在“摄入”时（项目添加、`pty:spawn`）
+ * 就被应用，因此注册表只会存储绝对 cwd，消费方再做纵深防御。
  *
- * Non-tilde absolute paths are returned resolved/normalized. Anything that is
- * still RELATIVE after expansion is returned untouched (trimmed) so callers keep
- * their own "not-absolute" errors instead of it being silently resolved against
- * the Electron process cwd. Empty input passes straight through. Windows paths
- * (`C:\…`, UNC) are unaffected — they never start with `~`.
+ * 非波浪号的绝对路径会被解析/规范化后返回。展开后仍然是相对路径的内容
+ * 会原样（trim 后）返回，让调用方保留自己的“非绝对路径”错误，而不是被
+ * 悄悄相对 Electron 进程的 cwd 解析。空输入直接通过。Windows 路径
+ * （`C:\…`、UNC）不受影响——它们永远不会以 `~` 开头。
  */
 export function expandTilde(p: string): string {
   if (typeof p !== 'string') return p;
@@ -181,19 +173,19 @@ export function expandTilde(p: string): string {
 }
 
 /**
- * Normalize the hive home and its recent-list in one place (#140).
+ * 在一处规范化 hive 主目录及其最近列表（#140）。
  *
- * Onboarding SUGGESTS `~/HarnessAgents` in a free-text field, so the single most
- * common setup path — accept the default, press Finish — used to persist a literal
- * `~`. Finish immediately creates that directory, and Node's mkdir has no concept
- * of `~`: it tried to create a folder literally named "~" and died with
- * `ENOENT: no such file or directory, mkdir '~/HarnessAgents'`, wedging the wizard
- * on its last step. Expanding at the config-write boundary means every downstream
- * reader — mkdir, the hive root, the launch picker — sees one absolute path.
+ * 新手指引在自由文本字段里默认提示 `~/HarnessAgents`，因此最常见的安装
+ * 路径——接受默认值、点完成——过去会持久化一个字面量 `~`。点完成会立即
+ * 创建该目录，而 Node 的 mkdir 没有 `~` 的概念：它试图创建一个字面名叫
+ * "~" 的文件夹，然后以 `ENOENT: no such file or directory, mkdir
+ * '~/HarnessAgents'` 告终，把向导卡在最后一步。在 config 写入边界展开，
+ * 意味着每一个下游读取者——mkdir、hive 根、启动选择器——看到的都是
+ * 同一条绝对路径。
  *
- * `prior` is normalized too: entries written before this existed would otherwise
- * let the launch picker hand a stale `~/…` string straight back and reintroduce
- * the same failure. Deduped against the new home, newest first, capped.
+ * `prior` 也会被规范化：否则在此功能出现之前写入的条目，会让启动选择器
+ * 把过期的 `~/…` 字符串原样递回去，重新引入同样的失败。与新的主目录
+ * 去重，新的在前，并设上限。
  */
 export function normalizeHiveHome(
   home: string,
@@ -213,10 +205,9 @@ export function normalizeHiveHome(
   return { home: abs, recentHives: recentHives.slice(0, cap) };
 }
 
-/** Existence/metadata check for an ABSOLUTE path (v0.3.4 — backs the terminal
- *  ⌘-click markdown flow). `~/` is expanded here (the renderer doesn't know
- *  the home dir). Read-only metadata: returns whether a regular file exists and
- *  the normalized absolute path; never file contents. */
+/** 对绝对路径的存在性/元数据检查（v0.3.4——支撑终端 ⌘-点击 markdown 流程）。
+ *  这里会展开 `~/`（渲染进程不知道主目录）。只读元数据：返回普通文件
+ *  是否存在以及规范化后的绝对路径；绝不返回文件内容。 */
 export async function statAbs(p: string): Promise<{ exists: boolean; isFile: boolean; path: string }> {
   const abs = expandTilde(p);
   if (!isAbsolute(abs)) return { exists: false, isFile: false, path: p };

--- a/src/main/git.ts
+++ b/src/main/git.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { readFile, stat } from 'node:fs/promises';
 import { safeJoin } from './fs';
 
-/** Run git in `cwd` with `args`. Returns stdout text or an error. */
+/** 在 `cwd` 中用 `args` 运行 git。返回 stdout 文本或错误。 */
 function runGit(cwd: string, args: string[], timeoutMs = 8000): Promise<{
   ok: true; stdout: string;
 } | { ok: false; error: string }> {
@@ -11,7 +11,7 @@ function runGit(cwd: string, args: string[], timeoutMs = 8000): Promise<{
     let stdout = '';
     let stderr = '';
     const timer = setTimeout(() => {
-      try { proc.kill('SIGKILL'); } catch { /* noop */ }
+      try { proc.kill('SIGKILL'); } catch { /* 空操作 */ }
     }, timeoutMs);
     proc.stdout.on('data', d => { stdout += d.toString(); });
     proc.stderr.on('data', d => { stderr += d.toString(); });
@@ -33,8 +33,8 @@ export interface GitBranchInfo {
 }
 export interface GitStatusEntry {
   path: string;
-  index: string;   // staged status char
-  worktree: string; // unstaged status char
+  index: string;   // 已暂存状态字符
+  worktree: string; // 未暂存状态字符
 }
 export interface GitStatus {
   staged: GitStatusEntry[];
@@ -47,8 +47,8 @@ export interface GitCommit {
   parents: string[];
   subject: string;
   author: string;
-  time: number; // unix seconds
-  refs: string[]; // branch/tag refs
+  time: number; // unix 秒
+  refs: string[]; // 分支/标签引用
 }
 export interface GitAheadBehind {
   ahead: number;
@@ -86,8 +86,8 @@ export async function getStatus(cwd: string): Promise<GitStatus | { error: strin
 }
 
 export async function getLog(cwd: string, n: number): Promise<GitCommit[] | { error: string }> {
-  const sep = '\x1e';   // record separator
-  const fsep = '\x1f';  // field separator
+  const sep = '\x1e';   // 记录分隔符
+  const fsep = '\x1f';  // 字段分隔符
   const fmt = ['%H', '%P', '%s', '%an', '%at', '%D'].join(fsep) + sep;
   const res = await runGit(cwd, ['log', '--all', `--max-count=${n}`, `--pretty=format:${fmt}`]);
   if (!res.ok) return { error: res.error };
@@ -138,34 +138,32 @@ export async function getAheadBehind(cwd: string): Promise<GitAheadBehind | { er
   return { ahead, behind, upstream };
 }
 
-/** Best-effort detect: is `cwd` actually a git repo? */
+/** 尽力检测：`cwd` 到底是不是一个 git 仓库？ */
 export async function isRepo(cwd: string): Promise<boolean> {
   const res = await runGit(cwd, ['rev-parse', '--is-inside-work-tree']);
   return res.ok && res.stdout.trim() === 'true';
 }
 
-const MAX_DIFF_BYTES = 2 * 1024 * 1024; // 2 MB — keep the diff view responsive
+const MAX_DIFF_BYTES = 2 * 1024 * 1024; // 2 MB —— 保持 diff 视图的响应速度
 
-/** A file's two sides for a working-tree-vs-HEAD diff. `head` is the committed
- *  version ('' for a new/untracked file); `working` is the on-disk version ('' for
- *  a file deleted from the working tree). The renderer feeds these straight into
- *  Monaco's DiffEditor (original = head, modified = working). */
+/** 工作树与 HEAD 对比时一个文件的两侧。`head` 是已提交版本（新/未跟踪文件
+ *  为 ''）；`working` 是磁盘上的版本（已从工作树删除的文件为 ''）。渲染进程
+ *  直接把它们喂给 Monaco 的 DiffEditor（original = head，modified = working）。 */
 export interface GitDiff {
   ok: true;
-  path: string;            // resolved absolute path (display only)
+  path: string;            // 解析后的绝对路径（仅用于显示）
   relPath: string;
   head: string;
   working: string;
-  headExists: boolean;     // file is tracked at HEAD
-  workingExists: boolean;  // file is present in the working tree
-  isBinary: boolean;       // either side is binary → not text-diffable
+  headExists: boolean;     // 文件在 HEAD 被跟踪
+  workingExists: boolean;  // 文件存在于工作树
+  isBinary: boolean;       // 任一侧是二进制 → 无法做文本 diff
 }
 
 /**
- * Diff a single file: its committed (HEAD) content vs its current working-tree
- * content. `relPath` MUST be repo-root-relative and is path-validated against
- * `cwd` with the shared fs guard (no escaping the workspace). All git/fs access
- * stays in the main process — the renderer only ever receives the two text sides.
+ * 对比单个文件：它的已提交（HEAD）内容 vs 当前工作树内容。`relPath` 必须
+ * 相对于仓库根目录，并用共享 fs 守卫对照 `cwd` 做路径校验（不允许逃出
+ * 工作区）。所有 git/fs 访问都留在主进程——渲染进程只会收到两侧文本。
  */
 export async function getDiff(
   cwd: string, relPath: string
@@ -173,20 +171,20 @@ export async function getDiff(
   const abs = safeJoin(cwd, relPath);
   if (!abs) return { ok: false, error: 'path escapes repository root' };
 
-  // HEAD side: `git show HEAD:<path>` — errors (untracked / new file) → no head version.
+  // HEAD 侧：`git show HEAD:<path>` ——出错（未跟踪/新文件）→ 没有 HEAD 版本。
   let head = '';
   let headExists = false;
   const show = await runGit(cwd, ['show', `HEAD:${relPath}`]);
   if (show.ok) { head = show.stdout; headExists = true; }
 
-  // Working side: read the on-disk file. ENOENT → deleted from the working tree.
+  // 工作侧：读取磁盘上的文件。ENOENT → 已从工作树删除。
   let working = '';
   let workingExists = false;
   let workingBinary = false;
   try {
     const s = await stat(abs);
     if (s.size > MAX_DIFF_BYTES) {
-      return { ok: false, error: `file too large to diff (${(s.size / 1048576).toFixed(1)} MB)` };
+      return { ok: false, error: `文件过大，无法 diff（${(s.size / 1048576).toFixed(1)} MB）` };
     }
     const buf = await readFile(abs);
     workingExists = true;
@@ -209,49 +207,48 @@ export async function getDiff(
   };
 }
 
-/** The MAIN working tree of the repository `cwd` belongs to.
+/** `cwd` 所属仓库的主工作树。
  *
- *  For a normal checkout that's just the repo root. For a linked worktree it is
- *  the original repo, NOT the worktree directory — an isolated agent's cwd is
- *  `<harnessHome>/worktrees/<agent-id>`, whose basename is the agent id and says
- *  nothing about which project it's working on. `--git-common-dir` resolves to
- *  the shared `.git` of the main checkout from anywhere in the worktree family.
- *  Returns null when `cwd` isn't a git repo (or git is unavailable). */
+ *  普通检出就是仓库根目录。对于关联的 worktree，它是原始仓库，而不是
+ *  worktree 目录——隔离 agent 的 cwd 是 `<harnessHome>/worktrees/<agent-id>`，
+ *  其 basename 是 agent id，说明不了它在做哪个项目。`--git-common-dir` 从
+ *  worktree 家族的任何位置都能解析到主检出的共享 `.git`。当 `cwd` 不是 git
+ *  仓库（或 git 不可用）时返回 null。 */
 export async function mainRepoRoot(cwd: string): Promise<string | null> {
   const res = await runGit(cwd, ['rev-parse', '--path-format=absolute', '--git-common-dir']);
   if (!res.ok) return null;
   const gitDir = res.stdout.trim();
   if (!gitDir) return null;
-  // `<repo>/.git` → `<repo>`. A bare repo has no working tree to name, so its
-  // own path is the best answer we have.
+  // `<repo>/.git` → `<repo>`。裸仓库没有可命名的工作树，因此它
+  // 自己的路径就是我们能给的最好答案。
   const stripped = gitDir.replace(/[\\/]\.git[\\/]?$/, '');
   return stripped || gitDir;
 }
 
-/** Derive a safe `agent/<id>` branch name from a worktree path's basename. */
+/** 从 worktree 路径的 basename 派生出安全的 `agent/<id>` 分支名。 */
 function agentBranchFor(wtPath: string): string {
   const base = wtPath.split(/[\\/]/).filter(Boolean).pop() ?? 'agent';
   const slug = base.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'agent';
   return `agent/${slug}`;
 }
 
-/** Provision an isolated git worktree for an agent at `wtPath`, branching off
- *  `baseBranch`. Tries to create a fresh `agent/<id>` branch first; if that
- *  branch already exists, falls back to checking out `baseBranch` directly. */
+/** 在 `wtPath` 为 agent 提供隔离的 git worktree，从 `baseBranch` 分出分支。
+ *  先尝试创建全新的 `agent/<id>` 分支；若该分支已存在，则回退为直接检出
+ *  `baseBranch`。 */
 export async function addWorktree(
   cwd: string, wtPath: string, baseBranch: string
 ): Promise<{ ok: boolean; error?: string }> {
   const branch = agentBranchFor(wtPath);
   const fresh = await runGit(cwd, ['worktree', 'add', wtPath, '-b', branch, baseBranch]);
   if (fresh.ok) return { ok: true };
-  // Branch likely already exists (or the path is taken) — retry without -b.
+  // 分支很可能已存在（或路径被占用）——去掉 -b 重试。
   const fallback = await runGit(cwd, ['worktree', 'add', wtPath, baseBranch]);
   if (fallback.ok) return { ok: true };
   return { ok: false, error: fallback.error };
 }
 
-/** Best-effort removal of an agent's worktree. Forced so a dirty tree doesn't
- *  block teardown; failures are surfaced but callers may ignore them. */
+/** 尽力移除 agent 的 worktree。强制进行，这样脏工作树不会阻塞拆除；
+ *  失败会暴露出来，但调用方可以忽略。 */
 export async function removeWorktree(
   cwd: string, wtPath: string
 ): Promise<{ ok: boolean; error?: string }> {
@@ -260,21 +257,21 @@ export async function removeWorktree(
   return { ok: false, error: res.error };
 }
 
-/** Does this worktree hold work that must NOT be auto-discarded? `keep` is true if
- *  the working tree is dirty (uncommitted/untracked changes) OR the branch has
- *  commits the base branch doesn't (un-integrated / would-be-PR commits). Ephemeral
- *  workers never push, so "commits ahead of base" is the local proxy for "un-pushed
- *  / open PR" work. Fails SAFE: any git query we can't run is treated as "there
- *  might be work" → keep, so an uncertain state never triggers an auto-remove. */
+/** 这个 worktree 是否含有“绝不能自动丢弃”的工作？当工作树是脏的
+ *  （未提交/未跟踪的改动）或分支上有 base 分支没有的提交
+ *  （未集成/将成为 PR 的提交）时，`keep` 为 true。临时 worker 从不 push，
+ *  因此“领先 base 的提交”就是“未 push / 开着的 PR”工作的本地代理。
+ *  失败时安全：任何我们无法运行的 git 查询都被当作“可能有工作”→ keep，
+ *  这样不确定状态绝不会触发自动移除。 */
 export async function worktreeHasUnintegratedWork(
   wtPath: string, baseBranch: string
 ): Promise<{ keep: boolean; detail: string; branch: string; dirty: boolean; ahead: number }> {
   const br = await getBranch(wtPath);
   const branch = 'current' in br && br.current ? br.current : '(detached)';
-  // Uncommitted or untracked changes?
+  // 有没有未提交或未跟踪的改动？
   const status = await runGit(wtPath, ['status', '--porcelain']);
-  const dirty = status.ok ? status.stdout.trim().length > 0 : true; // unknown → assume dirty
-  // Commits on HEAD not reachable from the base branch?
+  const dirty = status.ok ? status.stdout.trim().length > 0 : true; // 未知 → 假定为脏
+  // HEAD 上有从 base 分支无法抵达的提交？
   let ahead = 0;
   let aheadKnown = true;
   const rl = await runGit(wtPath, ['rev-list', '--count', `${baseBranch}..HEAD`]);
@@ -282,64 +279,62 @@ export async function worktreeHasUnintegratedWork(
     const n = parseInt(rl.stdout.trim(), 10);
     ahead = Number.isFinite(n) ? n : 0;
   } else {
-    aheadKnown = false; // unknown → assume there is work
+    aheadKnown = false; // 未知 → 假定有工作
   }
   const keep = dirty || ahead > 0 || !aheadKnown;
   const detail = `dirty=${dirty}, commitsAheadOf(${baseBranch})=${aheadKnown ? ahead : 'unknown'}`;
   return { keep, detail, branch, dirty, ahead };
 }
 
-/** Is this preserved worker worktree SAFE to garbage-collect — i.e. is its work
- *  fully integrated (or empty) with nothing uncommitted to lose? Used by the
- *  ephemeral-worker GC sweep, which must NEVER discard un-integrated work.
+/** 这个被保留的 worker worktree 是否可以安全地交给垃圾回收——即它的工作
+ *  是否已完全集成（或为空），没有任何未提交的东西会丢失？供临时 worker 的
+ *  GC 清扫使用，它绝不能丢弃未集成的工作。
  *
- *  Returns `gc: true` ONLY when BOTH:
- *    (1) the working tree is clean (no uncommitted/untracked changes), AND
- *    (2) the worker's content is already in `baseBranch` — proven by EITHER
- *        commitsAheadOf(base) === 0 (HEAD reachable from base: fast-forward /
- *        plain merge, robust even after base advances) OR `git diff base HEAD`
- *        being empty (base's tree equals HEAD's tree: catches a SQUASH merge,
- *        which leaves the original commits unreachable so the ahead-count alone
- *        would never clear).
+ *  仅当同时满足以下两条时才返回 `gc: true`：
+ *    (1) 工作树干净（没有未提交/未跟踪的改动），且
+ *    (2) worker 的内容已经在 `baseBranch` 中——由以下任一证明：
+ *        commitsAheadOf(base) === 0（HEAD 可被 base 抵达：快进/普通合并，
+ *        即使 base 已前进仍然稳健），或 `git diff base HEAD` 为空
+ *        （base 的树等于 HEAD 的树：能抓住 SQUASH 合并，它会让原始提交
+ *        不可达，因此仅靠领先数永远无法清零）。
  *
- *  Fails SAFE in every other case: a dirty tree, un-integrated commits, OR any
- *  git query we can't run all yield `gc: false` (keep the worktree). This is the
- *  stronger sibling of `worktreeHasUnintegratedWork` — that gate decides whether
- *  to PRESERVE at teardown; this one decides whether a preserved worktree may now
- *  be reclaimed. */
+ *  其他所有情况都安全失败：脏工作树、未集成提交、或任何我们无法运行的
+ *  git 查询，全部产出 `gc: false`（保留 worktree）。它是
+ *  `worktreeHasUnintegratedWork` 的更强制约——那个门决定拆除时是否
+ *  “保留”；这个决定一个被保留的 worktree 现在是否可以回收。 */
 export async function worktreeIsGcSafe(
   wtPath: string, baseBranch: string
 ): Promise<{ gc: boolean; detail: string }> {
-  // (1) Clean tree?
+  // (1) 工作树干净？
   const status = await runGit(wtPath, ['status', '--porcelain']);
   if (!status.ok) return { gc: false, detail: 'status query failed' };
   if (status.stdout.trim().length > 0) return { gc: false, detail: 'working tree dirty' };
-  // (2a) HEAD fully reachable from base (ahead == 0)?
+  // (2a) HEAD 完全可被 base 抵达（领先数 == 0）？
   const rl = await runGit(wtPath, ['rev-list', '--count', `${baseBranch}..HEAD`]);
   if (rl.ok) {
     const n = parseInt(rl.stdout.trim(), 10);
     if (Number.isFinite(n) && n === 0) return { gc: true, detail: `clean + 0 commits ahead of ${baseBranch}` };
   }
-  // (2b) base tree identical to HEAD tree (squash-merge / equivalent content)?
-  // `git diff --quiet <base> HEAD` → exit 0 (ok) means NO differences.
+  // (2b) base 的树与 HEAD 的树相同（squash 合并/内容等价）？
+  // `git diff --quiet <base> HEAD` → 退出码 0（ok）表示没有任何差异。
   const diff = await runGit(wtPath, ['diff', '--quiet', baseBranch, 'HEAD']);
   if (diff.ok) return { gc: true, detail: `clean + tree identical to ${baseBranch} (integrated/squashed)` };
-  // Either there are real un-integrated commits, or a query failed → keep.
+  // 要么确有未集成的提交，要么查询失败 → 保留。
   return { gc: false, detail: `clean but content not yet in ${baseBranch}` };
 }
 
-// ─── v0.3.4: history / compare / checkout plumbing (git visualization) ───────
+// ─── v0.3.4：历史 / 对比 / 检出管道（git 可视化）──────────────────────────
 
-/** Renderer-supplied revs/refs are untrusted strings. Allow the conservative
- *  charset git refs actually use, refuse leading '-' (option injection), and
- *  always pass '--' before any path arguments at call sites. */
+/** 渲染进程提供的 revs/refs 是不可信字符串。只允许 git ref 实际使用的
+ *  保守字符集，拒绝开头的 '-'（选项注入），并且调用处总是在任何路径参数
+ *  之前传 '--'。 */
 export function isSafeRev(rev: string): boolean {
   return rev.length > 0 && rev.length <= 256 && !rev.startsWith('-') && /^[0-9A-Za-z._/^~@{}-]+$/.test(rev);
 }
 
-/** Full-history DAG page for the commit graph. Same record shape as getLog but
- *  topologically ordered (the graph layout assumes it) and pageable. Run this
- *  against mainRepoRoot(cwd) so every agent worktree branch appears. */
+/** 提交图的全历史 DAG 分页。与 getLog 相同的记录形状，但是拓扑排序
+ *  （图布局依赖这一点）且可分页。对 mainRepoRoot(cwd) 运行它，
+ *  这样每个 agent worktree 的分支都会出现。 */
 export async function getLogGraph(cwd: string, n: number, skip = 0): Promise<GitCommit[] | { error: string }> {
   const sep = '\x1e';
   const fsep = '\x1f';
@@ -369,18 +364,18 @@ export async function getLogGraph(cwd: string, n: number, skip = 0): Promise<Git
 
 export interface GitCommitFile {
   path: string;
-  status: string;      // A/M/D/R/C/T…
-  oldPath?: string;    // for renames/copies
+  status: string;      // A/M/D/R/C/T…（新增/修改/删除/重命名/复制/类型变更）
+  oldPath?: string;    // 用于重命名/复制
 }
 
-/** Parse `-z --name-status` output shared by diff-tree and diff. Records are
- *  STATUS\0path\0 — with renames/copies STATUS<score>\0old\0new\0. */
+/** 解析 diff-tree 和 diff 共用的 `-z --name-status` 输出。记录格式为
+ *  STATUS\0path\0——重命名/复制时为 STATUS<score>\0old\0new\0。 */
 function parseNameStatusZ(stdout: string): GitCommitFile[] {
   const tokens = stdout.split('\0').filter((t) => t.length > 0);
   const files: GitCommitFile[] = [];
   for (let i = 0; i < tokens.length; i++) {
     const status = tokens[i];
-    if (!/^[A-Z]/.test(status)) continue; // skip stray commit ids
+    if (!/^[A-Z]/.test(status)) continue; // 跳过杂散的提交 id
     const kind = status[0];
     if (kind === 'R' || kind === 'C') {
       const oldPath = tokens[i + 1];
@@ -396,7 +391,7 @@ function parseNameStatusZ(stdout: string): GitCommitFile[] {
   return files;
 }
 
-/** Files touched by one commit (rename-aware). */
+/** 单个提交改动的文件（识别重命名）。 */
 export async function getCommitFiles(cwd: string, sha: string): Promise<GitCommitFile[] | { error: string }> {
   if (!isSafeRev(sha)) return { error: 'invalid revision' };
   const res = await runGit(cwd, ['diff-tree', '--no-commit-id', '-r', '--root', '-z', '-M', '--name-status', sha, '--']);
@@ -404,10 +399,10 @@ export async function getCommitFiles(cwd: string, sha: string): Promise<GitCommi
   return parseNameStatusZ(res.stdout);
 }
 
-const MAX_SHOW_BYTES = 2 * 1024 * 1024; // match getDiff's cap
+const MAX_SHOW_BYTES = 2 * 1024 * 1024; // 与 getDiff 的上限一致
 
-/** One side of a rev-pinned diff: the file's content at `rev` ('' + exists:false
- *  when the path doesn't exist there — e.g. an added file's parent side). */
+/** rev 固定 diff 的一侧：文件在 `rev` 处的内容（该处路径不存在时为 '' +
+ *  exists:false——例如新增文件的父侧）。 */
 export async function getFileAtRev(cwd: string, rev: string, relPath: string): Promise<
   { ok: true; exists: boolean; isBinary: boolean; content: string } | { ok: false; error: string }
 > {
@@ -416,7 +411,7 @@ export async function getFileAtRev(cwd: string, rev: string, relPath: string): P
   const size = await runGit(cwd, ['cat-file', '-s', `${rev}:${relPath}`]);
   if (!size.ok) return { ok: true, exists: false, isBinary: false, content: '' };
   if ((parseInt(size.stdout.trim(), 10) || 0) > MAX_SHOW_BYTES) {
-    return { ok: false, error: 'file too large to diff (>2 MB)' };
+    return { ok: false, error: '文件过大，无法 diff（>2 MB）' };
   }
   const res = await runGit(cwd, ['show', `${rev}:${relPath}`]);
   if (!res.ok) return { ok: true, exists: false, isBinary: false, content: '' };
@@ -425,14 +420,14 @@ export async function getFileAtRev(cwd: string, rev: string, relPath: string): P
 }
 
 export interface GitCompare {
-  ahead: number;        // commits in head, not base
-  behind: number;       // commits in base, not head
+  ahead: number;        // head 有而 base 没有的提交
+  behind: number;       // base 有而 head 没有的提交
   mergeBase: string | null;
   files: GitCommitFile[];
 }
 
-/** Compare two refs. mode 'three' (default, PR-style): what head adds since the
- *  merge base. mode 'two': the literal state difference base→head. */
+/** 对比两个 ref。mode 'three'（默认，PR 风格）：head 自合并基以来新增了什么。
+ *  mode 'two'：base→head 的字面状态差异。 */
 export async function compareRefs(cwd: string, base: string, head: string, mode: 'two' | 'three'): Promise<GitCompare | { error: string }> {
   if (!isSafeRev(base) || !isSafeRev(head)) return { error: 'invalid revision' };
   const counts = await runGit(cwd, ['rev-list', '--left-right', '--count', `${base}...${head}`]);
@@ -464,20 +459,20 @@ export async function listWorktrees(cwd: string): Promise<GitWorktreeInfo[] | { 
   return out;
 }
 
-/** Guarded checkout (v0.3.4). FAIL-SAFE philosophy like worktreeHasUnintegratedWork:
- *  any doubt → refuse. Guards here cover the repo itself; the IPC layer adds the
- *  "no agent actively working in this tree" guard (it owns the pty registry). */
+/** 有守卫的检出（v0.3.4）。与 worktreeHasUnintegratedWork 相同的安全失败哲学：
+ *  任何疑虑 → 拒绝。这里的守卫覆盖仓库本身；IPC 层外加
+ *  “没有 agent 正在此树中工作”的守卫（它拥有 pty 注册表）。 */
 export async function checkoutRef(cwd: string, ref: string, detach: boolean): Promise<{ ok: true; detached: boolean } | { ok: false; error: string }> {
   if (!isSafeRev(ref)) return { ok: false, error: 'invalid revision' };
   const st = await getStatus(cwd);
-  if ('error' in st) return { ok: false, error: `could not verify a clean tree: ${st.error}` };
+  if ('error' in st) return { ok: false, error: `无法验证干净的树：${st.error}` };
   const dirty = st.staged.length + st.unstaged.length;
   if (dirty > 0) {
-    return { ok: false, error: `working tree has ${dirty} uncommitted change${dirty === 1 ? '' : 's'} — commit or stash first` };
+    return { ok: false, error: `工作树有 ${dirty} 处未提交的变更——请先提交或暂存` };
   }
   const res = await runGit(cwd, detach ? ['switch', '--detach', ref] : ['switch', ref], 15000);
   if (!res.ok) {
-    // A branch held by another worktree: name the holder instead of raw stderr.
+    // 被另一个 worktree 占用的分支：指出占用者，而不是裸抛 stderr。
     if (/already checked out|already used by worktree/i.test(res.error)) {
       const wts = await listWorktrees(cwd);
       const holder = Array.isArray(wts) ? wts.find((w) => w.branch === ref.replace(/^refs\/heads\//, '')) : undefined;

--- a/src/main/github.ts
+++ b/src/main/github.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 
-/** A GitHub issue, normalized for the renderer (labels/assignees flattened to names). */
+/** 一个 GitHub issue，为渲染进程归一化（labels/assignees 铺平为名字）。 */
 export interface GHIssue {
   number: number;
   title: string;
@@ -10,7 +10,7 @@ export interface GHIssue {
   assignees: string[];
 }
 
-/** Shape `gh issue list --json` emits for each issue (the fields we ask for). */
+/** `gh issue list --json` 为每个 issue 输出的形状（即我们要求的字段）。 */
 interface RawGHIssue {
   number?: number;
   title?: string;
@@ -22,11 +22,11 @@ interface RawGHIssue {
 }
 
 /**
- * List up to 30 issues in the repo at `cwd` via the `gh` CLI.
+ * 通过 `gh` CLI 列出 `cwd` 仓库中最多 30 个 issue。
  *
- * Returns `{ ok: false, error }` on any failure — spawn error (e.g. `gh` not
- * installed), non-zero exit (e.g. unauthenticated / not a repo), or a JSON
- * parse failure — so callers never have to try/catch.
+ * 任何失败都返回 `{ ok: false, error }`——spawn 错误（例如未安装 `gh`）、
+ * 非零退出（例如未认证 / 不是仓库）、或 JSON 解析失败——
+ * 因此调用方永远不需要 try/catch。
  */
 export function listIssues(cwd: string): Promise<{ ok: boolean; issues?: GHIssue[]; error?: string }> {
   return new Promise((resolve) => {
@@ -63,7 +63,7 @@ export function listIssues(cwd: string): Promise<{ ok: boolean; issues?: GHIssue
   });
 }
 
-/** A CI (GitHub Actions) workflow run, normalized for the renderer. */
+/** 一次 CI（GitHub Actions）工作流运行，为渲染进程归一化。 */
 export interface CIRun {
   name: string;
   status: string;
@@ -71,7 +71,7 @@ export interface CIRun {
   url: string;
 }
 
-/** Shape `gh run list --json` emits for each run (the fields we ask for). */
+/** `gh run list --json` 为每次运行输出的形状（即我们要求的字段）。 */
 interface RawCIRun {
   name?: string;
   status?: string;
@@ -81,12 +81,12 @@ interface RawCIRun {
 }
 
 /**
- * List up to 5 recent CI (GitHub Actions) workflow runs in the repo at `cwd`
- * via the `gh` CLI.
+ * 通过 `gh` CLI 列出 `cwd` 仓库中最多 5 条最近的 CI（GitHub Actions）
+ * 工作流运行。
  *
- * Returns `{ ok: false, error }` on any failure — spawn error (e.g. `gh` not
- * installed), non-zero exit (e.g. unauthenticated / not a repo / no Actions),
- * or a JSON parse failure — so callers never have to try/catch.
+ * 任何失败都返回 `{ ok: false, error }`——spawn 错误（例如未安装 `gh`）、
+ * 非零退出（例如未认证 / 不是仓库 / 没有 Actions）、或 JSON 解析失败——
+ * 因此调用方永远不需要 try/catch。
  */
 export function listCIRuns(cwd: string): Promise<{ ok: boolean; runs?: CIRun[]; error?: string }> {
   return new Promise((resolve) => {

--- a/src/main/groq.ts
+++ b/src/main/groq.ts
@@ -1,12 +1,12 @@
 /**
- * Groq chat completion for VDE AI assist, run only from Electron main.
+ * 供 VDE AI 辅助使用的 Groq 聊天补全，只在 Electron 主进程中运行。
  *
- * REQ-GQ-1: the Groq key is accepted as an argument from main config and is used
- * only in Authorization. It is never logged or returned.
- * REQ-GQ-2: this module returns suggestion text only; it has no fs/pty side
- * effects, so LLM output cannot auto-write files or type into terminals.
- * REQ-GQ-3: endpoint is pinned to Groq, request size is bounded, and payloads
- * with obvious secret material are blocked before egress.
+ * REQ-GQ-1：Groq key 作为参数从主进程 config 接收，仅用于 Authorization。
+ * 它绝不记录日志或返回。
+ * REQ-GQ-2：本模块只返回建议文本；它没有任何 fs/pty 副作用，
+ * 因此 LLM 输出不能自动写文件或向终端输入文字。
+ * REQ-GQ-3：端点固定为 Groq，请求大小有上限，明显含机密材料的
+ * 负载在离开前就会被拦截。
  */
 
 export const DEFAULT_GROQ_CHAT_MODEL = 'llama-3.1-8b-instant';
@@ -113,7 +113,7 @@ export async function groqChat(opts: GroqChatOptions): Promise<GroqChatResult> {
             opts.onToken?.(token);
           }
         } catch {
-          // Ignore malformed event chunks; the final accumulated text is what matters.
+          // 忽略格式错误的事件块；最终累积的文本才是关键。
         }
       }
     }

--- a/src/main/hero.ts
+++ b/src/main/hero.ts
@@ -1,11 +1,9 @@
 /**
- * Fetch + cache the Settings hero payload.
+ * 获取 + 缓存 Settings 的 hero 负载。
  *
- * Same shape as the skills catalog: served from cache when fresh, refreshed in
- * the background otherwise, and NEVER fatal — a failed fetch falls back to the
- * cached copy, then to the defaults compiled into the app. The card must render
- * instantly and offline, because it sits at the top of a dialog people open to
- * change a folder.
+ * 与技能目录形状相同：新鲜时从缓存提供，否则后台刷新，并且绝不致命——
+ * 抓取失败先回退到缓存副本，再回退到编译进应用的默认值。卡片必须能
+ * 即时且离线渲染，因为它位于人们为更换文件夹而打开的那个对话框顶部。
  */
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
@@ -14,7 +12,7 @@ import { parseHeroPayload, DEFAULT_HERO, type HeroPayload } from '../shared/hero
 
 const HERO_URL =
   'https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/main/docs/hero.json';
-/** Plan copy and sponsors change on a human timescale. */
+/** 套餐文案和赞助商按人类时间尺度变化。 */
 const TTL_MS = 6 * 60 * 60 * 1000;
 
 export async function loadHero(
@@ -32,14 +30,14 @@ export async function loadHero(
 
   try {
     const body = await getText(HERO_URL, { timeoutMs: 8000 });
-    // Parse the JSON and the SHAPE separately: valid JSON that is not a hero
-    // payload must still degrade to defaults rather than render as undefined.
+    // 分别解析 JSON 和“形状”：是合法 JSON 但不是 hero
+    // 负载的内容也必须降级为默认值，而不是渲染成 undefined。
     const hero = parseHeroPayload(JSON.parse(body));
     const payload = { hero, fetchedAt: Date.now() };
     try {
       mkdirSync(dirname(cachePath), { recursive: true });
       writeFileSync(cachePath, JSON.stringify(payload));
-    } catch { /* cache is an optimisation */ }
+    } catch { /* 缓存是一种优化 */ }
     return { ...payload, stale: false };
   } catch {
     if (cached) return { hero: cached.hero, fetchedAt: cached.fetchedAt, stale: true };

--- a/src/main/hiddenClaude.ts
+++ b/src/main/hiddenClaude.ts
@@ -7,56 +7,56 @@ import { projectDir } from './transcript';
 import { ensureKilled } from './procKill';
 
 /**
- * Shared helper: run a HIDDEN interactive claude session (ephemeral PTY) and
- * return the assistant's final text response.
+ * 共享辅助函数：运行一个“隐藏式”交互 claude 会话（临时 PTY），返回
+ * 助手最终的文本回复。
  *
- * "Hidden" means: not added to the PtyManager, not emitted to the renderer,
- * not visible in the agent list or OfficeFloor scene. Each call spawns its own
- * session and kills it after capture — no /clear needed, no context bleed.
+ * “隐藏”意味着：不加入 PtyManager、不向渲染进程发出、不出现在 agent
+ * 列表或 OfficeFloor 场景中。每次调用都派生自己的会话，捕获后立即杀掉——
+ * 无需 /clear，上下文不会串味。
  *
- * Uses an interactive PTY (not `claude -p`) so calls draw from the user's
- * normal interactive plan quota, not the Agent SDK credit that moves to a
- * separate claim-required pool from 2026-06-15.
+ * 使用交互式 PTY（而不是 `claude -p`），这样调用消耗的是用户常规的
+ * 交互式 plan 配额，而不是从 2026-06-15 起转移到独立“需领取”池的
+ * Agent SDK 额度。
  *
- * Session lifecycle:
- *   spawn → boot-quiet detect → bracketed-paste prompt + \r → idle-settle →
- *   transcript JSONL extract (last assistant text block) → kill
+ * 会话生命周期：
+ *   spawn → 检测启动完成（输出安静）→ 括号粘贴提示 + \r → 空闲稳定 →
+ *   从 transcript JSONL 提取（最后一个助手文本块）→ kill
  */
 
-/** ms of PTY silence that signals the TUI is ready for input (boot complete). */
+/** PTY 安静多少毫秒表示 TUI 已准备好接收输入（启动完成）。 */
 const BOOT_QUIET_MS = 1500;
 
 export interface HiddenClaudeOptions {
-  /** Model to use (e.g. 'claude-haiku-4-5'). */
+  /** 要使用的模型（例如 'claude-haiku-4-5'）。 */
   model: string;
-  /** Working directory for the claude session. */
+  /** claude 会话的工作目录。 */
   cwd: string;
-  /** Base claude command/binary. Defaults to 'claude'. */
+  /** 基础 claude 命令/二进制。默认为 'claude'。 */
   command?: string;
-  /** Tools the session is forbidden to use. Defaults to ['Edit','Write','NotebookEdit']. */
+  /** 会话禁止使用的工具。默认为 ['Edit','Write','NotebookEdit']。 */
   disallowedTools?: string[];
-  /** Directories added via --add-dir (for context gathering). */
+  /** 通过 --add-dir 加入的目录（用于收集上下文）。 */
   addDirs?: string[];
-  /** Hard cap ms before forcing prompt send regardless of boot activity. Default 7000. */
+  /** 无论启动活动如何，强制发送提示词前的硬性毫秒上限。默认 7000。 */
   bootCapMs?: number;
-  /** ms of PTY silence after the prompt that signals response is complete. Default 3500. */
+  /** 提示之后、表示回复完成的 PTY 安静毫秒数。默认 3500。 */
   idleMs?: number;
-  /** Total timeout ms. Default 180000. */
+  /** 总超时毫秒数。默认 180000。 */
   timeoutMs?: number;
-  /** Extra env merged over the resolved shell env (e.g. the shared MemPalace). */
+  /** 在解析出的 shell 环境之上合并的额外 env（例如共享的 MemPalace）。 */
   env?: Record<string, string>;
 }
 
 export interface HiddenClaudeResult {
   ok: boolean;
-  /** The assistant's final text response (stripped of any TUI framing). */
+  /** 助手最终的文本回复（已去除任何 TUI 外壳）。 */
   text?: string;
   error?: string;
 }
 
 /**
- * Extract the last assistant text block from the transcript JSONL written
- * at or after `spawnedAt`. Reuses projectDir() from transcript.ts.
+ * 从 `spawnedAt` 或其之后写入的 transcript JSONL 中提取最后一个助手
+ * 文本块。复用 transcript.ts 的 projectDir()。
  */
 function extractLastAssistantText(cwd: string, spawnedAt: number): string | null {
   try {
@@ -68,10 +68,10 @@ function extractLastAssistantText(cwd: string, spawnedAt: number): string | null
       if (!f.endsWith('.jsonl')) continue;
       try {
         const mtime = statSync(path.join(dir, f)).mtimeMs;
-        // 5 s slack: include files that already existed at spawn but were
-        // updated by this session. Sort by mtime and take the newest.
+        // 5 秒余量：把 spawn 时已存在、但被本会话更新过的文件
+        // 也算进来。按 mtime 排序并取最新的。
         if (mtime >= spawnedAt - 5000) candidates.push({ f, mtime });
-      } catch { /* file removed between readdir and stat — skip */ }
+      } catch { /* 文件在 readdir 与 stat 之间被移除——跳过 */ }
     }
     if (!candidates.length) return null;
     candidates.sort((a, b) => b.mtime - a.mtime);
@@ -99,7 +99,7 @@ function extractLastAssistantText(cwd: string, spawnedAt: number): string | null
 export function runHiddenClaude(prompt: string, opts: HiddenClaudeOptions): Promise<HiddenClaudeResult> {
   return new Promise((resolve) => {
     if (!prompt.trim()) { resolve({ ok: false, error: 'empty prompt' }); return; }
-    // Defense-in-depth: `~` is shell syntax, not a path Node understands.
+    // 纵深防御：`~` 是 shell 语法，不是 Node 认识的路径。
     const cwd = opts.cwd ? expandTilde(opts.cwd) : opts.cwd;
     if (!cwd || !existsSync(cwd)) {
       resolve({ ok: false, error: `cwd does not exist: ${opts.cwd}` });
@@ -124,9 +124,9 @@ export function runHiddenClaude(prompt: string, opts: HiddenClaudeOptions): Prom
     const timeoutMs = opts.timeoutMs ?? 180_000;
 
     const spawnedAt = Date.now();
-    // Windows: node-pty's CreateProcess can't exec the npm `.cmd`/extensionless
-    // `claude` shim directly (ERROR_BAD_EXE_FORMAT, error 193) — route non-.exe
-    // targets through cmd.exe. A real claude.exe (WinGet) launches directly. (#22)
+    // Windows：node-pty 的 CreateProcess 无法直接执行 npm 的 `.cmd`/无扩展名
+    // `claude` shim（ERROR_BAD_EXE_FORMAT，错误 193）——把非 .exe
+    // 目标经由 cmd.exe 路由。真正的 claude.exe（WinGet）可直接启动。（#22）
     const winWrap = process.platform === 'win32' && !/\.(exe|com)$/i.test(exe);
     const spawnFile = winWrap ? (process.env.ComSpec || 'cmd.exe') : exe;
     const spawnArgs = winWrap ? ['/c', exe, ...args] : args;
@@ -155,12 +155,12 @@ export function runHiddenClaude(prompt: string, opts: HiddenClaudeOptions): Prom
     let bootMaxTimer: NodeJS.Timeout;
     let globalTimer: NodeJS.Timeout;
 
-    // Hidden sessions are ephemeral CHECKS — nothing they spawn (MCP servers,
-    // helpers) may outlive them. Kill politely, then sweep the process group so
-    // every check releases its PIDs even if `claude` shrugs off the SIGHUP.
+    // 隐藏会话是临时性的“检查”——它们派生的任何东西（MCP 服务器、
+    // 辅助进程）都不得比它们活得更久。礼貌地杀掉，然后清扫进程组，
+    // 即使 `claude` 对 SIGHUP 不理不睬，每个检查也会释放自己的 PID。
     const kill = () => {
       const pid = ptyProc.pid;
-      try { ptyProc.kill(); } catch { /* noop */ }
+      try { ptyProc.kill(); } catch { /* 空操作 */ }
       ensureKilled(pid);
     };
 
@@ -186,7 +186,7 @@ export function runHiddenClaude(prompt: string, opts: HiddenClaudeOptions): Prom
       if (settled || promptSent) return;
       promptSent = true;
       if (bootTimer) { clearTimeout(bootTimer); bootTimer = null; }
-      // Bracketed paste + enter — same mechanism as submitToPty in useHive.ts.
+      // 括号粘贴 + 回车——与 useHive.ts 中 submitToPty 相同的机制。
       ptyProc.write(`\x1b[200~${prompt}\x1b[201~`);
       setTimeout(() => { if (!settled) ptyProc.write('\r'); }, 140);
     };
@@ -199,17 +199,17 @@ export function runHiddenClaude(prompt: string, opts: HiddenClaudeOptions): Prom
 
     ptyProc.onData(() => {
       if (!promptSent) {
-        // Boot phase: reset quiet timer; send prompt once output goes quiet.
+        // 启动阶段：重置安静计时器；输出一安静就发送提示词。
         if (bootTimer) clearTimeout(bootTimer);
         bootTimer = setTimeout(sendPrompt, BOOT_QUIET_MS);
       } else {
-        // Response phase: reset idle timer; capture when output settles.
+        // 回复阶段：重置空闲计时器；输出稳定时捕获。
         if (idleTimer) clearTimeout(idleTimer);
         idleTimer = setTimeout(captureAndFinish, idleMs);
       }
     });
 
-    // Session exited cleanly before idle — try to capture the transcript anyway.
+    // 会话在空闲前就干净退出——无论如何都尝试捕获 transcript。
     ptyProc.onExit(() => { if (!settled) captureAndFinish(); });
   });
 }

--- a/src/main/hire.ts
+++ b/src/main/hire.ts
@@ -1,9 +1,8 @@
 /**
- * Hire-manifest transport for the main process: fetch a manifest from an https
- * URL (deep link) or read one from disk (file import), and validate it via the
- * shared, dependency-free validator. See `src/shared/hire.ts` for the spec and
- * security model. Deliberately free of any `electron` import so it can be
- * smoke-tested as a plain Node module (mirrors webhook.ts's approach).
+ * 主进程的 hire-manifest 传输：从 https URL（深链接）抓取清单，或从磁盘
+ * 读取（文件导入），并通过共享的、零依赖的校验器验证。规格与安全模型见
+ * `src/shared/hire.ts`。刻意不 import 任何 `electron`，因此可以当作普通
+ * Node 模块做冒烟测试（与 webhook.ts 的做法一致）。
  */
 import { readFileSync, statSync } from 'node:fs';
 import { lookup } from 'node:dns/promises';
@@ -21,43 +20,42 @@ export type HireResult = { ok: true; manifest: HireManifest } | { ok: false; err
 
 function finish(v: HireValidation): HireResult {
   if (v.ok && v.manifest) return { ok: true, manifest: v.manifest };
-  return { ok: false, error: `invalid hire manifest: ${v.errors.join('; ')}` };
+  return { ok: false, error: `无效的 hire manifest：${v.errors.join('; ')}` };
 }
 
-/** Address ranges we must never fetch from (SSRF guard): loopback, RFC1918
- *  private, link-local incl. the 169.254.169.254 cloud-metadata endpoint, CGNAT,
- *  ULA, deprecated site-local, and unspecified/multicast/reserved. https alone
- *  does NOT make a target safe — a remote manifest can point/redirect at
- *  https://10.x or https://169.254.169.254, so the resolved ADDRESS is gated.
- *  node:net's BlockList does real prefix-membership (subnet math), which replaces
- *  the earlier hand-rolled v6 string-prefix logic that a v4-mapped hex form
- *  (e.g. ::ffff:7f00:1, the shape `new URL()` actually emits) sailed straight
- *  past. v4-in-v6 forms are de-mapped to their embedded v4 below before checking. */
+/** 我们绝不允许抓取的地址范围（SSRF 守卫）：回环、RFC1918 私网、链路本地
+ *  （含 169.254.169.254 云元数据端点）、CGNAT、ULA、已废弃的 site-local，
+ *  以及未指定/组播/保留地址。仅 https 并不能让目标安全——远程清单可以
+ *  指向/重定向到 https://10.x 或 https://169.254.169.254，因此被把关的是
+ *  解析后的“地址”。node:net 的 BlockList 做真正的前缀归属判断（子网运算），
+ *  取代了早先手写的 v6 字符串前缀逻辑——那种 v4 映射的十六进制形式
+ *  （例如 ::ffff:7f00:1，正是 `new URL()` 实际输出的形状）能直接溜过去。
+ *  下面的检查会把 v4-in-v6 形式先行解映射为内嵌的 v4。 */
 const SSRF_BLOCK = new BlockList();
-// IPv4 ranges.
-SSRF_BLOCK.addSubnet('0.0.0.0', 8, 'ipv4');        // 0.0.0.0/8 "this network" / unspecified
+// IPv4 范围。
+SSRF_BLOCK.addSubnet('0.0.0.0', 8, 'ipv4');        // 0.0.0.0/8 “本网络”/ 未指定
 SSRF_BLOCK.addSubnet('10.0.0.0', 8, 'ipv4');       // RFC1918
 SSRF_BLOCK.addSubnet('100.64.0.0', 10, 'ipv4');    // CGNAT
-SSRF_BLOCK.addSubnet('127.0.0.0', 8, 'ipv4');      // loopback
-SSRF_BLOCK.addSubnet('169.254.0.0', 16, 'ipv4');   // link-local + 169.254.169.254 cloud metadata
+SSRF_BLOCK.addSubnet('127.0.0.0', 8, 'ipv4');      // 回环
+SSRF_BLOCK.addSubnet('169.254.0.0', 16, 'ipv4');   // 链路本地 + 169.254.169.254 云元数据
 SSRF_BLOCK.addSubnet('172.16.0.0', 12, 'ipv4');    // RFC1918
 SSRF_BLOCK.addSubnet('192.168.0.0', 16, 'ipv4');   // RFC1918
-SSRF_BLOCK.addSubnet('224.0.0.0', 3, 'ipv4');      // 224/4 multicast + 240/4 reserved + broadcast
-// IPv6 ranges.
-SSRF_BLOCK.addAddress('::1', 'ipv6');              // loopback
-SSRF_BLOCK.addAddress('::', 'ipv6');               // unspecified
-SSRF_BLOCK.addSubnet('fc00::', 7, 'ipv6');         // ULA (fc00::/7)
-SSRF_BLOCK.addSubnet('fe80::', 10, 'ipv6');        // link-local (fe80::/10)
-SSRF_BLOCK.addSubnet('fec0::', 10, 'ipv6');        // deprecated site-local (fec0::/10)
-SSRF_BLOCK.addSubnet('ff00::', 8, 'ipv6');         // multicast (ff00::/8)
+SSRF_BLOCK.addSubnet('224.0.0.0', 3, 'ipv4');      // 224/4 组播 + 240/4 保留 + 广播
+// IPv6 范围。
+SSRF_BLOCK.addAddress('::1', 'ipv6');              // 回环
+SSRF_BLOCK.addAddress('::', 'ipv6');               // 未指定
+SSRF_BLOCK.addSubnet('fc00::', 7, 'ipv6');         // ULA（fc00::/7）
+SSRF_BLOCK.addSubnet('fe80::', 10, 'ipv6');        // 链路本地（fe80::/10）
+SSRF_BLOCK.addSubnet('fec0::', 10, 'ipv6');        // 已废弃的 site-local（fec0::/10）
+SSRF_BLOCK.addSubnet('ff00::', 8, 'ipv6');         // 组播（ff00::/8）
 
-/** Expand an IPv6 literal into its eight 16-bit groups, handling `::` compression
- *  and a trailing embedded dotted-quad. Returns null if malformed (→ fail closed). */
+/** 把 IPv6 字面量展开成八个 16 位组，处理 `::` 压缩和尾部内嵌的点分四段。
+ *  格式错误时返回 null（→ 关闭即失败）。 */
 function v6Groups(v6: string): number[] | null {
   let s = v6;
   const pct = s.indexOf('%');
-  if (pct >= 0) s = s.slice(0, pct); // drop any zone id
-  // A trailing dotted-quad (e.g. ::ffff:127.0.0.1) becomes two hex groups.
+  if (pct >= 0) s = s.slice(0, pct); // 丢弃任何 zone id
+  // 尾部的点分四段（例如 ::ffff:127.0.0.1）变成两个十六进制组。
   const lastColon = s.lastIndexOf(':');
   const tail = s.slice(lastColon + 1);
   if (tail.includes('.')) {
@@ -73,7 +71,7 @@ function v6Groups(v6: string): number[] | null {
   const back = halves.length === 2 ? (halves[1] ? halves[1].split(':') : []) : null;
   let groups: string[];
   if (back === null) {
-    groups = head; // no `::`
+    groups = head; // 没有 `::`
   } else {
     const missing = 8 - head.length - back.length;
     if (missing < 0) return null;
@@ -84,26 +82,25 @@ function v6Groups(v6: string): number[] | null {
   return nums.some((n) => Number.isNaN(n)) ? null : nums;
 }
 
-/** If a v6 literal embeds an IPv4 destination — v4-mapped `::ffff:a.b.c.d` (in
- *  BOTH dotted and hex-group form), the deprecated v4-compatible `::a.b.c.d`,
- *  NAT64 `64:ff9b::/96`, or 6to4 `2002::/16` — return that dotted v4 so the v4
- *  classifier gates it. These all route to a v4 destination, and the hex-group
- *  form is exactly what bypassed the old textual v6 check. Else null. */
+/** 若 v6 字面量内嵌了一个 IPv4 目的地——v4 映射的 `::ffff:a.b.c.d`（点分和
+ *  十六进制组两种形式都算）、已废弃的 v4 兼容 `::a.b.c.d`、NAT64
+ *  `64:ff9b::/96`、或 6to4 `2002::/16`——返回那个点分 v4，让 v4 分类器
+ *  把关。这些都路由到 v4 目的地，而十六进制组形式正是绕过旧文本 v6 检查
+ *  的元凶。否则返回 null。 */
 function embeddedV4(v6: string): string | null {
   const g = v6Groups(v6);
   if (!g) return null;
   const v4 = (hi: number, lo: number): string => `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
   const top6zero = g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0;
-  if (top6zero && g[5] === 0xffff) return v4(g[6], g[7]);                            // ::ffff:a.b.c.d (v4-mapped)
-  if (top6zero && g[5] === 0 && (g[6] !== 0 || g[7] !== 0)) return v4(g[6], g[7]);   // ::a.b.c.d / ::1 (v4-compatible)
+  if (top6zero && g[5] === 0xffff) return v4(g[6], g[7]);                            // ::ffff:a.b.c.d（v4 映射）
+  if (top6zero && g[5] === 0 && (g[6] !== 0 || g[7] !== 0)) return v4(g[6], g[7]);   // ::a.b.c.d / ::1（v4 兼容）
   if (g[0] === 0x0064 && g[1] === 0xff9b && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0) return v4(g[6], g[7]); // NAT64 64:ff9b::/96
   if (g[0] === 0x2002) return v4(g[1], g[2]);                                        // 6to4 2002::/16
   return null;
 }
 
-/** True if an IP LITERAL resolves into a blocked range. v4-in-v6 forms are
- *  de-mapped to the embedded v4 first; anything not parseable as an IP fails
- *  closed (returns true). */
+/** 当 IP 字面量落入被封禁的范围时返回 true。v4-in-v6 形式先解映射为内嵌的
+ *  v4；任何无法解析为 IP 的内容都按“关闭即失败”处理（返回 true）。 */
 function isBlockedIp(ip: string): boolean {
   const addr = ip.trim().toLowerCase();
   const kind = isIP(addr);
@@ -113,15 +110,15 @@ function isBlockedIp(ip: string): boolean {
     if (v4 && isIP(v4) === 4) return SSRF_BLOCK.check(v4, 'ipv4');
     return SSRF_BLOCK.check(addr, 'ipv6');
   }
-  return true; // not a parseable IP literal → fail closed
+  return true; // 不是可解析的 IP 字面量 → 关闭即失败
 }
 
-/** Resolve a host (or use the literal IP) and return true if ANY resolved
- *  address is in a blocked range. Unresolvable → blocked (fail closed). Closes
- *  the simple DNS-to-internal SSRF; a determined rebind between this lookup and
- *  fetch()'s own resolution is a residual we accept for v1 (no connection pinning). */
+/** 解析主机（或直接用字面量 IP），若“任一”解析出的地址在封禁范围内则返回
+ *  true。无法解析 → 视为封禁（关闭即失败）。堵住简单的 DNS 转内部 SSRF；
+ *  本查找与 fetch() 自身解析之间被蓄意 rebind 的攻击，是 v1 接受下来的
+ *  残余风险（不做连接钉扎）。 */
 async function isInternalHost(hostname: string): Promise<boolean> {
-  const host = hostname.replace('[', '').replace(']', ''); // strip IPv6 brackets
+  const host = hostname.replace('[', '').replace(']', ''); // 去掉 IPv6 括号
   if (isIP(host)) return isBlockedIp(host);
   try {
     const addrs = await lookup(host, { all: true });
@@ -129,45 +126,42 @@ async function isInternalHost(hostname: string): Promise<boolean> {
   } catch { return true; }
 }
 
-/** SSRF gate for ONE url — the initial request AND every redirect hop. The only
- *  internal target permitted is the documented http-loopback dev gallery (already
- *  gated by isAllowedManifestUrl); every other target must resolve to a PUBLIC
- *  address. Returns an error string when the target is internal, else null. */
+/** 对“单个”url 的 SSRF 门——初始请求以及每一跳重定向都要过。唯一允许的
+ *  内部目标是文档化的 http-loopback 开发画廊（已由 isAllowedManifestUrl
+ *  把关）；其余每个目标都必须解析到公网地址。目标为内部时返回错误字符串，
+ *  否则返回 null。 */
 async function assertPublicTarget(u: URL): Promise<string | null> {
   const devLoopbackHttp = u.protocol === 'http:' &&
     (u.hostname === 'localhost' || u.hostname === '127.0.0.1' || u.hostname === '[::1]');
   if (devLoopbackHttp) return null;
   if (await isInternalHost(u.hostname)) {
-    return 'manifest URL resolves to a private/loopback/link-local address (SSRF blocked)';
+    return 'manifest 地址解析到私网/回环/链路本地地址（已阻止 SSRF）';
   }
   return null;
 }
 
-/** Fetch + validate a hire manifest from an https URL. Bounded: 10s timeout,
- *  64 KB body cap, https only (the deep-link parser already enforces https,
- *  but this is also called with user-pasted URLs). */
+/** 从 https URL 抓取 + 校验 hire 清单。有边界：10 秒超时、64 KB 响应体
+ *  上限、仅 https（深链接解析器已经强制 https，但这里也会被用户粘贴的
+ *  URL 调用）。 */
 export async function fetchHireManifest(src: string): Promise<HireResult> {
   let url: URL;
-  try { url = new URL(src); } catch { return { ok: false, error: 'not a valid URL' }; }
-  if (!isAllowedManifestUrl(url)) return { ok: false, error: 'manifest URL must be https (http allowed for localhost only)' };
+  try { url = new URL(src); } catch { return { ok: false, error: '不是有效的 URL' }; }
+  if (!isAllowedManifestUrl(url)) return { ok: false, error: 'manifest 地址必须是 https（仅 localhost 允许 http）' };
 
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), 10_000);
   try {
-    // redirect:'manual' — `follow` would only validate the INITIAL url, so a
-    // remote https manifest could 302 to http://127.0.0.1:PORT/... or a cloud
-    // metadata endpoint, turning a clicked link into a blind GET to an internal
-    // service. We follow hops ourselves and re-validate each Location.
-    //   - the INITIAL url may be http-loopback (local gallery dev served over
-    //     http://localhost) — isAllowedManifestUrl permits that;
-    //   - a REDIRECT TARGET must be https. A real gallery never needs to bounce
-    //     you into loopback/internal http, and requiring https on hops closes
-    //     redirect-based SSRF to 127.0.0.1:PORT and link-local/metadata IPs
-    //     outright, while https→https redirects (shorteners, CDNs) still work.
-    //   - AND the resolved ADDRESS of every target (initial + each hop) must be
-    //     public: https://10.x / https://169.254.169.254 would otherwise sail
-    //     through the https-only check. assertPublicTarget resolves DNS and
-    //     blocks private/loopback/link-local/metadata IPs.
+    // redirect:'manual' —— `follow` 只会校验“初始”url，因此远程 https 清单
+    // 可以 302 到 http://127.0.0.1:PORT/... 或云元数据端点，把一次点击变成
+    // 对内部服务的盲目 GET。我们自行跟随每一跳，并重新校验每个 Location。
+    //   - 初始 url 可以是 http-loopback（本地画廊开发时经 http://localhost
+    //     提供服务）——isAllowedManifestUrl 允许它；
+    //   - 重定向目标必须是 https。真正的画廊绝不需要把你弹到回环/内部 http，
+    //     要求每跳 https 能直接堵死基于重定向的 SSRF（127.0.0.1:PORT 和
+    //     链路本地/元数据 IP），同时 https→https 重定向（短链、CDN）仍然可用。
+    //   - 并且每个目标（初始 + 每一跳）解析出的“地址”必须是公网：
+    //     https://10.x / https://169.254.169.254 否则就能溜过仅-https 检查。
+    //     assertPublicTarget 解析 DNS 并封禁私网/回环/链路本地/元数据 IP。
     const ssrf0 = await assertPublicTarget(url);
     if (ssrf0) return { ok: false, error: ssrf0 };
     let current = url;
@@ -180,10 +174,10 @@ export async function fetchHireManifest(src: string): Promise<HireResult> {
       });
       if (res.status >= 300 && res.status < 400) {
         const loc = res.headers.get('location');
-        if (!loc) return { ok: false, error: 'redirect without a location' };
+        if (!loc) return { ok: false, error: '重定向缺少 location' };
         let next: URL;
-        try { next = new URL(loc, current); } catch { return { ok: false, error: 'invalid redirect target' }; }
-        if (next.protocol !== 'https:') return { ok: false, error: 'redirect target must be https (a manifest may not redirect into http/loopback)' };
+        try { next = new URL(loc, current); } catch { return { ok: false, error: '无效的重定向目标' }; }
+        if (next.protocol !== 'https:') return { ok: false, error: '重定向目标必须是 https（manifest 不得重定向进 http/回环）' };
         const ssrfN = await assertPublicTarget(next);
         if (ssrfN) return { ok: false, error: ssrfN };
         current = next;
@@ -191,37 +185,35 @@ export async function fetchHireManifest(src: string): Promise<HireResult> {
       }
       break;
     }
-    if (!res) return { ok: false, error: 'fetch failed' };
-    if (res.status >= 300 && res.status < 400) return { ok: false, error: 'too many redirects' };
-    if (!res.ok) return { ok: false, error: `fetch failed: HTTP ${res.status}` };
+    if (!res) return { ok: false, error: '抓取失败' };
+    if (res.status >= 300 && res.status < 400) return { ok: false, error: '重定向次数过多' };
+    if (!res.ok) return { ok: false, error: `抓取失败：HTTP ${res.status}` };
 
-    // Bound the body as we read it — content-length is attacker-controlled
-    // (absent/chunked skips the check), and `res.text()` would buffer the whole
-    // stream first, so a hostile host could stream unbounded data and OOM us
-    // inside the 10s window. Read chunks, abort once bytes exceed the cap.
+    // 边读边限制响应体——content-length 是攻击者可控制的（缺失/分块会跳过
+    // 检查），而 `res.text()` 会先把整个流缓冲起来，因此恶意主机可以在 10 秒
+    // 窗口内无限流式放数据，把我们 OOM 掉。按块读取，字节数一超上限就中止。
     const len = Number(res.headers.get('content-length') ?? 0);
-    if (len > HIRE_MAX_BYTES) return { ok: false, error: 'manifest too large' };
+    if (len > HIRE_MAX_BYTES) return { ok: false, error: 'manifest 过大' };
     const text = await readBounded(res, HIRE_MAX_BYTES);
-    if (text === null) return { ok: false, error: 'manifest too large' };
+    if (text === null) return { ok: false, error: 'manifest 过大' };
 
     let parsed: unknown;
-    try { parsed = JSON.parse(text); } catch { return { ok: false, error: 'manifest is not valid JSON' }; }
+    try { parsed = JSON.parse(text); } catch { return { ok: false, error: 'manifest 不是有效的 JSON' }; }
     return finish(validateHireManifest(parsed));
   } catch (e) {
-    const msg = e instanceof Error && e.name === 'AbortError' ? 'fetch timed out' : String(e);
-    return { ok: false, error: `fetch failed: ${msg}` };
+    const msg = e instanceof Error && e.name === 'AbortError' ? '抓取超时' : String(e);
+    return { ok: false, error: `抓取失败：${msg}` };
   } finally {
     clearTimeout(timer);
   }
 }
 
-/** Read a response body, decoding as UTF-8, aborting once the byte count exceeds
- *  `maxBytes`. Returns null if the cap is exceeded. Byte-accurate (the cap is a
- *  byte limit, not UTF-16 code units). */
+/** 读取响应体，按 UTF-8 解码，字节数超过 `maxBytes` 即中止。超限返回 null。
+ *  按字节精确计算（上限是字节数，不是 UTF-16 码元）。 */
 async function readBounded(res: Response, maxBytes: number): Promise<string | null> {
   const body = res.body;
   if (!body) {
-    // No stream (e.g. some fetch polyfills) — fall back to text() with a post-check.
+    // 没有流（例如某些 fetch polyfill）——回退到 text() 并事后检查。
     const t = await res.text();
     return Buffer.byteLength(t, 'utf8') > maxBytes ? null : t;
   }
@@ -233,28 +225,27 @@ async function readBounded(res: Response, maxBytes: number): Promise<string | nu
     if (done) break;
     if (value) {
       total += value.byteLength;
-      if (total > maxBytes) { try { await reader.cancel(); } catch { /* noop */ } return null; }
+      if (total > maxBytes) { try { await reader.cancel(); } catch { /* 空操作 */ } return null; }
       chunks.push(value);
     }
   }
   return Buffer.concat(chunks).toString('utf8');
 }
 
-/** Read + validate a hire manifest from a local JSON file (file import). */
+/** 从本地 JSON 文件读取 + 校验 hire 清单（文件导入）。 */
 export function readHireManifestFile(path: string): HireResult {
   try {
-    if (statSync(path).size > HIRE_MAX_BYTES) return { ok: false, error: 'manifest too large' };
+    if (statSync(path).size > HIRE_MAX_BYTES) return { ok: false, error: 'manifest 过大' };
     const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
     return finish(validateHireManifest(parsed));
   } catch (e) {
-    return { ok: false, error: `could not read manifest: ${String(e)}` };
+    return { ok: false, error: `无法读取 manifest：${String(e)}` };
   }
 }
 
-/** Validate a file-picker batch independently: one bad manifest never discards
- * the valid neighbours selected with it. Errors name the file, not its full
- * local path, so the renderer can explain what was skipped without leaking a
- * user's directory structure into logs or screenshots. */
+/** 独立校验文件选择器的一次批量选择：一份坏清单绝不会连带丢弃与它一起
+ * 选中的有效清单。错误只点名文件名，不给出完整本地路径，这样渲染进程
+ * 能解释跳过了什么，又不会把用户的目录结构泄漏进日志或截图。 */
 export function readHireManifestFiles(paths: readonly string[]): {
   manifests: HireManifest[];
   errors: string[];

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1,22 +1,21 @@
 /**
- * The Hive — the on-disk multi-agent coordination layer.
+ * Hive —— 磁盘上的多智能体协调层。
  *
- * Lives under `<harnessHome>/hive/` as a single git repo that ONLY this main
- * process commits to (agents never call git — they just write files). See
- * HIVE.md for the full design. Responsibilities:
- *   - per-agent workspace (identity.md, memory.md, inbox/, outbox/, cursor.json)
- *   - hive identity (registry.json: id/role/cwd/session — what agents read),
- *     separate from the UI floor roster (`<harnessHome>/roster.json`)
- *   - shared blackboard (board.md), task ledger, and an append-only event log (log.jsonl)
- *   - a router that drains each agent's outbox into recipients' inboxes
+ * 位于 `<harnessHome>/hive/` 下，作为单一 git 仓库，只有这个主进程提交
+ * （智能体从不调用 git —— 它们只是写文件）。完整设计见 HIVE.md。职责：
+ *   - 每个智能体的工作区（identity.md、memory.md、inbox/、outbox/、cursor.json）
+ *   - hive 身份（registry.json：id/role/cwd/session —— 智能体读取的内容），
+ *     与 UI 楼层名册（`<harnessHome>/roster.json`）相互独立
+ *   - 共享黑板（board.md）、任务台账，以及仅追加的事件日志（log.jsonl）
+ *   - 一个路由器，将每个智能体的 outbox 清空投递到收件人的 inbox
  *
- * Human-in-the-loop is native to each agent's Claude Code session: permission
- * prompts surface in the agent's own terminal (and can be approved remotely via
- * `/remote-control`). The hive keeps no separate approval queue — a message aimed
- * at "human" is routed to the god/orchestrator, the human's proxy on the floor.
- *   - single-committer git with retry/backoff + stale-lock recovery
+ * 人机协作对每个智能体的 Claude Code 会话是原生的：权限提示会出现在该
+ * 智能体自己的终端中（也可通过 `/remote-control` 远程批准）。Hive 不设独立
+ * 的审批队列 —— 发给 "human" 的消息会被路由到 god/orchestrator，即该人在
+ * 楼层的代理。
+ *   - 单一提交者 git，带重试/退避 + 陈旧锁恢复
  *
- * Everything here runs in the Electron main process.
+ * 这里的一切都运行在 Electron 主进程中。
  */
 import {
   existsSync, mkdirSync, readFileSync, writeFileSync, renameSync,
@@ -44,12 +43,11 @@ import { mergeTaskLedger } from '../shared/taskLedger';
 import { expandTilde } from './fs';
 import { resolveGodName } from '../shared/godIdentity';
 
-/** The subset of HarnessConfig the hive consumes for the default-MCP merge.
- *  Kept as a local shape so hive.ts never imports the foundation-owned config
- *  module just for a type. */
+/** HarnessConfig 中 hive 消费的部分（用于默认 MCP 合并）。
+ *  保持为本地形状，这样 hive.ts 就无需仅为类型而引入基础配置模块。 */
 type McpDefaultsMap = { [id: string]: { enabled: boolean } } | undefined;
 
-// ─── Types ──────────────────────────────────────────────────────────────────
+// ─── 类型 ────────────────────────────────────────────────────────────────────
 
 export type MessageAct = 'request' | 'inform' | 'propose' | 'query' | 'agree' | 'refuse' | 'done';
 
@@ -58,7 +56,7 @@ export interface HiveMessage {
   conversation: string;
   in_reply_to: string | null;
   from: string;
-  to: string;                 // an agentId, 'god', or 'broadcast'
+  to: string;                 // 一个 agentId、'god' 或 'broadcast'
   act: MessageAct;
   subject: string;
   body: string;
@@ -68,33 +66,32 @@ export interface HiveMessage {
   created_at: string;
 }
 
-/** One hive message reshaped for the voice read-layer (`hive:messages`): the
- *  operator-briefing view of an inbox/outbox message. `subject` and `body` are
- *  REDACTED main-side (see {@link redactSecrets}) before this ever leaves the
- *  main process — the renderer/voice layer never sees a raw body, and never a
- *  secret. PII-free + secret-free by construction. */
+/** 一条为语音读取层（`hive:messages`）重塑的 hive 消息：inbox/outbox 消息的
+ *  操作员简报视图。`subject` 和 `body` 在离开主进程前已在主进程侧 REDACTED
+ *  （见 {@link redactSecrets}）—— 渲染器/语音层永远看不到原始 body，也永远
+ *  看不到机密。按构造即无 PII + 无机密。 */
 export interface VoiceMessage {
   id: string;
   conversation: string;
   from: string;
   to: string;
   act: MessageAct;
-  /** REDACTED subject line. */
+  /** 已 REDACTED 的主题行。 */
   subject: string;
-  /** REDACTED message body. */
+  /** 已 REDACTED 的消息正文。 */
   body: string;
   requires_reply: boolean;
-  /** Which mailbox folder this copy was read from, relative to `owner`. */
+  /** 这份副本是从哪个邮箱文件夹读出的，相对于 `owner`。 */
   direction: 'inbox' | 'outbox';
-  /** The agent whose mailbox this copy lives in. */
+  /** 拥有这份副本所在邮箱的智能体。 */
   owner: string;
-  /** True when read from an archived/handled subfolder (inbox/.done, outbox/.sent). */
+  /** 为 true 表示读自归档/已处理子文件夹（inbox/.done、outbox/.sent）。 */
   archived: boolean;
   created_at: string;
 }
 
-/** One question→answer exchange with the human, recorded ON the task card so
- *  the decision trail stays with the work it unblocked. */
+/** 与人类的一次一问一答，记录在任务卡片上，使决策轨迹始终伴随它所
+ *  解除阻塞的工作。 */
 export interface HumanQA {
   q: string;
   a?: string;
@@ -112,60 +109,55 @@ export interface HiveTask {
   dependsOn: string[];
   priority: number;
   createdAt: string;
-  /** First-class human feedback: the god appends {q} when a card can only
-   *  proceed with the human's input (status goes blocked); the harness UI
-   *  fills in {a}. The full history stays on the card forever. */
+  /** 一等公民的人类反馈：当卡片只能靠人类的输入才能推进时，god 追加 {q}
+   *  （状态变为 blocked）；harness UI 填入 {a}。完整历史永远留在卡片上。 */
   humanQA?: HumanQA[];
-  /** Outcome summary, surfaced by the Slack done-notifier when this card reaches
-   *  'done'. Optional; the notifier falls back to description/title. */
+  /** 结果摘要，当此卡片达到 'done' 时由 Slack 完成通知器展示。
+   *  可选；通知器回退到 description/title。 */
   result?: string;
-  /** Set when this task originated from a Slack message — the thread the
-   *  done-summary reply is posted back into. Consumed OUTBOUND only; populating
-   *  it is the inbound/kanban side's job and does not affect routing. */
+  /** 当此任务源自一条 Slack 消息时设置 —— 完成摘要回复会被回贴到的
+   *  线程。仅 OUTBOUND 消费；填充它是 inbound/看板侧的工作，不影响路由。 */
   slack?: { channel: string; thread_ts: string };
-  /** Set when this task originated from a generic webhook POST. Stores the SHA-256
-   *  of the capability token (never the raw token — that's returned to the caller
-   *  once and never persisted), so a GET status lookup can match by hashing the
-   *  presented token. Read-only capability: it never widens routing or exposure. */
+  /** 当此任务源自一个通用 webhook POST 时设置。存储能力令牌的 SHA-256
+   *  （绝不存原始令牌 —— 原始令牌只返回给调用方一次且从不持久化），这样
+   *  GET 状态查询可以通过哈希提交的令牌来匹配。只读能力：它不会扩大路由
+   *  或暴露面。 */
   webhook?: { tokenHash: string };
 }
 
 export interface AgentMeta {
   id: string;
   name: string;
-  /** Which CLI this agent runs on. Defaults to 'claude' when unset (legacy). */
+  /** 此智能体运行在哪个 CLI 上。未设置时默认 'claude'（旧版）。 */
   provider?: AgentProvider;
   role?: string;
   capabilities?: string[];
   cwd: string;
   isGod?: boolean;
-  /** Michael's prep assistant — enriches prompts and forwards them to Michael.
-   *  Send-only: excluded from broadcast fan-out so it never drains an inbox. */
+  /** Michael 的预备助手 —— 丰富提示词并将其转发给 Michael。
+   *  仅发送：从广播扇出中排除，使其永不耗尽 inbox。 */
   isAssistant?: boolean;
 }
 
 export interface RegistryAgent extends AgentMeta {
   status: 'idle' | 'working' | 'blocked' | 'gone';
   lastSeen: number;
-  /** True once the agent's terminal/PTY tab is closed. The record is retained
-   *  (not deleted) so its history/memory survive; only agents with a live PTY
-   *  are 'active'. Broadcast fan-out + roster reads skip archived agents. */
+  /** 智能体的终端/PTY 标签页关闭后为 true。记录被保留（不删除）以使其
+   *  历史/记忆得以存续；只有带活动 PTY 的智能体才算 'active'。广播扇出和
+   *  名册读取会跳过已归档智能体。 */
   archived?: boolean;
-  /** The human has this agent 1:1 and Michael must leave it alone until they
-   *  flip it back. Held agents stay ACTIVE and keep their terminal — this is
-   *  "do not dispatch to them", not "they are gone", which is why it is its own
-   *  flag rather than a reuse of `archived` or a breaker level. */
+  /** 人类正在与此智能体一对一协作，在人类将其切回之前 Michael 必须不打扰它。
+   *  被持有的智能体保持 ACTIVE 并保留其终端 —— 这是「不要分派给它」，不是
+   *  「它已消失」，所以它拥有自己的标志，而非复用 `archived` 或熔断等级。 */
   onHold?: boolean;
-  /** Most recent Claude Code session_id seen for this agent (Lane A #6.6a),
-   *  captured from hook payloads. Doubles as the `--resume` key (idempotent
-   *  resume after a crash/restart) AND the cost accounting/dedup key on every
-   *  AgentUsageSample / cost-ledger row. */
+  /** 此智能体最近一次看到的 Claude Code session_id（Lane A #6.6a），
+   *  从 hook 负载中捕获。兼任 `--resume` 键（崩溃/重启后可幂等恢复）以及
+   *  每条 AgentUsageSample / cost-ledger 行的成本核算/去重键。 */
   sessionId?: string;
-  /** Whether `cwd` is actually usable for a (re)spawn — i.e. an ABSOLUTE path
-   *  that exists as a directory. Computed + persisted at spawn so the roster
-   *  reliably exposes each worker's environment validity. A non-absolute fragment
-   *  (e.g. "ClaudeTerminalHarness") spawns into a nonexistent dir and fails; this
-   *  flag makes that visible instead of letting it slip through silently. */
+  /** `cwd` 是否真的可用于（重新）spawn —— 即一个存在且为目录的 ABSOLUTE
+   *  路径。在 spawn 时计算并持久化，使名册能可靠地暴露每个工作进程的环境
+   *  有效性。非绝对路径片段（如 "ClaudeTerminalHarness"）会 spawn 进一个
+   *  不存在的目录而失败；此标志使之可见，而不是让它悄悄溜过。 */
   cwdValid?: boolean;
 }
 
@@ -174,18 +166,18 @@ export interface Registry {
   agents: Record<string, RegistryAgent>;
 }
 
-/** Build env + extra spawn args that make an agent process hive-aware. */
+/** 构建让智能体进程具有 hive 感知能力的 env + 额外 spawn 参数。 */
 export interface SpawnInjection {
   args: string[];
   env: Record<string, string>;
-  /** The hive-protocol seed to TYPE into the TUI after boot rather than pass on
-   *  argv — set only for `seedDelivery:'type-into-tui'` providers (Crush), whose
-   *  bare TUI rejects a positional seed. The renderer types it through the same
-   *  per-pty write-chain as the inbox-wake nudge. (ondev-b) */
+  /** 启动后要「键入」TUI 的 hive 协议种子，而不是通过 argv 传递 —— 仅对
+   *  `seedDelivery:'type-into-tui'` 提供者（Crush）设置，其裸 TUI 会拒绝位置
+   *  参数种子。渲染器通过与 inbox 唤醒提示相同的 per-pty 写入链将其键入。
+   *  （ondev-b） */
   seedPrompt?: string;
-  /** Set when the agent spawned in a DEGRADED posture the user should know about
-   *  (today: the proxy-bridge sidecar never bound after retries, so a proxy-tier
-   *  agent such as Crush runs without hive events). Human-readable, one line. */
+  /** 当智能体以用户应当知晓的降级姿态 spawn 时设置（今天：代理桥接 sidecar
+   *  在重试后仍未绑定，因此 Crush 这类代理层智能体将无 hive 事件运行）。
+   *  人类可读，一行。 */
   degraded?: string;
 }
 
@@ -196,7 +188,7 @@ function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(sab), 0, 0, ms);
 }
 
-/** Filesystem- and sort-safe timestamp, e.g. 2026-05-30T14-03-11-123Z. */
+/** 文件系统与排序安全的时间戳，例如 2026-05-30T14-03-11-123Z。 */
 function stamp(): string {
   return new Date().toISOString().replace(/[:.]/g, '-');
 }
@@ -205,28 +197,27 @@ function shortRand(): string {
   return randomBytes(3).toString('hex');
 }
 
-/** Non-memory files `mempalace mine` must not ingest (Claude Code hooks config,
- *  cursor, raw inbox/outbox JSON). `mempalace mine` honors .gitignore, so we drop
- *  one in each agent dir; written on birth here and refreshed by the mine loop.
+/** `mempalace mine` 不得摄入的非记忆文件（Claude Code hooks 配置、光标、
+ *  原始 inbox/outbox JSON）。`mempalace mine` 遵循 .gitignore，所以我们会在
+ *  每个智能体目录放入一个；在诞生时写入，并由 mine 循环刷新。
  *
- *  `.codex/` is here for a second reason as well, and it is the load-bearing one:
- *  a Codex worker's CODEX_HOME lives INSIDE its agent dir (see installCodexHooks —
- *  Codex can only be given hooks through a config.toml in its own home, so it
- *  cannot share the user's ~/.codex). Codex then fills that folder with full
- *  session transcripts, an 80MB+ logs sqlite and a plugin cache, and the hive's
- *  git repo was faithfully versioning every revision of all of it. Twenty Codex
- *  agents took the hive's .git to 7.5GB, at which point git's own auto-gc tried to
- *  repack it and took 22GB of RAM doing so — the machine swapped, the app stopped
- *  responding. None of it was ever wanted in history: it is Codex's private
- *  scratch state, and it stays on disk (so resume still works) either way. */
-/** Proxy-bridge sidecar bind attempts per spawn, and the pause before each retry. */
+ *  把 `.codex/` 放在这里还有第二个原因，而且是关键的那个：Codex 工作进程的
+ *  CODEX_HOME 位于其智能体目录内部（见 installCodexHooks —— Codex 只能通过
+ *  它自己 home 里的 config.toml 获得 hooks，所以它无法共享用户的 ~/.codex）。
+ *  于是 Codex 会用完整的会话转录、一个 80MB+ 的 logs sqlite 和插件缓存塞满
+ *  那个文件夹，而 hive 的 git 仓库忠实地把所有内容的每个版本都纳入了版本控制。
+ *  二十个 Codex 智能体把 hive 的 .git 撑到 7.5GB，此时 git 自身的 auto-gc 尝试
+ *  重新打包，占用了 22GB 内存 —— 机器开始交换内存，应用停止响应。这些东西
+ *  从未被需要进入历史：它是 Codex 的私有临时状态，并且无论哪种情况它都留在
+ *  磁盘上（因此恢复仍可工作）。 */
+/** 每次 spawn 时代理桥接 sidecar 的绑定尝试次数，以及每次重试前的停顿。 */
 const PROXY_BIND_ATTEMPTS = 3;
 const PROXY_BIND_BACKOFF_MS = [250, 750];
 
 const MINE_IGNORE_LINES = ['settings.json', 'cursor.json', 'inbox/', 'outbox/', '.codex/'];
 
-/** Idempotently ensure `<agentDir>/.gitignore` excludes the non-memory files.
- *  Append-only: writes only the missing lines, leaving any existing entries. */
+/** 幂等地确保 `<agentDir>/.gitignore` 排除非记忆文件。
+ *  仅追加：只写入缺失的行，保留任何已有条目。 */
 function ensureMineIgnore(agentDir: string): void {
   const path = join(agentDir, '.gitignore');
   let existing = '';
@@ -235,52 +226,48 @@ function ensureMineIgnore(agentDir: string): void {
   const missing = MINE_IGNORE_LINES.filter((l) => !have.has(l));
   if (missing.length === 0) return;
   const prefix = existing && !existing.endsWith('\n') ? existing + '\n' : existing;
-  try { writeFileSync(path, prefix + missing.join('\n') + '\n', 'utf8'); } catch { /* best-effort */ }
+  try { writeFileSync(path, prefix + missing.join('\n') + '\n', 'utf8'); } catch { /* 尽力而为 */ }
 }
 
 /**
- * Strip secret-shaped substrings out of free text before it leaves the main
- * process toward the voice / renderer layer. This is the MAIN-SIDE privacy gate
- * for the voice read-layer's message-content path (`hive:messages`): a message
- * body can quote a key, paste a token, or echo a credential, so every body and
- * subject is run through this before it crosses IPC. The renderer holds ZERO
- * redaction policy — it only ever receives the already-cleaned string.
+ * 在自由文本离开主进程前往语音/渲染器层之前，剥离形似机密的子串。这是
+ * 语音读取层消息内容路径（`hive:messages`）的主进程侧隐私闸门：消息正文可能
+ * 引用一个 key、粘贴一个令牌，或回显一个凭据，所以每个 body 和 subject 在
+ * 跨越 IPC 之前都要经过这里。渲染器持有零脱敏策略 —— 它只接收已经清理过的
+ * 字符串。
  *
- * Deliberately CONSERVATIVE: it matches known credential SHAPES (provider key
- * prefixes, JWTs, PEM private keys, bearer tokens) and sensitive key=value /
- * key: value assignments, then replaces the secret with `[redacted]`. It does
- * NOT blanket-redact on entropy, so operator-meaningful content the briefing
- * needs — git SHAs, agent ids, file paths, ordinary prose — survives intact.
- * Over-redaction (e.g. a non-secret `apikey:openai` ref) is acceptable; leaking
- * a real secret is not.
+ * 刻意保持保守：它匹配已知的凭据「形态」（提供者 key 前缀、JWT、PEM 私钥、
+ * bearer 令牌）以及敏感的 key=value / key: value 赋值，然后将机密替换为
+ * `[redacted]`。它不会按熵做全盘脱敏，因此简报所需的、对操作者有意义的
+ * 内容 —— git SHA、智能体 id、文件路径、普通散文 —— 完整保留。过度脱敏
+ * （如一个非机密的 `apikey:openai` 引用）是可接受的；泄漏真实机密则不可。
  *
- * LOCKSTEP: the regex battery below is mirrored character-identically in
- * test/voice-messages.test.cjs (a .cjs test cannot import this TS module). If
- * you change a pattern here, mirror it there — the test is what PROVES a
- * secret-shaped value is stripped.
+ * 严格同步：下面的正则库在 test/voice-messages.test.cjs 中逐字符镜像（.cjs
+ * 测试无法导入此 TS 模块）。如果你改了这里的某个模式，就在那里镜像它 ——
+ * 正是该测试证明形似机密的值会被剥离。
  */
 export function redactSecrets(text: unknown): string {
   if (typeof text !== 'string' || !text) return typeof text === 'string' ? text : '';
   let s = text;
-  // 1. PEM private-key blocks (RSA/EC/OPENSSH/PGP — header through footer).
+  // 1. PEM 私钥块（RSA/EC/OPENSSH/PGP —— 从头到脚）。
   s = s.replace(/-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g, '[redacted]');
-  // 2. JSON Web Tokens — three base64url segments separated by dots.
+  // 2. JSON Web Tokens —— 由点分隔的三个 base64url 段。
   s = s.replace(/\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/g, '[redacted]');
-  // 3. Known credential prefixes: OpenAI/Anthropic (sk-, sk-ant-), Slack
-  //    (xoxb/xoxp/xoxa/xoxr/xoxs-, xapp-), GitHub (ghp_/gho_/ghu_/ghs_/ghr_,
-  //    github_pat_), AWS access-key ids (AKIA…), Google API keys (AIza…).
+  // 3. 已知的凭据前缀：OpenAI/Anthropic（sk-、sk-ant-）、Slack
+  //    （xoxb/xoxp/xoxa/xoxr/xoxs-、xapp-）、GitHub（ghp_/gho_/ghu_/ghs_/ghr_、
+  //    github_pat_）、AWS 访问密钥 id（AKIA…）、Google API 密钥（AIza…）。
   s = s.replace(
     /(?:sk-(?:ant-)?[A-Za-z0-9_-]{16,}|xox[bpaors]-[A-Za-z0-9-]{10,}|xapp-[A-Za-z0-9-]{10,}|gh[posru]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|AIza[A-Za-z0-9_-]{20,})/g,
     '[redacted]'
   );
-  // 4. Bearer tokens — keep the label, drop the credential.
+  // 4. Bearer 令牌 —— 保留标签，丢弃凭据。
   s = s.replace(/\b(bearer)\s+[A-Za-z0-9._~+/=-]{8,}/gi, '$1 [redacted]');
-  // 5. Sensitive key = value / key: value — keep the key name, drop the value.
-  //    An optional namespace prefix (aws_, gcp_, …) is folded into the captured
-  //    key so a LABELED secret survives the \b boundary: `aws_secret_access_key`
-  //    is all word chars, so a bare `\b(secret)\b` never sees it. Listing
-  //    secret_access_key / private_key alone is not enough — the prefix run is
-  //    what lets `aws_secret_access_key=…` (no AKIA shape on the value) redact.
+  // 5. 敏感 key = value / key: value —— 保留 key 名，丢弃值。
+  //    可选命名空间前缀（aws_、gcp_、…）被并入捕获的 key，使带标签的机密
+  //    能越过 \b 边界：`aws_secret_access_key` 全部是单词字符，所以裸的
+  //    `\b(secret)\b` 永远看不到它。仅列出 secret_access_key / private_key
+  //    不够 —— 正是前缀段让 `aws_secret_access_key=…`（值无 AKIA 形态）得以
+  //    脱敏。
   s = s.replace(
     /\b((?:[a-z0-9]+[_-])*(?:api[_-]?key|secret[_-]?access[_-]?key|secret|token|password|passwd|pwd|access[_-]?token|refresh[_-]?token|client[_-]?secret|signing[_-]?secret|webhook[_-]?secret|auth[_-]?token|bot[_-]?token|private[_-]?key))(\s*[:=]\s*)(["']?)[^\s"',}]{6,}\3/gi,
     (_m, k) => `${k}=[redacted]`
@@ -292,10 +279,10 @@ export function redactSecrets(text: unknown): string {
 
 export class HiveManager {
   /**
-   * @param getHome  Lazily resolve harnessHome so the hive follows config changes.
-   * @param emit     Optional sink for renderer-facing events (set by the main
-   *                 process to `webContents.send`). Used to animate routed
-   *                 messages on the office floor; a no-op in tests/headless.
+   * @param getHome  懒解析 harnessHome，使 hive 跟随配置变化。
+   * @param emit     面向渲染器事件的可选接收器（由主进程设为
+   *                 `webContents.send`）。用于在办公楼层上动画化路由消息；
+   *                 在测试/无头场景中为空操作。
    */
   constructor(
     private getHome: () => string | null,
@@ -304,30 +291,26 @@ export class HiveManager {
 
   private routerTimer: NodeJS.Timeout | null = null;
 
-  /** The embedded OTLP collector's loopback URL, set by the main process once the
-   *  collector is bound (telemetry.ts). null = telemetry off → no OTel env is
-   *  injected at spawn (the transcript reconciler remains the cost source). */
+  /** 内嵌 OTLP 收集器的回环 URL，由主进程在收集器绑定后设置（telemetry.ts）。
+   *  null = 遥测关闭 → spawn 时不注入任何 OTel env（转录协调器仍是成本来源）。 */
   private _otelEndpoint: string | null = null;
-  /** Point newly-spawned agents at the live telemetry collector. Call after the
-   *  collector starts; only affects spawns made afterwards. */
+  /** 让新 spawn 的智能体指向活动的遥测收集器。在收集器启动后调用；只影响
+   *  之后进行的 spawn。 */
   setOtelEndpoint(url: string | null): void {
     this._otelEndpoint = url;
   }
-  /** The collector URL agents are pointed at, or null when telemetry is off. */
+  /** 智能体被指向的收集器 URL，遥测关闭时为 null。 */
   otelEndpoint(): string | null {
     return this._otelEndpoint;
   }
 
-  /** What the app running this hive actually IS: its version, and whether it is a
-   *  packaged build or a local dev run.
+  /** 运行此 hive 的应用究竟是什么：它的版本，以及是打包构建还是本地开发运行。
    *
-   *  Agents could not see this before, and it cost real time. A multi-agent
-   *  investigation into anomalous file modes ran for hours before the explanation
-   *  turned out to be that the operator had quit a downloaded build and started a
-   *  local one, which inherits the launching shell's umask instead of Finder's
-   *  022. No agent could observe that, several published conclusions had to be
-   *  withdrawn, and log.jsonl carried no app-start marker to notice the switch
-   *  from either. */
+   *  智能体以前看不到这一点，而且它代价不菲。一次针对异常文件模式的多智能体
+   *  调查进行了数小时，最后才发现原因是操作者退出了下载的构建并启动了本地
+   *  构建 —— 本地构建继承启动 shell 的 umask，而非 Finder 的 022。没有智能体
+   *  能观察到这一点，几个已发布的结论不得不撤回，log.jsonl 也没有任何应用
+   *  启动标记能让人从两者中发现切换。 */
   private _runtime: { version: string; packaged: boolean; appPath?: string } | null = null;
   setRuntimeInfo(info: { version: string; packaged: boolean; appPath?: string } | null): void {
     this._runtime = info;
@@ -336,10 +319,9 @@ export class HiveManager {
     return this._runtime;
   }
 
-  /** Whether config.orchestratorMaySpawn is on, mirrored here so the prompt
-   *  builder can decide whether to tell god the spawn queue is available. Set at
-   *  bootstrap and on every config write; hive.ts deliberately does not import
-   *  the config module. */
+  /** config.orchestratorMaySpawn 是否开启，在此镜像一份，使提示词构建器能决定
+   *  是否告诉 god spawn 队列可用。在引导时和每次配置写入时设置；hive.ts 刻意
+   *  不导入配置模块。 */
   private _maySpawn = false;
   setOrchestratorMaySpawn(on: boolean): void {
     this._maySpawn = on;
@@ -348,7 +330,7 @@ export class HiveManager {
     return this._maySpawn;
   }
 
-  // — paths —
+  // — 路径 —
   root(): string | null {
     const home = this.getHome();
     return home ? join(home, 'hive') : null;
@@ -359,12 +341,12 @@ export class HiveManager {
   private agentDir(id: string): string {
     return join(this.root()!, 'agents', id);
   }
-  /** IPC endpoint the cth-hook shim talks to (Phase 1 autonomy).
-   *  On POSIX this is a Unix-domain socket file under the hive root. On Windows,
-   *  Node's `net` IPC uses named pipes (a flat `\\.\pipe\` namespace, not the
-   *  filesystem), so a raw file path fails to bind with EACCES — derive a stable,
-   *  per-root pipe name instead. Both the server (`listen`) and the shim
-   *  (`createConnection`) read this same value, so they stay in sync. */
+  /** cth-hook shim 通信的 IPC 端点（阶段 1 自治）。
+   *  在 POSIX 上，这是 hive 根目录下的一个 Unix 域套接字文件。在 Windows 上，
+   *  Node 的 `net` IPC 使用命名管道（平坦的 `\\.\pipe\` 命名空间，而非文件
+   *  系统），所以裸文件路径会以 EACCES 绑定失败 —— 改为派生一个稳定的、
+   *  按根目录的管道名。服务器（`listen`）和 shim（`createConnection`）都读取
+   *  同一个值，因此它们保持同步。 */
   sockPath(): string | null {
     const root = this.root();
     if (!root) return null;
@@ -378,33 +360,32 @@ export class HiveManager {
     const root = this.root();
     return root ? join(root, 'bin', 'cth-hook.cjs') : null;
   }
-  /** The proxy-bridge sidecar (qwen). Pure-Node loopback reverse-proxy that
-   *  observes a hookless CLI's LLM traffic and synthesizes the same HIVE_SOCK
-   *  payloads the hook shims emit. Written in ensureHive alongside cth-hook.cjs. */
+  /** 代理桥接 sidecar（qwen）。纯 Node 回环反向代理，观察无 hook CLI 的 LLM
+   *  流量，并合成 hook shim 发出的相同 HIVE_SOCK 负载。在 ensureHive 中与
+   *  cth-hook.cjs 一并写入。 */
   private proxyShimPath(): string | null {
     const root = this.root();
     return root ? join(root, 'bin', 'hive-proxy.cjs') : null;
   }
 
   /**
-   * The BUNDLED-NODE launcher: `<root>/bin/hive-node` (POSIX) / `hive-node.cmd`
-   * (Windows). Every `.cjs` shim in the hive is executed through it.
+   * BUNDLED-NODE 启动器：`<root>/bin/hive-node`（POSIX）/ `hive-node.cmd`
+   * （Windows）。hive 中的每个 `.cjs` shim 都通过它执行。
    *
-   * Why it exists: hooks are run by the agent CLI through a plain
-   * `/bin/sh -c` with a bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. A user whose
-   * node comes from nvm (PATH set only by an interactive login shell) has NO node
-   * there, so a hook written as `node "<shim>"` exits **127 — command not found**
-   * and every payload is silently lost: no live status, no Stop→inbox drain, no
-   * session ids. Electron's own binary IS a full Node runtime under
-   * `ELECTRON_RUN_AS_NODE=1`, and it is guaranteed present (it is us).
+   * 为什么存在：hook 由智能体 CLI 通过一个裸的 `/bin/sh -c` 与精简的
+   * `PATH=/usr/bin:/bin:/usr/sbin:/sbin` 运行。用户若从 nvm 获得 node
+   * （PATH 仅由交互式登录 shell 设置），那里就没有 node，因此写为
+   * `node "<shim>"` 的 hook 会以 **127 —— 找不到命令** 退出，每个负载都悄然
+   * 丢失：没有实时状态、没有 Stop→inbox 清空、没有会话 id。Electron 自身的
+   * 二进制在 `ELECTRON_RUN_AS_NODE=1` 下就是一个完整的 Node 运行时，并且它
+   * 一定存在（就是我们）。
    *
-   * A wrapper SCRIPT rather than an inline `ELECTRON_RUN_AS_NODE=1 "<exe>" …`
-   * prefix because that prefix is POSIX-sh syntax — it is a hard error under
-   * cmd.exe, which is what runs hook commands on Windows. The wrapper also gives
-   * agents a `$HIVE_NODE` they can invoke directly (running the Electron binary
-   * WITHOUT the env var would launch a second app window, not a script).
+   * 用包装脚本而非内联的 `ELECTRON_RUN_AS_NODE=1 "<exe>" …` 前缀，是因为该
+   * 前缀是 POSIX-sh 语法 —— 在 cmd.exe 下是硬错误，而 cmd.exe 正是 Windows
+   * 上运行 hook 命令的东西。包装脚本还给智能体一个可直接调用的 `$HIVE_NODE`
+   * （不带环境变量地运行 Electron 二进制会启动第二个应用窗口，而非脚本）。
    *
-   * Rewritten on every bootstrap, so an app update/move re-bakes execPath.
+   * 每次引导都会重写，因此应用更新/移动会重新烘焙 execPath。
    */
   private nodeLauncherPath(): string | null {
     const root = this.root();
@@ -412,8 +393,8 @@ export class HiveManager {
     return join(root, 'bin', process.platform === 'win32' ? 'hive-node.cmd' : 'hive-node');
   }
 
-  /** Write the launcher described above. Best-effort: on failure callers fall
-   *  back to bare `node`, i.e. exactly the pre-fix behavior. */
+  /** 写入上文所述的启动器。尽力而为：失败时调用方回退到裸 `node`，即
+   *  与修复前完全一致的行为。 */
   private writeNodeLauncher(): void {
     const p = this.nodeLauncherPath();
     if (!p) return;
@@ -429,56 +410,51 @@ export class HiveManager {
     }
   }
 
-  /** The launcher path if it is actually on disk, else null (→ callers fall back
-   *  to bare `node`, i.e. exactly the pre-fix behavior — never worse than before). */
+  /** 实际存在于磁盘上的启动器路径，否则为 null（→ 调用方回退到裸 `node`，
+   *  即与修复前完全一致的行为 —— 绝不会比以前更差）。 */
   private nodeLauncher(): string | null {
     const p = this.nodeLauncherPath();
     return p && existsSync(p) ? p : null;
   }
 
-  /** The ABSOLUTE bundled-node command to BAKE into any text an agent is expected
-   *  to run (`<launcher> <script> …`), falling back to bare `node`.
+  /** 要「烘焙」进任何期望智能体运行的文本中的 ABSOLUTE bundled-node 命令
+   *  （`<launcher> <script> …`），回退到裸 `node`。
    *
-   *  Exactly the value of the agent's `HIVE_NODE` env var — but agent-facing text
-   *  must never spell it as `$HIVE_NODE`: that is POSIX shell syntax. A Windows
-   *  agent runs its commands through cmd.exe/PowerShell, where `$HIVE_NODE`
-   *  expands to NOTHING (cmd) or to an undefined variable (PowerShell), so every
-   *  such instruction is dead on arrival there. The absolute path is correct on
-   *  every platform and needs no expansion at all. */
+   *  恰为智能体 `HIVE_NODE` 环境变量的值 —— 但面向智能体的文本绝不能把它写成
+   *  `$HIVE_NODE`：那是 POSIX shell 语法。Windows 智能体通过 cmd.exe/PowerShell
+   *  运行其命令，在那里 `$HIVE_NODE` 会展开为 NOTHING（cmd）或一个未定义变量
+   *  （PowerShell），所以每一条这样的指令在那里都形同虚设。绝对路径在所有平台上
+   *  都正确，且完全无需展开。 */
   nodeCommand(): string {
     return this.nodeLauncher() ?? 'node';
   }
 
   /**
-   * `<root>/bin/runtime` — the same bundled-node trick as `hive-node`, but the
-   * wrapper is NAMED `node`, so anything that resolves `node` off PATH finds one.
+   * `<root>/bin/runtime` —— 与 `hive-node` 相同的 bundled-node 技巧，但包装
+   * 脚本名为 `node`，因此任何从 PATH 解析 `node` 的东西都能找到一个。
    *
-   * `hive-node` only covers commands WE generate. It does nothing for node that
-   * the agent's own work needs at runtime: an MCP server declared as
-   * `node ./server.js`, a provider CLI that shells out to node, a `.cjs` helper an
-   * agent wrote itself. On a machine with no system node those all die with 127
-   * exactly like the hooks did.
+   * `hive-node` 只覆盖我们生成的命令。它对智能体自己工作所需的 node 毫无帮助：
+   * 一个声明为 `node ./server.js` 的 MCP 服务器、一个 shell 到 node 的提供者
+   * CLI、一个智能体自己编写的 `.cjs` 辅助脚本。在没有系统 node 的机器上，
+   * 它们都像 hook 一样以 127 死掉。
    *
-   * This dir is APPENDED to the agent's PATH (see pty.spawn), never prepended: a
-   * user who has their own node keeps their own version — we are strictly the
-   * fallback. Prepending would silently swap every agent's node for Electron's
-   * (20.18.1 as of Electron 32.3.3) underneath the user's own projects.
+   * 此目录被 APPEND 到智能体的 PATH（见 pty.spawn），绝不前置：有自己的 node
+   * 的用户会保留自己的版本 —— 我们严格只是回退。前置会悄然把每个智能体的
+   * node 换成用户自己项目之下的 Electron node（Electron 32.3.3 的 20.18.1）。
    *
-   * NOTE: `node` only — deliberately no `npm`/`npx`. Electron bundles the Node
-   * RUNTIME, not the npm CLI (which is ~12MB of JS we do not ship), so an `npm`
-   * wrapper here could only be a stub that fails confusingly. A missing `npm` is
-   * the honest signal; the install ladder (main/cliInstall.ts) detects it and
-   * installs a REAL system Node — which brings npm with it. This shim is only the
-   * last resort for when that install could not run (offline, or a platform with
-   * no official installer).
+   * 注意：只有 `node` —— 刻意没有 `npm`/`npx`。Electron 打包的是 Node 运行时，
+   * 不是 npm CLI（那是约 12MB 我们不随附的 JS），所以这里的 `npm` 包装只能是一
+   * 个令人困惑地失败的桩。缺少 `npm` 是诚实的信号；安装阶梯
+   * （main/cliInstall.ts）会检测并安装一个真正的系统 Node —— 它会带来 npm。
+   * 此 shim 只是当安装无法运行时（离线，或没有官方安装程序平台）的最后手段。
    */
   runtimeBinDir(): string | null {
     const root = this.root();
     return root ? join(root, 'bin', 'runtime') : null;
   }
 
-  /** Write the `node` shim described above. Best-effort: on failure the dir is
-   *  simply absent from PATH and behavior is exactly as before. */
+  /** 写入上文所述的 `node` shim。尽力而为：失败时该目录简单地不出现在
+   *  PATH 中，行为与之前完全一致。 */
   private writeRuntimeShims(): void {
     const dir = this.runtimeBinDir();
     if (!dir) return;
@@ -500,41 +476,38 @@ export class HiveManager {
     }
   }
 
-  /** Build a hook command string that runs `script` under the guaranteed node,
-   *  DOUBLE-QUOTED (safe for paths with spaces). */
+  /** 构建一条在保证的 node 下运行 `script` 的 hook 命令字符串，用双引号括起
+   *  （对含空格路径安全）。 */
   private nodeRun(script: string, ...args: string[]): string {
     const launcher = this.nodeLauncher();
     return [launcher ? `"${launcher}"` : 'node', `"${script}"`, ...args].join(' ');
   }
 
-  /** Same, but UNQUOTED — for the CLIs whose hook config mangles embedded quotes
-   *  (agy on cmd.exe) or stores the command in a quote-sensitive literal (codex's
-   *  single-quoted TOML). Safe because both the hive root and the launcher inside
-   *  it are space-free by construction; this only preserves each installer's
-   *  existing quoting convention while swapping `node` for the bundled runtime. */
+  /** 同上，但不加引号 —— 用于其 hook 配置会弄坏内嵌引号的 CLI（cmd.exe 上的
+   *  agy）或把命令存进引号敏感字面量的 CLI（codex 的单引号 TOML）。安全是因为
+   *  hive 根目录与其内的启动器按构造均不含空格；这只保留各安装器现有的引用
+   *  约定，同时把 `node` 换成捆绑运行时。 */
   private nodeRunUnquoted(script: string, ...args: string[]): string {
     return [this.nodeLauncher() ?? 'node', script, ...args].join(' ');
   }
 
-  /** One proxy sidecar per live proxy-tier agent, keyed by agentId. Spawned in
-   *  ensureAgent, killed on PTY exit / removeAgent / app quit (index.ts) — so a
-   *  dead agent never leaks an orphan loopback listener. */
+  /** 每个活动代理层智能体对应一个代理 sidecar，以 agentId 为键。在
+   *  ensureAgent 中 spawn，在 PTY 退出 / removeAgent / 应用退出时被杀（index.ts）
+   *  —— 因此死掉的智能体绝不会泄漏一个孤儿回环监听器。 */
   private proxyChildren = new Map<string, ChildProcess>();
 
-  // — bootstrap —
+  // — 引导 —
 
-  /** Create the hive skeleton + git repo if missing. Idempotent. */
+  /** 如缺失则创建 hive 骨架 + git 仓库。幂等。 */
   ensureHive(): void {
     const root = this.root();
     if (!root) return;
     mkdirSync(join(root, 'agents'), { recursive: true });
 
-    // Refreshed each bootstrap, like COMMANDS.md just below. It used to be
-    // written only when absent, which meant a hive created once never saw a
-    // protocol change again: this repo's own hive still carried the file from
-    // the day it was initialised, so every protocol addition since had reached
-    // new hives only. The file is generated, not user-authored, and agents are
-    // pointed at it as the authority, so a stale copy is worse than a rewrite.
+    // 每次引导都刷新，正如下面的 COMMANDS.md。过去只在缺失时写入，这意味着
+    // 一次创建的 hive 再也不会看到协议变更：这个仓库自己的 hive 仍带着创建
+    // 当天的文件，所以此后每次协议新增都只到达新 hive。该文件是生成的、非
+    // 用户编写，且智能体被指引以它为准，因此陈旧副本比重写更糟。
     writeFileSync(join(root, 'PROTOCOL.md'), PROTOCOL_MD, 'utf8');
 
     const registry = join(root, 'registry.json');
@@ -557,11 +530,10 @@ export class HiveManager {
     const log = join(root, 'log.jsonl');
     if (!existsSync(log)) writeFileSync(log, '', 'utf8');
 
-    // The Claude Code command reference Michael consults (refreshed each bootstrap
-    // so it tracks the bundled list).
+    // Michael 查阅的 Claude Code 命令参考（每次引导刷新，以跟踪捆绑列表）。
     writeFileSync(join(root, 'COMMANDS.md'), COMMANDS_MD, 'utf8');
 
-    // Keep the churny/ephemeral live files out of the hive git repo.
+    // 让多变/临时的活动文件留在 hive git 仓库之外。
     const gitignore = join(root, '.gitignore');
     const want = ['fleet.json', 'hooks.sock', 'cost-ledger.jsonl', '.DS_Store'];
     let lines: string[] = [];
@@ -569,16 +541,16 @@ export class HiveManager {
     const missing = want.filter((w) => !lines.includes(w));
     if (missing.length) writeFileSync(gitignore, [...lines.filter(Boolean), ...missing].join('\n') + '\n', 'utf8');
 
-    // The hook shim: a dumb pipe between a `claude` hook and our UDS. Refreshed
-    // on every bootstrap so it tracks code changes.
+    // hook shim：`claude` hook 与我们的 UDS 之间的一个哑管道。每次引导刷新
+    // 以跟踪代码变更。
     mkdirSync(join(root, 'bin'), { recursive: true });
     writeFileSync(this.shimPath()!, HOOK_SHIM, 'utf8');
-    // The proxy-bridge sidecar for hookless CLIs (qwen). Same refresh policy.
+    // 用于无 hook CLI（qwen）的代理桥接 sidecar。相同刷新策略。
     writeFileSync(this.proxyShimPath()!, PROXY_BRIDGE_SHIM, 'utf8');
-    // The bundled-node launcher every shim above is invoked through — MUST be
-    // written before any hook installer runs (they probe for it).
+    // 上面每个 shim 都通过它调用的 bundled-node 启动器 —— 必须在任何 hook
+    // 安装器运行前写入（它们会探测它）。
     this.writeNodeLauncher();
-    // …and the PATH-visible `node` fallback for the agent's OWN subprocesses.
+    // ……以及用于智能体自身子进程的、PATH 可见的 `node` 回退。
     this.writeRuntimeShims();
 
     if (!existsSync(join(root, '.git'))) {
@@ -587,15 +559,14 @@ export class HiveManager {
     }
   }
 
-  /** Validate an agent's cwd the way a spawn does — it must be an ABSOLUTE path
-   *  that exists as a directory. Surfaced as `cwdValid` on the registry entry so
-   *  the roster reliably exposes whether a worker's working directory is usable.
-   *  Best-effort; never throws (a stat error degrades to invalid). */
+  /** 像 spawn 那样校验智能体的 cwd —— 它必须是存在且为目录的 ABSOLUTE 路径。
+   *  在注册表项上以 `cwdValid` 呈现，使名册能可靠地暴露工作进程的工作目录
+   *  是否可用。尽力而为；绝不抛异常（stat 错误降级为无效）。 */
   private cwdValidity(cwd: string | undefined): { valid: boolean; issue: string | null } {
     if (!cwd || typeof cwd !== 'string') return { valid: false, issue: 'missing' };
-    // Defense-in-depth: a `~/…` cwd from an older registry entry (written before
-    // ingestion-time expansion) would read as 'not-absolute' forever. Expand first
-    // so the roster reports the truth about the directory the spawn would use.
+    // 纵深防御：较旧注册表项中的 `~/…` cwd（在摄取期展开前写入）会永远
+    // 被读成 'not-absolute'。先展开，使名册能报告 spawn 实际将使用的目录的
+    // 真相。
     cwd = expandTilde(cwd);
     if (!isAbsolute(cwd)) return { valid: false, issue: 'not-absolute' };
     try {
@@ -608,31 +579,29 @@ export class HiveManager {
   }
 
   /**
-   * Ensure an agent's workspace + registry entry, returning the spawn injection
-   * (provider-specific args + env) that makes the process hive-aware.
+   * 确保一个智能体的工作区 + 注册表项，返回使进程具有 hive 感知能力的 spawn
+   * 注入（提供者相关参数 + env）。
    */
   async ensureAgent(
     meta: AgentMeta,
     opts: {
       semanticMemory?: boolean;
       knowledgeGraph?: boolean;
-      /** ABSOLUTE path to the Knowledge-Graph CLI (`knowledge.env().KG_CLI`), baked
-       *  into the agent's prompt instead of a `$KG_CLI` shell reference — `$VAR` is
-       *  POSIX-only and expands to nothing under cmd.exe/PowerShell, so the KG
-       *  instructions were unusable on Windows. Optional: undefined degrades to the
-       *  old env-var spelling. */
+      /** Knowledge-Graph CLI 的 ABSOLUTE 路径（`knowledge.env().KG_CLI`），烘焙
+       *  进智能体提示词而非 `$KG_CLI` shell 引用 —— `$VAR` 仅限 POSIX，在
+       *  cmd.exe/PowerShell 下展开为空，所以 KG 指令在 Windows 上不可用。
+       *  可选：undefined 降级为旧的 env-var 拼写。 */
       kgCliPath?: string;
       theme?: 'light' | 'dark';
-      /** Consent state for the default-MCP bundle (W3). Threaded from the live
-       *  HarnessConfig by the caller; undefined → catalog defaults apply. */
+      /** 默认 MCP 包的同意状态（W3）。由调用方从实时 HarnessConfig 传入；
+       *  undefined → 应用目录默认值。 */
       mcpDefaults?: { [id: string]: { enabled: boolean } };
-      /** App-resources `skills/` source dir (W3). The bundled read-only skills are
-       *  copied into the agent's `.claude/skills/` per spawn; undefined or missing
-       *  is a no-op (tolerated until Kevin populates the resource dir). */
+      /** 应用资源 `skills/` 源目录（W3）。捆绑的只读技能在每次 spawn 时被
+       *  复制进智能体的 `.claude/skills/`；undefined 或缺失为空操作（在 Kevin
+       *  填充资源目录前容忍）。 */
       skillsDir?: string;
-      /** Extra directories the agent's sandbox may write (e.g. the shared
-       *  MemPalace dir, which `mempalace` mutates). Absolute paths; ignored
-       *  for providers without a sandbox. */
+      /** 智能体沙盒可能写入的额外目录（例如共享的 MemPalace 目录，`mempalace`
+       *  会改动它）。绝对路径；对无沙盒的提供者忽略。 */
       extraWritableDirs?: string[];
     } = {}
   ): Promise<SpawnInjection> {
@@ -644,9 +613,9 @@ export class HiveManager {
     mkdirSync(join(dir, 'inbox', '.done'), { recursive: true });
     mkdirSync(join(dir, 'outbox', '.sent'), { recursive: true });
 
-    // Resolve role BEFORE writing identity.md. A restart passes the floor
-    // roster's `description`, which can be a status caption ("on standby").
-    // identity.md and registry.role are the durable job from the hire.
+    // 在写 identity.md 之前解析 role。重启会传入楼层名册的 `description`，
+    // 它可能是状态标题（"on standby"）。identity.md 和 registry.role 才是雇佣
+    // 时的持久职责。
     const reg = this.registry();
     const prev = reg.agents[meta.id];
     if (meta.cwd) meta = { ...meta, cwd: expandTilde(meta.cwd) };
@@ -654,31 +623,29 @@ export class HiveManager {
     meta = { ...meta, role };
 
     const identity = join(dir, 'identity.md');
-    writeFileSync(identity, this.identityText(meta), 'utf8'); // refresh on each spawn
+    writeFileSync(identity, this.identityText(meta), 'utf8'); // 每次 spawn 刷新
 
-    // W3 — bundled read-only skills: refresh the agent's .claude/skills/ from the
-    // app-resources skills/ dir on every spawn (same policy as identity.md), so an
-    // agent always rides with the shipped safe skill set. Tolerant: a missing or
-    // partial source dir is a no-op (Kevin populates the resource dir in lp-manifest).
+    // W3 —— 捆绑只读技能：每次 spawn 都从应用资源 skills/ 目录刷新智能体的
+    // .claude/skills/（与 identity.md 同策略），使智能体始终携带随附的安全技能
+    // 集。容忍：缺失或部分的源目录为空操作（Kevin 在 lp-manifest 中填充资源
+    // 目录）。
     if (opts.skillsDir) this.copyBundledSkills(opts.skillsDir, join(dir, '.claude', 'skills'));
 
     const memory = join(dir, 'memory.md');
     if (!existsSync(memory)) {
       writeFileSync(memory, `# Memory — ${meta.name} (${meta.id})\n\n_Append durable facts, decisions, and context below._\n`, 'utf8');
     }
-    ensureMineIgnore(dir); // keep settings.json / cursor / messages out of mempalace's index
+    ensureMineIgnore(dir); // 让 settings.json / cursor / 消息远离 mempalace 的索引
     const cursor = join(dir, 'cursor.json');
     if (!existsSync(cursor)) this.writeJson(cursor, { lastProcessed: null });
 
-    // upsert registry — spread the PRIOR entry first so a respawn preserves
-    // fields the spawn `meta` doesn't carry, above all `sessionId`. Without this,
-    // ensureAgent (which runs before the resume lookup in the pty:spawn handler)
-    // would wipe the recorded session id, so `lastSession()` returns undefined and
-    // `--resume` is never attached — i.e. every restart starts a fresh thread.
-    // Validate the working directory at the source so a bad value is visible on
-    // the roster (cwdValid) rather than silently spawning into a nonexistent dir.
-    // Store the EXPANDED cwd, never the raw `~/…` the user typed — the registry is
-    // read by hooks, the roster and the worker watcher, none of which run a shell.
+    // upsert registry —— 先展开 PRIOR 条目，使重新 spawn 能保留 spawn `meta`
+    // 不携带的字段，尤其是 `sessionId`。没有它，ensureAgent（在 pty:spawn 处理器
+    // 中的恢复查找之前运行）会抹掉已记录的会话 id，于是 `lastSession()` 返回
+    // undefined，`--resume` 永远不会被附加 —— 即每次重启都会开一条全新线程。
+    // 在源头校验工作目录，使坏值在名册上可见（cwdValid），而非悄悄 spawn 进
+    // 一个不存在的目录。存储展开后的 cwd，绝不用用户键入的原始 `~/…` —— 注册表
+    // 会被 hook、名册和 worker 监视器读取，它们都不运行 shell。
     const cwd = this.cwdValidity(meta.cwd);
     reg.agents[meta.id] = {
       ...prev,
@@ -687,7 +654,7 @@ export class HiveManager {
       role,
       status: 'idle',
       cwdValid: cwd.valid,
-      // A (re)spawn always means a live terminal — clear any prior archived flag.
+      // （重新）spawn 总是意味着活动终端 —— 清除任何先前的已归档标志。
       archived: false,
       lastSeen: Date.now()
     };
@@ -695,7 +662,7 @@ export class HiveManager {
     this.atomicWriteJson(join(root, 'registry.json'), reg);
 
     this.appendLog({ kind: 'spawn', agentId: meta.id, name: meta.name, isGod: !!meta.isGod });
-    // Only logs on an invalid cwd (rare) — not a per-spawn line, so no log spam.
+    // 仅在 cwd 无效时记录（罕见）—— 不是每次 spawn 一行，避免日志刷屏。
     if (!cwd.valid) {
       this.appendLog({ kind: 'cwd_invalid', agentId: meta.id, cwd: meta.cwd, issue: cwd.issue });
     }
@@ -707,152 +674,104 @@ export class HiveManager {
       HIVE_ROOT: root,
       AGENT_DIR: dir
     };
-    // The bundled-node launcher, so an agent can run the hive's .cjs helpers (KG
-    // CLI, Slack reply helper) even when `node` is not on its PATH. Invoking the
-    // Electron binary directly would open a second app window, so this must stay
-    // the wrapper path and never process.execPath.
+    // bundled-node 启动器，使智能体即使 PATH 上没有 `node`，也能运行 hive 的
+    // .cjs 辅助脚本（KG CLI、Slack 回复辅助）。直接调用 Electron 二进制会打开
+    // 第二个应用窗口，所以必须保留包装路径，绝不能用 process.execPath。
     //
-    // Kept as an env var for agent CONVENIENCE and for anything that reads it
-    // programmatically — but agent-facing TEXT no longer references it by name:
-    // `$HIVE_NODE` is POSIX-only syntax and expands to nothing under cmd.exe /
-    // PowerShell, so every such instruction was dead on a Windows floor. Commands
-    // we write for an agent to run bake `nodeCommand()`'s absolute path instead.
+    // 保留为环境变量是为智能体便利以及任何以编程方式读取它的东西 —— 但面向
+    // 智能体的 TEXT 不再按名字引用它：`$HIVE_NODE` 是仅 POSIX 的语法，在
+    // cmd.exe / PowerShell 下展开为空，所以每一条此类指令在 Windows 楼层上都是
+    // 死的。我们写给智能体运行的命令改为烘焙 `nodeCommand()` 的绝对路径。
     env.HIVE_NODE = this.nodeCommand();
-    // Generic light/dark hint for TUIs that paint their own background. The app
-    // defaults to light but every agent CLI assumed a dark terminal, so Crush and
-    // OpenCode looked pasted into a light window. COLORFGBG is the classic
-    // "fg;bg" convention (rxvt/konsole) that lipgloss/termenv fall back to when
-    // an OSC 11 query gets no answer. Claude Code gets the same hint through its
-    // per-session settings.json (hookSettings); Crush and OpenCode through their
-    // per-agent config dirs below. A running TUI does not re-read this: new
-    // agents pick up the current theme, running ones keep the one they started with.
+    // 为自行绘制背景的 TUI 提供的通用明/暗提示。应用默认为浅色，但每个智能体
+    // CLI 都假定是深色终端，所以 Crush 和 OpenCode 看起来像贴进了一个浅色窗口。
+    // COLORFGBG 是经典的 "fg;bg" 约定（rxvt/konsole），lipgloss/termenv 在
+    // OSC 11 查询得不到回答时会回退到它。Claude Code 通过其 per-session
+    // settings.json（hookSettings）获得同样的提示；Crush 和 OpenCode 通过下面
+    // 各自的 per-agent 配置目录。运行中的 TUI 不会重读此值：新智能体采用当前
+    // 主题，运行中的则保留启动时的主题。
     if (opts.theme) env.COLORFGBG = opts.theme === 'dark' ? '15;0' : '0;15';
 
     const claudeProvider = isClaudeProvider(meta.provider ?? 'claude');
 
-    // Non-hive-aware providers (Antigravity's `agy`, OpenAI's `codex`, xAI's
-    // `grok`) don't
-    // understand Claude Code's flags (no `--append-system-prompt`, no telemetry,
-    // no `--settings`). Instead: (1) the hive identity+protocol rides in as the
-    // session's INITIAL prompt — the closest thing to `--append-system-prompt`
-    // these CLIs offer (after the first turn the session continues normally); and
-    // (2) lifecycle hooks are wired via the preset's `hookBridge` below. Together
-    // that makes a Gemini/Codex worker a full hive citizen — live status +
-    // Stop→inbox-drain — without Claude installed at all.
+    // 非 hive 感知提供者（Antigravity 的 `agy`、OpenAI 的 `codex`、xAI 的
+    // `grok`）不理解 Claude Code 的标志（没有 `--append-system-prompt`、没有
+    // 遥测、没有 `--settings`）。改为：（1）hive 身份+协议作为会话的 INITIAL
+    // 提示随行 —— 这些 CLI 提供的、最接近 `--append-system-prompt` 的东西
+    // （第一轮之后会话正常继续）；以及（2）生命周期 hook 通过下面 preset 的
+    // `hookBridge` 接入。二者结合使 Gemini/Codex worker 成为完全的 hive 公民 ——
+    // 实时状态 + Stop→inbox 清空 —— 而根本无需安装 Claude。
     //
-    // How the prompt rides in differs by CLI:
-    //  - agy takes it under a flag (`agy -i "<prompt>"`) → push [flag, prompt].
-    //  - codex/grok take it POSITIONALLY (`codex|grok "<prompt>"`) → push the
-    //    bare prompt as a trailing arg (node-pty passes argv literally, so it
-    //    arrives as one positional argument after codex's own flags).
+    // 提示随行方式因 CLI 而异：
+    //  - agy 在标志下接收（`agy -i "<prompt>"`）→ 推 [flag, prompt]。
+    //  - codex/grok 按 POSITIONAL 接收（`codex|grok "<prompt>"`）→ 把裸提示
+    //    作为尾随参数推入（node-pty 按字面传递 argv，所以它在 codex 自己的
+    //    标志之后作为一个位置参数到达）。
     if (!isHiveAwareProvider(meta.provider)) {
       const preset = providerPreset(meta.provider ?? 'claude');
       const flag = preset.initialPromptFlag;
       const prompt = this.injectedPrompt(meta, dir, root, opts.semanticMemory ?? false, opts.knowledgeGraph ?? false, opts.kgCliPath);
-      // agy, codex, and grok expose a Claude-style lifecycle-hook surface, so each
-      // gets the SAME live status + Stop→inbox-drain Claude does — selected by the
-      // preset's `hookBridge`. agy needs a translating shim (its hook stdin/stdout
-      // shape differs from Claude's); codex reuses the Claude `cth-hook` shim
-      // verbatim (its hook payload + response contract are already Claude-shaped)
-      // and is isolated to a per-agent CODEX_HOME so the user's global Codex
-      // configuration is never mutated. Both share the HIVE_SOCK wiring below.
+      // agy、codex 和 grok 暴露 Claude 风格的生命周期 hook 表面，所以每个都
+      // 获得与 Claude 相同的实时状态 + Stop→inbox 清空 —— 由 preset 的
+      // `hookBridge` 选择。agy 需要一个翻译 shim（其 hook stdin/stdout 形状
+      // 与 Claude 不同）；codex 逐字复用 Claude 的 `cth-hook` shim（其 hook
+      // 负载 + 响应契约已是 Claude 形状），并隔离到 per-agent CODEX_HOME，使
+      // 用户的全局 Codex 配置永不被改动。两者都共享下面的 HIVE_SOCK 接线。
       const preArgs: string[] = [];
       let degraded: string | undefined;
-      // Dispatch on the structured bridge descriptor (the foundation's `bridgeOf`
-      // derives {kind:'hooks'} from the legacy `hookBridge` for agy/codex, and
-      // returns the explicit {kind:'proxy'} for qwen). Two ways a hookless CLI
-      // becomes a hive citizen:
-      //   - 'hooks' → install a config-file hook shim (agy translator / codex verbatim).
-      //   - 'proxy' → spawn a loopback reverse-proxy sidecar that observes the CLI's
-      //               LLM traffic and SYNTHESIZES the same HIVE_SOCK payloads.
+      // 基于结构化桥接描述符分发（基座的 `bridgeOf` 从旧版 `hookBridge` 为
+      // agy/codex 派生 {kind:'hooks'}，并为 qwen 返回显式 {kind:'proxy'}）。
+      // 无 hook CLI 成为 hive 公民的两种方式：
+      //   - 'hooks' → 安装配置文件 hook shim（agy 翻译器 / codex 逐字）。
+      //   - 'proxy' → spawn 一个回环反向代理 sidecar，观察 CLI 的 LLM 流量并
+      //               合成相同的 HIVE_SOCK 负载。
       const desc = bridgeOf(meta.provider);
       const sock = this.sockPath();
       if (desc && sock) {
         env.HIVE_SOCK = sock;
         try {
           if (desc.kind === 'hooks') {
-            if (desc.shim === 'agy') this.installAgyHooks();
-            else if (desc.shim === 'codex') {
+            // 骨架钩子桥：Codex 是唯一仍使用 hooks 桥的 provider。
+            if (desc.shim === 'codex') {
               env.CODEX_HOME = this.installCodexHooks(dir, meta.id);
-              // Codex refuses to run hooks from a config dir without persisted
-              // "hook trust" (normally an interactive gate). Our hooks.json is
-              // hive-authored inside an isolated CODEX_HOME, so we bypass that gate
-              // for this automated spawn — the flag's documented use ("automation
-              // that already vets hook sources"). Without it the hooks silently
-              // never fire. Must precede the positional prompt.
+              // Codex 拒绝在没有持久化「hook 信任」（通常是一道交互式闸门）的
+              // 情况下从配置目录运行 hook。我们的 hooks.json 是在隔离的 CODEX_HOME
+              // 内由 hive 编写的，所以我们为此自动化 spawn 绕过该闸门 —— 该标志
+              // 的文档化用途就是「已审核 hook 来源的自动化」。没有它，hook 会悄然
+              // 永不触发。必须位于位置参数提示之前。
               preArgs.push('--dangerously-bypass-hook-trust');
-              // Auto mode keeps codex's OS sandbox (`-a never -s workspace-write`,
-              // agentProvider.ts). workspace-write only covers cwd, so the agent
-              // folder (inbox/.done, memory.md, outbox) and the shared hive root
-              // (research deliverables, the board for god) are added as extra
-              // writable roots. Harmless outside auto mode.
+              // 自动模式保持 codex 的 OS 沙盒（`-a never -s danger-full-access`，
+              // agentProvider.ts）。智能体文件夹（inbox/.done、memory.md、outbox）
+              // 和共享 hive 根目录（研究交付物、god 的看板）通过 --add-dir 作为
+              // 额外可写根加入。自动模式之外无害。（workspace-write 会在启动时
+              // 拒绝 --add-dir，codex 0.151，所以 full-access 才是让 hive 文件夹
+              // 可写的东西。）
               for (const d of this.sandboxWritableDirs(meta, dir, root, opts.extraWritableDirs)) preArgs.push('--add-dir', d);
             }
-            else if (desc.shim === 'pi') {
-              // Pi (earendil-works) has a rich pi.on(event) lifecycle. We drop a
-              // bundled extension into a PER-AGENT PI_CODING_AGENT_DIR (so the user's
-              // global ~/.pi is never touched) that posts cth-hook-shaped payloads to
-              // HIVE_SOCK on tool_call/agent_end and auto-approves tools when the floor
-              // is in auto mode. HIVE_AUTO_APPROVE (set in spawnAgentCore from
-              // config.autoMode) gates the auto-allow — Pam guardrail #5.
-              // LIVE-UNVERIFIED: the exact extension API surface needs BYOK keys to
-              // prove; the renderer idle inbox-wake nudge is the guaranteed drain.
-              env.PI_CODING_AGENT_DIR = this.installPiHooks(dir);
-            }
-            else if (desc.shim === 'opencode') {
-              // OpenCode (anomalyco/opencode) has no Claude-shaped Stop hook, but its
-              // plugin API exposes a real session.idle event (god Decision 1). We drop
-              // a bundled plugin into a PER-AGENT OPENCODE config dir that posts
-              // HIVE_SOCK payloads on tool.execute.before/after + session.idle — the
-              // same Stop→drain semantics, provider-agnostic, no traffic interception.
-              // LIVE-UNVERIFIED (plugin auto-load + session.idle firing); the renderer
-              // idle inbox-wake nudge is the guaranteed drain fallback.
-              env.OPENCODE_CONFIG_DIR = this.installOpenCodePlugin(dir, opts.theme);
-            }
-            else if (desc.shim === 'gemini') {
-              // Point only this worker at a per-agent system settings file so
-              // the bridge is trusted and ~/.gemini/settings.json stays untouched.
-              env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = this.installGeminiHooks(dir);
-            }
-            else if (desc.shim === 'grok') this.installGrokHooks();
           } else if (desc.kind === 'proxy') {
-            // Stable per-spawn session id, stamped on every synthesized payload so
-            // recordSession (registry resume key) and the cost ledger persist.
+            // 每次 spawn 的稳定会话 id，盖在每条合成负载上，使 recordSession
+            // （注册表恢复键）与成本台账得以持久化。
             const spawnTs = String(Date.now());
             const sessionId = `proxy-${meta.id}-${createHash('sha1').update(root + meta.id + spawnTs).digest('hex').slice(0, 12)}`;
             env.HIVE_PROXY_SESSION = sessionId;
-            // The CLI normally reads its upstream base URL from `baseUrlEnv`; capture
-            // the user's configured value as the sidecar's UPSTREAM, then point the
-            // CLI at the loopback proxy instead. Fall back to the cloud default if
-            // the user hasn't set one.
+            // CLI 通常从 `baseUrlEnv` 读取其上游 base URL；捕获用户配置的值作为
+            // sidecar 的 UPSTREAM，然后把 CLI 指向回环代理。用户未设置时回退到
+            // 云默认。
             const upstream = process.env[desc.baseUrlEnv]
               || (desc.api === 'anthropic' ? 'https://api.anthropic.com' : 'https://api.openai.com/v1');
-            // A loopback bind on port 0 fails only transiently (a busy moment, a
-            // slow sidecar start past the 4s ceiling), so try a few times before
-            // giving up: without this ONE bad moment at spawn cost the agent its
-            // hive events for the whole session.
+            // 端口 0 上的回环绑定只会在瞬时失败（忙碌时刻、sidecar 启动慢过
+            // 4 秒上限），所以放弃前多试几次：没有这个，spawn 时一个坏瞬间
+            // 就让智能体在整个会话中失去 hive 事件。
             const port = await this.startProxyBridgeWithRetry(meta.id, { sock, sessionId, api: desc.api, upstream });
-            // Only redirect the CLI through the proxy if the sidecar actually bound a
-            // port. On failure leave routing untouched → the CLI talks to its real
-            // upstream directly (degraded: no synthesized hive events, but it still
-            // runs). Deliberate degradation is fine; SILENT degradation is not, so
-            // the failure goes to log.jsonl, the renderer and the spawn result.
+            // 只有当 sidecar 实际绑定到端口时，才把 CLI 重定向到代理。失败时让
+            // 路由保持原样 → CLI 直接与其真实上游通信（降级：无合成 hive 事件，
+            // 但仍在运行）。刻意降级没问题；静默降级则不行，所以失败要写入
+            // log.jsonl、渲染器和 spawn 结果。
             if (port > 0) {
               const loopback = `http://127.0.0.1:${port}`;
-              if (meta.provider === 'crush') {
-                // Crush has NO base-URL env override, so the generic env-rewrite is a
-                // no-op for it. Route it instead via a per-agent CRUSH_GLOBAL_CONFIG
-                // whose chosen provider's base_url points at the loopback proxy
-                // (installCrushConfig — sibling of installCodexHooks). `upstream`
-                // (captured above from the inert sentinel env or cloud default) is the
-                // proxy's real target. Per-agent CRUSH_GLOBAL_DATA isolates session
-                // state from the user's global ~/.config/crush.
-                const crush = this.installCrushConfig(dir, loopback, desc.api, opts.theme);
-                env.CRUSH_GLOBAL_CONFIG = dir;
-                env.CRUSH_GLOBAL_DATA = crush.data;
-              } else {
-                env[desc.baseUrlEnv] = loopback;
-              }
+              // 唯一仍使用 proxy 桥的 provider 是 qwen——它从 baseUrlEnv
+              // （OPENAI_BASE_URL）读取上游，因此把 CLI 重定向到回环 sidecar。
+              env[desc.baseUrlEnv] = loopback;
             }
             else {
               degraded = `${meta.name} is running without hive events: its proxy bridge did not bind after ${PROXY_BIND_ATTEMPTS} attempts. Live status, cost and inbox wake will not work for this session. Respawn the agent to try again.`;
@@ -863,29 +782,28 @@ export class HiveManager {
           }
         } catch (e) { console.error(`[hive] install ${desc.kind} bridge failed:`, e); }
       }
-      // Inject the protocol text whichever way the CLI accepts it.
-      // type-into-tui (Crush): the bare TUI reads a positional as a Cobra subcommand
-      // → `Unknown command`. So DROP the positional and hand the protocol back as
-      // seedPrompt; the renderer types it into the TUI after boot (ondev-b).
+      // 无论 CLI 以哪种方式接受，注入协议文本。
+      // type-into-tui（Crush）：裸 TUI 会把位置参数当作 Cobra 子命令
+      // → `Unknown command`。所以丢弃位置参数，把协议交回为 seedPrompt；
+      // 渲染器在启动后将其键入 TUI（ondev-b）。
       const deg = degraded ? { degraded } : {};
       if (preset.seedDelivery === 'type-into-tui') return { args: [...preArgs], env, seedPrompt: prompt, ...deg };
-      // If a provider somehow exposes neither a flag nor a positional prompt, spawn bare.
+      // 如果某提供者既无标志也无位置参数提示，就裸 spawn。
       if (flag) return { args: [...preArgs, flag, prompt], env, ...deg };
       if (preset.positionalInitialPrompt) return { args: [...preArgs, prompt], env, ...deg };
       return { args: preArgs, env, ...deg };
     }
 
-    // Stage 7A — first-party Claude Code telemetry → the embedded loopback OTLP
-    // collector (telemetry.ts). Pure env, no --settings change. Only injected
-    // for Claude Code once the collector is up (otelEndpoint set), so telemetry-
-    // off installs and non-Claude providers spawn exactly as before.
+    // 阶段 7A —— 第一方 Claude Code 遥测 → 内嵌回环 OTLP 收集器（telemetry.ts）。
+    // 纯 env，不改 --settings。仅在收集器启动后（otelEndpoint 已设置）为
+    // Claude Code 注入，因此遥测关闭的安装和非 Claude 提供者与之前完全一致。
     if (claudeProvider && this._otelEndpoint) {
       env.CLAUDE_CODE_ENABLE_TELEMETRY = '1';
       env.OTEL_METRICS_EXPORTER = 'otlp';
       env.OTEL_LOGS_EXPORTER = 'otlp';
       env.OTEL_EXPORTER_OTLP_PROTOCOL = 'http/json';
       env.OTEL_EXPORTER_OTLP_ENDPOINT = this._otelEndpoint;
-      env.OTEL_METRIC_EXPORT_INTERVAL = '5000'; // 5s — near-live without spamming
+      env.OTEL_METRIC_EXPORT_INTERVAL = '5000'; // 5 秒 —— 近乎实时且不刷屏
       env.OTEL_LOGS_EXPORT_INTERVAL = '2000';
       env.OTEL_RESOURCE_ATTRIBUTES = `agent.id=${meta.id},agent.name=${meta.name}`;
     }
@@ -894,8 +812,8 @@ export class HiveManager {
 
     args.push('--append-system-prompt', this.injectedPrompt(meta, dir, root, opts.semanticMemory ?? false, opts.knowledgeGraph ?? false, opts.kgCliPath));
 
-    // Phase 1 — autonomy: attach lifecycle hooks via --settings (no edits to the
-    // user's repo) so the agent reports activity and drains its inbox on Stop.
+    // 阶段 1 —— 自治：通过 --settings 附加生命周期 hook（不修改用户仓库），使
+    // 智能体报告活动并在 Stop 时清空其 inbox。
     const sock = this.sockPath();
     const shim = this.shimPath();
     if (sock && shim) {
@@ -907,8 +825,8 @@ export class HiveManager {
     return { args, env };
   }
 
-  /** Update the durable job string (hire role) without respawning. Refreshes
-   *  registry.json + identity.md so the floor editor and the hive stay aligned. */
+  /** 不重新 spawn 地更新持久职责字符串（雇佣角色）。刷新 registry.json +
+   *  identity.md，使楼层编辑器和 hive 保持对齐。 */
   patchAgentRole(id: string, role: string): { ok: boolean; error?: string } {
     const root = this.root();
     if (!root) return { ok: false, error: 'hive disabled' };
@@ -917,7 +835,7 @@ export class HiveManager {
     try {
       const reg = this.registry();
       const agent = reg.agents[id];
-      if (!agent) return { ok: false, error: 'unknown agent' };
+      if (!agent) return { ok: false, error: '未知 agent' };
       if (agent.role === next) return { ok: true };
       agent.role = next;
       agent.lastSeen = Date.now();
@@ -932,10 +850,10 @@ export class HiveManager {
   }
 
   /**
-   * Flip an agent's archived flag and persist the registry. Closing a terminal
-   * tab archives the agent (retained + flagged, NOT deleted); a (re)spawn clears
-   * it. No-op if the agent isn't registered or the flag is already set the way
-   * asked. Best-effort — never throws, so a dying PTY/kill handler can't crash.
+   * 翻转智能体的 archived 标志并持久化注册表。关闭终端标签页会归档智能体
+   * （保留 + 标记，不删除）；（重新）spawn 会清除它。若智能体未注册或标志已
+   * 按请求设置，则为空操作。尽力而为 —— 绝不抛异常，因此垂死的 PTY/kill
+   * 处理器不会崩溃。
    */
   setArchived(id: string, archived: boolean): void {
     const root = this.root();
@@ -949,24 +867,23 @@ export class HiveManager {
       this.atomicWriteJson(join(root, 'registry.json'), reg);
       this.appendLog({ kind: 'archive', agentId: id, archived });
       this.commit(`hive: ${archived ? 'archive' : 'unarchive'} ${id}`);
-    } catch { /* best-effort — never crash a lifecycle handler */ }
+    } catch { /* 尽力而为 —— 绝不让生命周期处理器崩溃 */ }
   }
 
   /**
-   * Change an agent's display name without changing its durable identity.
-   * The registry key, agent directory, session id, and every mailbox path remain
-   * keyed by `id`; only the human-facing name is updated.
+   * 在不改变其持久身份的情况下更改智能体的显示名。
+   * 注册表键、智能体目录、会话 id 以及每个邮箱路径仍以 `id` 为键；只有
+   * 面向人类的名称被更新。
    *
-   * `fleet.json` is patched in the same operation so god's next prompt receives
-   * the new name immediately rather than waiting for the periodic fleet refresh.
+   * 在同一操作中修补 `fleet.json`，使 god 的下一个提示词立即收到新名称，
+   * 而不是等待周期性的 fleet 刷新。
    */
   /**
-   * Put an agent on hold, or take it off, and tell Michael immediately.
+   * 把智能体置于保留状态，或解除保留，并立即告知 Michael。
    *
-   * `fleet.json` is patched in the same operation for the same reason
-   * `renameAgent` does it: god's roster is injected from that file on its next
-   * prompt, and waiting up to 8s for the periodic refresh means one more
-   * dispatch can still land on someone the human has just claimed.
+   * 在同一操作中修补 `fleet.json`，理由与 `renameAgent` 相同：god 的名册
+   * 在其下一个提示词时从该文件注入，而等待长达 8 秒的周期性刷新意味着又
+   * 一次分派仍可能落到人类刚刚认领的人头上。
    */
   setAgentHold(id: string, hold: boolean): { ok: boolean; onHold?: boolean; error?: string } {
     const root = this.root();
@@ -974,7 +891,7 @@ export class HiveManager {
     try {
       const reg = this.registry();
       const agent = reg.agents[id];
-      if (!agent) return { ok: false, error: 'Agent not found' };
+      if (!agent) return { ok: false, error: '找不到 agent' };
       if (!!agent.onHold === hold) return { ok: true, onHold: hold };
 
       agent.onHold = hold;
@@ -988,7 +905,7 @@ export class HiveManager {
             const row = fleet.agents.find((candidate) => candidate.id === id);
             if (row) { row.onHold = hold; this.writeJson(fleetPath, fleet); }
           }
-        } catch { /* fleet is a cache — the registry above is the record */ }
+        } catch { /* fleet 是缓存 —— 上面的注册表才是记录 */ }
       }
       this.appendLog({ kind: 'agent-hold', id, onHold: hold });
       return { ok: true, onHold: hold };
@@ -1007,15 +924,15 @@ export class HiveManager {
     try {
       const reg = this.registry();
       const agent = reg.agents[id];
-      if (!agent) return { ok: false, error: 'Agent not found' };
+      if (!agent) return { ok: false, error: '找不到 agent' };
       if (agent.name === nextName) return { ok: true, name: nextName };
 
       const previousName = agent.name;
       agent.name = nextName;
       this.writeJson(join(root, 'registry.json'), reg);
 
-      // fleet.json is ephemeral and may not exist yet. When it does, keep its
-      // display name in lockstep with the registry so rosterContext() is fresh.
+      // fleet.json 是临时文件，可能还不存在。当它存在时，让它的显示名与注册表
+      // 保持同步，使 rosterContext() 保持新鲜。
       const fleetPath = join(root, 'fleet.json');
       if (existsSync(fleetPath)) {
         try {
@@ -1027,23 +944,22 @@ export class HiveManager {
               this.writeJson(fleetPath, fleet);
             }
           }
-        } catch { /* periodic snapshot will repair a malformed/stale fleet file */ }
+        } catch { /* 周期性快照会修复损坏/过期的 fleet 文件 */ }
       }
 
       this.appendLog({ kind: 'rename', agentId: id, previousName, name: nextName });
       this.commit(`hive: rename ${id}`);
       return { ok: true, name: nextName };
     } catch {
-      return { ok: false, error: 'Could not rename agent' };
+      return { ok: false, error: '无法重命名 agent' };
     }
   }
 
   /**
-   * Persist the agent's Claude Code session_id (Lane A #6.6a). Captured from hook
-   * payloads; written only when it actually changes (a new session), so this is a
-   * no-op on the vast majority of hook events. The id is the `--resume` key for
-   * idempotent resume after a crash/restart AND the accounting/dedup key for cost
-   * samples. Best-effort — never throws into a hook handler.
+   * 持久化智能体的 Claude Code session_id（Lane A #6.6a）。从 hook 负载捕获；
+   * 仅在实际变化（新会话）时写入，因此在绝大多数 hook 事件上是空操作。该 id
+   * 是崩溃/重启后幂等恢复的 `--resume` 键，也是成本样本的核算/去重键。
+   * 尽力而为 —— 绝不向 hook 处理器抛异常。
    */
   recordSession(agentId: string, sessionId: string): void {
     const root = this.root();
@@ -1051,31 +967,30 @@ export class HiveManager {
     try {
       const reg = this.registry();
       const agent = reg.agents[agentId];
-      if (!agent || agent.sessionId === sessionId) return; // unknown agent or unchanged → no write
+      if (!agent || agent.sessionId === sessionId) return; // 未知 agent 或未变化 → 不写
       agent.sessionId = sessionId;
       agent.lastSeen = Date.now();
       this.atomicWriteJson(join(root, 'registry.json'), reg);
       this.appendLog({ kind: 'session', agentId, sessionId });
       this.commit(`hive: session ${agentId}`);
-    } catch { /* best-effort — never crash a hook handler */ }
+    } catch { /* 尽力而为——绝不使 hook 处理器崩溃 */ }
   }
 
-  /** The last known session_id for an agent, or undefined. Used to build a
-   *  `claude --resume <id>` spawn so a restarted agent resumes its thread. */
+  /** 某智能体最后已知的 session_id，或 undefined。用于构建 `claude --resume
+   *  <id>` spawn，使重启的智能体恢复其线程。 */
   lastSession(agentId: string): string | undefined {
     return this.registry().agents[agentId]?.sessionId;
   }
 
-  /** Claude Code settings that route every relevant hook through the shim, plus
-   *  (W3) the default MCP bundle merged into this PER-SESSION settings file. cwd
-   *  scopes the filesystem/git servers; cfg (the consent map) gates which servers
-   *  are written. Claude-only — this is invoked solely on the Claude spawn path. */
+  /** 把所有相关 hook 路由到 shim 的 Claude Code 设置，加上（W3）合并进此
+   *  PER-SESSION 设置文件的默认 MCP 包。cwd 限定文件系统/git 服务器的范围；
+   *  cfg（同意映射）决定写入哪些服务器。仅 Claude —— 只在 Claude spawn 路径上
+   *  调用。 */
   /**
-   * Directories a sandboxed agent may write BESIDES its cwd: its own agent
-   * folder (hive housekeeping) and the hive root (research deliverables; the
-   * board and tasks.json for god; outbox delivery is done by main, not the agent).
-   * This is what lets auto mode keep the OS sandbox on — the old full-bypass
-   * posture existed only because these paths sit outside the project cwd.
+   * 沙盒智能体在 cwd 之外还可写入的目录：它自己的智能体文件夹（hive 内务）
+   * 和 hive 根目录（研究交付物；god 的 board 和 tasks.json；outbox 投递由主进程
+   * 完成，而非智能体）。正是这使自动模式能保持 OS 沙盒开启 —— 旧的完全绕过
+   * 姿态存在只是因为这些路径位于项目 cwd 之外。
    */
   private sandboxWritableDirs(meta: AgentMeta, dir: string, root: string, extra?: string[]): string[] {
     const out = [dir, root, ...(extra ?? [])].filter((d) => typeof d === 'string' && d.length > 0);
@@ -1083,8 +998,8 @@ export class HiveManager {
   }
 
   private hookSettings(shim: string, cwd: string, cfg: McpDefaultsMap, theme?: 'light' | 'dark', writableDirs: string[] = []): unknown {
-    // Bundled node, NOT bare `node` — see nodeLauncherPath(). Claude runs each of
-    // these through `sh -c` with a stripped PATH, where `node` is often absent.
+    // 捆绑 node，而非裸 `node` —— 见 nodeLauncherPath()。Claude 用精简 PATH 的
+    // `sh -c` 运行每一条，那里 `node` 常缺失。
     const cmd = this.nodeRun(shim);
     const entry = (matcher?: string) => ({
       ...(matcher ? { matcher } : {}),
@@ -1092,39 +1007,33 @@ export class HiveManager {
     });
     const mcpServers = this.buildDefaultMcpServers(cwd, cfg);
     return {
-      // Match the TUI's truecolor palette to the harness terminal theme —
-      // PER SESSION, so the user's global Claude theme (their own terminals
-      // outside the app) is never touched.
+      // 把 TUI 的 truecolor 调色板匹配到 harness 终端主题 —— 按会话，因此用户
+      // 的全局 Claude 主题（应用之外的终端）永不被触碰。
       //
-      // 'auto', not the literal light/dark. Pinning the value matched the theme at
-      // SPAWN and then ignored every change: Claude Code supports DEC 2031 theme
-      // notifications, but a pinned theme has nothing to reconsider, so flipping
-      // the app left a running agent painting its message blocks in the old
-      // palette (black highlight on a cream terminal). 'auto' is the value that
-      // listens. The terminal reports the current theme the moment the CLI enables
-      // 2031, so startup still matches without pinning anything.
+      // 'auto'，而非字面的 light/dark。钉死该值会在 SPAWN 时匹配主题，然后
+      // 忽略此后每次变更：Claude Code 支持 DEC 2031 主题通知，但钉死的主题
+      // 无需再考虑，于是切换应用会让运行中的智能体继续用旧调色板绘制其消息块
+      // （奶油色终端上的黑色高亮）。'auto' 是倾听的值。CLI 一启用 2031，终端
+      // 就立即报告当前主题，因此启动仍无需钉死任何东西即匹配。
       ...(theme ? { theme: 'auto' } : {}),
-      // W3 — default skills/MCP bundle. Written into the PER-SESSION settings file
-      // only (never ~/.claude), so the user's own MCP servers are never clobbered;
-      // Claude merges this additively. Omitted entirely when empty so a settings
-      // file with no enabled servers is unchanged from before.
+      // W3 —— 默认技能/MCP 包。只写进 PER-SESSION 设置文件（绝不写 ~/.claude），
+      // 因此用户自己的 MCP 服务器永不被覆盖；Claude 以追加方式合并。为空时整体
+      // 省略，使没有启用服务器的设置文件与之前一致。
       ...(Object.keys(mcpServers).length ? { mcpServers } : {}),
-      // The status line gets the session status JSON after every response —
-      // including context_window.{total_input_tokens,context_window_size},
-      // the only clean programmatic source for the session's REAL context
-      // window. The shim prints a compact in-terminal gauge and forwards the
-      // payload to the harness (agent-card context gauge, exact limit).
+      // 状态行在每次响应后获取会话状态 JSON —— 包括
+      // context_window.{total_input_tokens,context_window_size}，这是会话真实
+      // 上下文窗口唯一干净的程序化来源。shim 打印紧凑的终端内仪表，并把负载
+      // 转发给 harness（智能体卡片上下文仪表、精确上限）。
       statusLine: { type: 'command', command: `${cmd} --status`, padding: 0 },
-      // Native OS sandbox for Bash subprocesses (macOS Seatbelt / Linux bubblewrap).
-      // Auto mode spawns with `--permission-mode bypassPermissions`, which only
-      // silences PROMPTS; the sandbox is a separate, opt-in layer that was never
-      // switched on. Verified live (claude 2.1.239): with this block, bypass mode
-      // still writes cwd and the listed dirs but `touch $HOME/x` fails with
-      // "Operation not permitted". Two layers are needed: `sandbox.filesystem`
-      // governs Bash children, `permissions.additionalDirectories` governs the
-      // Edit/Write tools; with only one the agent deadlocks on its own inbox.
-      // failIfUnavailable stays false: a platform without a sandbox (Windows)
-      // runs as before rather than refusing to spawn.
+      // 面向 Bash 子进程的原生 OS 沙盒（macOS Seatbelt / Linux bubblewrap）。
+      // 自动模式以 `--permission-mode bypassPermissions` spawn，那只会静默
+      // 提示；沙盒是另一层可选层，从未被打开。已在线上验证（claude 2.1.239）：
+      // 有此块时，bypass 模式仍写 cwd 和所列目录，但 `touch $HOME/x` 以
+      // "Operation not permitted" 失败。需要两层：`sandbox.filesystem` 管辖
+      // Bash 子进程，`permissions.additionalDirectories` 管辖 Edit/Write 工具；
+      // 只给一层，智能体会在它自己的 inbox 上死锁。
+      // failIfUnavailable 保持 false：没有沙盒的平台（Windows）按之前的方式
+      // 运行，而非拒绝 spawn。
       ...(writableDirs.length
         ? {
             sandbox: { enabled: true, filesystem: { allowWrite: writableDirs } },
@@ -1139,8 +1048,8 @@ export class HiveManager {
         UserPromptSubmit: [entry()],
         Notification: [entry()],
         SessionStart: [entry()],
-        // #5C: surface mid-`/compact` so an agent boxing up its context reads as
-        // 'compacting' on the floor instead of looking frozen.
+        // #5C：暴露 `正在 /compact`，使正在打包上下文的智能体在楼层上显示为
+        // 'compacting'，而不是看似冻结。
         PreCompact: [entry()],
         PostCompact: [entry()]
       }
@@ -1148,12 +1057,11 @@ export class HiveManager {
   }
 
   /**
-   * W3 — build the per-agent `mcpServers` map from the default catalog. Includes a
-   * server only when it's enabled (catalog ∩ consent), scopes filesystem/git to the
-   * agent cwd (never whole-disk), and namespaces every id `munder-<id>` so a server
-   * of the same name in the user's own ~/.claude is never clobbered. A write/secret
-   * server is included ONLY on an explicit `enabled:true` consent — never via a
-   * default — so a malformed/partial config can't silently arm a keyed server.
+   * W3 —— 从默认目录构建 per-agent `mcpServers` 映射。仅包含已启用的服务器
+   * （目录 ∩ 同意），把 filesystem/git 限定到智能体 cwd（绝不整盘），并把每个
+   * id 命名空间化为 `munder-<id>`，使用户自己的 ~/.claude 中同名服务器永不被
+   * 覆盖。写/机密服务器仅当显式 `enabled:true` 同意时才包含 —— 绝不通过默认值
+   * —— 这样损坏/部分的配置不会悄然武装一个带密钥的服务器。
    */
   private buildDefaultMcpServers(
     cwd: string,
@@ -1164,12 +1072,11 @@ export class HiveManager {
       const consented = cfg?.[e.id]?.enabled;
       const enabled = consented ?? e.defaultEnabled;
       if (!enabled) continue;
-      // Defense-in-depth: a write/secret server requires an EXPLICIT opt-in; it can
-      // never ride in on a default (the catalog already ships these OFF, but this
-      // guards a hand-edited/partial mcpDefaults map too).
+      // 纵深防御：写/机密服务器要求显式选择加入；它永远不能靠默认值混入（目录
+      // 已经把这些默认关闭，但这也守卫了手改/部分的 mcpDefaults 映射）。
       if (e.tier !== 'safe-readonly' && consented !== true) continue;
-      // Replace the `<cwd>` placeholder (filesystem/git) with the agent cwd at merge
-      // time so these stay strictly workspace-scoped.
+      // 在合并时把 `<cwd>` 占位符（filesystem/git）替换为智能体 cwd，使这些
+      // 服务器严格限定在项目工作区内。
       const args = e.spec.args.map((a) => (a === '<cwd>' ? cwd : a));
       out[`munder-${e.id}`] = {
         command: e.spec.command,
@@ -1181,11 +1088,10 @@ export class HiveManager {
   }
 
   /**
-   * W3 — refresh an agent's bundled skills from the app-resources `skills/` dir.
-   * Mirrors `identity.md`: overwritten every spawn so the shipped safe set tracks
-   * the app. Best-effort and fully tolerant — a missing/empty source dir is a no-op
-   * (Kevin populates the resource dir in lp-manifest), and any IO error is swallowed
-   * so skill provisioning can never block a spawn.
+   * W3 —— 从应用资源 `skills/` 目录刷新智能体的捆绑技能。镜像 `identity.md`：
+   * 每次 spawn 覆盖，使随附的安全技能集跟随应用。尽力而为且完全容忍 —— 缺失/
+   * 空源目录为空操作（Kevin 在 lp-manifest 中填充资源目录），任何 IO 错误都被
+   * 吞掉，使技能供给绝不阻塞 spawn。
    */
   private copyBundledSkills(srcDir: string, destDir: string): void {
     try {
@@ -1206,16 +1112,15 @@ export class HiveManager {
   }
 
   /**
-   * W1 — start a proxy-bridge sidecar for a hookless proxy-tier agent (qwen).
-   * Spawns `<root>/bin/hive-proxy.cjs` under Node, which binds a loopback port and
-   * reports it back as a one-line `{"port":N}` on stdout. Resolves the bound port
-   * (or 0 on failure, so the caller degrades gracefully without redirecting the
-   * CLI). Idempotent: any prior sidecar for the agent is killed first, so a respawn
-   * never leaks a listener. Tracked in `proxyChildren` for teardown.
+   * W1 —— 为无 hook 的代理层智能体（qwen）启动代理桥接 sidecar。
+   * 在 Node 下 spawn `<root>/bin/hive-proxy.cjs`，它绑定一个回环端口，并在
+   * stdout 上以一行 `{"port":N}` 回报。解析已绑定的端口（失败时为 0，因此调用方
+   * 优雅降级，不重定向 CLI）。幂等：先杀掉该智能体任何先前的 sidecar，因此
+   * 重新 spawn 绝不泄漏监听器。记录在 `proxyChildren` 中以备拆除。
    */
-  /** startProxyBridge with a short retry ladder. Every attempt kills the previous
-   *  sidecar first (startProxyBridge is idempotent), so a retry never leaks a
-   *  listener. Resolves the bound port, or 0 once every attempt has failed. */
+  /** startProxyBridge 带一个短重试阶梯。每次尝试都先杀掉之前的 sidecar
+   *  （startProxyBridge 是幂等的），因此重试绝不泄漏监听器。解析已绑定的端口，
+   *  或当每次尝试都失败后返回 0。 */
   private async startProxyBridgeWithRetry(
     agentId: string,
     cfg: { sock: string; sessionId: string; api: 'openai' | 'anthropic'; upstream: string }
@@ -1246,7 +1151,7 @@ export class HiveManager {
         child = spawn(process.execPath, [script], {
           env: {
             ...process.env,
-            // Run the .cjs under Electron's bundled Node, not as a second app window.
+            // 在 Electron 的捆绑 Node 下运行 .cjs，而不是作为第二个应用窗口。
             ELECTRON_RUN_AS_NODE: '1',
             HIVE_SOCK: cfg.sock,
             AGENT_ID: agentId,
@@ -1254,8 +1159,8 @@ export class HiveManager {
             HIVE_PROXY_SESSION: cfg.sessionId,
             HIVE_PROXY_API: cfg.api
           },
-          // Read the port line from stdout; never inherit stdio (the sidecar must
-          // never write into the agent's terminal or leak request bodies to a log).
+          // 从 stdout 读取端口行；绝不继承 stdio（sidecar 绝不能写入智能体的
+          // 终端，也不能把请求体泄漏到日志）。
           stdio: ['ignore', 'pipe', 'ignore']
         });
       } catch (e) {
@@ -1279,30 +1184,29 @@ export class HiveManager {
       child.on('error', () => settle(0));
       child.on('exit', () => {
         if (this.proxyChildren.get(agentId) === child) this.proxyChildren.delete(agentId);
-        settle(0); // never hang the spawn if the sidecar dies before reporting
+        settle(0); // 若 sidecar 在报告前死亡，绝不挂起 spawn
       });
-      // Hard ceiling: if the sidecar never reports a port, degrade rather than hang.
+      // 硬上限：若 sidecar 永不报告端口，降级而非挂起。
       setTimeout(() => settle(0), 4000).unref?.();
     });
   }
 
-  /** Kill the proxy sidecar for an agent, if any. Idempotent; never throws. */
+  /** 杀掉某智能体的代理 sidecar（若有）。幂等；绝不抛异常。 */
   stopProxyBridge(agentId: string): void {
     const child = this.proxyChildren.get(agentId);
     if (!child) return;
     this.proxyChildren.delete(agentId);
-    try { child.kill(); } catch { /* already gone */ }
+    try { child.kill(); } catch { /* 已消失 */ }
   }
 
-  /** Kill every live proxy sidecar (app quit). Best-effort. */
+  /** 杀掉所有活动代理 sidecar（应用退出）。尽力而为。 */
   stopAllProxyBridges(): void {
     for (const id of [...this.proxyChildren.keys()]) this.stopProxyBridge(id);
   }
 
   /**
-   * Drain an agent's inbox for the Stop hook. Returns whether to block-to-continue
-   * and the message text to feed back. Uses the per-agent cursor so a message is
-   * surfaced exactly once (no infinite loop).
+   * 为 Stop hook 清空智能体的 inbox。返回是否要阻塞以继续，以及要回馈的
+   * 消息文本。使用 per-agent 游标，使一条消息恰好呈现一次（无无限循环）。
    */
   drainForStop(agentId: string): { block: boolean; reason?: string } {
     const dir = this.agentDir(agentId);
@@ -1322,14 +1226,14 @@ export class HiveManager {
     const reason = [
       `You have ${fresh.length} new hive message(s) in your inbox. Address them before finishing:`,
       lines,
-      // Native separators (join, not string-concatenated `/`) so a Windows agent is
-      // handed a path its own shell/tools accept, not `C:\…\agents\god/inbox/`.
+      // 原生分隔符（join，而非字符串拼接 `/`），使 Windows 智能体拿到的是其
+      // 自身 shell/工具接受的路径，而非 `C:\…\agents\god/inbox/`。
       `Open the files in ${join(dir, 'inbox')} for full detail, act on each, then move handled ones to ${join(dir, 'inbox', '.done')}. Reply via your outbox if a message requires it.`
     ].join('\n');
     return { block: true, reason };
   }
 
-  // — agent-facing text —
+  // — 面向智能体的文本 —
 
   private identityText(meta: AgentMeta): string {
     const caps = (meta.capabilities ?? []).join(', ') || '—';
@@ -1346,26 +1250,24 @@ export class HiveManager {
   }
 
   /**
-   * The system-prompt prefix injected into every spawn via --append-system-prompt.
+   * 通过 --append-system-prompt 注入到每次 spawn 的系统提示词前缀。
    *
-   * 🔒 PROMPT-CACHE INVARIANT — keep this prefix VOLATILE-FREE. It interpolates
-   * only values stable for an agent's whole lifetime (name, id, dir, root,
-   * semanticMemory). Do NOT add dates, UUIDs, counters, board/registry state, or
-   * any `Date.now()`-derived text here: a prefix that changes per spawn defeats
-   * Anthropic's prompt cache (re-priming the whole system prompt every turn).
-   * Volatile context belongs on the live channels — the inbox (hive messages) and
-   * the PTY — never baked into this prefix. (Lane A #6.1.)
+   * 🔒 提示缓存不变量 —— 保持此前缀「无易变内容」。它只插值对一个智能体整个
+   * 生命周期都稳定的值（name、id、dir、root、semanticMemory）。不要在此添加
+   * 日期、UUID、计数器、board/registry 状态，或任何 `Date.now()` 派生的文本：
+   * 每次 spawn 都变化的前缀会击穿 Anthropic 的提示缓存（每轮都重新播种整个
+   * 系统提示词）。易变上下文应属于活动通道 —— inbox（hive 消息）和 PTY ——
+   * 绝不烘焙进此前缀。（Lane A #6.1。）
    *
-   * 🪟 NO SHELL SYNTAX. Every path and command here is written the way the AGENT
-   * will actually type it, on the platform it is running on. That rules out two
-   * habits that were silently Windows-only breakage:
-   *  - `$VAR` — POSIX-only. Under cmd.exe `$HIVE_NODE`/`$KG_CLI` expand to nothing
-   *    and under PowerShell to an undefined variable, so those instructions were
-   *    dead on every Windows floor. Bake the ABSOLUTE resolved path instead: it is
-   *    platform-independent, needs no expansion, and stays prompt-cache-stable.
-   *  - `'…' + '/inbox/'` — string-concatenating separators told a Windows agent to
-   *    read `C:\Users\x\hive\agents\god/inbox/`. Use join() so the agent's own
-   *    tooling gets a path it can pass straight to its shell.
+   * 🪟 无 SHELL 语法。这里的每条路径和命令都按智能体在它所运行平台上真正会
+   * 键入的方式书写。这排除了两种曾是静默 Windows 专属故障的习惯：
+   *  - `$VAR` —— 仅 POSIX。在 cmd.exe 下 `$HIVE_NODE`/`$KG_CLI` 展开为空，
+   *    在 PowerShell 下展开为未定义变量，所以那些指令在每个 Windows 楼层上都
+   *    是死的。改为烘焙 ABSOLUTE 解析后的路径：它平台无关、无需展开、且保持
+   *    提示缓存稳定。
+   *  - `'…' + '/inbox/'` —— 字符串拼接分隔符告诉 Windows 智能体去读
+   *    `C:\Users\x\hive\agents\god/inbox/`。用 join()，使智能体自己的工具拿到
+   *    可直接传给其 shell 的路径。
    */
   private injectedPrompt(
     meta: AgentMeta,
@@ -1375,13 +1277,13 @@ export class HiveManager {
     knowledgeGraph: boolean,
     kgCliPath?: string
   ): string {
-    // Native-separator path helpers — see the 🪟 note above.
+    // 原生分隔符路径助手——见上方 🪟 注释。
     const inDir = (...parts: string[]): string => join(dir, ...parts);
     const inRoot = (...parts: string[]): string => join(root, ...parts);
-    // Resolved ONCE here, at THIS agent's own spawn — same prompt-cache-stable
-    // shape as name/id/dir/root above it, not a live re-read on every turn.
-    // Needed only for the PREP ASSISTANT persona below, which refers to god by
-    // name in prose; god's own prompt already gets its name via `meta.name`.
+    // 在这里、该 agent 自身 spawn 时一次性解析——与上方 name/id/dir/root 相同、
+    // 对提示缓存稳定的形状，而非每轮实时重读。
+    // 仅供下方 PREP ASSISTANT persona 需要，它以散文方式用名字称呼 god；
+    // god 自己的提示已经通过 `meta.name` 拿到名字。
     const godRegistry = meta.isAssistant ? this.registry() : null;
     const godNameForPrompt = godRegistry
       ? resolveGodName(godRegistry.agents[godRegistry.godId ?? 'god']?.name)
@@ -1389,36 +1291,32 @@ export class HiveManager {
     const ctxLine = 'LIVE CONTEXT: each agent row in the LIVE ROSTER carries a `ctx NN%` tag — its live context-window occupancy. Treat it as the real headroom signal when routing: prefer an agent with a LOW `ctx` for a big task; treat a HIGH `ctx` (near 100%) as busy rather than idle, even if the cumulative token count looks modest.';
 
     const memoryLine = semanticMemory
-      // The palace location is named, not spelled as `$MEMPALACE_PALACE_PATH`:
-      // `mempalace` reads that env var itself, and the POSIX `$` form was noise
-      // (or an empty expansion) for a Windows agent that tried to use it literally.
+      // 宫殿位置是点名而不是 `$MEMPALACE_PALACE_PATH` 拼写：`mempalace` 自己
+      // 读取那个环境变量，POSIX 的 `$` 形式对一个试图按字面使用它的 Windows
+      // 智能体来说是噪音（或空展开）。
       ? 'Semantic memory: the whole hive shares a searchable MemPalace at the path in your MEMPALACE_PALACE_PATH environment variable. To recall relevant past knowledge across the team, run `mempalace search "<query>"`; run `mempalace wake-up` at the start of a task for a memory digest. Your notes in memory.md are mined into the palace automatically — write durable facts there.'
       : '';
-    // Enterprise Knowledge Graph (opt-in). Volatile-free: the bundled-node launcher
-    // and the KG CLI are both fixed absolute paths for an install, so baking them
-    // keeps the prefix prompt-cache-stable while making the command runnable in
-    // cmd.exe/PowerShell as well as a POSIX shell.
+    // 企业知识图谱（可选加入）。无易变内容：捆绑 node 启动器和 KG CLI 对一个
+    // 安装来说都是固定绝对路径，所以烘焙它们既保持前缀提示缓存稳定，又让命令
+    // 在 cmd.exe/PowerShell 以及 POSIX shell 中均可运行。
     const hiveNode = this.nodeCommand();
     const kgCli = kgCliPath || (process.platform === 'win32' ? '%KG_CLI%' : '$KG_CLI');
     const knowledgeLine = knowledgeGraph
       ? `Enterprise knowledge: this organisation has a private Knowledge Graph of its own documents, policies, and business context. When a task needs that context — company-specific facts, house style, internal processes — query it instead of guessing: run \`"${hiveNode}" "${kgCli}" search "<query>"\` for ranked passages, \`"${hiveNode}" "${kgCli}" list\` to see what is available, and \`"${hiveNode}" "${kgCli}" get <id>\` for a full document. (That first path is the harness's bundled Node — use it instead of bare \`node\`, which may not be on your PATH.)`
       : '';
-    // Item 13: state the build. Agents had no way to tell which version, or even
-    // which KIND of build, they were running inside, so anything that varies
-    // between a packaged app and a local dev run (umask being the one that bit
-    // us) was invisible to every investigation.
+    // 第 13 项：说明构建。智能体过去无法得知它们运行在哪个版本、甚至是哪种
+    // 构建之中，所以任何在打包应用与本地开发运行之间变化的东西（umask 正是
+    // 咬过我们的那个）对每项调查都不可见。
     const rt = this.runtimeInfo();
     const runtimeLine = rt
       ? `RUNNING BUILD: Munder Difflin v${rt.version}, ${rt.packaged ? 'packaged app' : 'local dev build'}${rt.appPath ? `, from ${rt.appPath}` : ''}. Say this version if asked which one is running, and do not assume behaviour from an older one. A local dev build inherits the launching shell's environment (umask included) where a packaged app does not, so file modes and inherited env can legitimately differ between the two. \`log.jsonl\` records an \`app-start\` event on every launch, which is how you spot a restart or a build switch.`
       : '';
-    // Item 11: god could not find the spawn queue. The mechanism has worked since
-    // v0.4.4, but nothing told him it existed — the prompt said "spawn" without
-    // saying how, COMMANDS.md and PROTOCOL.md did not mention it, and the only
-    // description lived in a source comment. So he fell back to writing a hire
-    // manifest, which needs a human to click confirm, and it looked like nothing
-    // happened. Gated on the toggle: advertising a disabled path is worse than
-    // saying nothing, and COMMANDS.md documents it either way for the case where
-    // the operator turns it on after god was already running.
+    // 第 11 项：god 找不到 spawn 队列。该机制自 v0.4.4 起一直有效，但没有任何
+    // 东西告诉他它存在 —— 提示词只说 "spawn" 没说怎么做，COMMANDS.md 和
+    // PROTOCOL.md 都没有提到它，唯一的描述躺在一条源码注释里。于是他回退到写
+    // 雇佣清单，那需要人类点击确认，看起来就像什么都没发生。由开关门控：宣传
+    // 一条已禁用的路径比什么都不说更糟，而 COMMANDS.md 两种情况都记载了 ——
+    // 用于操作者在 god 已运行后把它打开的情形。
     const spawnQueueLine = meta.isGod && this.orchestratorMaySpawn()
       ? `SPAWNING A WORKER: you can start an ephemeral worker yourself by writing ONE JSON file into ${inRoot('spawn-requests')}/<id>.json. Required: \`objective\` (what the worker must do) and \`cwd\` (the repo it runs in). Optional: \`name\`, \`command\`, \`provider\`, \`model\`, \`isolate\` (default true = its own git worktree), \`tokenCap\`, and \`slack\` ({channel, thread_ts}) to route its failures back to a thread. The harness polls that directory, spawns \`worker-<id>\`, and moves the request to \`spawn-requests/.done/\` on success or \`.failed/\` with a reason. This is the ONLY way you can spawn; a hire manifest under research/hires/ needs the human to confirm it in the UI, so it is not a route you can complete on your own. Reuse an existing agent first, as above — a worker is a fresh spend every time.`
       : '';
@@ -1437,6 +1335,7 @@ export class HiveManager {
       `Your private workspace is ${dir}. The shared hive is ${root}. Full protocol: ${inRoot('PROTOCOL.md')}.`,
       '',
       'HIVE PROTOCOL — follow it every task:',
+      'LANGUAGE: communicate entirely in Simplified Chinese (简体中文). Write every report to god, every outbox message body, every task reply, and every conversation with the user or other agents in Simplified Chinese. Regardless of what language a task arrives in, your replies and all hive messages are in Chinese.',
       `1. At the START of a task, read ${inDir('memory.md')} and EVERY file in ${inDir('inbox')} (messages other agents sent you). After handling an inbox message, move its file into ${inDir('inbox', '.done')}.`,
       `2. Record durable facts, decisions, and context by appending to ${inDir('memory.md')}.`,
       `3. To ask another agent for something or share information, write ONE message JSON into ${inDir('outbox')} (schema in PROTOCOL.md). NEVER write into another agent's folder — the orchestrator delivers your outbox.`,
@@ -1453,9 +1352,9 @@ export class HiveManager {
     ].filter(Boolean).join('\n');
   }
 
-  // — messaging —
+  // — 消息 —
 
-  /** Normalize a partial message into a full HiveMessage. */
+  /** 把一条不完整消息规范化为完整的 HiveMessage。 */
   private normalize(partial: Partial<HiveMessage>, from: string): HiveMessage {
     const act = (partial.act ?? 'inform') as MessageAct;
     return {
@@ -1474,17 +1373,17 @@ export class HiveManager {
     };
   }
 
-  /** Atomically deliver a message into a recipient agent's inbox.
-   *  Returns false when the recipient has no inbox, so the caller can bounce and
-   *  log the drop rather than let the message vanish. */
+  /** 原子地把一条消息投递到收件人智能体的 inbox。
+   *  当收件人没有 inbox 时返回 false，使调用方能退回并记录丢弃，而不是让消息
+   *  凭空消失。 */
   private deliver(msg: HiveMessage, toId: string): boolean {
     const inbox = join(this.agentDir(toId), 'inbox');
-    if (!existsSync(inbox)) return false; // unknown recipient — the caller reports it
+    if (!existsSync(inbox)) return false; // 未知收件人 —— 由调用方报告
     this.atomicWriteJson(join(inbox, `${msg.id}.json`), msg);
     return true;
   }
 
-  /** Inject a message directly (used by the orchestrator / UI / tests). */
+  /** 直接注入一条消息（供编排器 / UI / 测试使用）。 */
   send(partial: Partial<HiveMessage>, from = 'system'): HiveMessage {
     const msg = this.normalize(partial, from);
     this.routeMessage(msg);
@@ -1494,35 +1393,33 @@ export class HiveManager {
 
   private routeMessage(msg: HiveMessage): void {
     if (msg.hops > HOP_CAP) {
-      // loop guard — drop a runaway message rather than let agents ping-pong.
-      // There's no human queue to fall back on; the god agent owns conflicts.
+      // 环路护栏 —— 丢弃失控消息，而不是让智能体互相乒乓。
+      // 没有可回退的人类队列；god 智能体拥有冲突。
       this.appendLog({ kind: 'drop', reason: 'hop-cap', from: msg.from, to: msg.to, id: msg.id });
       return;
     }
     const reg = this.registry();
     const godId = reg.godId ?? 'god';
-    // The hive has no separate human-approval queue — approvals are native to
-    // each agent's Claude Code session (and approvable remotely). A message aimed
-    // at "human" is handled by the god/orchestrator, the human's proxy here.
+    // hive 没有独立的人类审批队列 —— 审批对每个智能体的 Claude Code 会话是
+    // 原生的（并可远程批准）。发给 "human" 的消息由这里的 god/编排器（人类的
+    // 代理）处理。
     const resolveTo = (to: string): string => (to === 'human' || to === 'god' ? godId : to);
     const targets = msg.to === 'broadcast'
-      // The roster for fan-out is the ACTIVE registry: skip the send-only prep
-      // assistant and any archived agent (closed tab). Hookless providers are
-      // NOT skipped — the per-target path below already serves them a terminal
-      // work order, so excluding them here only made a broadcast invisible to an
-      // agent that direct mail reaches fine. See selectBroadcastTargets.
+      // 扇出的名册是 ACTIVE 注册表：跳过仅发送的预备助手和任何已归档智能体
+      // （已关闭标签页）。无 hook 提供者不会被跳过 —— 下面的 per-target 路径
+      // 已经给它们一份终端工作单，所以在这里排除它们只会让广播对一条直邮可达
+      // 的智能体不可见。见 selectBroadcastTargets。
       ? selectBroadcastTargets(reg.agents, msg.from)
-      // Never deliver to self — guards a god → "human" message looping back to god.
+      // 绝不投递给自己 —— 阻止 god → "human" 消息回环到 god。
       : [resolveTo(msg.to)].filter((t) => t !== msg.from);
-    // Targets that actually took delivery. The log below reports these instead of
-    // intent, so a bounced or dropped message can never read as delivered.
+    // 实际接收投递的目标。下面的日志报告这些而非意图，因此退回或丢弃的消息
+    // 永远不能被读成已投递。
     const delivered: string[] = [];
     for (const t of targets) {
-      // The send-only prep assistant must never be a delivery target: it doesn't
-      // drain an inbox, so direct mail to it would rot unread (observed live: a
-      // task brief plus the follow-up reprimand about the unread inbox, both
-      // unread for hours). Bounce such mail to god instead, so the sender's intent
-      // surfaces immediately and nothing is silently lost.
+      // 仅发送的预备助手绝不能成为投递目标：它不清空 inbox，所以直邮给它会在
+      // 那里腐烂无人读（线上观察：一份任务简报加上一封关于未读 inbox 的后续
+      // 训斥邮件，两者都数小时未读）。改为把此类邮件退回给 god，使发送者的
+      // 意图立即呈现，且没有东西被悄然丢失。
       if (reg.agents[t]?.isAssistant) {
         this.deliver({
           ...msg,
@@ -1531,43 +1428,52 @@ export class HiveManager {
         }, godId);
         continue;
       }
-      // A provider without safe-idle lifecycle state (a hookless custom command)
-      // would let direct mail rot unread. Claude and bridged Antigravity/Codex
-      // receive directly into inbox/ for guarded renderer delivery. Otherwise try
-      // a terminal work-order handoff to its REPL (#53);
-      // if the renderer is unavailable, bounce to god to relay. God is exempt
-      // (the bounce target).
+      // 没有安全空闲生命周期状态的 provider（一个无 hook 的自定义命令）会让
+      // 直接邮件烂在未读里。Claude 与桥接的 Antigravity/Codex 直接收进 inbox/，
+      // 由渲染进程受控投递。否则先尝试把终端工作单移交给其 REPL（#53）；
+      // 如果渲染进程不可用，则弹回给 god 转达。god 豁免（它就是弹回目标）。
+      //
+      // 链路修复（#link-fix）：terminal 型 worker 此前只走 emitTerminalHandoff、
+      // 不落收件箱文件 → inboxCount 恒为 0 → workerWake 看门狗永不唤醒它们。
+      // 改为双通道：既落收件箱文件（看门狗以 inboxCount>0 为唤醒条件），也尽力
+      // 发射 terminalHandoff（渲染端可见时的即时通道）。收件箱文件是权威——渲染
+      // 进程后台/节流或事件丢失时，worker 醒来读 inbox 仍能拿到消息并归档。
       if (t !== godId && !canReceiveInbox(reg.agents[t]?.provider)) {
-        if (!this.emitTerminalHandoff(msg, t)) {
-          this.deliver({
-            ...msg,
-            to: godId,
-            subject: `[undeliverable — "${t}" runs ${reg.agents[t]?.provider ?? 'a hookless CLI'} and the terminal handoff failed (renderer unavailable); relay this to it] ${msg.subject}`
-          }, godId);
-        } else delivered.push(t);
+        const inboxed = this.deliver(msg, t);
+        const handed = this.emitTerminalHandoff(msg, t);
+        if (inboxed || handed) { delivered.push(t); continue; }
+        this.deliver({
+          ...msg,
+          to: godId,
+          subject: `[undeliverable — "${t}" runs ${reg.agents[t]?.provider ?? 'a hookless CLI'} and the terminal handoff failed (renderer unavailable); relay this to it] ${msg.subject}`
+        }, godId);
         continue;
       }
-      // 1d — proxy-tier providers (qwen) CAN receive inbox, but only via a
-      // SYNTHESIZED Stop, which just advances the cursor — the sidecar observes the
-      // CLI's stream and can't inject a drain reason back into its turn. So the real
-      // mail rides the terminal work-order path verbatim, exactly like a hookless
-      // provider; the synthesized Stop→drain keeps the cursor in step.
+      // 1d —— 代理层提供者（qwen）能接收 inbox，但只能通过合成的 Stop，它只推进
+      // 游标 —— sidecar 观察 CLI 的流，无法把清空理由注入回它的回合。所以真实
+      // 邮件逐字走终端工作单路径，与无 hook 提供者完全一样；合成的 Stop→清空
+      // 让游标保持同步。
+      //
+      // 链路修复（#link-fix）：与上面分支一致，双通道投递——收件箱文件落盘
+      // （workerWake 看门狗以 inboxCount>0 为唤醒条件）+ 尽力 terminalHandoff。
+      // 与合成 Stop 推进游标（drainForStop）不冲突：游标只记录已呈现的消息，
+      // 收件箱文件是持久权威，worker 醒来按协议读 inbox 并归档即可。
       const proxyDesc = bridgeOf(reg.agents[t]?.provider);
       if (t !== godId && proxyDesc?.kind === 'proxy' && proxyDesc.inboxDelivery === 'terminal') {
-        if (!this.emitTerminalHandoff(msg, t)) {
-          this.deliver({
-            ...msg,
-            to: godId,
-            subject: `[undeliverable — "${t}" runs ${reg.agents[t]?.provider ?? 'a proxy-tier CLI'} and the terminal handoff failed (renderer unavailable); relay this to it] ${msg.subject}`
-          }, godId);
-        } else delivered.push(t);
+        const inboxed = this.deliver(msg, t);
+        const handed = this.emitTerminalHandoff(msg, t);
+        if (inboxed || handed) { delivered.push(t); continue; }
+        this.deliver({
+          ...msg,
+          to: godId,
+          subject: `[undeliverable — "${t}" runs ${reg.agents[t]?.provider ?? 'a proxy-tier CLI'} and the terminal handoff failed (renderer unavailable); relay this to it] ${msg.subject}`
+        }, godId);
         continue;
       }
       if (this.deliver(msg, t)) { delivered.push(t); continue; }
-      // No agents/<t>/inbox — an id that isn't on the floor. This was the one
-      // delivery failure with neither bounce nor log, so the sender saw a routed
-      // message and the mail simply ceased to exist. Record the drop beside the
-      // hop-cap one and bounce to god, mirroring the undeliverable bounces above.
+      // 没有 agents/<t>/inbox —— 一个不在楼层上的 id。这是唯一既无退回也无日志
+      // 的投递失败：发送者看到已路由的消息，而邮件就这么不存在了。把这个丢弃
+      // 记录在 hop-cap 那条旁边，并像上面那些无法投递的退回一样退回给 god。
       this.appendLog({ kind: 'drop', reason: 'no-inbox', from: msg.from, to: t, id: msg.id });
       if (t !== godId) {
         this.deliver({
@@ -1579,20 +1485,20 @@ export class HiveManager {
     }
     this.appendLog({ kind: 'message', from: msg.from, to: msg.to, act: msg.act, subject: msg.subject, id: msg.id, delivered });
     this.emitMessage(msg, targets);
-    // Main-process observer (e.g. the closing-time controller watching for the
-    // team's ACKs and the god's COMPLETE). Best-effort, never breaks routing.
-    try { this.routedObserver?.(msg, targets); } catch { /* observer error */ }
+    // 主进程观察者（例如监视团队 ACK 和 god 的 COMPLETE 的收尾控制器）。
+    // 尽力而为，绝不破坏路由。
+    try { this.routedObserver?.(msg, targets); } catch { /* 观察者错误 */ }
   }
 
-  /** Observer invoked for EVERY routed message with its resolved targets.
-   *  Used by main-process features that react to hive traffic (closing time). */
+  /** 针对每条已路由消息及其解析后的目标调用的观察者。
+   *  供对 hive 流量作出反应的主进程特性使用（收尾时间）。 */
   private routedObserver: ((msg: HiveMessage, targets: string[]) => void) | null = null;
   setRoutedObserver(cb: ((msg: HiveMessage, targets: string[]) => void) | null): void {
     this.routedObserver = cb;
   }
 
-  /** Tell the renderer a message was routed, with its resolved recipients, so
-   *  the floor can fly an envelope from the sender to each one. Best-effort. */
+  /** 告知渲染器一条消息已路由，及其解析后的收件人，使楼层可以从发送者向每个
+   *  收件人飞一个信封。尽力而为。 */
   private emitMessage(msg: HiveMessage, targets: string[]): void {
     this.emit?.('hive:message', {
       id: msg.id,
@@ -1601,14 +1507,14 @@ export class HiveManager {
       act: msg.act,
       subject: msg.subject,
       targets,
-      // Coral-tints the floor envelope for a message the agent flagged for the
-      // human (now routed to the god proxy). Cosmetic only — no queue behind it.
+      // 对智能体标记给人类（现已路由到 god 代理）的消息给楼层信封上珊瑚色。
+      // 仅装饰 —— 背后没有队列。
       needsHuman: msg.to === 'human'
     });
   }
 
-  /** Non-Claude providers cannot drain hive inbox; hand direct mail to the
-   *  renderer so it can queue a terminal work order for the target PTY. */
+  /** 非 Claude 提供者无法清空 hive inbox；把直邮交给渲染器，使其能为目标 PTY
+   *  排队一份终端工作单。 */
   private emitTerminalHandoff(msg: HiveMessage, targetId: string): boolean {
     const delivered = this.emit?.('hive:terminalHandoff', {
       id: msg.id,
@@ -1632,13 +1538,13 @@ export class HiveManager {
     return delivered;
   }
 
-  // — router: drain outboxes → inboxes —
+  // — 路由器：清空 outboxes → inboxes —
 
-  /** Poll-based router. Cheap and robust vs fs.watch quirks on macOS. */
+  /** 基于轮询的路由器。廉价且稳健，规避 macOS 上 fs.watch 的怪癖。 */
   startRouter(intervalMs = 1500): void {
     if (this.routerTimer || !this.enabled()) return;
     this.routerTimer = setInterval(() => {
-      try { this.routeOnce(); } catch { /* keep the loop alive */ }
+      try { this.routeOnce(); } catch { /* 让循环保持存活 */ }
     }, intervalMs);
   }
   stopRouter(): void {
@@ -1660,13 +1566,13 @@ export class HiveManager {
         try {
           const partial = JSON.parse(readFileSync(full, 'utf8')) as Partial<HiveMessage>;
           const msg = this.normalize(partial, id);
-          msg.from = id; // sender is authoritative — the owning directory
+          msg.from = id; // 发送者是权威 —— 所属目录
           this.routeMessage(msg);
-          renameSync(full, join(outbox, '.sent', f)); // archive, don't reprocess
+          renameSync(full, join(outbox, '.sent', f)); // 归档，不重新处理
           routed++;
         } catch {
-          // malformed file — quarantine so we don't spin on it
-          try { renameSync(full, join(outbox, '.sent', `bad-${f}`)); } catch { /* noop */ }
+          // 损坏文件 —— 隔离，避免我们反复处理它
+          try { renameSync(full, join(outbox, '.sent', `bad-${f}`)); } catch { /* 空操作 */ }
         }
       }
     }
@@ -1674,7 +1580,7 @@ export class HiveManager {
     return routed;
   }
 
-  // — read helpers (for IPC / UI) —
+  // — 读取辅助（供 IPC / UI）—
 
   registry(): Registry {
     const root = this.root();
@@ -1687,37 +1593,62 @@ export class HiveManager {
   }
   tasks(): unknown {
     const root = this.root();
-    return root ? this.readJson(join(root, 'tasks.json'), { tasks: [] }) : { tasks: [] };
+    return root ? this.readTasks() : { tasks: [] };
   }
 
-  /** Persist the task ledger to hive/tasks.json and commit it. Mirrors the
-   *  board/message persist pattern: write JSON, log the change, single-commit.
+  /**
+   * 读取 tasks.json 并规范化为 { tasks: [...] } 形状。god 手写该文件时
+   * 历史上曾写成顶层裸数组（导致 UI parseTasks 返回空、看板空白）。这里
+   * 兜底：若顶层是数组则自动包成 { tasks }，让读路径永远拿到统一结构，
+   * 从而 add/patch/delete 也不会基于空列表重写而真清空。
+   */
+  private readTasks(): { tasks?: unknown[] } {
+    const root = this.root();
+    if (!root) return { tasks: [] };
+    const path = join(root, 'tasks.json');
+    const raw = this.readJson<unknown>(path, { tasks: [] });
+    if (Array.isArray(raw)) return { tasks: raw };
+    if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'tasks' in raw) {
+      const t = raw.tasks;
+      return { tasks: Array.isArray(t) ? t : [] };
+    }
+    return { tasks: [] };
+  }
+
+  /** 把任务台账持久化到 hive/tasks.json 并提交它。镜像 board/message 的
+   *  持久化模式：写 JSON、记录变更、单次提交。
    *
-   *  MERGES by card id instead of clobbering. Callers hold PARTIAL models of a
-   *  card — the renderer's kanban parser knows nine fields, the god writes as
-   *  many as the work needs (`result`, the verbatim Slack reply posted back to
-   *  the user; `repo`; `scope`; `origin`; `commit`; …). A wholesale write meant
-   *  one small edit through the UI deleted every unmodelled field on EVERY card
-   *  on the board. Now an unmentioned field keeps its on-disk value.
+   *  按卡片 id 合并，而非整体覆盖。调用方持有卡片的 PARTIAL 模型 —— 渲染器的
+   *  看板解析器知道九个字段，god 按工作需要写多少就写多少（`result`、回贴给
+   *  用户的逐字 Slack 回复；`repo`；`scope`；`origin`；`commit`；…）。整体写入
+   *  意味着通过 UI 做一次小编辑就会删除看板上每张卡片的每个未建模字段。现在
+   *  未提及的字段保留其在磁盘上的值。
    *
-   *  Deleting a card still works: the incoming list IS the membership, so a card
-   *  dropped from it (TasksKanban dismiss, the voice delete_task action) is
-   *  gone. Merging protects fields, never card membership. */
+   *  删除卡片仍然有效：传入列表就是成员关系，所以从中移除的卡片
+   *  （TasksKanban 关闭、语音 delete_task 动作）就消失了。合并保护字段，
+   *  从不保护卡片成员关系。 */
   writeTasks(tasks: HiveTask[]): void {
     const root = this.root();
     if (!root) return;
+    // 防真清空/防结构损坏：入站必须是非空合法数组（每张卡含 id）。
+    // 若调用方传入空数组或非数组（如基于被写坏的裸数组/空列表重写），
+    // 拒写并告警，绝不静默覆盖磁盘上已有的台账。
+    if (!Array.isArray(tasks) || tasks.length === 0 || !tasks.every((t) => t && typeof t.id === 'string' && t.id)) {
+      this.appendLog({ kind: 'tasks-guard', count: Array.isArray(tasks) ? tasks.length : -1, reason: 'write-guard: invalid or empty task list rejected' });
+      return;
+    }
     this.ensureHive();
     const path = join(root, 'tasks.json');
-    const current = this.readJson<{ tasks?: unknown }>(path, { tasks: [] });
+    const current = this.readTasks();
     const merged = mergeTaskLedger(current?.tasks, tasks);
     this.writeJson(path, { tasks: merged });
     this.appendLog({ kind: 'tasks', count: merged.length });
     this.commit(`hive: tasks (${merged.length})`);
   }
 
-  /** Append one card against the latest on-disk ledger. Renderer callers must
-   *  use this instead of re-writing a collection they read before another
-   *  source (webhook, Slack, god, voice) added work. Idempotent by task id. */
+  /** 针对最新磁盘台账追加一张卡片。渲染器调用方必须用这个，而不是重写它们在
+   *  另一个来源（webhook、Slack、god、语音）加入工作之前读到的集合。按任务 id
+   *  幂等。 */
   addTask(task: HiveTask): boolean {
     const ledger = this.tasks() as { tasks?: HiveTask[] };
     const tasks = Array.isArray(ledger?.tasks) ? ledger.tasks : [];
@@ -1726,8 +1657,8 @@ export class HiveManager {
     return true;
   }
 
-  /** Patch one card against the latest on-disk ledger, preserving unrelated
-   *  cards and fields (notably webhook.tokenHash and Slack thread metadata). */
+  /** 针对最新磁盘台账修补一张卡片，保留无关的卡片和字段（尤其是 webhook.
+   *  tokenHash 和 Slack 线程元数据）。 */
   patchTask(id: string, patch: Partial<Omit<HiveTask, 'id'>>): boolean {
     const ledger = this.tasks() as { tasks?: HiveTask[] };
     const tasks = Array.isArray(ledger?.tasks) ? ledger.tasks : [];
@@ -1739,7 +1670,7 @@ export class HiveManager {
     return true;
   }
 
-  /** Delete only the named card from the latest on-disk ledger. */
+  /** 只从最新磁盘台账删除指定卡片。 */
   deleteTask(id: string): boolean {
     const ledger = this.tasks() as { tasks?: HiveTask[] };
     const tasks = Array.isArray(ledger?.tasks) ? ledger.tasks : [];
@@ -1752,47 +1683,44 @@ export class HiveManager {
     const p = join(this.agentDir(id), 'memory.md');
     return existsSync(p) ? readFileSync(p, 'utf8') : '';
   }
-  /** Whether an agent has recorded NON-TRIVIAL memory — i.e. has appended real
-   *  notes beyond the boilerplate header ensureAgent seeds. Lets the voice
-   *  read-layer answer "what has the team remembered" and enumerate who has
-   *  anything worth reading (every registered agent technically has a memory.md,
-   *  but most of the floor's history lives in a handful of them). Cheap: reads a
-   *  small markdown file; never throws. Works for ANY id, active OR archived. */
+  /** 某智能体是否记录了非平凡的记忆 —— 即在 ensureAgent 播种的样板头部之外
+   *  追加了真实笔记。让语音读取层能回答「团队记住了什么」并枚举谁有值得读的
+   *  内容（每个已注册智能体技术上都有一份 memory.md，但楼层的大部分历史活在
+   *  其中少数几份里）。廉价：读一个小的 markdown 文件；绝不抛异常。对任意 id
+   *  有效，active 或 archived 都行。 */
   hasMemory(id: string): boolean {
     const p = join(this.agentDir(id), 'memory.md');
     if (!existsSync(p)) return false;
     try {
-      // A fresh seed is ~90 chars (one header line + the prompt). Anything
-      // meaningfully longer means the agent appended durable facts.
+      // 新鲜种子约 90 字符（一行头部 + 提示）。任何明显更长的都意味着智能体
+      // 追加了持久事实。
       return readFileSync(p, 'utf8').trim().length > 200;
     } catch { return false; }
   }
   inbox(id: string): HiveMessage[] {
     return this.listMessages(join(this.agentDir(id), 'inbox'));
   }
-  /** Read an agent's OUTBOX (messages it has authored/sent). Symmetric with
-   *  inbox(); the router drains live outbox files into recipients' inboxes and
-   *  archives the original under outbox/.sent, so a sent message survives there. */
+  /** 读取某智能体的 OUTBOX（它撰写/发送的消息）。与 inbox() 对称；路由器会把
+   *  活动的 outbox 文件清空进收件人的 inbox，并把原件归档到 outbox/.sent 下，
+   *  因此已发送消息在那里保留。 */
   outbox(id: string): HiveMessage[] {
     return this.listMessages(join(this.agentDir(id), 'outbox'));
   }
 
   /**
-   * Voice read-layer: recent message CONTENT (inbox + outbox bodies) for the
-   * operator briefing, REDACTED main-side. This is the message-content half of
-   * the voice query surface (the activity half is logTail()).
+   * 语音读取层：最近消息内容（inbox + outbox 正文），供操作员简报，主进程侧
+   * 已 REDACTED。这是语音查询面的消息内容一半（活动一半是 logTail()）。
    *
-   * Modes:
-   *   - { id }                → the single message with that id, wherever it lives.
-   *   - { agentId }           → recent messages in that agent's mailbox only.
-   *   - {}                    → recent messages across the whole floor, newest first.
-   * `limit` caps the list (default 12, max 40); `includeArchived` (default true)
-   * also reads the handled subfolders (inbox/.done, outbox/.sent).
+   * 模式：
+   *   - { id }                → 拥有该 id 的唯一条消息，无论它在哪。
+   *   - { agentId }           → 只读那个智能体邮箱里的最近消息。
+   *   - {}                    → 整个楼层上的最近消息，最新在前。
+   * `limit` 限制列表（默认 12，最大 40）；`includeArchived`（默认 true）也读取
+   * 已处理子文件夹（inbox/.done、outbox/.sent）。
    *
-   * SECURITY: every subject + body is passed through redactSecrets() here, in
-   * main, so no secret and no raw body ever crosses IPC. Delivered messages exist
-   * in both the sender's outbox/.sent and the recipient's inbox/.done; we dedup
-   * by message id so each appears once.
+   * 安全：每个 subject + body 都在这里、在主进程内经过 redactSecrets()，因此
+   * 没有机密也没有原始正文会跨越 IPC。已投递消息同时存在于发送者的
+   * outbox/.sent 和收件人的 inbox/.done；我们按消息 id 去重，使每条只出现一次。
    */
   voiceMessages(opts: { agentId?: string; id?: string; limit?: number; includeArchived?: boolean } = {}): VoiceMessage[] {
     const root = this.root();
@@ -1802,7 +1730,7 @@ export class HiveManager {
 
     const wantId = typeof opts.id === 'string' ? opts.id.trim() : '';
     const onlyAgent = typeof opts.agentId === 'string' ? opts.agentId.trim() : '';
-    const includeArchived = opts.includeArchived !== false; // default true
+    const includeArchived = opts.includeArchived !== false; // 默认为 true
 
     let owners: string[];
     try {
@@ -1848,7 +1776,7 @@ export class HiveManager {
       }
     }
 
-    // Newest first by ISO created_at (lexicographic == chronological for ISO-8601).
+    // 按 ISO created_at 最新在前（对 ISO-8601 字典序 == 时间序）。
     out.sort((a, b) => String(b.created_at || '').localeCompare(String(a.created_at || '')));
     if (wantId) return out.slice(0, 1);
     const lim = typeof opts.limit === 'number' && isFinite(opts.limit)
@@ -1856,168 +1784,78 @@ export class HiveManager {
       : 12;
     return out.slice(0, lim);
   }
-  /** Count undrained inbox messages for an agent (cheap — for the fleet snapshot). */
+  /** 统计某智能体未清空的 inbox 消息数（廉价 —— 供 fleet 快照使用）。 */
   inboxBacklog(id: string): number {
     const dir = join(this.agentDir(id), 'inbox');
     if (!existsSync(dir)) return 0;
     try { return readdirSync(dir).filter((f) => f.endsWith('.json')).length; } catch { return 0; }
   }
-  /** Install the Antigravity (`agy`) lifecycle-hook bridge: write the normalizer
-   *  shim and merge a `munder-hive` hook group into agy's global hooks.json so a
-   *  Gemini worker reports PreToolUse/PostToolUse/Stop/PreInvocation/PostInvocation
-   *  to this HookServer (live status + guarded idle delivery), reusing the Claude pipeline.
-   *
-   *  Two agy-isms handled: (1) antigravity-cli#49 — agy LOADS hooks from
-   *  `~/.gemini/antigravity-cli/hooks.json` but TRIGGERS from `~/.gemini/config/
-   *  hooks.json`, so we write BOTH; (2) commands go to cmd.exe and agy mangles
-   *  embedded quotes, so the shim path must be space-free (hive roots are).
-   *  Runtime-scoped by AGENT_ID (the shim no-ops for non-hive agy sessions), so
-   *  this global config never disturbs the user's own `agy` usage. Best-effort,
-   *  idempotent (only our own group is overwritten). */
-  private installAgyHooks(): void {
-    const root = this.root();
-    if (!root) return;
-    const shim = join(root, 'bin', 'agy-hook.cjs');
-    mkdirSync(join(root, 'bin'), { recursive: true });
-    writeFileSync(shim, AGY_HOOK_SHIM, 'utf8');
-    // Bundled node, not bare `node` — agy's hooks run with a stripped PATH too.
-    const tool = (event: string) => ({
-      matcher: '*',
-      hooks: [{ type: 'command', command: this.nodeRunUnquoted(shim, event), timeout: 0 }]
-    });
-    const plain = (event: string) => ({
-      hooks: [{ type: 'command', command: this.nodeRunUnquoted(shim, event), timeout: 0 }]
-    });
-    const group = {
-      PreToolUse: [tool('PreToolUse')],
-      PostToolUse: [tool('PostToolUse')],
-      PreInvocation: [plain('PreInvocation')],
-      PostInvocation: [plain('PostInvocation')],
-      Stop: [plain('Stop')]
-    };
-    const gem = join(homedir(), '.gemini');
-    for (const p of [join(gem, 'config', 'hooks.json'), join(gem, 'antigravity-cli', 'hooks.json')]) {
-      try {
-        mkdirSync(dirname(p), { recursive: true });
-        let existing: Record<string, unknown> = {};
-        if (existsSync(p)) {
-          try { existing = JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>; } catch { existing = {}; }
-        }
-        existing['munder-hive'] = group;
-        writeFileSync(p, JSON.stringify(existing, null, 2), 'utf8');
-      } catch { /* best-effort per file */ }
-    }
-  }
 
-  /** Official Google Gemini CLI lifecycle bridge. Gemini's hook payload is
-   *  already snake_case; the shim maps event names into HookServer's common
-   *  vocabulary and translates deny/steering replies back to Gemini.
-   *
-   *  The system settings path is per agent. Gemini merges object and array
-   *  settings across layers, so auth and user settings remain in their normal
-   *  GEMINI_CLI_HOME while this trusted bridge stays isolated. */
-  private installGeminiHooks(dir: string): string {
-    const home = join(dir, '.gemini-hive');
-    const settingsPath = join(home, 'system-settings.json');
-    try {
-      mkdirSync(home, { recursive: true });
-      const shim = join(home, 'gemini-hook.cjs');
-      writeFileSync(shim, GEMINI_HOOK_SHIM, 'utf8');
-      const hook = (name: string, matcher?: string) => ({
-        ...(matcher ? { matcher } : {}),
-        sequential: true,
-        hooks: [{
-          name: `munder-hive-${name}`,
-          type: 'command',
-          command: this.nodeRunUnquoted(shim),
-          timeout: 30000
-        }]
-      });
-      const settings = {
-        hooksConfig: { enabled: true, notifications: false },
-        hooks: {
-          SessionStart: [hook('session-start')],
-          BeforeAgent: [hook('before-agent')],
-          BeforeTool: [hook('before-tool', '.*')],
-          AfterTool: [hook('after-tool', '.*')],
-          AfterAgent: [hook('after-agent')]
-        }
-      };
-      writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
-    } catch (e) { console.error('[hive] installGeminiHooks failed:', e); }
-    return settingsPath;
-  }
 
-  /** Codex lifecycle-hook bridge → full hive parity for a `codex` worker (live
-   *  status + Stop→inbox-drain), the codex counterpart of installAgyHooks().
+  /** Codex 生命周期 hook 桥 → 让 `codex` worker 获得完整 hive 对等能力（实时
+   *  状态 + Stop→inbox 排空）。
    *
-   *  Codex's hook contract is already Claude-shaped: snake_case stdin
-   *  (hook_event_name/tool_name/tool_input/session_id/cwd) and a matching response
-   *  contract, where `Stop` honoring {decision:'block',reason} means "continue,
-   *  using reason as the next prompt" — exactly what drainForStop() returns. So we
-   *  reuse the Claude `cth-hook` shim VERBATIM (no translator, unlike agy) and let
-   *  HookServer handle everything unchanged.
+   *  Codex 的 hook 契约已经是 Claude 形状：snake_case 的 stdin
+   *  （hook_event_name/tool_name/tool_input/session_id/cwd）与匹配的响应契约，
+   *  其中 `Stop` 尊重 {decision:'block',reason}，意思是「继续，把 reason 用作下一条
+   *  提示」——正是 drainForStop() 返回的东西。所以我们逐字复用 Claude 的
+   *  `cth-hook` 垫片（不像 agy 那样需要翻译器），让 HookServer 原样处理一切。
    *
-   *  ISOLATION: rather than mutate the user's global Codex configuration (which
-   *  also holds their login), we point this worker at a PER-AGENT CODEX_HOME
-   *  (`<dir>/.codex`, alongside Claude's settings.json) holding our own config.toml
-   *  with `[hooks]` tables — so the hooks fire ONLY for hive workers and a personal
-   *  `codex` run is untouched. Rollout directories are linked into that isolated
-   *  home from namespaced paths under the standard global scan roots. The user's
-   *  ~/.codex/auth.json is linked in and their config.toml is copied + extended
-   *  (login + model/provider/trust settings still apply).
-   *  Returns the CODEX_HOME path for the caller to put in the worker's env. */
+   *  隔离：不改动用户的全局 Codex 配置（其中还存有他们的登录），而是把这个
+   *  worker 指向一个 PER-AGENT CODEX_HOME（`<dir>/.codex`，与 Claude 的
+   *  settings.json 并列），其中存放我们自己的带 `[hooks]` 表的 config.toml——
+   *  于是 hook 只对 hive worker 触发，个人的 `codex` 运行不受打扰。Rollout 目录
+   *  从标准全局扫描根下的带命名空间路径链接进那个隔离 home。用户的
+   *  ~/.codex/auth.json 被链接进来，其 config.toml 被复制并扩展
+   *  （login + model/provider/trust 设置仍然生效）。
+   *  返回 CODEX_HOME 路径，供调用方放进 worker 的 env。 */
   private installCodexHooks(dir: string, agentId: string): string {
     const home = join(dir, '.codex');
     try {
       mkdirSync(home, { recursive: true });
       const userHome = join(homedir(), '.codex');
-      // Symlink the user's login so the isolated home authenticates as them.
-      // (config.toml is NOT symlinked — we write our own below, seeded from theirs,
-      // because it must carry our [hooks] tables.) Fall back to copy where symlinks
-      // need privilege (Windows). Idempotent — skip if already linked.
+      // 符号链接用户的登录，让隔离 home 以他们的身份认证。
+      // （config.toml 不符号链接——我们在下面写入自己的，以他们的为种子，
+      // 因为它必须携带我们的 [hooks] 表。）在符号链接需要特权（Windows）时
+      // 回退为复制。幂等——已链接则跳过。
       const authSrc = join(userHome, 'auth.json');
       const authDest = join(home, 'auth.json');
       if (existsSync(authSrc) && !existsSync(authDest)) {
         try { symlinkSync(authSrc, authDest); }
-        catch { try { copyFileSync(authSrc, authDest); } catch { /* best-effort */ } }
+        catch { try { copyFileSync(authSrc, authDest); } catch { /* 尽力而为 */ } }
       }
-      // The managed app-server daemon used by Codex Remote Control is launched
-      // from the standalone install rooted at $CODEX_HOME/packages. Share the
-      // user's installed binaries without duplicating them into every agent.
+      // Codex Remote Control 使用的受管 app-server 守护进程从根在
+      // $CODEX_HOME/packages 的独立安装启动。共享用户已安装的二进制，
+      // 而不复制进每个 agent。
       const packagesSrc = join(userHome, 'packages');
       const packagesDest = join(home, 'packages');
       if (existsSync(packagesSrc) && !existsSync(packagesDest)) {
         try {
           symlinkSync(packagesSrc, packagesDest, process.platform === 'win32' ? 'junction' : 'dir');
-        } catch { /* remote integration falls back to a local TUI if unavailable */ }
+        } catch { /* 远程集成不可用时回退到本地 TUI */ }
       }
-      // Wire lifecycle hooks via config.toml `[hooks]` tables — the user-layer
-      // discovery surface Codex actually scans. (A bare $CODEX_HOME/hooks.json is
-      // plugin-scoped — referenced FROM a plugin manifest — and is NOT discovered
-      // for a plain config dir; verified empirically that it never fires.) We seed
-      // this config.toml from the user's (their model/provider/trust settings carry
-      // over) and append a `[[hooks.<Event>]]` group per event, each pointing at the
-      // SAME cth-hook shim — reused verbatim (Codex's hook payload + response are
-      // already Claude-shaped, so HookServer/drainForStop run unchanged). Regenerated
-      // each spawn (idempotent). A single-quoted TOML literal avoids path escaping
-      // (hive roots are space/quote-free). NOTE: hooks fire in INTERACTIVE codex
-      // sessions (how hive workers run), not in headless `codex exec`.
+      // 通过 config.toml 的 `[hooks]` 表接线生命周期 hook——这是 Codex 真正
+      // 扫描的用户层发现面。（裸的 $CODEX_HOME/hooks.json 是插件作用域的——
+      // 从插件清单引用——普通配置目录不会发现它；实证它从不触发。）我们用
+      // 用户的 config.toml 播种（他们的 model/provider/trust 设置带过来），并为
+      // 每个事件追加一个 `[[hooks.<Event>]]` 组，每个都指向同一个 cth-hook
+      // 垫片——逐字复用（Codex 的 hook 负载与响应已是 Claude 形状，因此
+      // HookServer/drainForStop 原样运行）。每次 spawn 重新生成（幂等）。单引号
+      // TOML 字面量避免路径转义（hive 根无空格/引号）。注意：hook 在 INTERACTIVE
+      // codex 会话（hive worker 的运行方式）中触发，不在无头 `codex exec` 中。
       //
-      // `timeout` IS SECONDS HERE — do NOT copy Claude's `timeout: 0` sentinel into
-      // this file. Codex parses the key as `timeout_sec` and normalizes it with
-      // `timeout_sec.unwrap_or(600).max(1)`, so 0 does not mean "no timeout": it is
-      // floored to ONE SECOND, the shortest budget there is. That shipped through
-      // v0.3.7 and made every codex worker log `SessionStart hook (failed) — hook
-      // timed out after 1s` (same for UserPromptSubmit), because each hook cold-starts
-      // the Electron binary via hive-node and then waits on hooks.sock — measured
-      // 0.08-0.16s idle but 0.6-0.7s under 8 concurrent spawns, which is exactly what
-      // session start and prompt dispatch look like. 30s clears that by two orders of
-      // magnitude while still capping a wedged shim well before its own 5s internal
-      // cap stops mattering; bare omission (600s) would leave a hang looking like a
-      // freeze. Verify any change with codex's own resolver, no model spend:
-      // `codex app-server` → initialize → `hooks/list` reports the normalized
-      // timeoutSec per event.
+      // 这里的 `timeout` 单位是秒——不要把 Claude 的 `timeout: 0` 哨兵复制进
+      // 本文件。Codex 把该键解析为 `timeout_sec`，并用
+      // `timeout_sec.unwrap_or(600).max(1)` 归一化，因此 0 不意味着「无超时」：
+      // 它被压到 ONE SECOND——现存最短的预算。这一点随 v0.3.7 发布，让每个
+      // codex worker 都记录 `SessionStart hook (failed) — hook timed out after 1s`
+      // （UserPromptSubmit 同理），因为每个 hook 都经 hive-node 冷启动 Electron
+      // 二进制然后等待 hooks.sock——实测空闲 0.08-0.16s，但 8 个并发 spawn 时
+      // 为 0.6-0.7s，而这正是会话启动与提示派发时的样子。30s 把该时间缩短两个
+      // 数量级，同时仍能在卡死垫片自己 5s 内部上限失效之前封住它；裸省略
+      // （600s）会让卡死看起来像冻结。用 codex 自己的解析器验证任何改动，
+      // 不花模型的钱：`codex app-server` → initialize → `hooks/list` 报告每个
+      // 事件归一化后的 timeoutSec。
       const shim = this.shimPath();
       let config = existsSync(join(userHome, 'config.toml'))
         ? readFileSync(join(userHome, 'config.toml'), 'utf8') : '';
@@ -2031,9 +1869,9 @@ export class HiveManager {
       }
       writeFileSync(join(home, 'config.toml'), config, 'utf8');
 
-      // Keep each worker's CODEX_HOME isolated while putting its rollout data
-      // below Codex's standard scan roots. External usage tools can then discover
-      // the sessions without understanding the hive's private directory layout.
+      // 保持每个 worker 的 CODEX_HOME 隔离，同时把其 rollout 数据放到 Codex
+      // 标准扫描根之下。外部使用工具因此能在不理解 hive 私有目录布局的情况下
+      // 发现会话。
       this.exposeCodexDataDirs(home, userHome, agentId);
     } catch (e) { console.error('[hive] installCodexHooks failed:', e); }
     return home;
@@ -2109,14 +1947,14 @@ export class HiveManager {
       symlinkSync(target, source, process.platform === 'win32' ? 'junction' : 'dir');
     } catch (e) {
       if (!existsSync(source) && existsSync(target)) {
-        try { this.moveCodexDataDir(target, source); } catch { /* data remains at target */ }
+        try { this.moveCodexDataDir(target, source); } catch { /* 数据保留在目标处 */ }
       }
       throw e;
     }
   }
 
-  /** Remove rollout directories moved under the user's standard Codex scan
-   *  roots before a full hive reset removes the isolated CODEX_HOME links. */
+  /** 在完整 hive 重置移除隔离的 CODEX_HOME 链接之前，移除移到用户标准 Codex
+   *  扫描根下的 rollout 目录。 */
   removeExposedCodexData(): void {
     const root = this.root();
     if (!root) return;
@@ -2146,174 +1984,19 @@ export class HiveManager {
     }
   }
 
-  /** Pi (earendil-works) bridge. Pi has a rich `pi.on(event, …)` lifecycle but no
-   *  Claude-shaped hook file; instead we drop a bundled EXTENSION into a PER-AGENT
-   *  PI_CODING_AGENT_DIR (so the user's global ~/.pi is never mutated) that, when Pi
-   *  loads it, posts cth-hook-shaped payloads to HIVE_SOCK on tool_call/agent_end and
-   *  auto-approves tool calls when the floor is in auto mode (HIVE_AUTO_APPROVE).
-   *  Emitting an `agent_end`→`Stop` keeps the harness status in step (→ idle), which
-   *  lets the renderer idle inbox-wake nudge deliver mail. Returns the per-agent dir
-   *  for PI_CODING_AGENT_DIR.
-   *
-   *  LIVE-UNVERIFIED: Pi's exact extension-discovery path + event API need BYOK keys
-   *  to confirm; this is written best-effort and wrapped so a wrong guess can never
-   *  break the spawn. The renderer nudge is the guaranteed drain regardless. */
-  private installPiHooks(dir: string): string {
-    const home = join(dir, '.pi-agent');
-    try {
-      // Pi discovers extensions under its agent dir; we write to the documented
-      // `extensions/` location (and keep it isolated per agent).
-      const extDir = join(home, 'extensions');
-      mkdirSync(extDir, { recursive: true });
-      writeFileSync(join(extDir, 'hive-bridge.js'), PI_EXTENSION, 'utf8');
-      // A manifest so Pi auto-loads the extension on start (best-effort; harmless if
-      // Pi ignores it). Kept minimal and hive-authored.
-      const manifest = { name: 'munder-hive-bridge', version: '0.3.1', main: 'extensions/hive-bridge.js', auto: true };
-      writeFileSync(join(home, 'extensions.json'), JSON.stringify(manifest, null, 2), 'utf8');
-    } catch (e) { console.error('[hive] installPiHooks failed:', e); }
-    return home;
-  }
 
-  /** OpenCode (anomalyco/opencode) bridge — god Decision 1 (native plugin, not proxy).
-   *  OpenCode has no Claude-shaped Stop hook, but its plugin API exposes a real
-   *  `session.idle` lifecycle event. We drop a bundled PLUGIN into a PER-AGENT config
-   *  dir's `plugin/` folder (OpenCode auto-loads `*.js` plugins from there) that posts
-   *  HIVE_SOCK payloads on tool.execute.before/after + session.idle — the same
-   *  Stop→drain semantics as codex's hooks, provider-agnostic, no traffic interception.
-   *  Returns the config dir for OPENCODE_CONFIG_DIR (isolates from ~/.config/opencode).
-   *
-   *  LIVE-UNVERIFIED: plugin auto-load + session.idle firing + the inject path need
-   *  BYOK keys to confirm; written best-effort, wrapped so it can't break the spawn.
-   *  The renderer idle inbox-wake nudge is the guaranteed drain fallback. */
-  private installOpenCodePlugin(dir: string, theme?: 'light' | 'dark'): string {
-    const home = join(dir, '.opencode');
-    try {
-      // Theme: OpenCode's `system` theme keeps the terminal's own fg/bg (xterm's,
-      // which already follows the app theme) and builds its greys from the
-      // detected background, so it reads right on light AND dark. Written to
-      // tui.json (current builds) and opencode.json (older builds read `theme`
-      // there and migrate it; the migration skips when tui.json already exists).
-      // Per-agent dir only, the user's ~/.config/opencode is never touched.
-      if (theme) {
-        mkdirSync(home, { recursive: true });
-        const choice = { theme: 'system' };
-        writeFileSync(join(home, 'tui.json'), JSON.stringify({ $schema: 'https://opencode.ai/tui.json', ...choice }, null, 2), 'utf8');
-        writeFileSync(join(home, 'opencode.json'), JSON.stringify({ $schema: 'https://opencode.ai/config.json', ...choice }, null, 2), 'utf8');
-      }
-      // BOTH `plugin/` and `plugins/`. OpenCode's current docs specify `plugins/`
-      // (plural); older builds — and the shape this bridge was originally written
-      // against — auto-load from `plugin/` (singular). Since the whole bridge is
-      // LIVE-UNVERIFIED (no BYOK keys to prove which the installed version reads),
-      // guessing one of them is a coin flip whose losing side is silent: the plugin
-      // simply never loads and the agent's only inbox drain becomes the renderer
-      // nudge. Writing the same ~2KB file twice costs nothing, is idempotent, and
-      // is correct whichever directory the installed OpenCode actually scans.
-      for (const name of ['plugin', 'plugins']) {
-        const pluginDir = join(home, name);
-        mkdirSync(pluginDir, { recursive: true });
-        writeFileSync(join(pluginDir, 'hive-bridge.js'), OPENCODE_PLUGIN, 'utf8');
-      }
-    } catch (e) { console.error('[hive] installOpenCodePlugin failed:', e); }
-    return home;
-  }
 
-  /** Crush (charmbracelet/crush) proxy routing. Crush has NO base-URL env override, so
-   *  the generic proxy env-rewrite is a no-op for it; instead we write a per-agent
-   *  CRUSH_GLOBAL_CONFIG whose standard providers' `base_url` all point at the loopback
-   *  proxy (so whatever model the worker picks, its LLM traffic routes through the
-   *  sidecar → synthesized Status/Stop/cost → status goes idle → the terminal
-   *  work-order + renderer nudge deliver mail). A per-agent CRUSH_GLOBAL_DATA isolates
-   *  session state from the user's global ~/.config/crush. Keys ride BYOK env vars
-   *  (Crush reads ANTHROPIC_API_KEY/OPENAI_API_KEY/… directly), so none are written
-   *  here. `api` follows the proxy's wire shape (advisory). Returns the config + data
-   *  paths for the spawn env.
-   *
-   *  LIVE-UNVERIFIED: the single-upstream proxy serves one provider/endpoint shape at a
-   *  time — for full synthesized events pick a model whose provider matches the
-   *  configured upstream (or a local OpenAI-compatible endpoint). Cross-provider mixing
-   *  is humanQA; the renderer nudge still delivers mail regardless. */
-  private installCrushConfig(dir: string, loopbackUrl: string, api: 'openai' | 'anthropic', theme?: 'light' | 'dark'): { config: string; data: string } {
-    const config = join(dir, 'crush.json');
-    const data = join(dir, '.crush-data');
-    try {
-      mkdirSync(data, { recursive: true });
-      // Override base_url → loopback for ONLY the provider whose wire-shape matches
-      // the proxy (`api`): the single-upstream sidecar forwards bytes unchanged, so
-      // routing a different-wire/host provider (e.g. anthropic when api='openai', or
-      // openrouter/groq which are openai-wire but different hosts) through it would
-      // hit the wrong endpoint and the call would fail. Those are left to their real
-      // upstreams (working calls, un-proxied — no synthesized events, but mail still
-      // drains via the renderer nudge + the pty-quiescence idle fallback). For the
-      // default god (openai-wire) and a local OpenAI-compatible endpoint this routes
-      // through the proxy cleanly. Cross-provider Crush-via-proxy is on-device
-      // live-verify (Dwight verify-crush MF1; the default god model is openai-wire to
-      // match). Literal loopback (Dwight's b1 — no ${VAR} expansion edge cases);
-      // Crush merges config so only base_url is rewritten.
-      const wireProvider = api === 'anthropic' ? 'anthropic' : 'openai';
-      const providers: Record<string, { base_url: string }> = { [wireProvider]: { base_url: loopbackUrl } };
-      // Theme: Crush ships one (dark) palette and no light theme, but
-      // `options.tui.transparent` stops it painting its own background, so it
-      // sits on xterm's, which follows the app theme. Set whenever the app
-      // passes a theme, dark included, so both modes look the same way.
-      const options = theme ? { tui: { transparent: true } } : undefined;
-      writeFileSync(config, JSON.stringify(options ? { providers, options } : { providers }, null, 2), 'utf8');
-    } catch (e) { console.error('[hive] installCrushConfig failed:', e); }
-    return { config, data };
-  }
 
-  /** Grok lifecycle-hook bridge → live hive status, session capture, guarded
-   *  inbox delivery, and operator gates for `grok` workers.
-   *
-   *  Grok supports the same hook events and decision vocabulary as Claude Code,
-   *  but its stdin payload uses camelCase keys. A small adapter normalizes those
-   *  keys to HookServer's Claude-shaped contract. The hook is installed in the
-   *  user's global Grok hook directory because global hooks are trusted and
-   *  Grok sessions/resume stay in the user's normal GROK_HOME. The adapter is
-   *  strictly scoped by AGENT_ID, so ordinary Grok sessions exit without doing
-   *  anything. Best-effort and idempotent. */
-  private installGrokHooks(): void {
-    const root = this.root();
-    if (!root) return;
-    try {
-      const shim = join(root, 'bin', 'grok-hook.cjs');
-      mkdirSync(join(root, 'bin'), { recursive: true });
-      writeFileSync(shim, GROK_HOOK_SHIM, 'utf8');
-      const tool = (matcher?: string) => ({
-        ...(matcher ? { matcher } : {}),
-        // Let Grok apply its event-aware defaults (5s normally, 600s for Stop).
-        // Grok is a HOOK bridge (not a proxy sidecar), so it is hit by the same
-        // `node: command not found` 127 — bundled node here too.
-        hooks: [{ type: 'command', command: this.nodeRun(shim) }]
-      });
-      const hooks = {
-        PreToolUse: [tool('.*')],
-        PostToolUse: [tool('.*')],
-        Stop: [tool()],
-        SubagentStop: [tool('.*')],
-        SessionStart: [tool('.*')],
-        UserPromptSubmit: [tool()],
-        PreCompact: [tool('.*')],
-        PostCompact: [tool('.*')]
-      };
-      const hookDir = join(homedir(), '.grok', 'hooks');
-      mkdirSync(hookDir, { recursive: true });
-      writeFileSync(
-        join(hookDir, 'munder-hive.json'),
-        JSON.stringify({ hooks }, null, 2),
-        'utf8'
-      );
-    } catch (e) { console.error('[hive] installGrokHooks failed:', e); }
-  }
 
-  /** Write the live fleet snapshot Michael reads (`fleet.json`, gitignored).
-   *  Best-effort — called from a timer, must never throw. */
+  /** 写 Michael 读取的实时 fleet 快照（`fleet.json`，已 gitignore）。
+   *  尽力而为——从定时器调用，绝不能抛异常。 */
   writeFleetSnapshot(snapshot: unknown): void {
     const root = this.root();
     if (!root) return;
-    try { writeFileSync(join(root, 'fleet.json'), JSON.stringify(snapshot, null, 2), 'utf8'); } catch { /* noop */ }
+    try { writeFileSync(join(root, 'fleet.json'), JSON.stringify(snapshot, null, 2), 'utf8'); } catch { /* 空操作 */ }
   }
 
-  /** Is this agent the hive's god/orchestrator? */
+  /** 该 agent 是否是 hive 的 god/编排者？ */
   isGod(agentId: string): boolean {
     try {
       const reg = this.registry();
@@ -2322,27 +2005,23 @@ export class HiveManager {
   }
 
   /**
-   * A compact, one-shot LIVE ROSTER line built from `fleet.json` — injected into
-   * god's context as `additionalContext` on SessionStart and every
-   * UserPromptSubmit (see HookServer).
+   * 由 `fleet.json` 构建的紧凑、一次性 LIVE ROSTER 行——在 SessionStart 与每次
+   * UserPromptSubmit 时注入 god 的上下文作为 `additionalContext`（见 HookServer）。
    *
-   * Why: fleet.json/registry.json are always fresh on disk (8s snapshot +
-   * archiveOrphanedAgents on boot + PTY-exit archiving), but god's CONTEXT is not.
-   * After an app restart god resumes a session whose transcript still describes
-   * the OLD floor, and it will happily message agents that no longer exist. It is
-   * told to read fleet.json, but "told to" is not "always knows" — so we push the
-   * truth in on every turn instead. One line, so the cost is negligible.
+   * 为什么：fleet.json/registry.json 在磁盘上总是新鲜的（8s 快照 + 启动时
+   * archiveOrphanedAgents + PTY 退出归档），但 god 的 CONTEXT 不是。应用重启后，
+   * god 恢复一个 transcript 仍描述旧楼层的会话，它会高兴地给已不存在的 agent
+   * 发消息。它被告知要读 fleet.json，但「被告知」不等于「总会知道」——所以我们
+   * 每一轮主动把真相推进去。一行而已，成本可忽略。
    *
-   * `ctxOf` (optional, supplied by HookServer) lets the caller layer the LIVE
-   * context-window occupancy on top of the disk snapshot — each agent gets a
-   * `ctx NN%` so god can see at a glance whose context is nearly full when it
-   * routes work. fleet.json only carries cumulative `tokens`, which is a spend
-   * figure, not how full the CURRENT window is; the real occupancy lives in
-   * HookServer.contextById (from the statusLine shim). Omitted when the callback
-   * is absent or an agent has no Status tick yet.
+   * `ctxOf`（可选，由 HookServer 提供）让调用方把 LIVE 上下文窗口占用叠加在
+   * 磁盘快照之上——每个 agent 得到一个 `ctx NN%`，god 在路由工作时一眼就能
+   * 看到谁的上下文几乎满了。fleet.json 只携带累计的 `tokens`，那是花费数字、
+   * 不是当前窗口有多满；真实占用活在 HookServer.contextById（来自 statusLine
+   * 垫片）。回调缺失或某个 agent 还没有 Status tick 时省略。
    *
-   * Returns null when there is nothing to say (no hive, no snapshot, no agents),
-   * so the hook stays a no-op rather than injecting noise.
+   * 无话可说（无 hive、无快照、无 agent）时返回 null，hook 因此保持空操作，
+   * 而不是注入噪音。
    */
   rosterContext(
     ctxOf?: (agentId: string) => { tokens: number; limit: number } | undefined
@@ -2369,8 +2048,8 @@ export class HiveManager {
             : s < 5400 ? `${Math.round(s / 60)}m ago`
               : `${Math.round(s / 3600)}h ago`;
 
-      // Cap the list so a big floor can't crowd out the actual prompt. The
-      // remainder is still counted, and fleet.json is one Read away.
+      // 限制列表长度，大楼层才不至于挤掉真正的提示。其余仍被统计，fleet.json
+      // 一次 Read 即可取。
       const MAX = 24;
       const shown = agents.slice(0, MAX);
       let anyCtx = false;
@@ -2383,14 +2062,12 @@ export class HiveManager {
         if (a.inboxBacklog) bits.push(`inbox ${a.inboxBacklog}`);
         if (a.breaker && a.breaker !== 'ok' && a.breaker !== 'none') bits.push(`breaker ${a.breaker}`);
         if (a.isGod) bits.push('you');
-        // First in the row after the role would be louder, but this reads in
-        // the same scan as `breaker` and `inbox`, and god already treats those
-        // as routing signals.
+        // 放在角色之后的行首会更响亮，但该位置与 `breaker`、`inbox` 处于同一
+        // 扫描视线，而 god 已把那些当作路由信号。
         if (a.onHold) { bits.push('ON HOLD — 1:1 with the human'); anyHold = true; }
-        // Live context-window occupancy from the statusLine shim — lets god see
-        // which agents are near-full when routing, instead of guessing from the
-        // cumulative token count. Clamp to 0-100; a fresh meter can briefly
-        // report more than 100% before a window rotation.
+        // 来自 statusLine 垫片的实时上下文窗口占用——让 god 在路由时看到哪些
+        // agent 接近满载，而不是从累计 token 数猜测。钳制到 0-100；新仪表在
+        // 窗口轮换前可能短暂报告超过 100%。
         const cw = ctxOf?.(a.id);
         if (cw && cw.limit > 0) {
           const pct = Math.max(0, Math.min(100, Math.round((cw.tokens / cw.limit) * 100)));
@@ -2440,31 +2117,29 @@ export class HiveManager {
     const root = this.root();
     if (!root) return;
     const line = JSON.stringify({ ts: Date.now(), ...event }) + '\n';
-    try { appendFileSync(join(root, 'log.jsonl'), line, 'utf8'); } catch { /* noop */ }
+    try { appendFileSync(join(root, 'log.jsonl'), line, 'utf8'); } catch { /* 空操作 */ }
   }
 
   /**
-   * Append one cost sample to the durable, append-only ledger at
-   * `<root>/cost-ledger.jsonl` (Lane A #6.6d). This is the SOLE durable cost
-   * store; its row is exactly the shape Kevin (#4) reserves for the cost_ledger
-   * SQLite table, so migration is a mechanical INSERT…SELECT.
+   * 把一个成本样本追加到位于 `<root>/cost-ledger.jsonl` 的持久、只追加账本
+   * （Lane A #6.6d）。这是唯一的持久成本存储；它的行恰是 Kevin（#4）为
+   * cost_ledger SQLite 表预留的形状，因此迁移是一次机械的 INSERT…SELECT。
    *
-   * 🔒 PII: persist ONLY the allowlisted AgentUsageSample — NEVER a raw OTel
-   * record (those carry user.email / account / org / hashed-user-id). The sample
-   * is PII-free by construction upstream (the provider's normalize step), so we
-   * add no redaction here; we just must not widen what we write. The file lives
-   * at the hive ROOT, so `mempalace mine` (which only scans per-agent dirs) never
-   * ingests it — no palace noise, no MINE_IGNORE entry needed.
+   * 🔒 PII：只持久化白名单中的 AgentUsageSample——绝不存原始 OTel 记录
+   * （那些带有 user.email / account / org / hashed-user-id）。样本在上游
+   * （provider 的 normalize 步骤）就已经无 PII，因此此处不添加脱敏；我们只是
+   * 不能加宽写入的内容。文件位于 hive 根，因此 `mempalace mine`（只扫描
+   * 按-agent 目录）绝不会摄取它——无 palace 噪音，也无需 MINE_IGNORE 条目。
    *
-   * Like appendLog: append to disk now (durable immediately), let it ride the
-   * next natural commit. Best-effort — never throws into the beat.
+   * 与 appendLog 一样：立刻追加到磁盘（即刻持久），让它随下一次自然提交。
+   * 尽力而为——绝不把异常抛进 beat。
    */
   appendCostLedger(sample: AgentUsageSample): void {
     const root = this.root();
     if (!root) return;
-    // Fully snake_case so the row maps 1:1 onto Kevin's (#4) cost_ledger SQLite
-    // columns (agent_id, session_id, ts, input, output, cache_read,
-    // cache_creation, model, usd) — migration is a straight INSERT…SELECT.
+    // 完全 snake_case，行因此与 Kevin（#4）的 cost_ledger SQLite 列一一对应
+    // （agent_id, session_id, ts, input, output, cache_read,
+    // cache_creation, model, usd）——迁移是一次直白的 INSERT…SELECT。
     const row = {
       agent_id: sample.agentId,
       session_id: sample.sessionId,
@@ -2476,10 +2151,10 @@ export class HiveManager {
       model: sample.model,
       usd: sample.usd
     };
-    try { appendFileSync(join(root, 'cost-ledger.jsonl'), JSON.stringify(row) + '\n', 'utf8'); } catch { /* noop */ }
+    try { appendFileSync(join(root, 'cost-ledger.jsonl'), JSON.stringify(row) + '\n', 'utf8'); } catch { /* 空操作 */ }
   }
 
-  // — json + atomic io —
+  // — json + 原子 io —
   private readJson<T>(p: string, fallback: T): T {
     try { return JSON.parse(readFileSync(p, 'utf8')) as T; } catch { return fallback; }
   }
@@ -2492,7 +2167,7 @@ export class HiveManager {
     renameSync(tmp, p);
   }
 
-  // — git (single committer, retry + stale-lock recovery) —
+  // — git（单一提交者，重试 + 陈旧锁恢复）—
   private git(args: string[], cwd: string): { ok: boolean; out: string; err: string } {
     const res = spawnSync('git', ['-c', 'commit.gpgsign=false', '-c', 'user.name=Hive', '-c', 'user.email=hive@local', ...args], {
       cwd, encoding: 'utf8', timeout: 8000
@@ -2500,49 +2175,44 @@ export class HiveManager {
     return { ok: res.status === 0, out: res.stdout ?? '', err: res.stderr ?? '' };
   }
 
-  /** Has the one-time cost-ledger untrack pass run in this process yet? */
+  /** 一次性 cost-ledger untrack 流程是否已在本进程运行过？ */
   private untrackedCostLedger = false;
 
   /**
-   * Stop versioning the cost ledger.
+   * 停止对成本账本做版本控制。
    *
-   * `cost-ledger.jsonl` is append-only and gains a row per usage sample, so a
-   * repo that tracks it stores a fresh copy of the WHOLE file on every hive
-   * commit — and the hive commits constantly. A quarter-gigabyte ledger with a
-   * few thousand commits behind it is several hundred gigabytes of blob that
-   * git has to walk, which is what turns a routine `gc` into a multi-gigabyte
-   * `pack-objects` run. The ignore line in ensureHive keeps new copies out;
-   * this drops the one already in the index, because git keeps recording a
-   * file it is already tracking no matter what .gitignore says — so the ignore
-   * line alone reads as a fix while the repo goes on growing. The ledger stays
-   * on disk, so the cost history the app reads is untouched.
+   * `cost-ledger.jsonl` 只追加，每个用量样本增加一行，因此跟踪它的仓库会在
+   * 每次 hive 提交时存下整个文件的新副本——而 hive 频繁提交。一个四分之一 GB
+   * 的账本背后几千次提交，就是 git 要行走的几百 GB blob，这正是让例行 `gc`
+   * 变成多 GB `pack-objects` 运行的东西。ensureHive 里的忽略行挡住新副本；
+   * 这里把已在索引中的那个去掉，因为无论 .gitignore 说什么，git 都会继续记录
+   * 它已在跟踪的文件——于是单看忽略行像是一个修复，仓库却继续膨胀。账本仍在
+   * 磁盘上，应用读到的成本历史不受影响。
    */
   private untrackCostLedger(root: string): void {
     if (this.untrackedCostLedger) return;
     this.untrackedCostLedger = true;
-    // Probe before mutating: `rm --cached` on a repo that never tracked it
-    // would still rewrite the index on every launch, inside the retry path.
+    // 变更前先探测：`rm --cached` 作用于从未跟踪它的仓库，仍然会在每次启动时
+    // 重写索引，而这发生在重试路径内部。
     const tracked = this.git(['ls-files', '--', 'cost-ledger.jsonl'], root);
     if (!tracked.ok || !tracked.out.trim()) return;
     this.git(['rm', '--cached', '-q', '--ignore-unmatch', '--', 'cost-ledger.jsonl'], root);
     console.warn('[hive] untracked the cost ledger from the hive repo');
   }
 
-  /** Has the one-time Codex-home untrack pass run in this process yet? */
+  /** 一次性 Codex-home untrack 流程是否已在本进程运行过？ */
   private untrackedCodexHomes = false;
 
   /**
-   * Stop versioning Codex worker homes that are ALREADY in the index.
+   * 停止对已在索引中的 Codex worker homes 做版本控制。
    *
-   * Adding `.codex/` to each agent's .gitignore only keeps NEW paths out; git
-   * happily keeps recording a file it is already tracking, so a hive that
-   * predates that ignore line goes on committing every SQLite and transcript
-   * revision exactly as before — the .gitignore reads as a fix while the repo
-   * keeps growing. This closes that: once per process, refresh every agent's
-   * ignore file (agents that are not running never pass through spawn, and the
-   * mine loop only reaches them if mempalace is installed) and drop any tracked
-   * `.codex` path from the index. The files stay on disk, so `codex --resume`
-   * is unaffected; only their history stops.
+   * 给每个 agent 的 .gitignore 加 `.codex/` 只挡住新路径；git 会愉快地继续记录
+   * 它已在跟踪的文件，因此早于那一行 ignore 的 hive 会一如既往地提交每一次
+   * SQLite 与 transcript 修订——.gitignore 读起来像修复，仓库却继续膨胀。这里
+   * 把它封死：每进程一次，刷新每个 agent 的忽略文件（未运行的 agent 永远不会
+   * 经过 spawn，而 mine 循环只有安装了 mempalace 才会触达它们），并把任何已
+   * 跟踪的 `.codex` 路径从索引中移除。文件留在磁盘上，`codex --resume` 因此
+   * 不受影响；只是它们的历史停止记录。
    */
   private untrackCodexHomes(root: string): void {
     if (this.untrackedCodexHomes) return;
@@ -2551,16 +2221,16 @@ export class HiveManager {
     if (!existsSync(agentsDir)) return;
     try {
       for (const id of readdirSync(agentsDir)) ensureMineIgnore(join(agentsDir, id));
-    } catch { /* best-effort */ }
-    // Probe before mutating: `rm --cached` on a clean repo would still rewrite
-    // the index on every launch, and this runs inside the commit retry path.
+    } catch { /* 尽力而为 */ }
+    // 变更前先探测：`rm --cached` 作用于干净仓库，仍然会在每次启动时重写索引，
+    // 而这运行在提交重试路径内部。
     const tracked = this.git(['ls-files', '--', 'agents/*/.codex'], root);
     if (!tracked.ok || !tracked.out.trim()) return;
     this.git(['rm', '-r', '--cached', '-q', '--ignore-unmatch', '--', 'agents/*/.codex'], root);
     console.warn('[hive] untracked previously-committed Codex homes from the hive repo');
   }
 
-  /** Commit all hive changes. No-op if there is nothing staged. */
+  /** 提交所有 hive 变更。没有暂存内容则为空操作。 */
   commit(message: string): void {
     const root = this.root();
     if (!root || !existsSync(join(root, '.git'))) return;
@@ -2573,7 +2243,7 @@ export class HiveManager {
       if (commit.ok) return;
       if (/nothing to commit/i.test(commit.out + commit.err)) return;
       if (!add.ok || /index\.lock/i.test(commit.err)) { sleepSync(50 * (attempt + 1)); continue; }
-      return; // a non-lock failure — give up quietly, the next mutation retries
+      return; // 非锁失败——安静放弃，下一次变更会重试
     }
   }
 
@@ -2581,16 +2251,16 @@ export class HiveManager {
     const lock = join(root, '.git', 'index.lock');
     try {
       if (existsSync(lock) && Date.now() - statSync(lock).mtimeMs > 10_000) rmSync(lock);
-    } catch { /* noop */ }
+    } catch { /* 空操作 */ }
   }
 }
 
-// ─── PROTOCOL.md (written into the hive, readable by every agent) ────────────
+// ─── PROTOCOL.md（写入 hive，每个 agent 可读）────────────────────────────────
 
-/** The Claude Code command reference written to <hive>/COMMANDS.md, rendered from
- *  the SAME source as the UI "commands" tab so they never drift. Leads with the
- *  orchestrator note: slash = own session only, cli = shell/fleet; monitor
- *  siblings via fleet.json (claude agents does NOT see them). */
+/** 写入 <hive>/COMMANDS.md 的 Claude Code 命令参考，与 UI "命令" 选项卡
+ *  来自同一份源，永远不会漂移。以编排者说明开头：slash = 仅作用于自身会话，
+ *  cli = shell/车队；通过 fleet.json 监控兄弟代理
+ *  （claude agents 看不到它们）。 */
 function renderCommandsMd(): string {
   const lines: string[] = [
     '# Claude Code commands',
@@ -2600,6 +2270,13 @@ function renderCommandsMd(): string {
     '- **cli** commands run in your shell (Bash) and can target the fleet, spawn, or query.',
     '',
     'To MONITOR the other agents in this hive, read `fleet.json` in the hive root (live per-agent tokens, cost, status, last tool, breaker level, inbox backlog) plus `registry.json` — `claude agents` does NOT list your hive siblings. Use `claude -p "..." --output-format json` for a one-off headless query.',
+    '',
+    '## File encoding on Windows (PowerShell)',
+    'This hive\'s data files (`log.jsonl`, `fleet.json`, `registry.json`, `tasks.json`, messages, memory) are UTF-8 **without** a byte-order mark. Windows PowerShell 5.1 (`powershell.exe`) reads such files with the system ANSI codepage (GBK/cp936 on this machine) unless you say otherwise, which mangles Chinese into mojibake (`璧氶挶` instead of `赚钱`).',
+    '- When reading a hive/UTF-8 file with PowerShell, ALWAYS pass `-Encoding UTF8`, e.g. `Get-Content -Encoding UTF8 -Raw log.jsonl | ConvertFrom-Json`.',
+    '- When writing, also pass `-Encoding UTF8` (`Set-Content -Encoding UTF8`, `Add-Content -Encoding UTF8`, `Out-File -Encoding UTF8`).',
+    '- Never rely on PowerShell\'s default encoding for hive files; default is ANSI, not UTF-8, on zh-CN Windows.',
+    '- `[Console]::OutputEncoding` is also GBK here — pipe through `Out-String -Width` or re-encode if a command prints non-ASCII and you need it intact.',
     ''
   ];
   for (const g of COMMAND_GROUPS) {
@@ -2756,12 +2433,27 @@ searchable MemPalace and you have the \`mempalace\` CLI:
 
 Your \`memory.md\` is mined into the palace automatically, so the durable facts you
 write there become searchable by every agent. You don't run \`mine\` yourself.
+
+## File encoding on Windows (PowerShell)
+This hive's files (\`log.jsonl\`, \`fleet.json\`, \`registry.json\`, \`tasks.json\`, inbox/outbox
+messages, memory) are UTF-8 **without** a byte-order mark. Windows PowerShell 5.1
+(\`powershell.exe\`) reads such files using the system ANSI codepage (GBK/cp936 on this
+machine) unless you say otherwise, which turns Chinese into mojibake (\`璧氶挶\` instead
+of \`赚钱\`). The Bash tool on Windows runs through PowerShell.
+- When reading a hive/UTF-8 file with PowerShell, ALWAYS pass \`-Encoding UTF8\`, e.g.
+  \`Get-Content -Encoding UTF8 -Raw log.jsonl | ConvertFrom-Json\`.
+- When writing, also pass \`-Encoding UTF8\` (\`Set-Content -Encoding UTF8\`,
+  \`Add-Content -Encoding UTF8\`, \`Out-File -Encoding UTF8\`).
+- Never rely on PowerShell's default encoding for hive files; on zh-CN Windows the default
+  is ANSI/GBK, not UTF-8.
+- If a PowerShell command prints non-ASCII and the output looks garbled, re-encode via
+  \`Out-String -Width\` or set \`[Console]::OutputEncoding\` for that one command.
 `;
 
-// ─── cth-hook shim (written to <hive>/bin/cth-hook.cjs) ──────────────────────
-// A minimal pipe: read the hook payload on stdin, tag it with this agent's id,
-// forward it to the hive's UDS, and relay the response back to `claude`. All the
-// real logic lives in the main process (HookServer). Never blocks a stop on error.
+// ─── cth-hook 垫片（写入 <hive>/bin/cth-hook.cjs）─────────────────────────────
+// 极简管道：从 stdin 读取 hook 负载，打上该代理的 id，转发到 hive 的 UDS，
+// 再把响应转回给 `claude`。所有真正逻辑在主进程（HookServer）中。
+// 错误时绝不阻塞停止。
 const HOOK_SHIM = `#!/usr/bin/env node
 'use strict';
 const net = require('net');
@@ -2775,11 +2467,10 @@ process.stdin.on('end', () => {
   if (!payload.agent_id) payload.agent_id = process.env.AGENT_ID || null;
   const sock = process.env.HIVE_SOCK;
   if (isStatus) {
-    // Status-line mode: Claude Code pipes the session status JSON (incl.
-    // context_window.total_input_tokens / .context_window_size) after every
-    // response. Print the in-terminal gauge IMMEDIATELY (the TUI is waiting),
-    // then forward the payload to the harness fire-and-forget so the agent
-    // card's context gauge updates push-based, with the EXACT window size.
+    // Status-line 模式：Claude Code 在每次响应后把会话状态 JSON（含
+    // context_window.total_input_tokens / .context_window_size）送进来。立即打印
+    // 终端内仪表（TUI 在等待），再把负载 fire-and-forget 转发给 harness，
+    // 让 agent 卡片的上下文仪表以推送方式、用 EXACT 窗口大小更新。
     payload.hook_event_name = 'Status';
     const cw = payload.context_window || {};
     const used = cw.total_input_tokens, size = cw.context_window_size;
@@ -2811,19 +2502,18 @@ process.stdin.on('end', () => {
 });
 `;
 
-// ─── agy-hook shim (written to <hive>/bin/agy-hook.cjs) ──────────────────────
-// Antigravity's `agy` CLI fires lifecycle hooks (PreToolUse/PostToolUse/Stop/
-// PreInvocation/PostInvocation) but with a DIFFERENT stdin shape than Claude
-// (conversationId / toolCall{name,args} / workspacePaths, and no hook_event_name
-// — the event arrives as argv from the hooks.json command). This shim normalizes
-// that into the same HookPayload the HookServer already consumes, so status,
-// inbox-drain-on-Stop, and tool gating are reused UNCHANGED, then translates the
-// server's Claude-shaped response back into agy's stdout contract (decision:
-// allow|deny|block + a message). Scoped by AGENT_ID: a personal agy session
-// (no AGENT_ID in env) is a no-op, so the global hooks.json never disturbs the
-// user's own agy usage — only hive workers (spawned with AGENT_ID set) bridge.
-// NOTE (agy bug, antigravity-cli#49): the loader reads ~/.gemini/antigravity-cli/
-// hooks.json but the trigger reads ~/.gemini/config/hooks.json — we write BOTH.
+// ─── agy-hook 垫片（写入 <hive>/bin/agy-hook.cjs）─────────────────────────────
+// Antigravity 的 `agy` CLI 会触发生命周期钩子（PreToolUse/PostToolUse/Stop/
+// PreInvocation/PostInvocation），但与 Claude 相比 stdin 形状不同
+// （conversationId / toolCall{name,args} / workspacePaths，且没有 hook_event_name
+// ——事件作为 argv 从 hooks.json 命令传来）。此垫片将其标准化为
+// HookServer 已经消费的相同 HookPayload，从而状态、Stop 时的收件箱排空、
+// 工具门控都会原样复用，再把服务端的 Claude 形状响应转译回 agy 的 stdout 契约
+// （decision: allow|deny|block + 一条消息）。以 AGENT_ID 为作用域：
+// 没有 AGENT_ID 的个人 agy 会话是无操作，因此全局 hooks.json 绝不会打扰
+// 用户自己的 agy 使用——只有 hive 工作线程（带 AGENT_ID 生成）才会桥接。
+// NOTE（agy bug, antigravity-cli#49）：加载器读 ~/.gemini/antigravity-cli/
+// hooks.json 但触发器读 ~/.gemini/config/hooks.json —— 我们写入 BOTH。
 const AGY_HOOK_SHIM = `#!/usr/bin/env node
 'use strict';
 const net = require('net');
@@ -2834,7 +2524,7 @@ process.stdin.setEncoding('utf8');
 process.stdin.on('data', (d) => { data += d; });
 process.stdin.on('end', () => {
   const sock = process.env.HIVE_SOCK;
-  if (!agentId || !sock) { process.exit(0); } // not a hive worker → ignore
+  if (!agentId || !sock) { process.exit(0); } // 非 hive worker → 忽略
   let agy = {};
   try { agy = JSON.parse(data || '{}'); } catch (_) {}
   const tc = agy.toolCall || {};
@@ -2849,10 +2539,10 @@ process.stdin.on('end', () => {
   };
   let resp = '';
   const done = () => {
-    // Translate the HookServer's Claude-shaped reply into agy's contract. CRITICAL:
-    // agy treats ANY object written to stdout as a decision and FAIL-CLOSES (an
-    // empty/decision-less object = DENY). So emit JSON ONLY when there's a real
-    // directive (deny/block/steer); otherwise write NOTHING — no output = allow.
+    // 把 HookServer 的 Claude 形状回复转译进 agy 的契约。关键：
+    // agy 把写入 stdout 的任何对象都当作一个决策并 FAIL-CLOSE（一个
+    // 空/无决策对象 = DENY）。因此只在存在真实指令（deny/block/steer）时才发出
+    // JSON；否则什么都不写——无输出 = allow。
     let out = null;
     try {
       const r = JSON.parse(resp || '{}');
@@ -2875,14 +2565,14 @@ process.stdin.on('end', () => {
 });
 `;
 
-// ─── pi bridge extension (written to <agentDir>/.pi-agent/extensions/) ───────
-// A bundled extension for Pi (earendil-works). Pi exposes a pi.on(event,…)
-// lifecycle; this posts cth-hook-shaped payloads to HIVE_SOCK on tool_call /
-// tool_result / agent_end and AUTO-APPROVES tool calls when the floor is in auto
-// mode (HIVE_AUTO_APPROVE, gated by config.autoMode — Pam guardrail #5). The
-// agent_end→Stop keeps the harness status in step (→ idle) so the renderer idle
-// inbox-wake nudge can deliver mail. Fully wrapped so a wrong API guess can never
-// break the spawn. LIVE-UNVERIFIED (Pi's exact extension surface needs BYOK keys).
+// ─── pi 桥接扩展（写入 <agentDir>/.pi-agent/extensions/）──────────────────────
+// 为 Pi（earendil-works）打包的扩展。Pi 暴露了 pi.on(event,…) 生命周期；
+// 在 tool_call / tool_result / agent_end 时向 HIVE_SOCK 发送 cth-hook 形状
+// 的负载，并在楼层处于自动模式时自动批准工具调用
+// （HIVE_AUTO_APPROVE，由 config.autoMode 门控——Pam 护栏 #5）。
+// agent_end→Stop 让状态与主循环同步（→ idle），这样渲染进程的空闲
+// 收件箱唤醒提示可以投递邮件。全部包裹，让错误的 API 猜测也永远不会
+// 破坏生成。LIVE-UNVERIFIED（Pi 的确切扩展面需要 BYOK keys）。
 const PI_EXTENSION = `'use strict';
 var net = require('node:net');
 var SOCK = process.env.HIVE_SOCK;
@@ -2915,13 +2605,14 @@ module.exports.activate = function (pi) { return register(pi); };
 module.exports.default = module.exports;
 `;
 
-// ─── opencode bridge plugin (written to <agentDir>/.opencode/plugin/) ────────
-// A bundled plugin for OpenCode (anomalyco/opencode) — god Decision 1. OpenCode
-// has no Claude-shaped Stop hook but its plugin API exposes a real session.idle
-// event; this posts cth-hook-shaped payloads to HIVE_SOCK on tool.execute.before/
-// after + session.idle. The session.idle→Stop keeps status in step (→ idle) so the
-// renderer idle inbox-wake nudge delivers mail. ESM (OpenCode runs on Bun). Fully
-// wrapped. LIVE-UNVERIFIED (plugin auto-load + session.idle firing need BYOK keys).
+// ─── opencode 桥接插件（写入 <agentDir>/.opencode/plugin/）─────────────────────
+// 为 OpenCode（anomalyco/opencode）打包的插件——god 决策 1。OpenCode
+// 没有 Claude 形状的 Stop 钩子，但其插件 API 暴露了真实的 session.idle
+// 事件；它在 tool.execute.before/
+// after + session.idle 时向 HIVE_SOCK 发送 cth-hook 形状的负载。session.idle→Stop
+// 让状态与主循环同步（→ idle），这样渲染进程的空闲收件箱唤醒提示投递邮件。
+// ESM（OpenCode 运行在 Bun 上）。全部包裹。LIVE-UNVERIFIED（插件自动加载 +
+// session.idle 触发需要 BYOK keys）。
 const OPENCODE_PLUGIN = `import { createConnection } from 'node:net';
 const SOCK = process.env.HIVE_SOCK;
 const AGENT = process.env.AGENT_ID || null;
@@ -2949,16 +2640,16 @@ export const HiveBridge = async () => {
 export default HiveBridge;
 `;
 
-// ─── proxy-bridge sidecar (written to <hive>/bin/hive-proxy.cjs) ─────────────
-// One per proxy-tier agent (qwen). A dependency-free, loopback-only reverse
-// proxy: the agent's CLI is pointed at this (via ANTHROPIC_BASE_URL/OPENAI_BASE_URL),
-// and it forwards every request to the user's real upstream UNCHANGED (headers,
-// body, streaming). It TEES each response to synthesize the same HIVE_SOCK payloads
-// the hook shims emit — Status (context gauge), PostToolUse (breaker), Stop (idle
-// drain), and the new CostSample (cost ledger) — so a hookless CLI becomes a hive
-// citizen. NEVER logs bodies or keys; the captured body is parsed in-memory and
-// dropped. Idle is heuristic: a turn that ends with no tool call and no new request
-// within an ~800ms debounce → Stop (a new request cancels it).
+// ─── proxy-bridge sidecar（写入 <hive>/bin/hive-proxy.cjs）────────────────────
+// 每个代理层级的 agent（qwen）一个。无依赖、仅 loopback 的反向代理：
+// agent 的 CLI 指向这里（通过 ANTHROPIC_BASE_URL/OPENAI_BASE_URL），
+// 并把每个请求原封不动地转发给用户的真实上游（headers、body、流式）。
+// 它对每个响应进行 TEES，以合成与 hook 垫片相同的 HIVE_SOCK 负载——
+// Status（上下文仪表盘）、PostToolUse（熔断器）、Stop（空闲排空）
+// 和新的 CostSample（成本账本）——让没有钩子的 CLI 成为 hive 公民。
+// 绝不记录 body 或 keys；捕获的 body 在内存中解析后丢弃。
+// 空闲是启发式的：一轮结束后如果没有工具调用，且 ~800ms 内没有新请求 → Stop
+// （新请求会取消它）。
 const PROXY_BRIDGE_SHIM = `#!/usr/bin/env node
 'use strict';
 const http = require('http');
@@ -2974,17 +2665,10 @@ const API = process.env.HIVE_PROXY_API === 'anthropic' ? 'anthropic' : 'openai';
 
 function trimSlash(s) { while (s.length && s.charAt(s.length - 1) === '/') s = s.slice(0, -1); return s; }
 
-// Per-model context-window size for the Status gauge; fallback 200k.
-function ctxSize(model) {
-  const m = String(model || '').toLowerCase();
-  if (m.indexOf('[1m]') !== -1 || m.indexOf('-1m') !== -1) return 1000000;
-  if (m.indexOf('claude') !== -1) return 200000;
-  if (m.indexOf('gpt-4o') !== -1 || m.indexOf('gpt-4.1') !== -1 || m.indexOf('o1') !== -1 || m.indexOf('o3') !== -1) return 128000;
-  if (m.indexOf('qwen') !== -1) return 262144;
-  return 200000;
-}
+// 所有引擎统一 1M 上下文窗口（用于 Status 仪表盘）。
+const CONTEXT_WINDOW_SIZE = 1000000;
 
-// Fire-and-forget emit of a shim-shaped payload to the hive socket. Never throws.
+// 以垫片形状的负载向 hive socket 发起一次 fire-and-forget 发射。绝不抛错。
 function emit(payload) {
   if (!SOCK) return;
   try {
@@ -3010,7 +2694,7 @@ function safeArgs(s) {
   try { return JSON.parse(s); } catch (e) { return { _raw: String(s).slice(0, 500) }; }
 }
 
-// Parse a completed response (single JSON or an SSE stream) and synthesize events.
+// 解析已完成的响应（单 JSON 或 SSE 流）并合成事件。
 function parseAndEmit(bodyStr, isSse) {
   const objs = [];
   if (isSse) {
@@ -3030,7 +2714,7 @@ function parseAndEmit(bodyStr, isSse) {
 
   let model = null, input = 0, output = 0, cacheRead = 0, cacheCreation = 0, sawUsage = false;
   const toolCalls = [];
-  const oaiTools = {}; // accumulate streaming openai tool_calls by index
+  const oaiTools = {}; // 按索引累积流式 openai tool_calls
 
   for (let i = 0; i < objs.length; i++) {
     const o = objs[i];
@@ -3050,7 +2734,7 @@ function parseAndEmit(bodyStr, isSse) {
       } else if (o.type === 'content_block_start' && o.content_block && o.content_block.type === 'tool_use') {
         toolCalls.push({ name: o.content_block.name, input: o.content_block.input || {} });
       } else if (o.usage && !o.type) {
-        // non-streaming full message body
+        // 非流式完整消息体
         const u = o.usage;
         input += u.input_tokens || 0;
         output += u.output_tokens || 0;
@@ -3104,11 +2788,11 @@ function parseAndEmit(bodyStr, isSse) {
   }
 
   if (sawUsage) {
-    emit({ hook_event_name: 'Status', agent_id: AGENT_ID, context_window: { total_input_tokens: input + cacheRead + cacheCreation, context_window_size: ctxSize(model) } });
+    emit({ hook_event_name: 'Status', agent_id: AGENT_ID, context_window: { total_input_tokens: input + cacheRead + cacheCreation, context_window_size: CONTEXT_WINDOW_SIZE } });
     emit({ hook_event_name: 'CostSample', agent_id: AGENT_ID, session_id: SESSION, model: model, input: input, output: output, cache_read: cacheRead, cache_creation: cacheCreation });
   }
   if (toolCalls.length) {
-    cancelStop(); // a tool call means the turn continues
+    cancelStop(); // 一次工具调用意味着回合继续
     for (let i = 0; i < toolCalls.length; i++) {
       emit({ hook_event_name: 'PostToolUse', agent_id: AGENT_ID, session_id: SESSION, tool_name: toolCalls[i].name, tool_input: toolCalls[i].input });
     }
@@ -3121,7 +2805,7 @@ let upstreamUrl = null;
 try { upstreamUrl = new URL(UPSTREAM); } catch (e) {}
 
 const server = http.createServer(function (req, res) {
-  cancelStop(); // a new request means the turn is still going
+  cancelStop(); // 新请求意味着回合仍在进行
   if (!upstreamUrl) { res.statusCode = 502; res.end('proxy: no upstream'); return; }
   let target;
   try { target = new URL(trimSlash(UPSTREAM) + req.url); } catch (e) { res.statusCode = 502; res.end('proxy: bad url'); return; }
@@ -3129,8 +2813,8 @@ const server = http.createServer(function (req, res) {
   const lib = isHttps ? https : http;
   const headers = Object.assign({}, req.headers);
   headers.host = target.host;
-  // Ask upstream for plaintext so the tee can parse SSE/JSON reliably; the client
-  // gets uncompressed bytes (loopback — negligible) and no content-encoding to undo.
+  // 向上游请求明文，tee 才能可靠解析 SSE/JSON；客户端拿到未压缩字节（回环——
+  // 可忽略），也无须解掉任何 content-encoding。
   delete headers['accept-encoding'];
   const opts = {
     protocol: target.protocol,
@@ -3148,7 +2832,7 @@ const server = http.createServer(function (req, res) {
     const chunks = [];
     let total = 0;
     upRes.on('data', function (chunk) {
-      res.write(chunk); // stream straight through to the CLI
+      res.write(chunk); // 直接流到 CLI
       if (wantParse && total < 4194304) { chunks.push(chunk); total += chunk.length; }
     });
     upRes.on('end', function () {
@@ -3174,9 +2858,9 @@ server.listen(0, '127.0.0.1', function () {
 });
 `;
 
-// Official Gemini CLI bridge. Gemini already sends snake_case payload fields;
-// normalize its event names, then translate HookServer decisions back into
-// Gemini's documented hook output contract.
+// 官方 Gemini CLI 桥接。Gemini 已经发送 snake_case 字段；
+// 规范化其事件名，再把 HookServer 决策转译回
+// Gemini 文档化的 hook 输出契约。
 const GEMINI_HOOK_SHIM = `#!/usr/bin/env node
 'use strict';
 const net = require('net');
@@ -3228,12 +2912,11 @@ process.stdin.on('end', () => {
 });
 `;
 
-// ─── grok-hook shim (written to <hive>/bin/grok-hook.cjs) ───────────────────
-// Grok's lifecycle events and decisions are Claude-compatible, but the wire
-// payload is camelCase and uses snake_case event values. Normalize the input for
-// HookServer and translate its Claude-style permission denial into Grok's direct
-// decision form. Scoped by AGENT_ID so the trusted global hook is inert outside
-// Munder-spawned workers.
+// ─── grok-hook 垫片（写入 <hive>/bin/grok-hook.cjs）───────────────────────────
+// Grok 的生命周期事件与决策与 Claude 兼容，但 wire 负载是 camelCase
+// 并使用 snake_case 事件值。对 HookServer 规范化输入，并把其
+// Claude 风格的权限拒绝转译回 Grok 的直接决策形式。以 AGENT_ID 为作用域，
+// 使可信全局钩子在 Munder 生成的 worker 之外保持惰性。
 const GROK_HOOK_SHIM = `#!/usr/bin/env node
 'use strict';
 const net = require('net');

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -1,18 +1,19 @@
 /**
- * HookServer — the bridge between `claude` lifecycle hooks and the harness.
+ * HookServer —— `claude` 生命周期 hook 与 harness 之间的桥梁。
  *
- * Each spawned agent is launched with `--settings` pointing its hooks at a tiny
- * shim (see HOOK_SHIM in hive.ts) that forwards the hook payload to the Unix
- * domain socket this server listens on. We then:
- *   - drive avatar state from PreToolUse/PostToolUse/Notification/etc., and
- *   - report lifecycle boundaries while renderer-side guarded queues deliver
- *     inbox work only after the session reaches a safe idle prompt.
+ * 每个派生的 agent 都以 `--settings` 启动，把它的 hook 指向一个极小的
+ * shim（见 hive.ts 中的 HOOK_SHIM），shim 把 hook 负载转发到本服务器
+ * 监听的 Unix 域套接字。然后我们：
+ *   - 根据 PreToolUse/PostToolUse/Notification 等驱动头像状态，以及
+ *   - 上报生命周期边界，同时渲染进程侧的受守卫队列只会在会话到达
+ *     安全空闲提示之后才投递 inbox 工作。
  *
- * Runs in the Electron main process.
+ * 运行在 Electron 主进程。
  */
 import { createServer, type Server } from 'node:net';
 import { existsSync, rmSync } from 'node:fs';
 import { Notification, type WebContents } from 'electron';
+import { l10n } from './l10n';
 import type { HiveManager } from './hive';
 import type { HarnessConfig } from './config';
 import type { ControlRegistry } from './control';
@@ -25,7 +26,7 @@ interface HookPayload {
   agent_id?: string | null;
   session_id?: string;
   transcript_path?: string;
-  /** Status-line payloads only: the session's live context accounting. */
+  /** 仅状态行负载：会话的实时上下文计量。 */
   context_window?: { total_input_tokens?: number; context_window_size?: number };
   cwd?: string;
   tool_name?: string;
@@ -34,11 +35,11 @@ interface HookPayload {
   prompt?: string;
   source?: string;
   notification_type?: string;
-  /** Notification hook text, e.g. "Claude is waiting for your input" (idle) vs a
-   *  permission request. Used to tell "needs you" from "just done / lingering". */
+  /** Notification hook 文本，例如“Claude is waiting for your input”（空闲）
+   *  与权限请求的区别。用于区分“需要你”与“刚做完 / 还在逗留”。 */
   message?: string;
-  /** CostSample payloads only (synthesized by the proxy-bridge sidecar for
-   *  qwen). Raw token counts for one response, fed to the cost ledger. */
+  /** 仅 CostSample 负载（由 proxy-bridge sidecar 为 qwen 合成）。
+   *  一次响应的原始 token 计数，送入成本账本。 */
   model?: string;
   input?: number;
   output?: number;
@@ -48,74 +49,73 @@ interface HookPayload {
 
 export class HookServer {
   private server: Server | null = null;
-  /** agentId → the live session's transcript file, learned from hook payloads.
-   *  Lets the harness read per-agent telemetry (e.g. current context size)
-   *  even when several agents share one cwd. */
+  /** agentId → 当前会话的 transcript 文件，从 hook 负载中学得。
+   *  即使多个 agent 共享同一个 cwd，harness 也能据此读取每个 agent
+   *  的遥测数据（例如当前上下文大小）。 */
   private transcriptPaths = new Map<string, string>();
-  /** agentId → the latest context-window accounting from the statusLine shim
-   *  (current tokens + the REAL window size — 200k vs 1M, which nothing else
-   *  exposes). The renderer already gets this pushed live on `hive:contextUpdate`;
-   *  we also retain the last value here so a main-side read (the voice read-layer's
-   *  get_agent_detail / list_agents) can report "how full is each agent's context"
-   *  without depending on a renderer round-trip. */
+  /** agentId → 来自 statusLine shim 的最新上下文窗口计量（当前 token + 真实
+   *  窗口大小——200k vs 1M，别的任何地方都拿不到）。渲染进程已经通过
+   *  `hive:contextUpdate` 实时收到它；我们在这里也保留最后的值，这样主进程
+   *  侧的读取（voice 读取层的 get_agent_detail / list_agents）能报告“每个
+   *  agent 的上下文装得多满”，而不依赖渲染进程的一次往返。 */
   private contextById = new Map<string, { tokens: number; limit: number; ts: number }>();
 
   constructor(
     private hive: HiveManager,
     private getWebContents: () => WebContents | null,
     private getConfig: () => HarnessConfig,
-    /** #7C — operator control state. Optional so tests can omit it. */
+    /** #7C —— 操作员控制状态。可选，测试可以省略。 */
     private control?: ControlRegistry,
-    /** Circuit breaker (Lane A #6.6b) — fed the hook-derived signals (session id,
-     *  repeated identical tool calls). Optional so the server still runs without it. */
+    /** 熔断器（Lane A #6.6b）——喂入 hook 派生的信号（session id、
+     *  重复的相同工具调用）。可选，没有它服务器照样运行。 */
     private breaker?: CircuitBreaker,
-    /** Standing goal text for an agent (from the durable roster). Optional so
-     *  tests can omit it; when set, injected on SessionStart / UserPromptSubmit. */
+    /** agent 的长期目标文本（来自持久化 roster）。可选，测试可以省略；
+     *  设置后会在 SessionStart / UserPromptSubmit 时注入。 */
     private getStandingGoal?: (agentId: string) => string | null,
-    /** Optional observer of every hook boundary (agentId, event, message). The
-     *  worker inbox-wake watchdog (workerWake.ts) feeds on this to learn when an
-     *  agent is parked on a permission/HITL prompt so it never types into it. */
+    /** 每个 hook 边界的可选观察者（agentId、event、message）。
+     *  worker 的 inbox-wake 看门狗（workerWake.ts）靠这个得知一个 agent
+     *  何时停在权限/HITL 提示上，从而绝不向它输入文字。 */
     private onEvent?: (agentId: string | undefined, event: string, message: string | undefined) => void
   ) {}
 
   start(): void {
     const sock = this.hive.sockPath();
     if (!sock || this.server) return;
-    // Clear a stale socket file left by a previous run.
-    try { if (existsSync(sock)) rmSync(sock); } catch { /* noop */ }
+    // 清除上一次运行留下的过期套接字文件。
+    try { if (existsSync(sock)) rmSync(sock); } catch { /* 空操作 */ }
 
     this.server = createServer((conn) => {
       let buf = '';
       conn.on('data', (d) => {
         buf += d.toString();
         const nl = buf.indexOf('\n');
-        if (nl === -1) return; // wait for the full line
+        if (nl === -1) return; // 等待完整的一行
         let payload: HookPayload = {};
-        try { payload = JSON.parse(buf.slice(0, nl)); } catch { /* ignore */ }
+        try { payload = JSON.parse(buf.slice(0, nl)); } catch { /* 忽略 */ }
         let res: unknown = {};
         try { res = this.handle(payload); } catch { res = {}; }
         conn.end(JSON.stringify(res ?? {}));
       });
-      conn.on('error', () => { /* shim hung up — ignore */ });
+      conn.on('error', () => { /* shim 挂断了——忽略 */ });
     });
     this.server.on('error', (e) => console.error('[hive] hook server error:', e));
     this.server.listen(sock);
   }
 
   stop(): void {
-    try { this.server?.close(); } catch { /* noop */ }
+    try { this.server?.close(); } catch { /* 空操作 */ }
     this.server = null;
     const sock = this.hive.sockPath();
-    try { if (sock && existsSync(sock)) rmSync(sock); } catch { /* noop */ }
+    try { if (sock && existsSync(sock)) rmSync(sock); } catch { /* 空操作 */ }
   }
 
-  /** The transcript file of an agent's CURRENT session, if any hook has fired. */
+  /** 若发生过任何 hook，则是 agent 当前会话的 transcript 文件。 */
   transcriptPath(agentId: string): string | undefined {
     return this.transcriptPaths.get(agentId);
   }
 
-  /** The latest context-window accounting for an agent (current tokens + the real
-   *  window size), or undefined if no statusLine tick has fired for it yet. */
+  /** agent 最新的上下文窗口计量（当前 token + 真实窗口大小），
+   *  若尚无 statusLine 心跳则为 undefined。 */
   contextFor(agentId: string): { tokens: number; limit: number; ts: number } | undefined {
     return this.contextById.get(agentId);
   }
@@ -128,27 +128,27 @@ export class HookServer {
       this.transcriptPaths.set(agentId, p.transcript_path);
     }
 
-    // Status-line payloads carry the session's EXACT context accounting —
-    // current tokens AND the real window size (200k vs 1M, which nothing else
-    // exposes). Forward to the renderer for the agent-card context gauge.
-    // Handled FIRST and returned early: this is pure telemetry from the
-    // statusLine shim, not a real hook boundary — it must never trip the
-    // HALT gate or feed the breaker's loop detector below. The early return
-    // also (deliberately) skips recordSession for status ticks: a statusLine
-    // payload's session_id adds nothing the real hooks don't already record,
-    // and telemetry should never write to the registry. transcript_path IS
-    // still captured above, where every payload shape benefits from it.
+    // 状态行负载携带会话“精确”的上下文计量——
+    // 当前 token 以及真实窗口大小（200k vs 1M，别的任何地方都拿不到）。
+    // 转发给渲染进程，供 agent 卡片的上下文仪表使用。
+    // 最先处理并提前返回：这是来自 statusLine shim 的纯遥测，
+    // 不是真正的 hook 边界——它绝不能触发 HALT 门，
+    // 也绝不能喂给下面的熔断器循环检测。提前返回
+    // 还（刻意地）让状态心跳跳过 recordSession：statusLine
+    // 负载的 session_id 不会给真实 hook 尚未记录的内容增加任何东西，
+    // 而且遥测绝不应写入注册表。transcript_path 仍然
+    // 会在上面被捕获，所有负载形态都能受益于它。
     if (event === 'Status') {
       const cw = p.context_window;
       if (agentId && cw && typeof cw.total_input_tokens === 'number'
         && typeof cw.context_window_size === 'number' && cw.context_window_size > 0) {
-        // Retain for main-side reads (voice get_agent_detail / list_agents) …
+        // 为主进程侧读取保留（voice get_agent_detail / list_agents）……
         this.contextById.set(agentId, {
           tokens: cw.total_input_tokens,
           limit: cw.context_window_size,
           ts: Date.now()
         });
-        // … and forward live to the renderer's agent-card context gauge.
+        // ……并实时转发给渲染进程的 agent 卡片上下文仪表。
         this.getWebContents()?.send('hive:contextUpdate', {
           agentId,
           tokens: cw.total_input_tokens,
@@ -158,24 +158,24 @@ export class HookServer {
       return {};
     }
 
-    // 7C.3 — a graceful operator HALT overrides everything (incl. the inbox
-    // drain below): stop the agent CLEANLY at this hook boundary rather than
-    // killing the PTY. session_id is in the payload for a later --resume.
+    // 7C.3 —— 操作员的优雅 HALT 覆盖一切（包括下面的 inbox
+    // 排空）：在这个 hook 边界“干净”地停住 agent，而不是
+    // 杀掉 PTY。payload 里带 session_id，供以后 --resume 用。
     if (agentId && this.control?.shouldHalt(agentId)) {
       this.emit(agentId, event, p);
       return { continue: false, stopReason: 'Halted by the operator from the floor.' };
     }
 
-    // Capture the Claude Code session id for idempotent --resume + cost dedup
-    // (Lane A #6.6a). Cheap: recordSession writes only when it changes.
+    // 捕获 Claude Code session id，用于幂等的 --resume + 成本去重
+    // （Lane A #6.6a）。很便宜：recordSession 只在变化时写入。
     if (agentId && p.session_id) this.hive.recordSession(agentId, p.session_id);
 
-    // CostSample — synthesized by the proxy-bridge sidecar (qwen) on every
-    // response with usage. Persist it to the SAME cost ledger as Claude's OTel
-    // path, keyed by the synthesized session_id, then return early so cost stays
-    // OUT of the Claude-only OTel/breaker/drain paths below. `usd` is the fallback
-    // per-model estimate (a local model normally costs ~$0, but the row keeps the
-    // accounting schema uniform). Pure telemetry — never feeds the loop detector.
+    // CostSample —— 由 proxy-bridge sidecar（qwen）在每次带 usage 的
+    // 响应上合成。按合成的 session_id 持久化到与 Claude OTel 路径
+    // 相同的成本账本，然后提前返回，让这笔成本
+    // 不进入下面只属于 Claude 的 OTel/熔断/排空路径。`usd` 是回退的
+    // 按模型估算（本地模型通常约 $0，但该行保持核算
+    // schema 统一）。纯遥测——绝不喂给循环检测器。
     if (event === 'CostSample') {
       if (agentId && p.session_id) {
         const input = p.input ?? 0;
@@ -202,37 +202,37 @@ export class HookServer {
       return {};
     }
 
-    // Feed the breaker its hook-derived loop signal: a tool that actually ran.
-    // A repeated identical (name+input) PostToolUse is the runaway-loop tell.
+    // 给熔断器喂它 hook 派生的循环信号：一个真正运行过的工具。
+    // 重复的相同（name+input）PostToolUse 就是失控循环的征兆。
     if (event === 'PostToolUse' && agentId) {
       this.breaker?.recordToolUse(agentId, p.tool_name, p.tool_input);
     }
 
-    // Compaction exemption (issue #109): PreCompact opens it so the compaction
-    // token burst can't trip the Δoutput arms; PostCompact — or any SessionStart,
-    // since a fresh session makes in-flight compaction state moot — closes it
-    // down to the trailing grace (a no-op when nothing was compacting).
+    // 压缩豁免（issue #109）：PreCompact 打开它，这样压缩时的
+    // token 洪峰不会触发 Δoutput 分支；PostCompact——或任何
+    // SessionStart，因为新会话会让进行中的压缩状态失去意义——把它
+    // 关闭到尾部宽限（没有在压缩时就是空操作）。
     if (event === 'PreCompact' && agentId) this.breaker?.recordCompactStart(agentId);
     if ((event === 'PostCompact' || event === 'SessionStart') && agentId) {
       this.breaker?.recordCompactEnd(agentId);
     }
 
     if ((event === 'Stop' || event === 'SubagentStop') && agentId) {
-      // Respect any upstream Stop hook that already re-entered this boundary.
+      // 尊重任何已经重新进入此边界的上游 Stop hook。
       if (p.stop_hook_active) { this.emit(agentId, event, p); return {}; }
-      // Never turn unread hive mail into a forced continuation at Stop. That old
-      // path bypassed terminal-draft/HITL safety and could spend credits while a
-      // user was answering a question. Inbox files remain durable; the renderer
-      // wakes the agent later through its guarded idle-only delivery path.
-      this.notify(agentId ?? 'Agent', 'finished — idle');
+      // 绝不在 Stop 时把未读的 hive 邮件变成强制继续。那条旧
+      // 路径绕过了终端草稿/HITL 安全，而且可能在用户
+      // 正在回答问题时消耗额度。inbox 文件保持持久；渲染进程
+      // 稍后会通过它受守卫的仅-空闲投递路径唤醒 agent。
+      this.notify(agentId ?? l10n('Agent', '成员'), l10n('finished — idle', '已完成 — 空闲'));
       this.emit(agentId, event, p);
       return {};
     }
 
-    // 7C.1 — HITL gate: deny a tool call at the PreToolUse boundary when the
-    // agent is paused or this tool is gated. Race-free (immediate return, no
-    // renderer round-trip → can't hit the shim timeout). Slow human APPROVAL is
-    // deliberately left to Claude's native permission prompt.
+    // 7C.1 —— HITL 门：当 agent 已暂停或该工具被门控时，在 PreToolUse
+    // 边界拒绝工具调用。无竞态（立即返回，不经过
+    // 渲染进程往返 → 不会撞上 shim 超时）。缓慢的人工 APPROVAL
+    // 刻意交给 Claude 的原生权限提示。
     if (event === 'PreToolUse' && agentId && this.control) {
       const d = this.control.toolDecision(agentId, p.tool_name ?? '');
       if (d.deny) {
@@ -248,34 +248,34 @@ export class HookServer {
       }
     }
 
-    // 7C.2 — mid-run steering: inject queued operator guidance as context on the
-    // next eligible hook (no fragile typing into the TUI). Delivered once.
-    // Merged with the roster line below so the two injections never displace each
-    // other (only ONE additionalContext can be returned per hook).
+    // 7C.2 —— 运行中 steering：在下一个符合条件的 hook 上把排队中的
+    // 操作员指导作为上下文注入（不做脆弱的 TUI 打字）。只投递一次。
+    // 与下面的 roster 行合并，这样两股注入永远不会互相挤掉
+    // 对方（每个 hook 只能返回“一个”additionalContext）。
     let steer: string | null = null;
     if ((event === 'UserPromptSubmit' || event === 'PostToolUse') && agentId && this.control) {
       steer = this.control.takeSteer(agentId) ?? null;
     }
 
-    // Keep god's roster CURRENT. fleet.json is always fresh on disk, but god's
-    // context is not: after a restart it resumes a transcript describing the old
-    // floor and messages agents that are long gone. Push the live roster in as
-    // additionalContext at the start of each session and on every prompt, so god
-    // knows the floor all the time instead of only when it remembers to Read.
-    // God-only and one line — every other agent is unaffected.
+    // 让 god 的 roster 保持最新。fleet.json 在磁盘上总是新鲜的，但 god 的
+    // 上下文不是：重启后它会恢复一段描述旧工作区的 transcript，
+    // 然后给早已离开的 agent 发消息。在每次会话开始时以及每个提示词时
+    // 把实时 roster 作为 additionalContext 推入，这样 god 始终
+    // 了解工作区，而不是只在它记得 Read 的时候。
+    // 仅 god 且只有一行——其他 agent 完全不受影响。
     const wantsRoster = (event === 'SessionStart' || event === 'UserPromptSubmit')
       && !!agentId && this.hive.isGod(agentId);
-    // Hand the roster the LIVE context-window occupancy (contextById) so each
-    // agent line can carry a `ctx NN%` — god then sees whose context is nearly
-    // full when it routes work, instead of guessing from cumulative token spend.
+    // 把实时的上下文窗口占用（contextById）交给 roster，这样每行
+    // agent 都能带上 `ctx NN%`——god 在路由工作时就能看到谁的上下文
+    // 快满了，而不是靠累计 token 花费去猜。
     const roster = wantsRoster
       ? this.hive.rosterContext((id) => this.contextFor(id))
       : null;
 
-    // Standing goal (hire Briefing) — durable roster field, re-read every cycle so
-    // an Edit Agent save is picked up on the next SessionStart / UserPromptSubmit
-    // without restarting the worker. Kept out of --append-system-prompt (volatile-
-    // free cache invariant); lives on the live hook channel instead.
+    // 长期目标（hire Briefing）——持久化 roster 字段，每个周期重新读取，
+    // 这样一次 Edit Agent 保存就会在下一个 SessionStart / UserPromptSubmit
+    // 被拾取，无需重启 worker。不放进 --append-system-prompt
+    // （无易变内容的缓存不变量）；而是放在实时的 hook 通道上。
     const wantsGoal = (event === 'SessionStart' || event === 'UserPromptSubmit') && !!agentId;
     const goalRaw = wantsGoal ? (this.getStandingGoal?.(agentId) ?? null) : null;
     const goal = goalRaw
@@ -292,36 +292,36 @@ export class HookServer {
       };
     }
 
-    // A Notification hook that means "the agent is blocked waiting for the user"
-    // (idle prompt) deserves a desktop toast too — distinct from a permission
-    // request, which surfaces natively in the agent's own Claude Code session
-    // (approvable remotely via /remote-control).
+    // 一条表示“agent 正卡在等待用户”的 Notification hook
+    // （空闲提示）也值得一个桌面 toast——它与权限请求不同，
+    // 权限请求会在 agent 自己的 Claude Code 会话中原生浮现
+    // （可通过 /remote-control 远程批准）。
     if (
       event === 'Notification' &&
       (p.notification_type === 'idle' ||
         (p.message ?? '').toLowerCase().includes('waiting for your input'))
     ) {
-      this.notify(agentId ?? 'Agent', p.message ?? 'needs your attention');
+      this.notify(agentId ?? l10n('Agent', '成员'), p.message ?? l10n('needs your attention', '需要你的关注'));
     }
 
-    // Forward everything else to the renderer so avatars reflect real activity.
+    // 其余一切转发给渲染进程，让头像反映真实活动。
     this.emit(agentId, event, p);
     return {};
   }
 
-  /** Fire a native desktop notification — gated on the user's `notifications`
-   *  setting. Only the OS toast is gated; the hive:hookEvent emit is always sent
-   *  so avatars/UI stay live regardless. Best-effort: never throw into the hook. */
+  /** 触发一条原生桌面通知——以用户的 `notifications` 设置为门。
+   *  只有 OS toast 被门控；hive:hookEvent 事件总是会发送，
+   *  这样头像/UI 无论如何都保持实时。尽力而为：绝不向 hook 抛错。 */
   private notify(title: string, body: string): void {
     if (!this.getConfig().notifications) return;
     try {
       if (!Notification.isSupported()) return;
       new Notification({ title, body }).show();
-    } catch { /* notifications unsupported on this platform — ignore */ }
+    } catch { /* 该平台不支持通知——忽略 */ }
   }
 
-  /** Tell the renderer a tool call was gated/denied (#7C.1) so it can surface it
-   *  (toast / control strip) — distinct from the avatar hook stream. */
+  /** 告诉渲染进程一次工具调用被门控/拒绝（#7C.1），让它可以浮现出来
+   *  （toast / 控制条）——与头像 hook 流区分开。 */
   private emitControl(agentId: string, tool: string | undefined, reason: string | undefined): void {
     this.getWebContents()?.send('control:approvalRequest', { agentId, tool, reason });
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, powerMonitor, powerSaveBlocker, screen, shell, Notification } from 'electron';
+import { l10n } from './l10n';
 import { spawn } from 'node:child_process';
 import {
   rmSync, existsSync, readFileSync, readdirSync, statSync, cpSync, writeFileSync,
@@ -93,12 +94,11 @@ import {
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
 
-// Keep the main process alive on an unexpected throw/rejection. The harness is a
-// multi-agent supervisor — a single stray throw (e.g. node-pty's ConPTY console
-// helper choking when a fast-exiting agent CLI's console is already gone) must
-// NOT take the whole app and every running agent down with it. Log and continue
-// rather than letting the default handler exit the process.
-// (Restored during the #71 merge — the PR's rebase dropped these handlers.)
+// 让主进程在意外 throw/rejection 时保持存活。harness 是一个多 agent 的
+// 监督者——任何一次孤立的异常（例如 node-pty 的 ConPTY 控制台助手在快速退出的
+// agent CLI 控制台已消失时卡死）都绝不能把整个应用和所有运行中的 agent 一起拖垮。
+// 记录日志并继续运行，而不是让默认处理器退出进程。
+// （在 #71 合并期间恢复——该 PR 的 rebase 把这两个处理器弄丢了。）
 process.on('uncaughtException', (err) => {
   console.error('[main] uncaughtException (kept alive):', err);
 });
@@ -145,15 +145,15 @@ function runCodexDaemonCommand(
         : { ok: false, error: stderr.trim() || `Codex exited with code ${code ?? 'unknown'}` });
     });
     timer = setTimeout(() => {
-      try { child.kill(); } catch { /* already exited */ }
+      try { child.kill(); } catch { /* 已退出 */ }
       finish({ ok: false, error: `Codex daemon command timed out after ${timeoutMs}ms` });
     }, timeoutMs);
   });
 }
 
-/** Start/enable one managed remote-control daemon for this isolated Codex home,
- * then point the TUI at its app-server socket. Failure is non-fatal: the worker
- * still starts as a normal local Codex session. */
+/** 为这个隔离的 Codex home 启动/启用一个受管的远程控制守护进程，
+ * 然后把 TUI 指向它的 app-server socket。失败不致命：worker 仍会
+ * 以普通本地 Codex 会话的方式启动。 */
 async function enableCodexRemoteForSpawn(
   opts: SpawnOptions & { hive?: AgentMeta },
   agentId: string
@@ -163,9 +163,9 @@ async function enableCodexRemoteForSpawn(
   if (!realHome) return false;
   try {
     const alias = codexRemoteAliasPath(realHome, agentId);
-    // Bail before touching the filesystem if even the short alias would exceed
-    // sun_path — the daemon would start and then die on bind, and the warning
-    // below names the real reason instead of a generic readiness timeout.
+    // 在触碰文件系统之前先退出：即使短别名也会超过 sun_path——守护进程
+    // 会启动后因 bind 失败而死，而下面的告警会点出真实原因，而不是一个
+    // 笼统的 readiness 超时。
     if (!codexRemoteSocketFits(alias)) {
       console.warn('[codex-remote] socket path exceeds sun_path; starting local TUI:', alias);
       return false;
@@ -188,8 +188,8 @@ async function enableCodexRemoteForSpawn(
       ...(opts.env ?? {}),
       CODEX_HOME: alias
     };
-    // shellEnv's resolver mirrors PtyManager's (which is private + returns
-    // {path, found}); the daemon just needs the best executable path.
+    // shellEnv 的解析器镜像了 PtyManager 的解析方式（后者是私有的，返回
+    // {path, found}）；守护进程只需要拿到最佳可执行文件路径即可。
     const executable = resolveCliCommand(opts.command);
     const started = await runCodexDaemonCommand(
       executable,
@@ -222,14 +222,13 @@ async function enableCodexRemoteForSpawn(
     return false;
   }
 }
-/** Live PTY id → its hive agent id, recorded at spawn. The pty:kill handler only
- *  gets the PTY id, so this lets a closed tab archive the right registry agent. */
+/** 活跃 PTY id → 其 hive agent id，在 spawn 时记录。pty:kill 处理器只能拿到
+ *  PTY id，所以有了它，关闭标签页时就能归档正确的 registry agent。 */
 const ptyToAgent = new Map<string, string>();
-/** PTY id → the spawn it should auto restart-and-continue into once a first-time
- *  CLI install finishes. The missing-CLI short-circuit runs the engine's installer
- *  in this PTY; when it exits cleanly the exit handler re-runs the SAME spawn (with
- *  install disabled) so the freshly-installed CLI launches in the SAME pty/window —
- *  no user click. Cleared the moment it's consumed, so it can never loop installs. */
+/** PTY id → 首次 CLI 安装完成后应自动重启并继续进入的 spawn。缺 CLI 的
+ *  短路路径会在这个 PTY 里运行引擎的安装器；当它干净退出时，退出处理器会
+ *  重新运行同一个 spawn（禁用安装），于是刚装好的 CLI 会在同一个
+ *  pty/window 里启动——无需用户点击。一旦被消费就清除，因此绝不会循环安装。 */
 const pendingInstallRelaunch = new Map<string, { opts: AgentSpawnOptions; owner: Electron.WebContents | null; bin: string; rung: string }>();
 const hive = new HiveManager(
   () => readConfig().harnessHome,
@@ -239,42 +238,40 @@ const hive = new HiveManager(
     try { wc.send(channel, payload); return true; } catch { return false; }
   }
 );
-// #7C — operator control state (pause/gate/steer/halt), read by the HookServer
-// when deciding hook returns.
+// #7C — 操作者控制状态（pause/gate/steer/halt），由 HookServer 在决定
+// hook 返回值时读取。
 const control = new ControlRegistry();
-// Stage 7A — the live observability tap. Receives Claude Code's first-party OTel
-// over loopback OTLP/JSON and exposes the locked usage-provider seam. resolveCwd
-// lets the transcript fallback find an agent's cwd from the hive registry.
+// Stage 7A — 实时可观测性探针。通过 loopback OTLP/JSON 接收 Claude Code 的
+// 第一方 OTel，并暴露锁定的 usage-provider 接缝。resolveCwd 让 transcript
+// 回退机制能从 hive registry 找到 agent 的 cwd。
 const telemetry = new TelemetryCollector({
-  emit: (channel, payload) => { try { liveWebContents()?.send(channel, payload); } catch { /* window tore down */ } },
+  emit: (channel, payload) => { try { liveWebContents()?.send(channel, payload); } catch { /* 窗口已拆除 */ } },
   resolveCwd: (agentId) => hive.registry().agents[agentId]?.cwd ?? null,
-  // D11: scopes the transcript fallback to this agent's own session instead of
-  // summing every transcript in a (routinely shared) cwd.
+  // D11: 把 transcript 回退范围限定到该 agent 自己的会话，而不是把
+  // （通常共享的）cwd 里的每一条 transcript 都加起来。
   resolveSessionId: (agentId) => hive.lastSession(agentId)
 });
-// Usage provider (Seam 1) — the INTEGRATION swap: Oscar's telemetry collector (#7)
-// IS the provider, replacing Lane A's interim StubUsageProvider. Same
-// getAgentUsage(agentId) pull seam, so the breaker + cost ledger consumers are
-// untouched; telemetry has a transcript fallback built in, so it works before any
-// live OTel arrives.
+// Usage provider（Seam 1）— INTEGRATION 交换：Oscar 的 telemetry 收集器（#7）
+// 就是 provider，取代 Lane A 的临时 StubUsageProvider。沿用同一个
+// getAgentUsage(agentId) 拉取接缝，因此 breaker + 成本账本的使用方都不受影响；
+// telemetry 内置 transcript 回退，所以在任何实时 OTel 到达之前就能工作。
 const usageProvider: UsageProvider = telemetry;
-// Circuit breaker (Lane A #6.6b) — the REAL policy (replaces Lane C's interim
-// glue). POLICY only; the heartbeat beat feeds it signals (via usageProvider) +
-// enforces its decisions. Config read live so a settings change applies next beat.
+// Circuit breaker（Lane A #6.6b）— 真正的策略（取代 Lane C 的临时粘合层）。
+// 仅策略本身；heartbeat beat 通过 usageProvider 喂给它信号，并执行它的决策。
+// 配置实时读取，因此设置变更在下一个 beat 即生效。
 const breaker = new CircuitBreaker(() => {
   const c = readConfig();
   return { ...(c.circuitBreaker ?? {}), costCapUsd: c.costCapUsd, costCapTokens: c.costCapTokens, agentTokenCaps: c.agentTokenCaps };
 });
-// Always-on beats (decoupled from the optional heartbeat): the live fleet snapshot
-// Michael reads + the breaker beat, so guardrails + monitoring work even when the
-// heartbeat mission is disabled (it ships off).
+// 常开 beat（与可选的 heartbeat 解耦）：Michael 读取的实时 fleet 快照 +
+// breaker beat，这样即使 heartbeat 任务被禁用（它随产品出厂），护栏与监控仍能工作。
 let fleetTimer: ReturnType<typeof setInterval> | null = null;
 let breakerBeatTimer: ReturnType<typeof setInterval> | null = null;
-// Feed the breaker's api_error-storm trip from Oscar's OTel api_error spans —
-// Jim's one breaker input with no on-branch source (telemetry.onApiError seam).
+// 用 Oscar 的 OTel api_error spans 喂给 breaker 的 api_error 风暴熔断——
+// Jim 唯一一个没有 on-branch 来源的 breaker 输入（telemetry.onApiError 接缝）。
 telemetry.onApiError((agentId) => breaker.recordError(agentId));
-// Shared roster on disk — created early so HookServer can re-read standing goals
-// on every UserPromptSubmit (Edit Agent saves land here via persistAgents).
+// 磁盘上的共享 roster —— 尽早创建，这样 HookServer 能在每次 UserPromptSubmit
+// 时重新读取常驻目标（Edit Agent 的保存经 persistAgents 落到这里）。
 const roster = new RosterStore(() => readConfig().harnessHome);
 function standingGoalFromRoster(agentId: string): string | null {
   const snap = roster.read();
@@ -287,13 +284,13 @@ function standingGoalFromRoster(agentId: string): string | null {
   }
   return null;
 }
-// Worker inbox-wake watchdog (#151): finds idle workers with undrained inbox mail
-// and types the same guarded nudge the renderer would have (so a throttled
-// background window can't leave a worker parked on an unread inbox forever).
-// HookServer feeds it the hook stream so a permission/HITL prompt blocks nudges.
+// Worker inbox-wake watchdog（#151）：找出收件箱有未读邮件的空闲 worker，
+// 并打出渲染进程本会发出的同款受控提醒（这样被限流的后台窗口不会让 worker
+// 永远停在未读收件箱上）。HookServer 把 hook 流喂给它，因此权限/HITL
+// 提示会阻止 nudge。
 const workerWake = new WorkerWakeWatchdog();
-// HookServer needs BOTH: Oscar's control registry (HITL pause/gate/steer/halt via
-// hook returns) AND Jim's breaker (feed recordToolUse on each PostToolUse).
+// HookServer 两者都需要：Oscar 的控制注册表（经 hook 返回实现 HITL
+// pause/gate/steer/halt）以及 Jim 的 breaker（在每次 PostToolUse 喂 recordToolUse）。
 const hookServer = new HookServer(
   hive,
   () => liveWebContents(),
@@ -307,10 +304,10 @@ const memory = new MemoryManager(
   () => readConfig().harnessHome,
   () => { const c = readConfig(); return { enabled: c.semanticMemory !== false, model: c.embeddingModel ?? 'minilm' }; }
 );
-// Enterprise Knowledge Graph — file-backed store + agent CLI (default OFF).
+// Enterprise Knowledge Graph —— 文件后端存储 + agent CLI（默认关闭）。
 const knowledge = new KnowledgeManager();
-/** Reads the reflect tunables from config each tick (defaults baked in here so a
- *  pre-existing config.json without the keys still gets sane values). */
+/** 每次 tick 从 config 读取 reflect 可调参数（默认值内置在这里，因此一个
+ *  不含这些键的既有 config.json 仍能拿到合理值）。 */
 function reflectSettings(): ReflectSettings {
   const c = readConfig();
   return {
@@ -322,72 +319,71 @@ function reflectSettings(): ReflectSettings {
     minBytes: c.reflectMinBytes ?? 16_384
   };
 }
-// Finishes the janitor's missing condense half: bounds each agent's memory.md
-// (Haiku tail-summary, backup→verify→atomic-swap) so it never grows unbounded.
+// 补齐 janitor 缺失的 condense 半边：限制每个 agent 的 memory.md 大小
+// （Haiku 尾部摘要、备份→校验→原子替换），使其永不无限增长。
 const reflector = new MemoryReflector(
   () => readConfig().harnessHome,
   () => readConfig().defaultCommand ?? 'claude',
   () => memory.env(),
   reflectSettings,
-  (event) => { try { hive.appendLog(event); } catch { /* best-effort */ } }
+  (event) => { try { hive.appendLog(event); } catch { /* 尽力而为 */ } }
 );
-// Durable harness state (SQLite, main process). Phase A: window bounds (kv) +
-// net-new command history. Opened in whenReady, closed in the teardown blocks.
+// 持久化 harness 状态（SQLite，主进程）。Phase A：窗口边界（kv）+ 全新命令历史。
+// 在 whenReady 中打开，在 teardown 块中关闭。
 const persist = new PersistStore();
-/** The PRIMARY window — the one running the hive/god orchestration and the sink
- *  for process-global timer events (missions, breaker, Slack ingestion). It is
- *  the most-recently-focused live window, so global events follow the user.
- *  Additional "floor" windows are tracked in `allWindows` below. */
+/** 主窗口 —— 运行 hive/god 编排的窗口，也是进程级全局定时事件
+ * （missions、breaker、Slack 摄取）的落点。它是最新聚焦的活跃窗口，
+ * 因此全局事件跟随用户。额外的 “floor” 窗口记录在下面的 `allWindows` 中。 */
 let mainWindow: BrowserWindow | null = null;
-/** Every open window (primary + floors). A registry, not a single handle, so
- *  multi-window lifecycle (focus tracking, quit fan-out) is correct. */
+/** 所有打开的窗口（主窗口 + floors）。它是注册表而非单个句柄，因此
+ *  多窗口生命周期（焦点跟踪、退出扇出）是正确的。 */
 const allWindows = new Set<BrowserWindow>();
-/** Monotonic floor counter → a stable, unique session partition per floor so
- *  each floor's renderer state (localStorage: agents, queues, selection) is
- *  isolated from every other window's. */
+/** 单调 floor 计数器 → 每个 floor 一个稳定、唯一的会话分区，因此每个
+ *  floor 的渲染进程状态（localStorage：agents、queues、selection）都与其他
+ *  窗口完全隔离。 */
 let floorSeq = 0;
 
-/** When true, skip the quit interceptor (user already confirmed). */
+/** 为 true 时，跳过退出拦截器（用户已确认）。 */
 let allowQuit = false;
 
-/** Agents spawned with `isolate: true` get a dedicated git worktree; this maps
- *  the agent/pty id → the worktree path so we can tear it down on kill. */
+/** 以 `isolate: true` 生成的 agent 会得到一个专用 git worktree；本映射把
+ *  agent/pty id → worktree 路径，这样 kill 时能拆除它。 */
 const worktreePaths = new Map<string, string>();
-/** id → the original repo cwd the worktree was created from (needed to run
- *  `git worktree remove` from the parent tree, not the worktree itself). */
+/** id → 创建该 worktree 时所在的原始仓库 cwd（需要在父树上运行
+ *  `git worktree remove`，而不是在 worktree 自身里）。 */
 const worktreeOrigins = new Map<string, string>();
 
-/** A live god-triggered ephemeral worker, tracked from spawn to teardown. */
+/** 一个活跃的、由 god 触发的临时 worker，从 spawn 跟踪到 teardown。 */
 interface WorkerRec {
-  workerId: string;       // == the PTY id == hive agent id (`worker-<reqId>`)
-  reqId: string;          // the spawn-request id
-  name?: string;          // display name (for the worker tab)
+  workerId: string;       // == PTY id == hive agent id（`worker-<reqId>`）
+  reqId: string;          // spawn-request 的 id
+  name?: string;          // 显示名（用于 worker 标签页）
   slack?: { channel: string; thread_ts: string };
-  baseBranch: string;     // the branch its worktree was cut from (for ahead-of-base)
-  spawnedAt: number;      // epoch ms
-  releasing?: boolean;    // kill issued; awaiting teardownPty (skip re-processing)
-  /** Per-worker TOTAL-token cap from the spawn-request (overrides the config
-   *  default). 0/undefined = no per-request cap. P4 plumbing — unlimited today. */
+  baseBranch: string;     // 其 worktree 从中切出的分支（用于 ahead-of-base 判断）
+  spawnedAt: number;      // epoch 毫秒
+  releasing?: boolean;    // 已发出 kill；等待 teardownPty（跳过重复处理）
+  /** 来自 spawn-request 的每 worker TOTAL-token 上限（覆盖 config
+   *  默认值）。0/undefined = 无每请求上限。P4 管道——目前不限。 */
   tokenCap?: number;
 }
-/** Live ephemeral workers by id. Populated by the spawn-request watcher; consulted
- *  by teardownPty so a finished/crashed/reaped worker's worktree is PRESERVED (not
- *  force-removed) when it holds unintegrated work — god is the sole integrator. */
+/** 按 id 索引的活跃临时 worker。由 spawn-request watcher 填充；teardownPty
+ *  查询它，从而在已结束/崩溃/被回收的 worker 持有未集成工作时保留其 worktree
+ *  （而非强制移除）——god 是唯一的集成者。 */
 const liveWorkers = new Map<string, WorkerRec>();
 
-/** The loopback secret broker (Phase 2). Workers reach registered integrations through
- *  it without ever seeing a credential. getRecord/getSecret are injected so the broker
- *  stays electron-free + unit-testable. Started in bootstrapHiveServices; each worker is
- *  granted a per-worker capability token at spawn (revoked in teardownPty). */
+/** loopback 密钥经纪人（Phase 2）。worker 通过它访问已注册的集成，而永远不会
+ *  看到任何凭据。getRecord/getSecret 被注入，因此经纪人保持无 electron 依赖且
+ *  可单测。在 bootstrapHiveServices 中启动；每个 worker 在 spawn 时被授予
+ *  每 worker 的能力 token（在 teardownPty 中撤销）。 */
 const integrationBroker = new IntegrationBroker({
   getRecord: integrations.getRecord,
   getSecret: integrations.getSecret
 });
 
-/** BYOK backend model-providers whose API keys the non-Claude CLI engines
- *  (OpenCode/Crush/pi/qwen) read from standard env vars. Keys are stored
- *  WRITE-ONLY in the same encrypted secret broker as integrations, under
- *  `apikey:<backend>`, and materialized MAIN-ONLY at spawn (never over IPC). */
+/** BYOK 后端模型提供方：非 Claude CLI 引擎（OpenCode/Crush/pi/qwen）从标准
+ *  环境变量读取其 API 密钥。密钥以 WRITE-ONLY 方式存储在与 integrations 相同的
+ *  加密密钥经纪人中，键为 `apikey:<backend>`，且仅在 spawn 时于 MAIN 侧实体化
+ *  （绝不经过 IPC）。 */
 const BACKEND_KEY_ENV: Record<string, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
@@ -397,78 +393,73 @@ const BACKEND_KEY_ENV: Record<string, string> = {
 };
 const providerKeyRef = (backend: string): string => `apikey:${backend}`;
 
-/** A worker worktree that teardown PRESERVED because it held unintegrated work.
- *  Tracked so the GC sweep can reclaim it (+ its scratch dir) once the work lands
- *  in base or the worktree is removed by hand — see gcPreservedWorktrees(). */
+/** teardown 因持有未集成工作而保留的 worker worktree。跟踪它，以便一旦工作
+ *  落入 base 或被手工移除，GC sweep 就能回收它（连同其 scratch 目录）——
+ *  见 gcPreservedWorktrees()。 */
 interface PreservedWorktree {
   workerId: string;
   wtPath: string;
-  origCwd: string;        // the parent repo to run `git worktree remove` from
-  baseBranch: string;     // re-checked against this for "integrated yet?"
-  scratchDir: string | null; // HIVE_ROOT/agents/<workerId> — removed alongside the worktree
+  origCwd: string;        // 用于运行 `git worktree remove` 的父仓库
+  baseBranch: string;     // 据此重新检查“是否已集成？”
+  scratchDir: string | null; // HIVE_ROOT/agents/<workerId> —— 与 worktree 一起移除
   slack?: { channel: string; thread_ts: string };
-  preservedAt: number;    // epoch ms
+  preservedAt: number;    // epoch 毫秒
 }
-/** Preserved worker worktrees awaiting integration, keyed by worktree path. The GC
- *  sweep drains this: an entry is removed (worktree + scratch GC'd) only when the
- *  work is provably integrated, or when the worktree is already gone from disk. */
+/** 等待集成的已保留 worker worktrees，按 worktree 路径为键。GC sweep 会清空
+ *  它：只有工作被证实已集成、或 worktree 已从磁盘消失时，条目才会被移除
+ * （worktree + scratch 一并 GC）。 */
 const preservedWorktrees = new Map<string, PreservedWorktree>();
 
 /**
- * Tear down everything tied to a PTY id: archive its hive agent, remove its
- * isolated git worktree, and drop the bookkeeping-map entries. Runs on BOTH an
- * explicit `pty:kill` AND a natural PTY exit (the child finished, crashed, or
- * was killed externally) — without this the agent stays "active" (broadcasts
- * keep mailing a dead inbox), the worktree orphans (plus a dangling `git
- * worktree` registration in the user's real repo), and the maps leak an entry
- * per dead PTY.
+ * 拆除与某个 PTY id 相关的一切：归档其 hive agent、移除其隔离 git worktree、
+ * 并清除簿记 map 条目。在显式 `pty:kill` 和自然 PTY 退出（子进程结束、崩溃、
+ * 或从外部被杀）两种情况下都会运行——否则 agent 会一直保持 “active”
+ * （广播会继续投递到已死的收件箱）、worktree 会变成孤儿（还在用户真实仓库里
+ * 留下悬空的 `git worktree` 注册），map 也会为每个死 PTY 泄漏一条条目。
  *
- * Idempotent: guarded on map presence and the already-idempotent
- * `hive.setArchived`, so a double call is a harmless no-op. NOTE: an explicit
- * `ptyManager.kill()` does NOT reach here via onExit — kill() deletes the
- * session synchronously, so node-pty's later async exit callback fails the
- * session-identity guard and is swallowed. Every kill site must therefore call
- * teardownPty itself right after the kill (all of them do). Best-effort — every
- * step is wrapped so a teardown error can never crash the caller (an IPC
- * handler or node-pty's onExit).
+ * 幂等：以 map 存在性和本就幂等的 `hive.setArchived` 为守卫，因此重复调用是
+ * 无害的空操作。注意：显式 `ptyManager.kill()` 不会经 onExit 到达这里——
+ * kill() 会同步删除会话，所以 node-pty 之后的异步退出回调会因会话身份守卫而
+ * 失败并被吞掉。因此每个 kill 调用点都必须在 kill 之后自己调用 teardownPty
+ * （它们全都这么做了）。尽力而为——每一步都包了 try，因此 teardown 错误
+ * 绝不会让调用方（IPC 处理器或 node-pty 的 onExit）崩溃。
  */
 function teardownPty(id: string): void {
-  // Ephemeral-worker flag, read BEFORE the cleanup below deletes the entry. All
-  // worker deaths (done-release, idle/token reap, manual stop, crash) funnel
-  // through here, so this is the one place their floor card gets archived
-  // (workers card via the hive:agentSpawned broadcast in processSpawnRequest).
-  // pty id == worker id == agent id for workers.
+  // 临时-worker 标志，必须在下面的清理删除该条目之前读取。所有 worker 死亡
+  // （完成释放、空闲/token 回收、手动停止、崩溃）都汇聚到这里，所以这里是
+  // 它们的 floor 卡片被归档的唯一地点（worker 卡片经 processSpawnRequest 中
+  // 的 hive:agentSpawned 广播）。对 worker 而言，pty id == worker id == agent id。
   const wasWorker = liveWorkers.has(id);
-  // 0) Revoke this id's broker capability (if any). Idempotent + harmless for a
-  //    non-worker PTY; ensures a dead worker's token can never reach an integration.
-  try { integrationBroker.revoke(id); } catch { /* best-effort */ }
-  // 1) Archive the agent — retained + flagged; only live-PTY agents are active.
+  // 0) 撤销该 id 的经纪人能力（如有）。对非 worker PTY 幂等且无害；
+  //    确保死 worker 的 token 永远无法触达任何集成。
+  try { integrationBroker.revoke(id); } catch { /* 尽力而为 */ }
+  // 1) 归档 agent —— 保留并标记；只有持有活跃 PTY 的 agent 才处于 active。
   const agentId = ptyToAgent.get(id);
   if (agentId) {
     ptyToAgent.delete(id);
-    // Drop watchdog state so a dead agent can't get nudged or leak its grace.
-    try { workerWake.forget(agentId, id); } catch { /* best-effort */ }
-    // Drop breaker state so a dead agent can't leak/zombie a tripped level.
-    try { breaker.forget(agentId); } catch { /* best-effort */ }
-    // A replacement using this id needs a new usage counter, not the dead PTY's.
-    try { telemetry.forgetAgent(agentId); } catch { /* best-effort */ }
-    // W1 — kill this agent's proxy-bridge sidecar (qwen), if any, so a dead
-    // PTY never leaves an orphan loopback listener. No-op for non-proxy agents.
+    // 丢弃 watchdog 状态，这样死 agent 不会被 nudge，也不会泄漏宽限期。
+    try { workerWake.forget(agentId, id); } catch { /* 尽力而为 */ }
+    // 丢弃 breaker 状态，这样死 agent 不会泄漏/僵尸化一个已熔断的等级。
+    try { breaker.forget(agentId); } catch { /* 尽力而为 */ }
+    // 复用该 id 的替代品需要全新的 usage 计数器，而不是死 PTY 的那个。
+    try { telemetry.forgetAgent(agentId); } catch { /* 尽力而为 */ }
+    // W1 —— 若存在，杀掉该 agent 的代理桥接 sidecar（qwen），这样死 PTY
+    // 绝不会留下孤儿 loopback 监听器。对非代理 agent 为空操作。
     try { hive.stopProxyBridge(agentId); } catch (e) { console.error('[hive] stopProxyBridge failed:', e); }
     if (hive.enabled()) {
       try { hive.setArchived(agentId, true); } catch (e) { console.error('[hive] setArchived failed:', e); }
     }
   }
-  // 2) Remove the isolated worktree, if any. Non-blocking; errors are logged.
+  // 2) 移除隔离 worktree（如有）。非阻塞；错误会被记录。
   const wtPath = worktreePaths.get(id);
   if (wtPath) {
     const origCwd = worktreeOrigins.get(id) ?? wtPath;
     worktreePaths.delete(id);
     worktreeOrigins.delete(id);
-    // Ephemeral workers get a SAFETY-GATED teardown: never auto-remove a worktree
-    // that holds unintegrated work. This sits INSIDE teardownPty so it covers ALL
-    // teardown routes — a worker that finished (controller kill), crashed, or was
-    // idle-reaped all land here. Normal agents keep the immediate force-remove.
+    // 临时 worker 走 SAFETY-GATED teardown：绝不自动移除持有未集成工作的
+    // worktree。它位于 teardownPty 内部，因此覆盖所有 teardown 路径——已结束
+    // （控制器 kill）、已崩溃、或被空闲回收的 worker 都会落在这里。普通 agent
+    // 保留立即的强制移除。
     const worker = liveWorkers.get(id);
     if (worker) {
       liveWorkers.delete(id);
@@ -479,29 +470,28 @@ function teardownPty(id: string): void {
         .catch(e => console.error('[worktree] removeWorktree threw:', e));
     }
   }
-  // A worker whose isolation failed (non-repo cwd) has no worktree to gate above —
-  // still clear its tracking entry so the controller stops watching a dead PTY.
+  // 隔离失败的 worker（非仓库 cwd）没有 worktree 需要上面的门控——仍要清除
+  // 其跟踪条目，让控制器停止监视一个死 PTY。
   if (liveWorkers.has(id)) liveWorkers.delete(id);
-  // Archive the dead worker's floor card (mirrors killAgent's voice-kill path;
-  // the renderer's archiveAgent is a no-op if the card is already gone). NOT
-  // done for regular agents: their kill flows already manage their own card.
+  // 归档死 worker 的 floor 卡片（镜像 killAgent 的 voice-kill 路径；若卡片
+  // 已消失，渲染进程的 archiveAgent 是空操作）。常规 agent 不做此事：它们的
+  // kill 流程已自行管理各自的卡片。
   if (wasWorker) {
-    try { liveWebContents()?.send('hive:agentArchived', { id }); } catch { /* window torn down */ }
+    try { liveWebContents()?.send('hive:agentArchived', { id }); } catch { /* 窗口已拆除 */ }
   }
   syncKeepAwake();
 }
 
-/** Send an inform to the god agent (the human's proxy). The ephemeral-worker
- *  controller uses this to surface every terminal failure AND to carry the Slack
- *  {channel,thread_ts} so god can post a 'couldn't complete' reply — closing the
- *  Slack loop (the success path is the worker replying in-thread itself). */
+/** 向 god agent（人类的代理）发送一条 inform。临时-worker 控制器用它来上报
+ *  每一个终态失败，并携带 Slack {channel,thread_ts}，使 god 能发布
+ *  “无法完成” 的回复——从而闭环 Slack 回路（成功路径是 worker 自己在线程内回复）。 */
 function informGod(subject: string, body: string, slack?: { channel: string; thread_ts: string }): void {
   try {
     const slackLine = slack
-      // The bundled-node launcher, spelled as an ABSOLUTE PATH — NOT bare `node`
-      // (absent from the PATH of any machine whose node comes from nvm) and NOT
-      // `$HIVE_NODE` (POSIX-only: cmd.exe/PowerShell expand it to nothing, so the
-      // whole reply command was dead on Windows).
+      // 内置 node 启动器，写为 ABSOLUTE PATH——既不是裸 `node`
+      // （node 来自 nvm 的任何机器 PATH 中都没有它），也不是 `$HIVE_NODE`
+      // （仅 POSIX：cmd.exe/PowerShell 会把它展开为空，整个回复命令在
+      // Windows 上就是死的）。
       ? `\n\n[SLACK] Close the loop — post a reply to channel ${slack.channel} thread ${slack.thread_ts} via:\n  "${hive.nodeCommand()}" "${slackReplyScriptPath()}" --channel ${slack.channel} --thread ${slack.thread_ts} --text "<your message>"`
       : '';
     hive.send({ to: 'god', act: 'inform', subject, body: body + slackLine }, 'ephemeral-worker');
@@ -510,17 +500,16 @@ function informGod(subject: string, body: string, slack?: { channel: string; thr
   }
 }
 
-/** Gated worktree teardown for an ephemeral worker: remove it ONLY when it holds no
- *  unintegrated work; otherwise leave it (and its branch) in place and ping god, the
- *  sole integrator. Async + best-effort; on any uncertainty it KEEPS the worktree
- *  (fail-safe — never auto-discard possibly-valuable work). */
+/** 临时 worker 的门控 worktree teardown：仅当它不持有未集成工作时才移除；
+ *  否则保留它（及其分支）并 ping god——唯一的集成者。异步 + 尽力而为；
+ *  任何不确定情况下都保留 worktree（fail-safe——绝不自动丢弃可能宝贵的工作）。 */
 async function finalizeWorkerWorktree(wtPath: string, origCwd: string, worker: WorkerRec): Promise<void> {
   try {
     const work = await worktreeHasUnintegratedWork(wtPath, worker.baseBranch);
     if (work.keep) {
       console.warn(`[worker] PRESERVING worktree with unintegrated work: ${wtPath} (${work.detail})`);
-      // Track it so the GC sweep can reclaim it (+ scratch dir) once integrated —
-      // the worker is gone from liveWorkers by now, so its identity lives here.
+      // 跟踪它，这样一旦集成完成，GC sweep 就能回收它（+ scratch 目录）——
+      // 此时 worker 已从 liveWorkers 中消失，所以其身份就记录在这里。
       preservedWorktrees.set(wtPath, {
         workerId: worker.workerId, wtPath, origCwd, baseBranch: worker.baseBranch,
         scratchDir: workerScratchDir(worker.workerId), slack: worker.slack, preservedAt: Date.now()
@@ -536,13 +525,12 @@ async function finalizeWorkerWorktree(wtPath: string, origCwd: string, worker: W
     }
     const r = await removeWorktree(origCwd, wtPath);
     if (!r.ok) { console.error('[worker] removeWorktree failed:', r.error); return; }
-    // Worktree is gone (clean/integrated at teardown), but DEFER its scratch-dir
-    // cleanup to the throttled GC sweep rather than deleting it synchronously here:
-    // HIVE_ROOT/agents/<id> holds the worker's memory.md and the MemPalace miner
-    // ingests it asynchronously, so an immediate delete can beat the miner and
-    // permanently lose the worker's durable notes from the shared palace. Register
-    // it (its worktree path is now absent) so the sweep's path-gone branch reclaims
-    // the scratch after a window — same throttled path the preserved case uses.
+    // Worktree 已消失（teardown 时干净/已集成），但把 scratch 目录的清理
+    // 推迟到限流的 GC sweep，而不是在这里同步删除：HIVE_ROOT/agents/<id>
+    // 存放着 worker 的 memory.md，MemPalace miner 会异步摄取它——立即删除可能
+    // 抢在 miner 之前，永久丢失 worker 留在共享 palace 里的持久笔记。注册它
+    // （其 worktree 路径现已不存在），让 sweep 的 path-gone 分支在一段时间后
+    // 回收 scratch——与保留情形走同一条限流路径。
     preservedWorktrees.set(wtPath, {
       workerId: worker.workerId, wtPath, origCwd, baseBranch: worker.baseBranch,
       scratchDir: workerScratchDir(worker.workerId), slack: worker.slack, preservedAt: Date.now()
@@ -552,69 +540,66 @@ async function finalizeWorkerWorktree(wtPath: string, origCwd: string, worker: W
   }
 }
 
-/** The hive scratch dir for a worker (its inbox/outbox/memory): HIVE_ROOT/agents/<id>.
- *  Null when there's no hive root. */
+/** worker 的 hive scratch 目录（其 inbox/outbox/memory）：HIVE_ROOT/agents/<id>。
+ *  无 hive root 时返回 null。 */
 function workerScratchDir(workerId: string): string | null {
   const root = hive.root();
   return root ? join(root, 'agents', workerId) : null;
 }
 
-/** Best-effort removal of a worker's scratch (hive agent) dir. Guarded to ONLY ever
- *  delete a path that resolves to exactly HIVE_ROOT/agents/<workerId> and never a
- *  still-live worker — so a crafted/mismatched id can't escape the agents root. */
+/** 尽力而为地移除 worker 的 scratch（hive agent）目录。守卫确保只会删除
+ *  解析后精确等于 HIVE_ROOT/agents/<workerId> 的路径，且绝不删除仍在活跃的
+ *  worker——因此一个伪造/错配的 id 也无法逃出 agents 根目录。 */
 function removeWorkerScratch(workerId: string): void {
-  if (liveWorkers.has(workerId)) return; // never wipe a live worker's mailbox
+  if (liveWorkers.has(workerId)) return; // 绝不擦除活跃 worker 的邮箱
   const dir = workerScratchDir(workerId);
   const root = hive.root();
   if (!dir || !root) return;
   const agentsRoot = join(root, 'agents');
-  // Path-safety: the resolved dir must sit directly under agents/ with basename == id.
+  // 路径安全：解析后的目录必须直接位于 agents/ 之下，且 basename == id。
   if (resolve(dir) !== join(resolve(agentsRoot), basename(dir)) || basename(dir) !== workerId) return;
   try { rmSync(dir, { recursive: true, force: true }); }
   catch (e) { console.error('[worker] removeWorkerScratch failed:', e); }
 }
-// A natural PTY exit must run the same teardown as an explicit kill — EXCEPT when
-// the PTY was the missing-CLI installer: a clean exit there means the engine CLI was
-// just installed, so auto restart-and-continue by re-running the SAME spawn into the
-// SAME pty/window (no user click). Provider-agnostic. Idempotent by construction: the
-// relaunch carries `noAutoInstall`, so the installer can never fire (let alone loop) a
-// second time — a binary that's somehow still missing just spawns and exits normally.
+// 自然 PTY 退出必须执行与显式 kill 相同的 teardown——除非该 PTY 是缺 CLI
+// 的安装器：那里一次干净退出意味着引擎 CLI 刚安装完成，所以自动重启并继续——
+// 把同一个 spawn 重新运行进同一个 pty/window（无需用户点击）。与提供方无关。
+// 结构上幂等：重启携带 `noAutoInstall`，因此安装器绝不可能会再次触发（更别说
+// 循环）——一个莫名仍然缺失的二进制只是正常 spawn 然后退出。
 ptyManager.setExitHandler((id, exitCode) => {
   const pending = pendingInstallRelaunch.get(id);
   if (pending) {
     pendingInstallRelaunch.delete(id);
-    // Activation funnel: did the auto-installer actually complete? A non-zero exit
-    // is the Linux-installer-cannot-finish-unattended signal that used to be silent.
+    // 激活漏斗：自动安装器真的完成了吗？非零退出是
+    // Linux-安装器-无法-无人值守-完成 的信号，过去它曾被静默忽略。
     const provider = pending.opts.provider ?? inferAgentProvider(pending.opts.command, undefined);
     if (exitCode === 0) {
       analytics.track('agent_install_finished', { provider, rung: pending.rung, outcome: 'agent_launched' });
-      // Re-arm the renderer's pooled terminal (clear the "process exited" line +
-      // re-enable input) so the freshly-spawned CLI paints onto a clean, typeable
-      // grid, then re-run the normal spawn — which now finds the installed binary.
+      // 重新武装渲染进程的池化终端（清除 “process exited” 行 + 重新启用输入），
+      // 让新 spawn 的 CLI 画到干净、可输入的网格上，然后重新运行正常 spawn——
+      // 此时它已能找到刚安装的二进制。
       const wc = (pending.owner && !pending.owner.isDestroyed()) ? pending.owner : liveWebContents();
-      try { wc?.send(`pty:relaunch:${id}`); } catch { /* window gone */ }
+      try { wc?.send(`pty:relaunch:${id}`); } catch { /* 窗口已消失 */ }
       void spawnAgentCore({ ...pending.opts, noAutoInstall: true }, pending.owner);
-      return; // an install PTY has no agent/worktree to tear down
+      return; // 安装型 PTY 没有需要拆除的 agent/worktree
     }
-    // Non-zero exit = install failed; leave its honest manual-fix message on screen.
+    // 非零退出 = 安装失败；把诚实的手动修复提示留在屏幕上。
     analytics.track('agent_install_finished', { provider, rung: pending.rung, outcome: 'install_failed' });
   }
   teardownPty(id);
 });
 
-/** Keep the system from suspending the harness while agents are running.
- *  Windows Modern Standby suspends desktop apps (and their child `claude`
- *  processes!) shortly after the display sleeps/locks — the whole hive froze
- *  mid-turn until unlock. `prevent-app-suspension` blocks exactly that while
- *  still letting the display turn off and the session lock. Held only while at
- *  least one PTY is alive, so an idle harness doesn't pin a laptop awake.
+/** 当 agent 运行期间，防止系统挂起 harness。Windows Modern Standby 会在
+ *  显示器休眠/锁定后不久挂起桌面应用（以及它们的子 `claude` 进程！）——
+ *  整个 hive 会在回合中途冻结，直到解锁。`prevent-app-suspension` 正好挡住
+ *  这种情况，同时仍允许显示器关闭、会话加锁。仅在至少有一个 PTY 存活时持有，
+ *  因此空闲的 harness 不会把笔记本钉在唤醒状态。
  *
- *  Opt-in `config.strongKeepalive` escalates to `prevent-display-sleep`, which on
- *  macOS ALSO blocks true system sleep (lid-close/idle) so timers & PTYs keep
- *  firing on time while away — at a battery cost. The default ('prevent-app-
- *  suspension') still lets the Mac truly sleep; we survive that and catch up once
- *  on resume (see onSystemResume). Re-evaluated on every call so toggling the
- *  flag while agents run swaps the blocker mode live. */
+ *  可选 `config.strongKeepalive` 升级为 `prevent-display-sleep`，在 macOS 上
+ *  还会阻止真正的系统睡眠（合盖/空闲），让离开时定时器与 PTY 也能准时触发——
+ *  代价是耗电。默认（'prevent-app-suspension'）仍允许 Mac 真正睡眠；我们能挺
+ *  过去并在恢复后补齐（见 onSystemResume）。每次调用都会重新评估，因此在
+ *  agent 运行中切换标志会实时切换阻止模式。 */
 type KeepAwakeMode = 'prevent-app-suspension' | 'prevent-display-sleep';
 let keepAwakeId: number | null = null;
 let keepAwakeMode: KeepAwakeMode | null = null;
@@ -623,10 +608,10 @@ function syncKeepAwake(): void {
   const desired: KeepAwakeMode | null = live
     ? (readConfig().strongKeepalive ? 'prevent-display-sleep' : 'prevent-app-suspension')
     : null;
-  if (desired === keepAwakeMode) return; // no change — avoid stop/start churn + log spam
-  // Tear down the current blocker (mode change, or going idle with no agents).
+  if (desired === keepAwakeMode) return; // 无变化——避免 stop/start 抖动和日志刷屏
+  // 拆除当前的阻止器（模式变更，或转入无 agent 的空闲）。
   if (keepAwakeId !== null) {
-    try { if (powerSaveBlocker.isStarted(keepAwakeId)) powerSaveBlocker.stop(keepAwakeId); } catch { /* noop */ }
+    try { if (powerSaveBlocker.isStarted(keepAwakeId)) powerSaveBlocker.stop(keepAwakeId); } catch { /* 空操作 */ }
     keepAwakeId = null;
   }
   keepAwakeMode = desired;
@@ -638,21 +623,20 @@ function syncKeepAwake(): void {
   }
 }
 
-/** A mission's live scheduler handles: the initial `setTimeout` that waits out
- *  the time remaining until its next due fire, and the steady `setInterval`
- *  armed once it has fired. Both are tracked so shutdown can clear whichever is
- *  pending. */
+/** 任务的实时调度器负责：最初的 `setTimeout`（等待距离下一次应触发还剩多久），
+ *  以及触发后装备的稳定 `setInterval`。两者都被跟踪，以便关机时能清除
+ *  任何一个挂起的定时器。 */
 interface MissionTimer {
   timeout?: NodeJS.Timeout;
   interval?: NodeJS.Timeout;
 }
 
-/** Active scheduler timers keyed by mission id. */
+/** 按任务 id 为键的活跃调度器定时器。 */
 const missionTimers = new Map<string, MissionTimer>();
 
-/** Clear and forget every armed mission timer (both the setTimeout and the
- *  setInterval handle). Safe to call from syncMissions and from shutdown
- *  teardown so a tick never fires into half-torn-down services. */
+/** 清除并忘记所有已装备的任务定时器（setTimeout 和 setInterval 句柄）。
+ *  可从 syncMissions 和关机 teardown 安全调用，因此 tick 绝不会触发进
+ *  半拆除的服务里。 */
 function clearMissionTimers(): void {
   for (const t of missionTimers.values()) {
     if (t.timeout) clearTimeout(t.timeout);
@@ -661,46 +645,41 @@ function clearMissionTimers(): void {
   missionTimers.clear();
 }
 
-/** Rebuild the scheduler from persisted config: clear every existing timer,
- *  then arm each enabled mission honoring its lastFiredAt — a setTimeout for the
- *  time remaining until its next due fire, which then settles into a steady
- *  interval. Each tick dispatches the mission to its target agent and stamps
- *  lastFiredAt back into config. Called on boot (after the router starts) and
- *  after every missions:save. */
+/** 从持久化配置重建调度器：清除每个现有定时器，然后装备每个启用的任务，
+ *  并尊重其 lastFiredAt——先用 setTimeout 等到下一次应触发还剩的时间，
+ *  随后稳定为固定间隔。每个 tick 把任务分发给目标 agent，并把 lastFiredAt
+ *  写回 config。在启动时（router 启动后）以及每次 missions:save 后调用。 */
 function syncMissions(): void {
   clearMissionTimers();
   const missions = readConfig().missions ?? [];
   for (const m of missions) {
     if (!m.enabled) continue;
-    // A weekly mission (day-of-week + time) is armed below and does NOT need an
-    // interval, so the interval guard has to come after that branch — it used to
-    // be folded into the line above and would have rejected every one of them.
+    // 每周任务（星期几 + 时间）在下方装备，且不需要 interval，所以 interval
+    // 守卫必须放在那个分支之后——过去它被并进上面那行，会把每一个周任务都拒绝掉。
     const weekly = m.kind === 'heartbeat' ? null : normalizeWeekly(m.weekly);
     if (!weekly && !(m.intervalMs > 0)) continue;
-    // Heartbeat (Lane A #1) opts out of the fixed setInterval and self-reschedules
-    // with an adaptive cadence. Registered into the same missionTimers map so
-    // clearMissionTimers() tears it down identically on quit/reset.
+    // Heartbeat（Lane A #1）不采用固定 setInterval，而以自适应节奏自我重排。
+    // 注册进同一个 missionTimers map，因此 clearMissionTimers() 在退出/重置时
+    // 以相同方式拆除它。
     if (m.kind === 'heartbeat') { armHeartbeat(m); continue; }
     const fire = (): void => {
       try {
-        // A 'compact' maintenance mission (maint-1) is compaction-ONLY: it carries
-        // no dispatch body/target, so skip the hive.send and just fire auto-compact.
-        // Gate on `kind!=='compact'` ALONE — that already excludes the compact mission;
-        // we deliberately do NOT add `&& m.body`, so other (dispatch) missions keep
-        // their prior behaviour, including the historical empty-body send (Pam N1).
+        // 一个 'compact' 维护任务（maint-1）只做压缩：它不携带分发 body/target，
+        // 所以跳过 hive.send，只触发 auto-compact。仅以 `kind!=='compact'` 为门控——
+        // 那已经排除了 compact 任务；我们刻意不添加 `&& m.body`，因此其他
+        // （分发类）任务保持原有行为，包括历史上空 body 的发送（Pam N1）。
         if (m.kind !== 'compact' && hive.enabled()) {
           hive.send({ to: m.to, act: 'request', subject: m.label, body: m.body }, 'scheduler');
         }
-        // Auto-compact: do NOT jam /compact into busy terminals. Hand it to the
-        // renderer, which queues a /compact per agent (deduped — never two at
-        // once) and delivers it only when that agent goes idle (its drain loop),
-        // so a working agent compacts between steps, never mid-step.
+        // Auto-compact：不要把 /compact 硬塞进繁忙的终端。交给渲染进程，它按
+        // agent 排队 /compact（去重——绝不两个同时）并且只在 agent 空闲时
+        // （其 drain loop）才投递，因此工作中的 agent 在步骤之间压缩，绝不在
+        // 步骤中途。
         //
-        // The CADENCE now belongs to the context trigger, not to a mission — but
-        // the legacy per-mission `autoCompact` flag keeps working, routed through
-        // the same emit so there is exactly ONE path from main to the renderer.
-        // It carries the context trigger's current rule so a mission-driven
-        // compaction obeys the same pressure thresholds as a trigger-driven one.
+        // CADENCE 现在属于 context trigger，而不是任务——但遗留的每任务
+        // `autoCompact` 标志仍然可用，经同一个 emit 路由，因此从 main 到
+        // renderer 只有一条路径。它携带 context trigger 的当前规则，让任务驱动的
+        // 压缩遵守与触发驱动相同的压力阈值。
         if (m.autoCompact || m.kind === 'compact') {
           emitContextTrigger('compact', contextRule('compact'));
         }
@@ -709,24 +688,22 @@ function syncMissions(): void {
           x.id === m.id ? { ...x, lastFiredAt: Date.now() } : x
         );
         writeConfig({ missions: next });
-        // Let the SCHEDULES panel refresh its "last fired" without a reload (#2.3).
-        try { liveWebContents()?.send('missions:updated'); } catch { /* window gone */ }
+        // 让 SCHEDULES 面板在不重载的情况下刷新 “last fired”（#2.3）。
+        try { liveWebContents()?.send('missions:updated'); } catch { /* 窗口已消失 */ }
       } catch (e) {
         console.error('[scheduler] mission', m.id, e);
       }
     };
     const entry: MissionTimer = {};
     if (weekly) {
-      // Weekly self-reschedules: there is no steady interval to settle into,
-      // because the gap between two slots varies (Fri to Mon is not Mon to Wed,
-      // and the week the clocks change is not 168 hours long).
+      // 每周自我重排：没有稳定的 interval 可落定，因为两个时段之间的间隔
+      // 各不相同（周五到周一不是周一到周三，而且改时钟的那一周也不是 168 小时）。
       //
-      // `justFired` is a spin guard, not a nicety. weeklyDelayMs returns 0 for a
-      // slot that was missed and not yet run, and it learns "already run" from
-      // the persisted lastFiredAt — so if fire()'s writeConfig ever failed, the
-      // next computation would return 0 again, forever. Passing `now` as the
-      // last-fired floor after a fire makes the catch-up branch unreachable, so
-      // the worst case is a lost stamp rather than a hot loop.
+      // `justFired` 是防自旋守卫，不是锦上添花。weeklyDelayMs 对错过且尚未运行
+      // 的时段返回 0，并从持久化的 lastFiredAt 得知“已运行”——所以如果 fire()
+      // 的 writeConfig 曾失败，下一次计算会再次返回 0，永远如此。在 fire 之后把
+      // `now` 作为 last-fired 下限传入，使追赶分支不可达，最坏情况只是丢一次
+      // 时间戳，而不是死循环。
       const rearm = (justFired: boolean): void => {
         const now = Date.now();
         const persisted = (readConfig().missions ?? []).find((x) => x.id === m.id)?.lastFiredAt ?? 0;
@@ -738,9 +715,8 @@ function syncMissions(): void {
       missionTimers.set(m.id, entry);
       continue;
     }
-    // Honor lastFiredAt so a partially-elapsed interval is not restarted from
-    // zero on reboot or when an unrelated mission is edited: wait only the time
-    // remaining until the next due fire, then settle into a steady interval.
+    // 尊重 lastFiredAt，使部分流逝的 interval 不会在重启或编辑不相关任务时
+    // 从零重新开始：只等待到下一次应触发为止的剩余时间，然后落定为稳定 interval。
     const remaining = Math.max(0, m.intervalMs - (Date.now() - (m.lastFiredAt ?? 0)));
     entry.timeout = setTimeout(() => {
       fire();
@@ -750,28 +726,26 @@ function syncMissions(): void {
   }
 }
 
-// ─── Context trigger (auto-compact / auto-clear own their own timers) ────────
-// Compaction used to ride on a mission (`compact-maintenance`), which meant the
-// operator had TWO competing controls for one behaviour — a schedule with an
-// interval and a trigger with a cadence. The mission is retired (see the
-// retirement migration in ensureDefaultMissions); these timers are the single
-// remaining source of scheduled context maintenance.
+// ─── Context trigger（auto-compact / auto-clear 各自拥有自己的定时器）────────
+// 压缩曾经挂在一个任务上（`compact-maintenance`），这意味着操作者对一个行为
+// 有两个相互竞争的控制——一个带 interval 的调度，一个带 cadence 的触发。该任务
+// 已退役（见 ensureDefaultMissions 里的退役迁移）；这些定时器是计划性上下文
+// 维护剩下的唯一来源。
 //
-// Main owns only the CADENCE. The pressure gate (`minContextPct`) needs each
-// agent's live context usage, which only the renderer has, so the whole rule
-// rides along in the event and the renderer decides which agents actually get
-// the command. That split is why the payload carries the rule rather than a bare
-// "go" signal.
+// Main 只拥有 CADENCE。压力闸门（`minContextPct`）需要每个 agent 的实时上下文
+// 使用量，而这只有渲染进程才有，所以整条规则随事件一起传送，由渲染进程决定哪些
+// agent 真正收到该命令。正因为这种分工，载荷携带的是规则而不是一个裸的
+// “go” 信号。
 
-/** Timers for the two halves, keyed by action. Same two-phase shape as
- *  `missionTimers` (a setTimeout for the remaining time, then a steady interval)
- *  so a partially-elapsed cadence survives a re-arm. */
+/** 两个半区的定时器，按 action 为键。与 `missionTimers` 相同的两阶段形态
+ *  （先 setTimeout 等待剩余时间，再稳定为固定 interval），因此部分流逝的
+ *  cadence 能在重新装备后存活。 */
 const contextTimers = new Map<'compact' | 'clear', MissionTimer>();
 
-/** `ContextRule` has no `lastFiredAt` (unlike `ScheduledMission`), so the last-run
- *  instants live in the durable kv store instead. Without them every re-arm —
- *  boot, a settings edit, a wake from sleep — would restart a 2h cadence from
- *  zero, and an operator who edits the rule twice a day would never see it fire. */
+/** `ContextRule` 没有 `lastFiredAt`（不同于 `ScheduledMission`），所以上次运行
+ *  时刻存放在持久化 kv store 里。没有它们，每次重新装备——启动、设置编辑、
+ *  从睡眠唤醒——都会让 2h cadence 从零重启，一天编辑两次规则的操作者永远
+ *  看不到它触发。 */
 const CONTEXT_LAST_RUN_KV_KEY = 'triggers.context.lastRun';
 let contextLastRun: Record<string, number> | null = null;
 
@@ -783,11 +757,10 @@ function contextRunMap(): Record<string, number> {
   return contextLastRun;
 }
 
-/** When the rule last ran. An UNRECORDED half is stamped NOW rather than read as
- *  the epoch: `remaining` would otherwise clamp to 0 and compact every terminal
- *  the instant the app boots. It is the same trap `ensureDefaultMissions` avoids
- *  by stamping `lastFiredAt` when it seeds a mission — a first launch should wait
- *  a full cadence, not open with an interruption. */
+/** 规则上次运行的时间。未记录的一半会被盖上 NOW 而不是读成 epoch：否则
+ *  `remaining` 会夹到 0，在应用启动的瞬间就压缩每个终端。这与
+ *  `ensureDefaultMissions` 播种任务时盖上 `lastFiredAt` 避开的是同一个陷阱——
+ *  首次启动应等待一个完整 cadence，而不是以一次中断开场。 */
 function contextLastRunAt(action: 'compact' | 'clear'): number {
   const map = contextRunMap();
   const v = map[action];
@@ -799,17 +772,17 @@ function stampContextRun(action: 'compact' | 'clear'): number {
   const map = contextRunMap();
   const at = Date.now();
   map[action] = at;
-  try { persist.setKv(CONTEXT_LAST_RUN_KV_KEY, map); } catch { /* DB best-effort */ }
+  try { persist.setKv(CONTEXT_LAST_RUN_KV_KEY, map); } catch { /* DB 尽力而为 */ }
   return at;
 }
 
-/** The live rule for one half, deep-filled. `readConfig` already fills both
- *  halves, so the default is only a belt-and-braces fallback. */
+/** 一个半区的实时规则，已深度填充。`readConfig` 已经填充了两个半区，所以
+ *  这个默认值只是双保险回退。 */
 function contextRule(action: 'compact' | 'clear'): ContextRule {
   return readConfig().contextTrigger?.[action] ?? DEFAULT_CONTEXT_TRIGGER[action];
 }
 
-/** Clear and forget both context timers (setTimeout + setInterval handles). */
+/** 清除并忘记两个 context 定时器（setTimeout + setInterval 句柄）。 */
 function clearContextTimers(): void {
   for (const t of contextTimers.values()) {
     if (t.timeout) clearTimeout(t.timeout);
@@ -818,25 +791,23 @@ function clearContextTimers(): void {
   contextTimers.clear();
 }
 
-/** Ask the renderer to run one half of the context trigger.
+/** 请求渲染进程运行 context trigger 的一个半区。
  *
- *  Both callers funnel through here — the legacy per-mission `autoCompact` flag
- *  and the context trigger's own timer — so there is exactly one path from main
- *  to the renderer for each action. */
+ *  两个调用方都汇聚到这里——遗留的每任务 `autoCompact` 标志和 context trigger
+ *  自己的定时器——因此对每个 action，从 main 到 renderer 恰好只有一条路径。 */
 function emitContextTrigger(action: 'compact' | 'clear', rule: ContextRule): void {
-  try { liveWebContents()?.send('trigger:context', { action, rule }); } catch { /* window gone */ }
-  // TRANSITIONAL ALIAS: the renderer still carries the pre-Triggers
-  // `mission:autoCompact` listener as a fallback. Both fire for compact until
-  // every consumer has moved to `trigger:context`; then this line goes.
+  try { liveWebContents()?.send('trigger:context', { action, rule }); } catch { /* 窗口已消失 */ }
+  // 过渡期别名：渲染进程仍保留着 pre-Triggers 的 `mission:autoCompact`
+  // 监听器作为回退。compact 时两者都会触发，直到每个使用方都迁到
+  // `trigger:context`；届时这行删除。
   if (action === 'compact') {
-    try { liveWebContents()?.send('mission:autoCompact'); } catch { /* window gone */ }
+    try { liveWebContents()?.send('mission:autoCompact'); } catch { /* 窗口已消失 */ }
   }
 }
 
-/** (Re)arm both context timers from persisted config. Clear-then-arm, so calling
- *  it after a settings change, on boot, or on wake from sleep can never stack
- *  duplicates. Honors elapsed-time-since-last-run exactly like mission arming:
- *  an overdue rule fires ONCE and then settles into its steady cadence. */
+/** 从持久化配置（重新）装备两个 context 定时器。先清后装，因此设置变更、
+ *  启动、或从睡眠唤醒后调用它绝不会叠加重复。与任务装备一样精确地尊重
+ *  距上次运行的流逝时间：逾期规则触发一次后即落定为稳定 cadence。 */
 function syncContextTriggers(): void {
   clearContextTimers();
   for (const action of ['compact', 'clear'] as const) {
@@ -845,8 +816,8 @@ function syncContextTriggers(): void {
     const fire = (): void => {
       try {
         stampContextRun(action);
-        // Re-read: the operator may have edited the message/thresholds since the
-        // timer was armed, and the renderer should act on what's current.
+        // 重新读取：操作者可能已编辑消息/阈值（自定时器装备以来），
+        // 渲染进程应对当前值采取行动。
         emitContextTrigger(action, contextRule(action));
       } catch (e) {
         console.error('[triggers] context', action, e);
@@ -862,27 +833,26 @@ function syncContextTriggers(): void {
   }
 }
 
-/** Startup migration (#57/#58): archive every agent entry that is `archived:false`
- *  but has NO live PTY. This runs in bootstrapHiveServices, BEFORE the renderer can
- *  respawn anything, so at this point NO agent owns a PTY — every `archived:false`
- *  entry is therefore a stale carry-over from a prior session that quit/crashed
- *  WITHOUT archiving (e.g. the pre-acc13a3 'assistant' Dwight entry). Left as-is
- *  they have no live PTY, so the breaker beat steers them and the steer bounces to
- *  GOD as a requires_reply GOD can't clear → inbox flood.
+/** 启动迁移（#57/#58）：归档每个 `archived:false` 但没有活跃 PTY 的 agent
+ *  条目。这在 bootstrapHiveServices 中运行，早于渲染进程能重新 spawn 任何东西，
+ *  因此此刻没有 agent 拥有 PTY——每个 `archived:false` 条目都是上一会话未归档
+ *  就退出/崩溃（例如 pre-acc13a3 的 'assistant' Dwight 条目）留下的陈旧遗留。
+ *  若放任不管，它们没有活跃 PTY，breaker beat 会 steering 它们，而 steering 会
+ *  作为 requires_reply 弹回 GOD，GOD 无法清除 → 收件箱洪泛。
  *
- *  "No live PTY" = ptyForAgent(id) === undefined (ptyToAgent is populated only at
- *  spawn and pruned on teardown). God is never archived. A user's real agents are
- *  unaffected: the "restore team" flow respawns them through ensureAgent, which
- *  re-clears `archived` — restorability does not depend on the archived flag. */
+ *  “无活跃 PTY” = ptyForAgent(id) === undefined（ptyToAgent 只在 spawn 时填充、
+ *  teardown 时清理）。God 永不被归档。用户的真实 agent 不受影响：“restore team”
+ *  流程经 ensureAgent 重新 spawn 它们，后者会重新清除 `archived`——可恢复性
+ *  不依赖 archived 标志。 */
 function archiveOrphanedAgents(): void {
   if (!hive.enabled()) return;
   try {
     const reg = hive.registry();
     for (const [id, a] of Object.entries(reg.agents)) {
       if (a.archived) continue;
-      if (id === reg.godId) continue;        // god is never archived
-      if (ptyForAgent(id)) continue;         // has a live PTY → genuinely active
-      hive.setArchived(id, true);            // stale archived:false orphan → archive
+      if (id === reg.godId) continue;        // god 永不被归档
+      if (ptyForAgent(id)) continue;         // 有活跃 PTY → 确实活跃
+      hive.setArchived(id, true);            // 陈旧的 archived:false 孤儿 → 归档
       console.log('[migration] archived orphaned agent (no live PTY):', id);
     }
   } catch (e) {
@@ -890,11 +860,10 @@ function archiveOrphanedAgents(): void {
   }
 }
 
-/** One-time migration: ensure the built-in hourly ops standup exists for installs
- *  that predate it. Guarded by `opsStandupSeeded` so a user who later deletes the
- *  mission doesn't get it re-added on every boot. Stamps lastFiredAt = now so the
- *  first standup waits a full interval instead of firing (and compacting every
- *  terminal) immediately on launch. */
+/** 一次性迁移：确保内置的小时级 ops standup 存在于早于它的安装中。以
+ *  `opsStandupSeeded` 为守卫，因此用户之后删除该任务也不会在每次启动时被
+ *  重新加回。盖上 lastFiredAt = now，使首次 standup 等待一个完整间隔，而不是
+ *  启动瞬间就触发（并压缩每个终端）。 */
 function ensureDefaultMissions(): void {
   const cfg = readConfig();
   if (!cfg.opsStandupSeeded) {
@@ -905,9 +874,9 @@ function ensureDefaultMissions(): void {
       opsStandupSeeded: true
     });
   }
-  // Seed the built-in heartbeat (Lane A #1) once. Shipped DISABLED, so it just
-  // appears in the SCHEDULES panel for the user to turn on; lastFiredAt = now so
-  // it doesn't fire on the very first launch after a user enables it.
+  // 一次性播种内置 heartbeat（Lane A #1）。随产品以 DISABLED 发布，所以它只是
+  // 出现在 SCHEDULES 面板里让用户开启；lastFiredAt = now 让它在用户启用后的
+  // 第一次启动时不立即触发。
   const cfg2 = readConfig();
   if (!cfg2.heartbeatSeeded) {
     const missions = cfg2.missions ?? [];
@@ -918,19 +887,17 @@ function ensureDefaultMissions(): void {
     });
   }
 
-  // maint-1 RETIREMENT: `compact-maintenance` is no longer a mission. Scheduled
-  // compaction is now the CONTEXT TRIGGER's job, so the operator has exactly one
-  // control (a cadence + a pressure gate + an editable message) instead of two
-  // that could disagree — a mission saying "hourly" while the trigger said "2h"
-  // was a real, unresolvable conflict.
+  // maint-1 RETIREMENT：`compact-maintenance` 不再是任务。计划性压缩现在是
+  // CONTEXT TRIGGER 的职责，因此操作者只有一个控制（cadence + 压力闸门 +
+  // 可编辑消息），而不是两个可能互相矛盾的控制——任务说 “hourly” 而触发器说
+  // “2h” 是真实、不可调和的冲突。
   //
-  // The carry-over preserves the operator's decisions: whether compaction was ON
-  // and how often. It runs at most once per install, and its guard is the
-  // mission's own ABSENCE — nothing seeds `compact-maintenance` any more, so once
-  // this has removed it there is nothing left to carry and a later hand-edit of
-  // the trigger can never be clobbered. That keeps the `*Seeded` convention's
-  // promise (exactly once, ever) without a config flag that would only ever be
-  // read here; `compactMaintenanceSeeded` is left set so nothing re-seeds it.
+  // 迁移保留操作者的决策：压缩是否开启、多久一次。它每台安装最多运行一次，
+  // 其守卫是任务自身的 ABSENCE——再也没有东西播种 `compact-maintenance`，所以
+  // 一旦移除就没有可迁移的，之后对触发器的手动编辑也绝不会被覆盖。这样在无需
+  // 一个只在这里被读的 config 标志的前提下，保住了 `*Seeded` 约定的承诺
+  // （永久恰好一次）；`compactMaintenanceSeeded` 保持已设置，使任何东西都不会
+  // 重新播种它。
   const cfg3 = readConfig();
   const missions3 = cfg3.missions ?? [];
   const retiring = missions3.find((m) => m.id === COMPACT_MAINTENANCE_MISSION.id);
@@ -943,36 +910,33 @@ function ensureDefaultMissions(): void {
         compact: {
           ...current.compact,
           enabled: retiring.enabled,
-          // A hand-tuned interval is a decision; only a missing/absurd one falls
-          // back to whatever the trigger already carries.
+          // 手工调整过的 interval 是一个决策；只有缺失/荒谬的值才回退到
+          // 触发器已携带的值。
           everyMs: retiring.intervalMs > 0 ? retiring.intervalMs : current.compact.everyMs
         }
       },
       compactMaintenanceSeeded: true
     });
-    // …and its elapsed time, so retiring the mission mid-cycle doesn't restart a
-    // 2h cadence from zero (the timers honour last-run exactly as arming did).
+    // ……以及它的流逝时间，这样在周期中途退役任务不会让 2h cadence
+    // 从零重启（定时器像装备时一样精确地尊重上次运行时间）。
     if (typeof retiring.lastFiredAt === 'number' && retiring.lastFiredAt > 0) {
       const map = contextRunMap();
       map.compact = retiring.lastFiredAt;
-      try { persist.setKv(CONTEXT_LAST_RUN_KV_KEY, map); } catch { /* DB best-effort */ }
+      try { persist.setKv(CONTEXT_LAST_RUN_KV_KEY, map); } catch { /* DB 尽力而为 */ }
     }
     console.log('[triggers] retired the compact-maintenance mission into contextTrigger.compact',
       `(enabled: ${retiring.enabled}, everyMs: ${retiring.intervalMs})`);
   }
 
-  // autoCompact RETIREMENT: the flag above was only ever half-removed. Retiring
-  // `compact-maintenance` left `autoCompact: true` sitting on the ops standup, so
-  // a default install still asked for compaction on TWO cadences — hourly from the
-  // standup, 2-hourly from the trigger — which is precisely the disagreement that
-  // retirement claims to have ended. (config.ts even documented a migration that
-  // strips this; it did not exist.)
+  // autoCompact RETIREMENT：上面的标志只被移除了一半。退役 `compact-maintenance`
+  // 后，`autoCompact: true` 仍留在 ops standup 上，因此默认安装仍会在两个 cadence
+  // 上请求压缩——standup 每小时一次、触发器每两小时一次——这恰恰是退役声称要
+  // 结束的那种分歧。（config.ts 甚至记录了一个会剥离它的迁移；它并不存在。）
   //
-  // Strip it wherever it survives. This is a pure de-duplication, not a behaviour
-  // change: contextTrigger.compact still runs, still on the user's own cadence and
-  // pressure gate, and it is what actually performed every one of these
-  // compactions already — both paths have called emitContextTrigger since Triggers
-  // landed. Idempotent, so it costs one no-op scan per boot once clean.
+  // 无论它残留在哪里都剥离它。这是纯粹的去重，不是行为变更：contextTrigger.compact
+  // 仍会运行，仍遵循用户自己的 cadence 和压力闸门，而且正是它在执行此前每一次
+  // 压缩——自 Triggers 落地起，两条路径都已调用 emitContextTrigger。幂等，因此
+  // 一旦干净，每次启动只花费一次 no-op 扫描。
   const cfg4 = readConfig();
   const missions4 = cfg4.missions ?? [];
   if (missions4.some((m) => m.autoCompact)) {
@@ -987,19 +951,18 @@ function ensureDefaultMissions(): void {
   }
 }
 
-// ─── Heartbeat (Lane A #1) + circuit-breaker beat (#6.6b) ────────────────────
+// ─── Heartbeat（Lane A #1）+ 熔断器 beat（#6.6b）────────────────────
 
-/** Is the floor quiet? Derived ONLY from signals the main process owns or can
- *  stat — log.jsonl mtime (the master signal: every routed msg/drain/spawn/task
- *  append touches it), each agent's inbox + outbox/.sent mtimes, and every live
- *  PTY's lastOutputAt (an agent printing/thinking counts as activity). Crucially
- *  NOT registry.status, which is written 'idle' once at spawn and never
- *  transitions in main — reading it would see the floor quiet forever. */
+/** floor 是否安静？只从主进程拥有或能 stat 的信号推导——log.jsonl 的 mtime
+ *  （主信号：每次路由的 msg/drain/spawn/task 追加都会触碰它）、每个 agent 的
+ *  inbox + outbox/.sent 的 mtime，以及每个活跃 PTY 的 lastOutputAt（agent 打印/
+ *  思考算作活动）。关键是不用 registry.status——它在 spawn 时被写为 'idle' 且
+ *  在主进程中从不转换——读它会永远看到 floor 安静。 */
 function isFloorQuiet(thresholdMs: number): boolean {
   const root = hive.root();
   if (!root) return false;
   const times: number[] = [];
-  const pushMtime = (p: string): void => { try { times.push(statSync(p).mtimeMs); } catch { /* missing */ } };
+  const pushMtime = (p: string): void => { try { times.push(statSync(p).mtimeMs); } catch { /* 缺失 */ } };
   pushMtime(join(root, 'log.jsonl'));
   const agentsDir = join(root, 'agents');
   if (existsSync(agentsDir)) {
@@ -1009,21 +972,20 @@ function isFloorQuiet(thresholdMs: number): boolean {
     }
   }
   for (const t of ptyManager.list()) times.push(t.lastOutputAt);
-  if (times.length === 0) return false; // nothing to judge → don't fire
+  if (times.length === 0) return false; // 无信号可判 → 不触发
   return Date.now() - Math.max(...times) > thresholdMs;
 }
 
-/** Newest coordination-file mtime for one agent (inbox + inbox/.done, outbox +
- *  outbox/.sent, memory.md) — FILES only, deliberately excluding PTY output, so
- *  "no-progress" means "not coordinating" even while the agent is busy printing
- *  tokens. inbox/.done and the outbox dir count because handling mail (moving a
- *  message to .done, drafting an outbox message) IS coordination — without them
- *  an inbox-ack turn reads as no-progress (issue #109's second trigger). */
+/** 一个 agent 最新的协调文件 mtime（inbox + inbox/.done、outbox +
+ *  outbox/.sent、memory.md）——只算文件，刻意排除 PTY 输出，因此 “无进展”
+ *  意味着 “未在协调”，即使 agent 正在忙于打印 token。inbox/.done 和 outbox 目录
+ *  也算，因为处理邮件（把消息移到 .done、起草 outbox 消息）就是协调——没有它们，
+ *  一次收件箱确认回合会被读成无进展（issue #109 的第二个触发器）。 */
 function lastCoordinationAt(agentId: string): number {
   const root = hive.root();
   if (!root) return 0;
   const times: number[] = [0];
-  const pushMtime = (p: string): void => { try { times.push(statSync(p).mtimeMs); } catch { /* missing */ } };
+  const pushMtime = (p: string): void => { try { times.push(statSync(p).mtimeMs); } catch { /* 缺失 */ } };
   const dir = join(root, 'agents', agentId);
   pushMtime(join(dir, 'inbox'));
   pushMtime(join(dir, 'inbox', '.done'));
@@ -1033,15 +995,15 @@ function lastCoordinationAt(agentId: string): number {
   return Math.max(...times);
 }
 
-/** PTY id owning a given agent id, or undefined. */
+/** 拥有给定 agent id 的 PTY id，或 undefined。 */
 function ptyForAgent(agentId: string): string | undefined {
   for (const [ptyId, a] of ptyToAgent) if (a === agentId) return ptyId;
   return undefined;
 }
 
-/** "Stuck" = some worker's PTY is actively printing (recent output) while its
- *  coordination files have gone stale — working-but-not-coordinating. Tightens
- *  the heartbeat cadence so we notice a wedged agent sooner. */
+/** “卡住” = 某个 worker 的 PTY 正在积极打印（近期有输出），而其协调文件已
+ *  过期——在工作但未协调。这会收紧 heartbeat cadence，让我们更快发现卡死的
+ *  agent。 */
 function looksStuck(windowMs: number): boolean {
   const reg = hive.registry();
   const now = Date.now();
@@ -1055,8 +1017,8 @@ function looksStuck(windowMs: number): boolean {
   return false;
 }
 
-/** Bounded digest for god — paths + counts, never full files (reference-passing,
- *  #6.2). A few hundred tokens at most. */
+/** 给 god 的有界摘要——路径 + 计数，绝不含完整文件（reference-passing，
+ *  #6.2）。至多几百个 token。 */
 function buildHeartbeatDigest(quietMs: number, actionable = 0): string {
   const reg = hive.registry();
   const active = Object.entries(reg.agents).filter(([id, a]) => !a.archived && id !== reg.godId);
@@ -1064,9 +1026,9 @@ function buildHeartbeatDigest(quietMs: number, actionable = 0): string {
   const boardHead = hive.board().split('\n').slice(0, 10).join('\n').trim();
   const log = hive.logTail(8).map((e) => { try { return JSON.stringify(e); } catch { return ''; } }).filter(Boolean).join('\n');
   const withInbox = active.filter(([id]) => hive.inbox(id).length > 0).map(([, a]) => a.name);
-  // When real agent/human mail is waiting, lead with an explicit call-to-action
-  // instead of the "quiet" line — this beat fired BECAUSE of unread actionable
-  // inbox, not because the floor went quiet, and god must read it now.
+  // 当真实 agent/人类邮件在等待时，以明确的行动号召开头，而不是 “quiet” 行——
+  // 这个 beat 之所以触发是因为有未读的 actionable 收件箱，而不是因为 floor 变
+  // 安静了，god 必须现在就读它。
   const header = actionable > 0
     ? `Floor heartbeat — ${actionable} actionable inbox message(s) awaiting you (worker/human mail). Drain your inbox NOW and act on them.`
     : `Floor heartbeat — quiet ~${Math.round(quietMs / 60000)}m.`;
@@ -1085,17 +1047,16 @@ function buildHeartbeatDigest(quietMs: number, actionable = 0): string {
   ].join('\n');
 }
 
-/** Senders whose mail is the scheduler's OWN noise (heartbeat beats, ops-standup
- *  via 'scheduler', breaker steers, generic 'system') — never a reason to wake
- *  god. Everything else (a worker agent id, 'webhook', a human reply) is real
- *  mail god must act on. Kept narrow so any future real sender counts by default. */
+/** 发件方其邮件是调度器自身噪音的（heartbeat beats、经 'scheduler' 的 ops-
+ *  standup、breaker steers、通用 'system'）——绝不是唤醒 god 的理由。其余一切
+ * （worker agent id、'webhook'、人类回复）都是 god 必须处理的真实邮件。保持
+ * 狭窄，让任何未来的真实发件方默认被计入。 */
 const SYSTEM_SENDERS = new Set(['heartbeat', 'scheduler', 'breaker', 'system']);
 
-/** Count of UNREAD actionable messages in god's inbox — real agent/human mail,
- *  excluding the scheduler's own beats. Drives an inbox-aware re-engage so a
- *  worker's reply (or a human answer) doesn't sit unread while the floor is busy:
- *  the floor-quiet gate alone misses that case — any active agent keeps the floor
- *  "loud", so god was never re-engaged until everything else went idle. */
+/** god 收件箱中未读的 actionable 消息数——真实 agent/人类邮件，排除调度器自己
+ *  的 beats。驱动收件箱感知的 re-engage，使 worker 的回复（或人类的回答）不会在
+ *  floor 忙碌时无人阅读：仅靠 floor-quiet 闸门会漏掉这种情况——任何活跃 agent 都
+ *  让 floor 保持 “loud”，所以直到其他一切都空闲之前，god 永不被重新拉入。 */
 function godActionableInboxCount(): number {
   try {
     const godId = hive.registry().godId;
@@ -1104,28 +1065,26 @@ function godActionableInboxCount(): number {
   } catch { return 0; }
 }
 
-/** Re-engage a quiet floor: drop a durable digest into god's inbox. We never
- *  type directly into god's PTY here — if he's busy that would jam mid-step. The
- *  inbox message is delivered by the renderer's busy-aware inbox-wake (it nudges
- *  god to read his inbox only once he's idle), so the heartbeat defers around a
- *  working god instead of interrupting him. */
+/** 重新拉入安静的 floor：往 god 的收件箱投一条持久摘要。我们绝不在这里直接
+ *  往 god 的 PTY 打字——如果他正忙，那会卡在回合中途。收件箱消息由渲染进程
+ *  的 busy-aware inbox-wake 投递（它只在 god 空闲时才提醒他读收件箱），因此
+ *  heartbeat 绕开工作中 god 而不是打断他。 */
 function reengageGod(digest: string): void {
   if (!hive.enabled()) return;
   hive.send({ to: 'god', act: 'request', subject: 'Heartbeat', body: digest }, 'heartbeat');
 }
 
-/** A native toast for breaker constrain/stop, gated on the notifications setting. */
+/** breaker constrain/stop 的原生 toast，受 notifications 设置门控。 */
 function breakerToast(title: string, body: string): void {
   if (!readConfig().notifications) return;
   try { if (Notification.isSupported()) new Notification({ title, body }).show(); }
-  catch { /* unsupported platform */ }
+  catch { /* 不支持的平台 */ }
 }
 
-/** One circuit-breaker beat: pull a fresh usage sample per active agent, append
- *  it to the durable cost ledger (the SOLE durable cost store), tick the breaker,
- *  emit each BreakerState on control:breakerState (Seam 2), and enforce any
- *  escalation. God is in the LEDGER (cost visibility) but NOT the breaker inputs
- *  (the heartbeat manages god; we never auto-steer/kill the orchestrator). */
+/** 一次熔断器 beat：为每个活跃 agent 拉取一份新 usage 样本，追加到持久成本
+ *  账本（唯一的持久成本存储），tick 熔断器，在 control:breakerState（Seam 2）上
+ *  发出每个 BreakerState，并强制执行任何升级。God 在 LEDGER（成本可见性）中但
+ *  不在 breaker 输入里（heartbeat 管理 god；我们绝不自动 steering/kill 编排者）。 */
 function runBreakerBeat(progressWindowMs: number): void {
   if (!hive.enabled()) return;
   const reg = hive.registry();
@@ -1133,41 +1092,34 @@ function runBreakerBeat(progressWindowMs: number): void {
   const inputs: BreakerInput[] = [];
   for (const [id, a] of Object.entries(reg.agents)) {
     if (a.archived) continue;
-    // #57/#58: skip assistant + orphaned shells. The breaker must only evaluate
-    // live, real agents. An assistant entry (e.g. the pre-acc13a3 headless
-    // 'Dwight') or any orphaned entry left archived:false with NO live PTY would
-    // otherwise be steered, and that steer bounces to GOD as a requires_reply GOD
-    // can't clear → inbox flood. ptyForAgent(id) === undefined means no live PTY.
-    // God is exempt from this orphan check (it keeps its own flow + the godId skip
-    // below) so its ledger row is unaffected. Live real agents always own a PTY
-    // (ptyToAgent is set at spawn), so their breaker behavior is unchanged.
+    // #57/#58：跳过 assistant + 孤儿 shell。breaker 只能评估活跃、真实的 agent。
+    // 一个 assistant 条目（例如 pre-acc13a3 的无头 'Dwight'）或任何留成
+    // archived:false 且没有活跃 PTY 的孤儿条目，否则会被 steering，而那个 steer
+    // 会作为 requires_reply 弹回 GOD，GOD 无法清除 → 收件箱洪泛。
+    // ptyForAgent(id) === undefined 意味着没有活跃 PTY。God 豁免此孤儿检查
+    // （它有自己的流程 + 下面的 godId 跳过）因此其账本行不受影响。活跃真实 agent
+    // 总是拥有 PTY（ptyToAgent 在 spawn 时设置），因此它们的 breaker 行为不变。
     if (a.isAssistant) continue;
     if (id !== reg.godId && !ptyForAgent(id)) continue;
     const sample = usageProvider.getAgentUsage(id);
-    // #56: only append a ledger row for a LIVE session sample. A dead/orphaned
-    // agent with a frozen transcript still yields a sample via the transcript
-    // fallback, but with an EMPTY sessionId (aggregateLive returns null → no live
-    // OTel session). Appending it every ~30s rewrote the identical row forever
-    // (2,417 dupes observed). A truthy sessionId is set only by a live session
-    // (aggregateLive picks the most-recent live session id), so this gates on
-    // "is there a live session" without changing any live-agent behavior.
-    if (sample?.sessionId) hive.appendCostLedger(sample); // ledger covers everyone incl. god
-    // Second source for the resume key. recordSession() is otherwise reachable
-    // ONLY from the hook shim, so any window where hooks don't land leaves the
-    // registry with no sessionId and "Restart & Continue" refuses to continue —
-    // while this very sample proves the app knew the live session id all along
-    // (it was already being written to the cost ledger one line above). Same id,
-    // same liveness gate; recordSession writes only on change, so this is a
-    // no-op once the hooks are flowing.
+    // #56：只为 LIVE 会话样本追加账本行。死/孤儿 agent 的冻结 transcript 仍会
+    // 经 transcript 回退产出样本，但 sessionId 为空（aggregateLive 返回 null →
+    // 无 live OTel 会话）。每 ~30s 追加它就会永远重写同一行（观察到 2,417 个
+    // 重复）。truthy sessionId 只由 live 会话设置（aggregateLive 挑选最近的 live
+    // 会话 id），因此这以 “是否存在 live 会话” 为门控，不改变任何 live-agent 行为。
+    if (sample?.sessionId) hive.appendCostLedger(sample); // 账本覆盖所有人，含 god
+    // resume key 的第二个来源。recordSession() 否则只能从 hook shim 触达，因此
+    // 任何 hook 落空的时间窗都会让 registry 没有 sessionId，“Restart & Continue”
+    // 拒绝继续——而这份样本本身就证明应用一直都知道 live 会话 id（它上面一行
+    // 已被写入成本账本）。同一 id、同一 liveness 门控；recordSession 只在变化时
+    // 写入，所以 hook 正常流动后这是空操作。
     if (sample?.sessionId) hive.recordSession(id, sample.sessionId);
-    if (id === reg.godId) continue;            // breaker skips god
-    // Progress = fresh coordination files OR a recent OTel tool span. The span
-    // leg closes the background-work blind spot: subagent/Workflow tool calls
-    // never reach the parent session's PostToolUse hook (so the breaker's own
-    // distinct-tool clock stays stale) but their spans DO flow through the
-    // collector under this agent's id — an idle parent supervising a hard-
-    // working background fleet is progressing, not wedged. Observed live: the
-    // one residual no-progress false positive after the #109 fixes.
+    if (id === reg.godId) continue;            // breaker 跳过 god
+    // 进展 = 新鲜的协调文件 OR 近期的 OTel 工具 span。span 这一支补上了后台
+    // 工作的盲区：subagent/Workflow 工具调用永远不会到达父会话的 PostToolUse
+    // hook（所以 breaker 自己的 distinct-tool 时钟保持陈旧），但它们的 span 确实
+    // 以该 agent 的 id 流过收集器——一个空闲的父 agent 监督着辛苦工作的后台
+    // 舰队是进展中，而不是卡死。#109 修复后观察到的唯一残留 no-progress 误报。 
     const spans = telemetry.getSpans(id);
     const lastSpanAt = spans.length ? spans[spans.length - 1].ts : 0;
     inputs.push({
@@ -1177,33 +1129,33 @@ function runBreakerBeat(progressWindowMs: number): void {
     });
   }
   for (const d of breaker.tick(inputs, now)) {
-    try { liveWebContents()?.send('control:breakerState', d.state); } catch { /* window gone */ }
+    try { liveWebContents()?.send('control:breakerState', d.state); } catch { /* 窗口已消失 */ }
     if (d.action === 'none') continue;
     const name = reg.agents[d.state.agentId]?.name ?? d.state.agentId;
     const reason = d.state.reason;
     if (d.action === 'steer') {
       hive.send({ to: d.state.agentId, act: 'request', subject: 'Circuit breaker: steer',
-        body: `Automated guardrail: ${reason}. Re-check your approach — if you're looping or stuck, STOP repeating, summarize what you've tried, and ask god for direction.` }, 'breaker');
+        body: `自动护栏：${reason}。重新审视你的方法——如果你在循环或卡住，STOP 重复，总结你已尝试的，并向 god 请示方向。` }, 'breaker');
     } else if (d.action === 'constrain') {
       hive.send({ to: d.state.agentId, act: 'request', subject: 'Circuit breaker: constrain',
-        body: `Automated guardrail escalated: ${reason}. Stop active work now: switch to read-only/plan, write a short plan of your next step, and send it to god for sign-off BEFORE running more tools.` }, 'breaker');
-      breakerToast(`${name} constrained`, reason);
+        body: `自动护栏升级：${reason}。现在停止主动工作：切换到只读/计划模式，写下你下一步的简短计划，并在运行更多工具之前先发给 god 审批。` }, 'breaker');
+      breakerToast(l10n(`${name} constrained`, `${name} 已受限`), reason);
     } else if (d.action === 'stop') {
       const ptyId = ptyForAgent(d.state.agentId);
-      if (ptyId) { try { ptyManager.kill(ptyId); } catch { /* already gone */ } teardownPty(ptyId); }
-      breakerToast(`${name} stopped by circuit breaker`, reason);
+      if (ptyId) { try { ptyManager.kill(ptyId); } catch { /* 已消失 */ } teardownPty(ptyId); }
+      breakerToast(l10n(`${name} stopped by circuit breaker`, `${name} 已被熔断器停止`), reason);
     }
   }
 }
 
-/** Lifetime spend, folded from cost-ledger.jsonl. `telemetry`'s usd counter is
- *  cumulative-since-process-start and restarts at ~0 on every app restart, so
- *  it cannot answer "what has this agent cost us". See costLifetime.ts. */
+/** 生命周期花费，从 cost-ledger.jsonl 折叠而来。`telemetry` 的 usd 计数器是
+ *  自进程启动以来的累计值，每次应用重启都从 ~0 重新开始，因此它无法回答
+ *  “这个 agent 到底花了我们多少钱”。见 costLifetime.ts。 */
 const costTotals = new CostLedgerTotals();
 
-/** Build + write the live fleet snapshot Michael reads (`<hive>/fleet.json`).
- *  Always-on (independent of the heartbeat) since `claude agents` can't see the
- *  hive's sibling sessions. PII-free; never throws (called from a timer). */
+/** 构建并写入 Michael 读取的实时 fleet 快照（`<hive>/fleet.json`）。
+ *  常开（独立于 heartbeat），因为 `claude agents` 看不到 hive 的兄弟会话。
+ *  无 PII；绝不抛异常（从定时器调用）。 */
 function writeFleetSnapshot(): void {
   if (!hive.enabled()) return;
   try {
@@ -1211,7 +1163,7 @@ function writeFleetSnapshot(): void {
     const snap = telemetry.snapshot();
     const usageById = new Map(snap.usage.map((u) => [u.agentId, u]));
     const now = Date.now();
-    // Async + incremental; returns immediately and never throws into the timer.
+    // 异步 + 增量；立即返回，绝不向定时器抛异常。
     const hiveRoot = hive.root();
     if (hiveRoot) void costTotals.refresh(join(hiveRoot, 'cost-ledger.jsonl'));
     const agents = Object.entries(reg.agents)
@@ -1220,8 +1172,8 @@ function writeFleetSnapshot(): void {
         const u = usageById.get(id);
         const spans = snap.spans[id] ?? [];
         const tokens = u ? u.input + u.output + u.cacheRead + u.cacheCreation : 0;
-        // `usd` is LIFETIME (reset-corrected). Until the first fold completes we
-        // fall back to the session figure rather than publishing a cold $0.
+        // `usd` 是 LIFETIME（重置校正后的）。在第一次折叠完成之前，
+        // 回退到会话数值，而不是发布冰冷的 $0。
         const lifetime = costTotals.usdFor(id);
         const sessionUsd = u ? Number(u.usd.toFixed(4)) : 0;
         return {
@@ -1246,31 +1198,31 @@ function writeFleetSnapshot(): void {
   }
 }
 
-/** Arm the heartbeat with an adaptive, self-rescheduling cadence (recursive
- *  setTimeout instead of a fixed setInterval). Each beat runs the cost/breaker
- *  pass, re-engages a quiet floor, stamps lastFiredAt, then re-arms: ~base on a
- *  normal beat, base/4 (min 30s) when an agent looks stuck, base*2.5 right after
- *  a re-engage. Registered into missionTimers so shutdown tears it down. */
+/** 以自适应、自重排的 cadence 装备 heartbeat（递归 setTimeout，而非固定
+ *  setInterval）。每个 beat 运行成本/熔断器检查、重新拉入安静 floor、盖上
+ *  lastFiredAt，然后重新装备：正常 beat 用 ~base，agent 看起来卡住时用 base/4
+ *  （最短 30s），re-engage 之后马上用 base*2.5。注册进 missionTimers 以便关机
+ *  拆除它。 */
 function armHeartbeat(m: ScheduledMission): void {
   const base = m.intervalMs;
   const quiet = m.quietThresholdMs ?? 300_000;
   const beat = (): void => {
     let next = base;
     try {
-      // (the breaker beat + cost ledger now run on their own always-on timer)
-      // Re-engage god when the floor is quiet OR when real agent/human mail is
-      // waiting in god's inbox — the latter is independent of floor-quiet so a
-      // worker's reply doesn't sit unread while other agents keep the floor busy.
+      // （breaker beat + 成本账本现在运行在它们自己的常开定时器上）
+      // 当 floor 安静或真实 agent/人类邮件在 god 收件箱等待时重新拉入 god——
+      // 后者独立于 floor-quiet，因此 worker 的回复不会在其他 agent 让 floor 忙碌
+      // 时无人阅读。
       const actionable = godActionableInboxCount();
       if (isFloorQuiet(quiet) || actionable > 0) {
         reengageGod(buildHeartbeatDigest(quiet, actionable));
-        next = Math.round(base * 2.5);            // back off after re-engaging
+        next = Math.round(base * 2.5);            // re-engage 后退避
       } else if (looksStuck(quiet)) {
-        next = Math.max(30_000, Math.round(base / 4)); // tighten when an agent is wedged
+        next = Math.max(30_000, Math.round(base / 4)); // agent 卡死时收紧
       }
       const cur = readConfig().missions ?? [];
       writeConfig({ missions: cur.map((x) => (x.id === m.id ? { ...x, lastFiredAt: Date.now() } : x)) });
-      try { liveWebContents()?.send('missions:updated'); } catch { /* window gone */ }
+      try { liveWebContents()?.send('missions:updated'); } catch { /* 窗口已消失 */ }
     } catch (e) {
       console.error('[heartbeat]', e);
     }
@@ -1282,42 +1234,38 @@ function armHeartbeat(m: ScheduledMission): void {
   missionTimers.set(m.id, { timeout: setTimeout(beat, remaining) });
 }
 
-/** The live renderer webContents, or null if the window is gone/destroyed.
- *  Anything that emits to the renderer from a timer/socket/child callback must
- *  route through here — during quit the window can be destroyed while those
- *  callbacks are still in flight, and `.send()` on a destroyed webContents
- *  throws "Object has been destroyed" (the main-process crash dialog). */
+/** 活跃的渲染进程 webContents，窗口已消失/销毁则为 null。任何从
+ *  定时器/socket/子进程回调向渲染进程发消息的东西都必须经此路由——退出期间
+ *  窗口可能在那些回调仍在飞行时被销毁，对已销毁 webContents 调用 `.send()`
+ *  会抛 “Object has been destroyed”（主进程崩溃对话框）。 */
 function liveWebContents(): Electron.WebContents | null {
   const wc = mainWindow?.webContents;
   if (wc && !wc.isDestroyed()) return wc;
-  // Primary gone (closed/destroyed): fall back to any other live window so a
-  // global event still reaches a renderer instead of being silently dropped.
+  // 主窗口已消失（关闭/销毁）：回退到任何其他活跃窗口，让全局事件仍能到达
+  // 某个渲染进程，而不是被静默丢弃。
   for (const w of allWindows) {
     if (!w.isDestroyed() && !w.webContents.isDestroyed()) return w.webContents;
   }
   return null;
 }
 
-// ─── Slack webhook server (Slack message → Michael's queue) ──────────────────
-/** The running Slack ingestion server, or null when disabled/stopped. */
+// ─── Slack webhook 服务器（Slack 消息 → Michael 的队列）──────────────────
+/** 运行中的 Slack 摄取服务器，禁用/停止时为 null。 */
 let slackServer: SlackWebhookServer | null = null;
-/** The loopback-only reply endpoint (lets the bundled helper post back to Slack
- *  without ever seeing the bot token). Lifecycle is tied to `slackServer`. */
+/** 仅 loopback 的回复端点（让内置 helper 无需看到 bot token 即可回复 Slack）。
+ *  生命周期与 `slackServer` 绑定。 */
 let slackReplyServer: SlackReplyServer | null = null;
-/** Last public tunnel URL handed out — persisted so Settings can re-show the
- *  Request URL after a reopen (Slack reuses it until the server is stopped). */
+/** 最近发放的公共隧道 URL——持久化，使 Settings 在重开之后仍能重新显示
+ *  Request URL（Slack 会一直复用它，直到服务器停止）。 */
 let lastSlackUrl: string | undefined;
 
-/** AUTONOMOUS REQUEST PROTOCOL — built PER MESSAGE (not a static const) so it can
- *  embed the request's concrete `channel`, `thread_ts`, and the resolved helper
- *  path. Prepended (server-side, authoritatively) to the working instruction god
- *  reads for any Slack-origin request: there is no interactive human at the
- *  keyboard, so god must route fast, delegate WITH the exact reply command (so the
- *  worker posts its real result back into THIS thread itself), stay autonomous,
- *  and only block on enumerated high-severity actions. Prepended to god's PROMPT
- *  only — the human-facing kanban card TITLE stays the user's raw text (the
- *  renderer keeps them split). Trailing space is intentional so the user's message
- *  reads naturally after it. */
+/** AUTONOMOUS REQUEST PROTOCOL —— 逐消息构建（而非静态 const），因此可以
+ *  内嵌请求具体的 `channel`、`thread_ts` 和已解析的 helper 路径。被（服务端、
+ *  权威地）前置到 god 读取的任何 Slack 来源请求的工作指令前：键盘前没有交互
+ *  的人类，所以 god 必须快速路由、以精确的回复命令委派（这样 worker 把它的
+ *  真实结果自己发回本线程）、保持自主，并且只在枚举的高严重性操作上阻塞。
+ *  只前置到 god 的 PROMPT——面向人类的看板卡片 TITLE 仍是用户的原始文本
+ *  （渲染进程保持二者分离）。结尾空格是有意的，让用户消息紧随其后自然可读。 */
 function buildAutonomousRequestProtocol(channel: string, threadTs: string, helperPath: string): string {
   return `[AUTONOMOUS REQUEST PROTOCOL — this request arrived via Slack; no interactive human is watching] Handle it under this protocol:
 1. ROUTE FAST — triage and hand this to the single most-relevant agent right away. CHECK THE LIVE ROSTER FIRST (active agents in registry.json + their state in fleet.json) and prefer an EXISTING agent that fits — especially when the request names one ("ask Pam…", "have Jim…"): route to that agent and only spawn a new one if none is a sensible fit. Decompose only if it genuinely needs several. Don't sit on it.
@@ -1329,66 +1277,64 @@ function buildAutonomousRequestProtocol(channel: string, threadTs: string, helpe
 The user's message starts now: `;
 }
 
-// ─── Slack done-notifier (Slack-origin task → done → one summary reply) ───────
-/** Polls the shared kanban (hive/tasks.json) for Slack-origin tasks that reach
- *  'done' and posts ONE summary reply into the originating thread. Lifecycle is
- *  tied to `slackServer`. OUTBOUND-only: it never touches inbound queue/lanes. */
+// ─── Slack done-notifier（Slack 来源任务 → done → 一条摘要回复）────────
+/** 轮询共享看板（hive/tasks.json）中达到 'done' 的 Slack 来源任务，并往起源
+ *  线程发布一条摘要回复。生命周期与 `slackServer` 绑定。仅 OUTBOUND：绝不触碰
+ *  入站队列/lanes。 */
 let slackDoneTimer: ReturnType<typeof setInterval> | null = null;
-/** Re-entrancy guard so a slow post can't overlap the next tick. */
+/** 重入守卫，使慢发布不会与下一个 tick 重叠。 */
 let slackDonePolling = false;
-/** Task ids already notified — exactly-once across re-reads AND restarts. Lazily
- *  loaded from / persisted to `slackDoneNotifiedPath()`. */
+/** 已通知的任务 id——跨重读和重启都精确一次。惰性从 `slackDoneNotifiedPath()`
+ *  加载 / 持久化到它。 */
 let slackDoneNotified: Set<string> | null = null;
-/** Ids already 'done' when the observer started — baselined (never notified) so a
- *  summary only ever fires on a live …→done transition, not on pre-existing dones. */
+/** observer 启动时已为 'done' 的 id——作为基线（永不通知），因此摘要只会在
+ *  实时的 …→done 转换时触发，而不是在既有的 done 上触发。 */
 let slackDoneBaseline: Set<string> | null = null;
-/** thread_ts values an agent has ALREADY answered directly via the loopback
- *  `/reply` endpoint. The done-summary poller skips these — the agent's own
- *  substantive reply already landed in-thread, so the poller is a fallback, not a
- *  duplicator (this is what stops the bare/duplicate `:white_check_mark:` posts). */
+/** agent 已经经 loopback `/reply` 端点直接回答过的 thread_ts 值。done-summary
+ *  轮询器跳过这些——agent 自己的实质性回复已经在线程内落地，所以轮询器只是
+ *  回退，不是复制器（这正是阻止裸/重复 `:white_check_mark:` 发布的东西）。 */
 const directlyRepliedThreads = new Set<string>();
 
-/** Absolute path to the bundled `md-slack-reply.cjs` helper. Packaged: under
- *  `process.resourcesPath` (electron-builder extraResources). Dev: the repo's
- *  `resources/` dir, resolved from the app path. */
+/** 内置 `md-slack-reply.cjs` helper 的绝对路径。打包版：位于
+ *  `process.resourcesPath`（electron-builder extraResources）。开发版：仓库的
+ *  `resources/` 目录，从 app 路径解析。 */
 function slackReplyScriptPath(): string {
   return app.isPackaged
     ? join(process.resourcesPath, 'md-slack-reply.cjs')
     : join(app.getAppPath(), 'resources', 'md-slack-reply.cjs');
 }
 
-/** W3 — the bundled read-only `skills/` source dir copied into each agent's
- *  `.claude/skills/` at spawn. Same packaged/dev resolution as the helpers above.
- *  Tolerated-missing until lp-manifest (Kevin) populates it (the hive copy is a
- *  no-op on an absent dir). */
+/** W3 —— 打包的只读 `skills/` 源目录，在 spawn 时复制进每个 agent 的
+ *  `.claude/skills/`。与上方 helpers 相同的打包/开发解析。在 lp-manifest
+ *  （Kevin）填充它之前容忍缺失（hive 副本对缺失目录是空操作）。 */
 function skillsResourceDir(): string {
   return app.isPackaged
     ? join(process.resourcesPath, 'skills')
     : join(app.getAppPath(), 'resources', 'skills');
 }
 
-/** Where the helper discovers `{ port, token }` for the loopback endpoint. Kept
- *  under userData (NOT the git repo, NOT mined into MemPalace). */
+/** helper 发现 loopback 端点 `{ port, token }` 的地方。放在 userData 下
+ *  （不在 git 仓库，不被挖进 MemPalace）。 */
 function slackReplyConfigPath(): string {
   return join(app.getPath('userData'), 'slack-reply.json');
 }
 
-/** Ledger of task ids whose done-summary has already been posted. Ids ONLY — no
- *  secret ever lands here. Under userData (out of the repo, out of MemPalace). */
+/** 已发布 done-summary 的任务 id 账本。仅 id——这里绝不落任何密钥。
+ *  在 userData 下（仓库之外，MemPalace 之外）。 */
 function slackDoneNotifiedPath(): string {
   return join(app.getPath('userData'), 'slack-done-notified.json');
 }
 
-/** Directory where downloaded Slack attachments are saved (out of repo, out of MemPalace). */
+/** 下载的 Slack 附件保存目录（仓库之外，MemPalace 之外）。 */
 function slackFilesDir(): string {
   return join(app.getPath('userData'), 'slack-files');
 }
 
-/** Per-file download size cap — reject files larger than 10 MB before writing. */
+/** 单文件下载大小上限——写入前拒绝大于 10 MB 的文件。 */
 const SLACK_FILE_MAX_BYTES = 10 * 1024 * 1024;
 
-/** Sanitize a Slack filename: keep only the basename, replace non-safe chars,
- *  prefix with a random hex tag to prevent collisions and path-traversal attacks. */
+/** 清理 Slack 文件名：只保留 basename，替换不安全字符，加随机十六进制标签
+ *  前缀以防冲突和路径穿越攻击。 */
 function sanitizeSlackFilename(name: string | undefined, tag: string): string {
   const safe = (typeof name === 'string' && name)
     ? basename(name).replace(/[^\w.\-]/g, '_').replace(/^\.+/, '_').slice(0, 200) || 'file'
@@ -1397,9 +1343,9 @@ function sanitizeSlackFilename(name: string | undefined, tag: string): string {
 }
 
 /**
- * Download a single Slack private file into slackFilesDir() using the bot token.
- * Returns the local path on success, null on any failure (size limit, network, etc.).
- * The bot token is used only in the Authorization header and is NEVER logged.
+ * 用 bot token 把单个 Slack 私有文件下载进 slackFilesDir()。成功返回本地路径，
+ * 任何失败（大小限制、网络等）返回 null。bot token 只用于 Authorization 头，
+ * 绝不记录日志。
  */
 function downloadSlackFile(
   file: SlackEventFile,
@@ -1434,7 +1380,7 @@ function downloadSlackFile(
         headers: { authorization: `Bearer ${botToken}` } },
       (res) => {
         if (res.statusCode && res.statusCode >= 400) {
-          res.resume(); // drain response body
+          res.resume(); // 排空响应体
           resolve(null);
           return;
         }
@@ -1447,7 +1393,7 @@ function downloadSlackFile(
           if (written > SLACK_FILE_MAX_BYTES) {
             aborted = true;
             stream.destroy();
-            try { unlinkSync(destPath); } catch { /* best-effort cleanup */ }
+            try { unlinkSync(destPath); } catch { /* 尽力清理 */ }
             res.destroy();
             resolve(null);
             return;
@@ -1468,8 +1414,8 @@ function downloadSlackFile(
 }
 
 /**
- * Download all raw Slack files (up to cap) and return the local-path file list.
- * Failures are silently dropped — a partial list is still useful to the agent.
+ * 下载所有原始 Slack 文件（达到上限）并返回本地路径文件列表。失败被静默丢弃——
+ * 部分列表对 agent 仍有价值。
  */
 async function downloadSlackFiles(
   rawFiles: SlackEventFile[],
@@ -1487,7 +1433,7 @@ function loadSlackDoneNotified(): Set<string> {
   try {
     const arr = JSON.parse(readFileSync(slackDoneNotifiedPath(), 'utf8'));
     if (Array.isArray(arr)) return new Set(arr.filter((x): x is string => typeof x === 'string'));
-  } catch { /* missing/corrupt → start empty */ }
+  } catch { /* 缺失/损坏 → 从空开始 */ }
   return new Set();
 }
 
@@ -1496,18 +1442,17 @@ function persistSlackDoneNotified(set: Set<string>): void {
   catch (e) { console.error('[slack] could not persist done-notify ledger:', e); }
 }
 
-/** Slack `chat.postMessage` errors that are permanent for this config — retrying
- *  can never make them succeed, so a failed post with one of these is recorded
- *  (not retried) to avoid flooding the log every 5s. Anything else is treated as
- *  transient and left to retry. */
+/** 对此配置而言永久性的 Slack `chat.postMessage` 错误——重试永远不可能让它们
+ *  成功，所以带这些错误的失败发布会被记录（不再重试），避免每 5s 刷爆日志。
+ *  其他一切按瞬态处理，留给重试。 */
 const TERMINAL_SLACK_ERRORS = new Set<string>([
   'missing_scope', 'invalid_auth', 'not_authed', 'account_inactive',
   'token_revoked', 'token_expired', 'no_permission', 'channel_not_found',
   'not_in_channel', 'is_archived', 'restricted_action', 'org_login_required',
 ]);
 
-/** The single in-thread summary for a finished task. Sourced from the task's
- *  result/description (falling back to the title), trimmed Slack-friendly. */
+/** 已完成任务的单条线程内摘要。取自任务的 result/description（回退到标题），
+ *  裁剪为 Slack 友好长度。 */
 function slackDoneSummary(task: HiveTask): string {
   const body = (task.result ?? task.description ?? '').trim();
   const head = `:white_check_mark: *${task.title}*`;
@@ -1515,23 +1460,22 @@ function slackDoneSummary(task: HiveTask): string {
   return text.length > 2800 ? `${text.slice(0, 2799)}…` : text;
 }
 
-/** One observation pass over the kanban. Posts a summary for any Slack-origin
- *  task that has newly reached 'done'. Best-effort and self-guarding — it must
- *  never throw into the timer, and the bot token never leaves this function. */
+/** 对看板的一次观察 pass。为任何新达 'done' 的 Slack 来源任务发布摘要。
+ *  尽力而为且自我保护——绝不能向定时器抛异常，bot token 绝不离开本函数。 */
 async function pollSlackDoneTasks(): Promise<void> {
   if (slackDonePolling) return;
   const botToken = readConfig().slackBotToken;
-  if (!botToken) return; // can't post without the token — nothing to do
+  if (!botToken) return; // 没有 token 无法发布——无事可做
   let tasks: HiveTask[];
   try {
     const ledger = hive.tasks() as { tasks?: HiveTask[] };
     tasks = Array.isArray(ledger?.tasks) ? ledger.tasks : [];
-  } catch { return; } // unreadable/missing tasks.json → skip this tick
+  } catch { return; } // 不可读/缺失的 tasks.json → 跳过本 tick
 
   const notified = slackDoneNotified ?? (slackDoneNotified = loadSlackDoneNotified());
 
-  // First tick seeds the baseline (ids already done) and posts nothing — so we
-  // only ever fire on a transition observed live this session.
+  // 第一个 tick 播种基线（已 done 的 id）且不发布任何东西——因此我们只会在
+  // 本会话实时观察到的转换上触发。
   if (slackDoneBaseline === null) {
     slackDoneBaseline = new Set(tasks.filter((t) => t.status === 'done').map((t) => t.id));
     return;
@@ -1542,33 +1486,33 @@ async function pollSlackDoneTasks(): Promise<void> {
   try {
     for (const t of tasks) {
       if (t.status !== 'done') continue;
-      if (baseline.has(t.id) || notified.has(t.id)) continue; // already handled
+      if (baseline.has(t.id) || notified.has(t.id)) continue; // 已处理过
       const slack = t.slack;
-      if (!slack || !slack.channel || !slack.thread_ts) continue; // non-Slack-origin → leave alone
-      // FALLBACK-ONLY: if the agent already posted a DIRECT reply into this thread
-      // (loopback /reply), the human has its substantive answer — don't double-post.
+      if (!slack || !slack.channel || !slack.thread_ts) continue; // 非 Slack 来源 → 不处理
+      // 仅回退：如果 agent 已在本线程发布 DIRECT 回复（loopback /reply），
+      // 人类已拿到其实质性回答——不要重复发布。
       if (directlyRepliedThreads.has(slack.thread_ts)) { notified.add(t.id); persistSlackDoneNotified(notified); continue; }
-      // Never post a bare `:white_check_mark: *title*` with no substance: if the card
-      // carries neither a result nor a description, there is nothing meaningful to
-      // deliver — skip it (still under the FALLBACK contract).
+      // 绝不发布没有实质内容的裸 `:white_check_mark: *title*`：如果卡片既没有
+      // 结果也没有描述，就没有任何有意义的东西可交付——跳过它（仍在 FALLBACK
+      // 契约下）。
       if (!(t.result ?? t.description ?? '').trim()) { notified.add(t.id); persistSlackDoneNotified(notified); continue; }
       const res = await postSlackReply({
         botToken, channel: slack.channel, thread_ts: slack.thread_ts, text: slackDoneSummary(t)
       });
       if (res.ok) {
         notified.add(t.id);
-        persistSlackDoneNotified(notified); // mark-on-success → exactly one delivered reply
+        persistSlackDoneNotified(notified); // 成功即标记 → 恰好一条已交付回复
       } else if (res.error && TERMINAL_SLACK_ERRORS.has(res.error)) {
-        // A permanent config/auth error (e.g. the bot token lacks `chat:write`)
-        // will NEVER succeed — record the id so we stop hammering every tick, and
-        // log the reason once. Never log the token or message body.
+        // 永久性配置/认证错误（例如 bot token 缺少 `chat:write`）永远不会成功——
+        // 记录该 id 让我们停止每个 tick 的猛攻，并记录一次原因。绝不记录 token
+        // 或消息体。
         notified.add(t.id);
         persistSlackDoneNotified(notified);
         console.error('[slack] done-summary post for task', t.id,
           '— giving up (terminal error:', res.error + '). Fix the Slack bot scope/permissions; later tasks post once resolved.');
       } else {
-        // Transient (network / rate-limit / unknown) → leave unmarked so a later
-        // tick retries. Log the id + error only; never the token or message body.
+        // 瞬态（网络 / 限流 / 未知）→ 保持未标记，让后续 tick 重试。只记录
+        // id + 错误；绝不记录 token 或消息体。
         console.error('[slack] done-summary post failed for task', t.id, '-', res.error, '(will retry)');
       }
     }
@@ -1577,24 +1521,23 @@ async function pollSlackDoneTasks(): Promise<void> {
   }
 }
 
-/** Begin watching the kanban for Slack-origin done-transitions (idempotent). */
+/** 开始观看看板上的 Slack 来源 done 转换（幂等）。 */
 function startSlackDoneObserver(): void {
   if (slackDoneTimer) return;
   slackDoneNotified = loadSlackDoneNotified();
-  slackDoneBaseline = null; // re-seed on the first tick of this session
+  slackDoneBaseline = null; // 在本会话第一个 tick 上重新播种
   slackDoneTimer = setInterval(() => { void pollSlackDoneTasks(); }, 5000);
 }
 
-/** Stop watching the kanban. Safe to call when not running. */
+/** 停止观看看板。未运行时调用也安全。 */
 function stopSlackDoneObserver(): void {
   if (slackDoneTimer) { clearInterval(slackDoneTimer); slackDoneTimer = null; }
   slackDoneBaseline = null;
 }
 
-/** Build a SlackWebhookServer from the current config and start it, replacing
- *  any running instance, and return the start result (incl. the public tunnel
- *  URL the user pastes into Slack). No-op + error result when the integration is
- *  disabled or the signing secret is unset. */
+/** 从当前 config 构建一个 SlackWebhookServer 并启动它，替换任何运行中的实例，
+ *  并返回启动结果（含用户粘贴到 Slack 里的公共隧道 URL）。集成被禁用或签名
+ *  密钥未设置时返回 no-op + 错误结果。 */
 async function startSlackServer(): Promise<{ ok: boolean; url?: string; error?: string }> {
   const cfg = readConfig();
   if (!cfg.slackEnabled || !cfg.slackSigningSecret) {
@@ -1605,57 +1548,55 @@ async function startSlackServer(): Promise<{ ok: boolean; url?: string; error?: 
     port: cfg.slackPort && cfg.slackPort > 0 ? cfg.slackPort : 3847,
     signingSecret: cfg.slackSigningSecret,
     channelId: cfg.slackChannelId,
-    // Fires from the HTTP server's event loop (not the IPC thread); route through
-    // liveWebContents() so a message arriving during window teardown can't throw.
-    // Downloads any file attachments (bot token stays in main; local paths go to IPC).
+    // 从 HTTP 服务器的事件循环触发（而非 IPC 线程）；经 liveWebContents()
+    // 路由，使窗口 teardown 期间到达的消息不会抛异常。下载任何文件附件
+    // （bot token 留在 main；本地路径走 IPC）。
     onMessage: async (m) => {
       const localFiles = await downloadSlackFiles(
         m._rawFiles ?? [],
         readConfig().slackBotToken
       );
-      // `text` stays the user's RAW Slack text → drives the readable kanban card
-      // title. `autonomyPreamble` is the authoritative policy block the renderer
-      // prepends ONLY to god's working instruction (his PTY prompt), keeping the
-      // card title human-facing-clean. Built PER MESSAGE so the AUTONOMOUS REQUEST
-      // PROTOCOL carries THIS request's concrete channel, thread_ts, and the
-      // resolved helper path — god hands the worker an exact reply command.
-      // Server-side so it applies to every session.
+      // `text` 保持用户的 RAW Slack 文本 → 驱动可读的看板卡片标题。
+      // `autonomyPreamble` 是权威策略块，渲染进程只把它前置到 god 的工作指令
+      // （他的 PTY prompt）前，让卡片标题保持面向人类可读。逐消息构建，使
+      // AUTONOMOUS REQUEST PROTOCOL 携带本请求具体的 channel、thread_ts 和已
+      // 解析的 helper 路径——god 交给 worker 一条精确的回复命令。
+      // 服务端构建，因此适用于每个会话。
       const ipcMsg: { text: string; channel: string; ts: string; thread_ts: string; autonomyPreamble: string; files?: typeof localFiles } = {
         text: m.text, channel: m.channel, ts: m.ts, thread_ts: m.thread_ts,
         autonomyPreamble: buildAutonomousRequestProtocol(m.channel, m.thread_ts, slackReplyScriptPath())
       };
       if (localFiles.length > 0) ipcMsg.files = localFiles;
       try { liveWebContents()?.send('slack:incomingMessage', ipcMsg); }
-      catch { /* window torn down */ }
+      catch { /* 窗口已拆除 */ }
     }
   });
   const res = await slackServer.start();
-  // ok:false means we never bound the port → drop the instance. ok:true with no
-  // url just means the tunnel is unavailable; the local handler is still live.
+  // ok:false 意味着我们从没绑定端口 → 丢弃实例。ok:true 但没有 url 只是意味着
+  // 隧道不可用；本地 handler 仍然活跃。
   if (!res.ok) { slackServer = null; return res; }
   if (res.url) lastSlackUrl = res.url;
-  // Bring up the loopback reply endpoint (token-gated, never tunneled) and drop
-  // the discovery file for the bundled helper. Best-effort: reply path being
-  // unavailable must not sink ingestion.
+  // 拉起 loopback 回复端点（token 门控、绝不隧道化），并放下内置 helper 的
+  // 发现文件。尽力而为：回复路径不可用不能拖垮摄取。
   await startSlackReplyServer();
-  // Begin watching the kanban for Slack-origin tasks that reach 'done', to post
-  // their one summary reply in-thread. OUTBOUND-only; never touches ingestion.
+  // 开始观看看板中达到 'done' 的 Slack 来源任务，以在线程内发布其一条摘要
+  // 回复。仅 OUTBOUND；绝不触碰摄取。
   startSlackDoneObserver();
   analytics.trackFeature('slack_trigger');
   return res;
 }
 
-/** Start the loopback reply endpoint and write its `{ port, token }` to userData
- *  so `md-slack-reply.cjs` can reach it. The bot token is read lazily from config
- *  at reply time and never written to this file. */
+/** 启动 loopback 回复端点，并把它的 `{ port, token }` 写入 userData，让
+ *  `md-slack-reply.cjs` 能触达它。bot token 在回复时从 config 惰性读取，
+ *  从不写入此文件。 */
 async function startSlackReplyServer(): Promise<void> {
   slackReplyServer?.stop();
   const token = randomBytes(24).toString('hex');
   slackReplyServer = new SlackReplyServer({
     token,
     getBotToken: () => readConfig().slackBotToken,
-    // An agent posted a DIRECT substantive reply into this thread → record it so the
-    // done-summary poller skips it (the poller is a fallback, not a duplicator).
+    // agent 已在本线程发布 DIRECT 实质性回复 → 记录它，使 done-summary 轮询器
+    // 跳过（轮询器是回退，不是复制器）。
     onReplied: (thread_ts) => { directlyRepliedThreads.add(thread_ts); }
   });
   const r = await slackReplyServer.start();
@@ -1671,54 +1612,51 @@ async function startSlackReplyServer(): Promise<void> {
   }
 }
 
-/** Stop and forget the Slack server (+ reply endpoint). Best-effort; safe to call
- *  when not running. The last tunnel URL is retained so Settings keeps showing it. */
+/** 停止并遗忘 Slack 服务器（+ 回复端点）。尽力而为；未运行时调用也安全。
+ *  保留最后一条隧道 URL，让 Settings 持续显示它。 */
 function stopSlackServer(): void {
   try { slackServer?.stop(); } catch (e) { console.error('[slack] stop failed:', e); }
   slackServer = null;
   try { slackReplyServer?.stop(); } catch (e) { console.error('[slack] reply stop failed:', e); }
   slackReplyServer = null;
   stopSlackDoneObserver();
-  try { if (existsSync(slackReplyConfigPath())) unlinkSync(slackReplyConfigPath()); } catch { /* noop */ }
+  try { if (existsSync(slackReplyConfigPath())) unlinkSync(slackReplyConfigPath()); } catch { /* 空操作 */ }
 }
 
-// ─── Generic inbound webhook + status API (multi-endpoint) ───────────────────
-/** The running generic-webhook server, or null when disabled/stopped. A PUBLIC
- *  (tunnel-forwarded) surface — secret-gated, unlike the loopback /reply. ONE
- *  server and ONE tunnel serve EVERY configured endpoint; the id in the request
- *  path picks which. Adding a webhook therefore costs no port and no tunnel, and
- *  never disturbs a caller already pointed at another endpoint's URL. */
+// ─── 通用入站 webhook + 状态 API（多端点）──────────────────────
+/** 运行中的通用 webhook 服务器，禁用/停止时为 null。PUBLIC（隧道转发）表面——
+ *  与 loopback /reply 不同，它受密钥门控。一个服务器 + 一条隧道服务所有已配置
+ *  端点；请求路径里的 id 决定选哪个。因此添加 webhook 不消耗端口和隧道，也绝不
+ *  打扰已指向另一端点 URL 的调用方。 */
 let webhookServer: WebhookServer | null = null;
-/** Last public tunnel URL handed out — retained so Settings can re-show the
- *  endpoint after a reopen (the tunnel rotates it per restart). */
+/** 最近发放的公共隧道 URL——保留，让 Settings 在重开之后仍能重新显示端点
+ *  （隧道每次重启都会轮换它）。 */
 let lastWebhookUrl: string | undefined;
 
-/** Local port the shared server binds to. The port is a property of the SERVER,
- *  not of any one trigger — `webhookPort` stays the (legacy) override. */
+/** 共享服务器绑定的本地端口。端口是服务器的属性，不属于任何单个触发器——
+ *  `webhookPort` 保持为（遗留）覆盖。 */
 const WEBHOOK_DEFAULT_PORT = 3849;
 
-/** The endpoints the operator has switched on. A disabled webhook is not merely
- *  rejected at the door — it is never handed to the server, so its id does not
- *  exist on the wire and its secret is not in memory on the request path. */
+/** 操作者已开启的端点。禁用的 webhook 不只是被拒之门外——它根本不会被交给
+ *  服务器，因此它的 id 不存在于线路上，其密钥也不在请求路径的内存里。 */
 function enabledWebhookEndpoints(): WebhookTrigger[] {
   return (readConfig().webhookTriggers ?? []).filter((t) => t.enabled && !!t.secret);
 }
 
-/** SHA-256 hex of a capability token. The raw token is returned to the caller
- *  exactly once (the POST response) and never persisted; only this digest lands
- *  on the kanban card, so a GET can match without the raw token ever resting. */
+/** 能力 token 的 SHA-256 十六进制。原始 token 恰好一次返回给调用方
+ *  （POST 响应），且从不持久化；只有这个摘要落到看板卡片上，因此 GET 可以在
+ *  原始 token 从不驻留的情况下完成匹配。 */
 function hashWebhookToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
 }
 
-/** tokenHash → id of the `pending` history entry it belongs to.
+/** tokenHash → 它所属 `pending` 历史条目的 id。
  *
- *  A message the mode gate held has NO kanban card (the card is what approval
- *  creates), so this map is the only way its caller's GET can be answered — and
- *  answered HONESTLY, as "awaiting-approval" rather than a lie about queued work.
- *  It stores the token's DIGEST, never the token, exactly like the card stamp,
- *  and it is mirrored into the durable kv store so a restart doesn't 404 every
- *  caller that is still politely waiting on the operator. */
+ *  被模式闸门挂起的消息没有看板卡片（卡片是审批创建的），所以这张 map 是它的
+ *  调用方 GET 能被回答的唯一途径——而且被诚实地回答为 “awaiting-approval”，
+ *  而不是谎称工作已排队。它存储 token 的 DIGEST，绝不存 token，与卡片戳记完全
+ *  一致，并镜像进持久 kv store，使重启不会让仍在礼貌等待操作者的每个调用方
+ *  收到 404。 */
 let heldWebhookTokens: Map<string, string> | null = null;
 const HELD_TOKENS_KV_KEY = 'triggers.webhook.heldTokens';
 
@@ -1737,8 +1675,8 @@ function persistHeldTokens(): void {
   catch (e) { console.error('[webhook] could not persist held-token map:', e); }
 }
 
-/** Drop mappings whose history entry has aged out of the (capped) ledger — the
- *  operator can no longer decide them, so their tokens are dead weight. */
+/** 丢弃其历史条目已从（有上限的）账本中过期的映射——操作者不再能裁决它们，
+ *  所以它们的 token 是死重。 */
 function pruneHeldTokens(): void {
   const map = heldTokens();
   if (map.size === 0) return;
@@ -1750,37 +1688,35 @@ function pruneHeldTokens(): void {
   if (changed) persistHeldTokens();
 }
 
-/** The token digest a held history entry was accepted under, if we still have it. */
+/** 被挂起历史条目在被接受时使用的 token 摘要，如果我们仍持有它。 */
 function heldTokenHashFor(entryId: string): string | undefined {
   for (const [hash, id] of heldTokens()) if (id === entryId) return hash;
   return undefined;
 }
 
-/** Tell the Triggers tab its ledger moved, so history live-refreshes instead of
- *  waiting for the operator to re-open the tab. */
+/** 告诉 Triggers 标签页其账本已变动，让历史实时刷新，而不是等操作者重新打开
+ *  该标签页。 */
 function notifyTriggerHistoryUpdated(): void {
-  try { liveWebContents()?.send('triggerHistory:updated'); } catch { /* window gone */ }
+  try { liveWebContents()?.send('triggerHistory:updated'); } catch { /* 窗口已消失 */ }
 }
 
 /**
- * Create the stamped kanban card for an inbound message and route it to god.
+ * 为入站消息创建已盖戳的看板卡片并路由给 god。
  *
- * Split out of `handleWebhookMessage` because the APPROVAL path takes exactly
- * this route later — an operator saying yes must produce the same card and the
- * same god request an auto-allowed message would have, or the two paths drift
- * and "approved" quietly means something weaker than "allowed".
+ * 从 `handleWebhookMessage` 中拆出，是因为 APPROVAL 路径稍后会走完全相同的
+ * 路线——操作者说 yes 时必须产生与自动放行消息相同的卡片、相同的 god 请求，
+ * 否则两条路径会漂移，“approved” 悄然变成比 “allowed” 更弱的东西。
  *
- * Returns false only when the card — the thing the caller polls — could not be
- * written. The god routing is best-effort: the card already exists and is
- * pollable even if the send hiccups.
+ * 只有当卡片——调用方轮询的东西——写不出来时才返回 false。god 路由是尽力而为：
+ * 即使发送出岔子，卡片也已经存在且可轮询。
  */
 function dispatchWebhookWork(arg: {
   taskId: string;
   title: string;
   message: string;
-  /** Stamped onto the card so a GET can match the caller's token. */
+  /** 盖到卡片上，使 GET 能与调用方的 token 匹配。 */
   tokenHash?: string;
-  /** 'webhook' | 'org' — only for the subject line and the god-facing note. */
+  /** 'webhook' | 'org' —— 仅用于主题行和给 god 的说明。 */
   origin: 'webhook' | 'org';
 }): boolean {
   try {
@@ -1794,18 +1730,17 @@ function dispatchWebhookWork(arg: {
       createdAt: new Date().toISOString(),
       ...(arg.tokenHash ? { webhook: { tokenHash: arg.tokenHash } } : {})
     };
-    // addTask appends against the latest on-disk ledger and is idempotent by task
-    // id, so a concurrent card writer (Slack, god, voice, another webhook) can't
-    // have its card lost to our stale whole-ledger overwrite. (writeTasks(...existing)
-    // recreated exactly that race.) A fresh taskId never collides, so this always adds.
+    // addTask 会基于磁盘上最新的账本追加，并按任务 id 幂等，所以并发写卡方
+    // （Slack、god、语音、另一个 webhook）不会因为我们的陈旧整账本覆写而丢卡
+    // （writeTasks 传入陈旧 existing 恰好会重现那个竞态）。全新的 taskId
+    // 永不会冲突，所以这里总是新增。
     hive.addTask(card);
   } catch (e) {
     console.error('[webhook] could not create task card:', e instanceof Error ? e.message : e);
     return false;
   }
-  // Body carries ONLY the sender's message + the card id (so whoever finishes it
-  // updates that card's status/result for the caller's GET) — never the secret,
-  // never the raw token.
+  // 消息体只携带发送者的消息 + 卡片 id（这样无论谁完成它，都能为该调用方的
+  // GET 更新该卡的状态/结果）——绝不含密钥，绝不含原始 token。
   try {
     hive.send({
       to: 'god',
@@ -1821,36 +1756,32 @@ function dispatchWebhookWork(arg: {
 }
 
 /**
- * A verified POST, run through the endpoint's TriggerMode.
+ * 一个已校验的 POST，经端点的 TriggerMode 处理。
  *
- * `isAutoAllowed(mode, kind)` is the whole gate. When it says yes this behaves
- * exactly as the single-endpoint server always did — card, god request, capability
- * token. When it says no NOTHING reaches the hive: the message is written to the
- * ledger as `pending` and sits there until the operator decides, and the caller
- * is handed its token plus a 202 so it can watch the hold rather than believe
- * work started.
+ * `isAutoAllowed(mode, kind)` 就是整个闸门。当它返回 yes 时，行为与单端点
+ * 服务器一贯的方式完全一致——建卡、请求 god、发能力 token。当它返回 no 时，
+ * 什么都到不了 hive：消息作为 `pending` 写入账本，等待操作者裁决；调用方拿到
+ * 它的 token 和一个 202，这样它能观察“挂起”状态，而不是以为工作已开始。
  *
- * Either way an `inbound` history row is recorded. The secret never reaches here
- * (the server hands over `{id,name}` only) and no credential is ever written to
- * the ledger.
+ * 无论哪种情况都会记录一条 `inbound` 历史行。密钥绝不会到这里（服务器只交接
+ * `{id,name}`），任何凭据也绝不会写入账本。
  */
 function handleWebhookMessage(msg: WebhookInbound, endpoint: WebhookEndpointRef): WebhookDispatch | null {
-  // 192-bit unguessable token, returned once; only its hash is stored.
+  // 192 位不可猜测的 token，只返回一次；只存储它的哈希。
   const token = randomBytes(24).toString('hex');
   const tokenHash = hashWebhookToken(token);
   const full = msg.title ?? msg.message;
   const title = full.length > 80 ? `${full.slice(0, 79)}…` : full;
 
   const trigger = (readConfig().webhookTriggers ?? []).find((t) => t.id === endpoint.id);
-  // An endpoint that vanished between the request and this lookup falls back to
-  // the STRICTEST mode, never the most permissive one.
+  // 端点在请求与此查找之间消失时，回退到最严格的模式，绝不回退到最宽松的。
   const mode: TriggerMode = trigger?.mode ?? DEFAULT_TRIGGER_MODE;
-  // The caller's own declaration wins; `classifyInboundKind` is the conservative
-  // guess for callers that don't declare (it leans 'directive' on purpose).
+  // 调用方自己的声明优先；`classifyInboundKind` 是给未声明的调用方的保守猜测
+  // （它刻意偏向 'directive'）。
   const kind: InboundKind = msg.kind ?? classifyInboundKind(msg.message);
   const peer = msg.from?.trim() || endpoint.name || endpoint.id;
-  // Minted here, not derived from the task id, because a HELD message has no task
-  // id yet and must still be pairable with the reply it eventually earns.
+  // 在这里铸造、而不是从任务 id 派生，因为被挂起的消息还没有任务 id，
+  // 但仍必须能与它最终获得的回复配对。
   const correlationId = randomBytes(8).toString('hex');
 
   const base = {
@@ -1880,15 +1811,15 @@ function handleWebhookMessage(msg: WebhookInbound, endpoint: WebhookEndpointRef)
   return { token, taskId, pending: false };
 }
 
-/** Resolve a capability token to its task's public status — scoped to the ONE
- *  card (or the ONE held message) whose stored hash matches; never lists or leaks
- *  any other task. Returns null for any non-match (the server answers 404 either
- *  way, so a probe can't tell "unknown" from "malformed"). */
+/** 将能力 token 解析为其任务（或挂起的消息）的公开状态——只限定在存储哈希
+ *  匹配的那一张卡（或那一条挂起的消息）范围内；绝不列出或泄露任何其他任务。
+ *  任何不匹配都返回 null（服务器两种情况下都回 404，所以探测者无法区分
+ *  “未知”与“格式错误”）。 */
 function lookupWebhookStatus(token: string): WebhookTaskStatus | null {
   const hash = hashWebhookToken(token);
 
-  // Held messages first — they have no card, and the O(1) hit keeps the common
-  // "still waiting" poll off the task scan entirely.
+  // 先查挂起的消息——它们没有卡，而 O(1) 命中让常见的“仍在等待”轮询
+  // 完全不必扫描任务。
   const heldEntryId = heldTokens().get(hash);
   if (heldEntryId) {
     const entry = listTriggerHistory().find((e) => e.id === heldEntryId);
@@ -1899,7 +1830,7 @@ function lookupWebhookStatus(token: string): WebhookTaskStatus | null {
     if (entry.decision === 'rejected') {
       return { status: 'rejected', title: entry.title ?? '' };
     }
-    // Approved: the release stamped this hash onto a real card, so fall through.
+    // 已批准：放行时把该哈希盖到了真实卡片上，所以继续往下走。
   }
 
   const wanted = Buffer.from(hash);
@@ -1912,7 +1843,7 @@ function lookupWebhookStatus(token: string): WebhookTaskStatus | null {
     const h = t.webhook?.tokenHash;
     if (!h) continue;
     const have = Buffer.from(h);
-    // Both are fixed-length sha-256 hex; compare in constant time defensively.
+    // 两者都是定长的 sha-256 十六进制串；防御性地用常数时间比较。
     if (have.length === wanted.length && timingSafeEqual(have, wanted)) {
       return { status: t.status, title: t.title, result: t.result };
     }
@@ -1920,15 +1851,13 @@ function lookupWebhookStatus(token: string): WebhookTaskStatus | null {
   return null;
 }
 
-// ─── Webhook done-observer (the OUTBOUND half of the trigger ledger) ─────────
-// Mirrors `pollSlackDoneTasks`: watch the kanban for webhook-origin cards that
-// reach 'done' and write the reply side of the conversation, tagged with the
-// inbound row's correlationId so the UI can pair request ↔ response.
+// ─── Webhook 完成观察器（触发账本的外向半边）────────────────────────────
+// 镜像 `pollSlackDoneTasks`：监视看板，把达到 'done' 的 webhook 来源卡片
+// 写入对话的回复一侧，并带上入站行的 correlationId，让 UI 能把请求与响应配对。
 //
-// Unlike the Slack poller there is no "baseline" of already-done ids: the LEDGER
-// is the record of what we've already paired, so a card that finished while the
-// app was closed still gets its outbound row on the next boot, and re-seeding
-// from the ledger makes a duplicate impossible.
+// 与 Slack 轮询器不同，这里没有“已完成 id 基线”：账本就是“我们已配对过什么”
+// 的记录，所以应用关闭期间完成的卡片，下次启动时仍会获得它的出站行；而从
+// 账本重新播种也使得重复变得不可能。
 let webhookDoneTimer: ReturnType<typeof setInterval> | null = null;
 let webhookOutboundRecorded: Set<string> | null = null;
 
@@ -1938,7 +1867,7 @@ function seedWebhookOutbound(): Set<string> {
     for (const e of listTriggerHistory()) {
       if (e.direction === 'outbound' && e.taskId) seen.add(e.taskId);
     }
-  } catch { /* unreadable ledger → treat as empty; appends are still deduped by taskId */ }
+  } catch { /* 账本不可读 → 视为空；追加仍按 taskId 去重 */ }
   return seen;
 }
 
@@ -1947,7 +1876,7 @@ function pollWebhookDoneTasks(): void {
   try {
     const ledger = hive.tasks() as { tasks?: HiveTask[] };
     tasks = Array.isArray(ledger?.tasks) ? ledger.tasks : [];
-  } catch { return; } // unreadable/missing tasks.json → skip this tick
+  } catch { return; } // 不可读/缺失的 tasks.json → 跳过本轮
   const done = tasks.filter((t) =>
     t.status === 'done' && (t.webhook != null || t.id.startsWith('webhook-')));
   if (done.length === 0) return;
@@ -1959,8 +1888,8 @@ function pollWebhookDoneTasks(): void {
   let wrote = false;
   for (const t of fresh) {
     const inbound = history.find((e) => e.direction === 'inbound' && e.taskId === t.id);
-    // No inbound row = a card from before the ledger existed. Nothing to pair it
-    // with, so mark it handled rather than writing a half of a conversation.
+    // 没有入站行 = 账本存在之前的卡片。没有可配对的，所以标记为已处理，
+    // 而不是只写对话的一半。
     if (!inbound) { recorded.add(t.id); continue; }
     appendTriggerHistory({
       source: inbound.source,
@@ -1980,7 +1909,7 @@ function pollWebhookDoneTasks(): void {
   if (wrote) notifyTriggerHistoryUpdated();
 }
 
-/** Begin watching the kanban for webhook-origin done-transitions (idempotent). */
+/** 开始监视看板中 webhook 来源的完成转换（幂等）。 */
 function startWebhookDoneObserver(): void {
   if (webhookDoneTimer) return;
   webhookOutboundRecorded = seedWebhookOutbound();
@@ -1989,17 +1918,16 @@ function startWebhookDoneObserver(): void {
   }, 5000);
 }
 
-/** Stop watching the kanban. Safe to call when not running. */
+/** 停止监视看板。未运行时也可安全调用。 */
 function stopWebhookDoneObserver(): void {
   if (webhookDoneTimer) { clearInterval(webhookDoneTimer); webhookDoneTimer = null; }
   webhookOutboundRecorded = null;
 }
 
-/** Build the shared WebhookServer from the enabled endpoints and start it. A
- *  server that is already up is RE-POINTED rather than restarted (see
- *  `reconcileWebhookServer`): restarting would mint a fresh tunnel URL and break
- *  every other endpoint's caller. The public tunnel is opened only here — never
- *  on a default; a webhook reaches the wire only once the operator enables it. */
+/** 用已启用的端点构建共享 WebhookServer 并启动它。已在运行的服务器是“重新
+ *  指向”而非重启（见 `reconcileWebhookServer`）：重启会铸造全新的隧道 URL，
+ *  破坏其他所有端点的调用方。公共隧道只在这里开启——绝不对默认值开启；
+ *  只有操作者启用某个 webhook 后它才会上线。 */
 async function startWebhookServer(): Promise<{ ok: boolean; url?: string; error?: string }> {
   const endpoints = enabledWebhookEndpoints();
   if (endpoints.length === 0) return { ok: false, error: 'no enabled webhook endpoints' };
@@ -2017,9 +1945,9 @@ async function startWebhookServer(): Promise<{ ok: boolean; url?: string; error?
   });
   webhookServer = server;
   const res = await server.start();
-  // ok:false covers BOTH "never bound the port" (fatal → drop the instance) and
-  // "bound fine, tunnel unavailable" (the security boundary is live and must stay
-  // reachable/stoppable — dropping it there would leak an unstoppable listener).
+  // ok:false 覆盖两种情况：“从未绑定端口”（致命 → 丢弃实例）和“绑定成功但
+  // 隧道不可用”（安全边界仍在线，必须保持可达/可停——在此处丢弃会漏掉一个
+  // 无法停止的监听器）。
   if (!res.ok && !server.listening()) { webhookServer = null; return res; }
   analytics.trackFeature('webhook_trigger');
   if (res.url) lastWebhookUrl = res.url;
@@ -2027,9 +1955,8 @@ async function startWebhookServer(): Promise<{ ok: boolean; url?: string; error?
   return res;
 }
 
-/** Bring the running server in line with config after any webhook mutation.
- *  Live endpoint swap when it's up, start when the enabled set becomes non-empty,
- *  stop when it empties. Never restarts a healthy server. */
+/** 任何 webhook 变更后，让运行中的服务器与配置保持一致。运行时热换端点、
+ * 启用集变为非空时启动、变空时停止。绝不停健康服务器的机。 */
 function reconcileWebhookServer(): void {
   const endpoints = enabledWebhookEndpoints();
   if (endpoints.length === 0) { stopWebhookServer(); return; }
@@ -2040,9 +1967,8 @@ function reconcileWebhookServer(): void {
   });
 }
 
-/** Per-endpoint public URLs for the settings surface's copy button. Empty string
- *  when no tunnel has ever come up — the UI shows the endpoint, just not a URL
- *  it could hand out yet. */
+/** 设置界面复制按钮需要的每个端点的公开 URL。隧道从未上线时为空字符串——
+ *  UI 显示端点，只是还没有可交出去的 URL。 */
 function webhookEndpointUrls(): { id: string; url: string }[] {
   const base = (webhookServer?.publicUrl() ?? lastWebhookUrl ?? '').replace(/\/+$/, '');
   return (readConfig().webhookTriggers ?? []).map((t) => ({
@@ -2051,24 +1977,23 @@ function webhookEndpointUrls(): { id: string; url: string }[] {
   }));
 }
 
-/** Stop and forget the webhook server. Best-effort; safe when not running. The
- *  last tunnel URL is retained so Settings keeps showing it. */
+/** 停止并遗忘 webhook 服务器。尽力而为；未运行时也安全。最后一个隧道 URL
+ *  会被保留，让设置界面继续显示它。 */
 function stopWebhookServer(): void {
   try { webhookServer?.stop(); } catch (e) { console.error('[webhook] stop failed:', e); }
   webhookServer = null;
-  // The done-observer deliberately OUTLIVES the server (it is a ledger concern,
-  // not a transport one) — it is torn down with the process/hive, not here.
+  // 完成观察器刻意比服务器活得更久（它是账本的事，不是传输的事）——它随
+  // 进程/hive 一起拆除，不在这里。
 }
 
-/** The persisted main-window geometry (kv key `window.bounds`). */
+/** 持久化的主窗口几何（kv 键 `window.bounds`）。 */
 interface WindowBounds { x?: number; y?: number; width: number; height: number }
 
 const DEFAULT_WIN = { width: 1440, height: 900 };
 const MIN_WIN = { width: 1280, height: 800 };
 
-/** Validate + clamp restored bounds: enforce the minimum size, and drop a
- *  position that no longer lands on any connected display (monitor unplugged) so
- *  the window can't open off-screen. Returns null for unusable input. */
+/** 校验并钳制恢复的边界：强制最小尺寸，并丢弃不再落在任何已连接显示器上的
+ *  位置（显示器被拔掉），避免窗口开到屏幕外。不可用的输入返回 null。 */
 function clampBounds(b: unknown): WindowBounds | null {
   if (!b || typeof b !== 'object') return null;
   const r = b as Partial<WindowBounds>;
@@ -2077,7 +2002,7 @@ function clampBounds(b: unknown): WindowBounds | null {
   const height = Math.max(MIN_WIN.height, Math.round(r.height));
   if (typeof r.x !== 'number' || typeof r.y !== 'number') return { width, height };
   const x = Math.round(r.x), y = Math.round(r.y);
-  // Keep the position only if the window rect overlaps some display's work area.
+  // 只有窗口矩形与某个显示器工作区重叠时才保留该位置。
   const onScreen = screen.getAllDisplays().some((d) => {
     const wa = d.workArea;
     return x < wa.x + wa.width && x + width > wa.x && y < wa.y + wa.height && y + height > wa.y;
@@ -2085,14 +2010,14 @@ function clampBounds(b: unknown): WindowBounds | null {
   return onScreen ? { x, y, width, height } : { width, height };
 }
 
-/** Minimal trailing-edge debounce for the move/resize flood. */
+/** 针对移动/缩放洪流的极简尾部防抖。 */
 function debounce(fn: () => void, ms: number): () => void {
   let t: NodeJS.Timeout | null = null;
   return () => { if (t) clearTimeout(t); t = setTimeout(() => { t = null; fn(); }, ms); };
 }
 
-/** Cascade a new floor off the focused window so it doesn't stack exactly on
- *  top, clamped on-screen (clampBounds drops an off-display position). */
+/** 让新楼层相对聚焦窗口级联，避免完全叠在上方；钳制在屏内（clampBounds
+ *  会丢弃屏外位置）。 */
 function floorCascade(): WindowBounds | null {
   const base = (mainWindow && !mainWindow.isDestroyed())
     ? mainWindow
@@ -2103,15 +2028,13 @@ function floorCascade(): WindowBounds | null {
   return clampBounds({ x: b.x + OFFSET, y: b.y + OFFSET, width: b.width, height: b.height });
 }
 
-// ─── Shareable hires: munderdifflin:// deep link + file import ──────────────
-// A hire manifest NEVER auto-spawns: it is validated, then handed to the
-// renderer, which pre-fills the Add-Agent modal for human review. See
-// src/shared/hire.ts for the spec + security model.
+// ─── 可共享的招募：munderdifflin:// 深链 + 文件导入 ─────────────────────
+// 一份招募清单绝不自动生成代理：先校验，再交给渲染器，由它预填 Add-Agent
+// 弹窗供人工审阅。规格与安全模型见 src/shared/hire.ts。
 
-/** Manifests that arrived before the renderer was ready to receive them.
- *  The renderer PULLS these via hire:drainPending once its subscription is
- *  mounted — main never pushes blind, so a fast-loading packaged renderer
- *  can't lose a deep link to a startup race. */
+/** 在渲染器就绪前到达的清单。渲染器订阅挂载后通过 hire:drainPending 主动
+ *  拉取这些清单——主进程绝不盲推，这样加载很快的打包版渲染器也不会因为
+ *  启动竞态而丢一个深链。 */
 const pendingHires: HireManifest[] = [];
 let rendererReadyForHires = false;
 
@@ -2144,8 +2067,8 @@ async function handleHireLink(link: string): Promise<void> {
   analytics.trackFeature('hire_install');
 }
 
-// Register the protocol. In dev (electron .) Windows needs the explicit
-// exe+args form or the registration points at electron.exe with no entry.
+// 注册协议。开发模式（electron .）下 Windows 需要显式的 exe+args 形式，
+// 否则注册会指向不带入口参数的 electron.exe。
 if (process.defaultApp) {
   if (process.argv.length >= 2) {
     app.setAsDefaultProtocolClient('munderdifflin', process.execPath, [resolve(process.argv[1])]);
@@ -2154,10 +2077,9 @@ if (process.defaultApp) {
   app.setAsDefaultProtocolClient('munderdifflin');
 }
 
-// Deep links on Windows/Linux arrive as the argv of a SECOND process — take the
-// single-instance lock and forward them to the running instance. (macOS gets
-// the 'open-url' event instead.) The lock also rules out two harnesses fighting
-// over the same hive, which was previously possible but never useful.
+// Windows/Linux 上的深链以第二个进程的 argv 到达——获取单实例锁并转发给
+// 运行中的实例。（macOS 改为接收 'open-url' 事件。）该锁也杜绝了两个 harness
+// 争夺同一 hive，这在以前是可能的但毫无用处。
 const gotInstanceLock = app.requestSingleInstanceLock();
 if (!gotInstanceLock) {
   allowQuit = true;
@@ -2178,20 +2100,20 @@ app.on('open-url', (evt, url) => {
   void handleHireLink(url);
 });
 
-// IPC: the renderer signals readiness and PULLS anything queued (deep links
-// that arrived before the window/subscription existed, incl. cold starts).
+// IPC：渲染器发出就绪信号并主动拉取任何排队内容（在窗口/订阅存在前到达的
+// 深链，包括冷启动）。
 ipcMain.handle('hire:drainPending', () => {
   rendererReadyForHires = true;
   const out = pendingHires.splice(0, pendingHires.length);
   return out;
 });
 
-// IPC: "import hires…" file picker in the Add-Agent modal. Every selected file
-// is validated independently; valid neighbours survive an invalid manifest.
+// IPC：Add-Agent 弹窗中的“导入招募清单…”文件选择器。每个选中文件都独立
+// 校验；有效的相邻文件在遇到无效清单时仍能存活。
 ipcMain.handle('hire:openFile', async () => {
   const res = await dialog.showOpenDialog({
-    title: 'Import hire manifests',
-    filters: [{ name: 'Hire manifest', extensions: ['json'] }],
+    title: l10n('Import hire manifests', '导入招募清单'),
+    filters: [{ name: l10n('Hire manifest', '招募清单'), extensions: ['json'] }],
     properties: ['openFile', 'multiSelections']
   });
   if (res.canceled || res.filePaths.length === 0) {
@@ -2206,17 +2128,15 @@ ipcMain.handle('hire:openFile', async () => {
 });
 
 /**
- * Create a window. The PRIMARY window (no opts) restores saved geometry, uses
- * the default session, runs the hive, and keeps the existing app-quit warning.
- * A FLOOR window (`{ floor: true }`) gets its own persistent session partition
- * — isolating its renderer state (agents/queues/selection) from every other
- * window — cascades its position, and on close stops only its OWN terminals
- * while the app keeps running.
+ * 创建一个窗口。主窗口（无 opts）恢复已保存的几何、使用默认会话、运行 hive、
+ * 并保留现有的退出确认提示。楼层窗口（`{ floor: true }`）获得自己独立的持久
+ * 会话分区——把它的渲染器状态（代理/队列/选中项）与其他窗口隔离——级联位置，
+ * 并在关闭时只停止它自己的终端，应用继续运行。
  */
 function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   const isFloor = opts.floor === true;
 
-  // Primary restores saved geometry; floors cascade off the focused window.
+  // 主窗口恢复已保存的几何；楼层相对聚焦窗口级联。
   let saved: WindowBounds | null = null;
   if (!isFloor) { try { saved = clampBounds(persist.getKv('window.bounds')); } catch { saved = null; } }
   const cascade = isFloor ? floorCascade() : null;
@@ -2234,43 +2154,40 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
     show: false,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      // Keep Chromium's OS renderer sandbox active; privileged work stays behind
-      // the narrow contextBridge/IPC surface owned by the main process.
+      // 保持 Chromium 的 OS 渲染器沙箱开启；特权工作留在主进程拥有的
+      // 窄 contextBridge/IPC 表面之后。
       sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
-      // The renderer runs the hive's heartbeat loops (inbox nudge, message
-      // flush, telemetry polls). Chromium throttles timers in occluded windows
-      // — incl. behind the LOCK SCREEN — which silently stalls the hive while
-      // the user is away. Don't.
+      // 渲染器运行 hive 的心跳循环（收件箱提醒、消息冲刷、遥测轮询）。
+      // Chromium 会节流被遮挡窗口里的定时器——包括锁屏之后——这会悄悄
+      // 让用户离开时的 hive 停摆。不要。
       backgroundThrottling: false,
-      // Each floor gets its OWN persistent session partition → isolated
-      // localStorage so floors never share or stomp each other's office state.
-      // The primary keeps the DEFAULT session so existing persisted state loads.
+      // 每个楼层获得自己独立的持久会话分区 → 隔离 localStorage，这样楼层之间
+      // 不会共享或互相践踏办公室状态。主窗口保留 DEFAULT 会话，让既有持久化
+      // 状态正常加载。
       ...(isFloor ? { partition: `persist:floor-${++floorSeq}` } : {})
     }
   });
 
-  // Capture the webContents once: after 'closed' the window is gone, but this
-  // reference stays valid as the per-PTY ownership key.
+  // 捕获 webContents 一次：'closed' 之后窗口消失，但此引用仍有效，
+  // 作为每个 PTY 的所有权键。
   const wc = win.webContents;
 
   allWindows.add(win);
-  // Global timer events follow the user — the most-recently-focused window is
-  // primary. The primary is also seeded synchronously so boot events route now.
+  // 全局定时器事件跟随用户——最近聚焦的窗口即主窗口。主窗口也在启动时
+  // 同步播种，让启动事件立刻有路由。
   win.on('focus', () => { mainWindow = win; });
   if (!isFloor) mainWindow = win;
 
-  // Permission gate for the renderer (our own trusted, local content). The only
-  // permission we constrain is microphone capture: it's allowed ONLY while a mic
-  // feature is actually live — Free Flow dictation (`freeflowEnabled`) OR a
-  // Realtime Michael voice session (`realtimeVoiceEnabled`, flipped on by the
-  // session at start() before getUserMedia, off at stop()). With both flags off,
-  // there's zero mic access even at the Electron layer. We deliberately do NOT
-  // gate on OpenAI-key presence: that key (`apikey:openai`) is shared with the CLI
-  // engines, so a CLI-only user must not have the mic gate opened. Every other
-  // permission keeps the app's prior permissive behavior (e.g. clipboard for
-  // xterm/editor copy must keep working).
+  // 渲染器（我们自己可信的本地内容）的权限门。唯一受约束的权限是麦克风
+  // 采集：只在一个麦克风功能实际启用时允许——Free Flow 听写
+  // （`freeflowEnabled`）或 Realtime Michael 语音会话（`realtimeVoiceEnabled`，
+  // 由会话在 start() 时 getUserMedia 之前打开、stop() 时关闭）。两个标志都关
+  // 时，即使在 Electron 层也没有任何麦克风访问。我们刻意不按 OpenAI 密钥
+  // 是否存在来开闸：那个密钥（`apikey:openai`）与 CLI 引擎共享，所以纯 CLI
+  // 用户绝不能把麦克风闸门打开。所有其他权限保持应用此前的宽松行为
+  // （例如 xterm/编辑器复制所用的剪贴板必须继续可用）。
   const micFeatureLive = (): boolean => {
     const cfg = readConfig();
     return cfg.freeflowEnabled === true || cfg.realtimeVoiceEnabled === true;
@@ -2290,59 +2207,57 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
     return true;
   });
 
-  // Only the primary persists geometry (kv `window.bounds`); floors cascade
-  // fresh each launch. Skip while maximized/minimized so a restore doesn't save
-  // the fullscreen rect.
+  // 只有主窗口持久化几何（kv `window.bounds`）；楼层每次启动时重新级联。
+  // 最大化/最小化时跳过，这样恢复不会保存全屏矩形。
   if (!isFloor) {
     const saveBounds = debounce(() => {
       if (win.isDestroyed() || win.isMinimized() || win.isMaximized()) return;
-      try { persist.setKv('window.bounds', win.getBounds()); } catch { /* DB best-effort */ }
+      try { persist.setKv('window.bounds', win.getBounds()); } catch { /* DB 尽力而为 */ }
     }, 400);
     win.on('resized', saveBounds);
     win.on('moved', saveBounds);
     win.on('close', () => {
       if (win.isDestroyed() || win.isMinimized() || win.isMaximized()) return;
-      try { persist.setKv('window.bounds', win.getBounds()); } catch { /* DB best-effort */ }
+      try { persist.setKv('window.bounds', win.getBounds()); } catch { /* DB 尽力而为 */ }
     });
   }
 
 
   win.once('ready-to-show', () => win.show());
 
-  // Never opens a window; hands the URL to the OS browser instead.
+  // 绝不打开窗口；改为把 URL 交给操作系统浏览器。
   //
-  // Scheme-checked, because this is now reachable from AUTHOR-CONTROLLED markup:
-  // a release drop's iframe has `allow-popups`, so a target="_blank" link in a
-  // release body arrives here. http(s) only — an unguarded openExternal will
-  // happily launch file://, or a registered custom scheme, on the user's machine.
+  // 做了协议校验，因为这里现在可由作者控制的内容触达：发布包 iframe 带有
+  // `allow-popups`，所以发布说明正文里的 target="_blank" 链接会到达此处。
+  // 只允许 http(s)——不加保护的 openExternal 会在用户机器上愉快地启动
+  // file:// 或已注册的自定义协议。
   win.webContents.setWindowOpenHandler(({ url }) => {
     if (/^https?:\/\//i.test(url)) shell.openExternal(url);
     return { action: 'deny' };
   });
 
-  // Close interception when live PTYs exist. The red-X destroys the window;
-  // intercept it the same way before-quit does so PTY users aren't surprised.
+  // 存在活动 PTY 时的关闭拦截。红叉会销毁窗口；用 before-quit 相同的方式
+  // 拦截它，让 PTY 用户不会措手不及。
   win.on('close', (e) => {
     if (allowQuit) return;
     if (isFloor) {
-      // A floor's close is NOT an app quit — confirm only its OWN terminals,
-      // via a self-contained native dialog (no renderer modal). Confirming lets
-      // the window close; its PTYs are stopped in the 'closed' handler.
+      // 楼层的关闭不是应用退出——只确认它自己的终端，通过自包含的原生对话框
+      // （无渲染器弹窗）。确认后窗口关闭；它的 PTY 在 'closed' 处理器中停止。
       const owned = ptyManager.countByOwner(wc);
       if (owned > 0) {
         const choice = dialog.showMessageBoxSync(win, {
           type: 'warning',
-          buttons: ['Close floor', 'Cancel'],
+          buttons: [l10n('Close floor', '关闭楼层'), l10n('Cancel', '取消')],
           defaultId: 1,
           cancelId: 1,
-          message: `Close this floor? ${owned} running terminal${owned === 1 ? '' : 's'} on it will be stopped.`,
-          detail: 'Other floors keep running.'
+          message: l10n(`Close this floor? ${owned} running terminal${owned === 1 ? '' : 's'} on it will be stopped.`, `要关闭这个楼层吗？上面运行的 ${owned} 个终端将被停止。`),
+          detail: l10n('Other floors keep running.', '其他楼层继续运行。')
         });
         if (choice === 1) e.preventDefault();
       }
       return;
     }
-    // Primary window: existing app-wide quit warning (renderer modal).
+    // 主窗口：现有的应用级退出提示（渲染器弹窗）。
     const count = ptyManager.list().length;
     if (count === 0) return;
     e.preventDefault();
@@ -2350,13 +2265,12 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
     wc.send('app:closeRequested', { ptyCount: count });
   });
 
-  // The primary is the default PTY sink; floors route purely by per-PTY owner.
+  // 主窗口是默认的 PTY 汇；楼层完全按每个 PTY 的所有权路由。
   if (!isFloor) ptyManager.attachWebContents(wc);
 
-  // A main-frame reload unmounts the renderer's hire subscription — queue again
-  // until the fresh renderer drains. Guard on isMainFrame: a stray sub-frame
-  // navigation must NOT flip readiness off (the renderer only drains on mount,
-  // so a later deep link would otherwise queue and sit until a full reload).
+  // 主框架重载会卸载渲染器的招募订阅——重新排队，直到新渲染器拉取。
+  // 用 isMainFrame 作守卫：杂散的子框架导航绝不能把就绪翻回 false
+  // （渲染器只在挂载时拉取，否则后续深链会排队并一直等到完整重载）。
   win.webContents.on('did-start-navigation', (details) => {
     if (details.isMainFrame) rendererReadyForHires = false;
   });
@@ -2369,9 +2283,9 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
 
   win.on('closed', () => {
     allWindows.delete(win);
-    // A closed floor must not leave its terminals running headless. (Natural
-    // onExit teardown — archive + worktree cleanup — still runs per PTY.)
-    if (isFloor) { try { ptyManager.killByOwner(wc); } catch { /* best-effort */ } }
+    // 已关闭的楼层不能留下它在后台空转的终端。（自然的 onExit 拆除——归档 +
+    // 工作树清理——仍按每个 PTY 执行。）
+    if (isFloor) { try { ptyManager.killByOwner(wc); } catch { /* 尽力而为 */ } }
     if (mainWindow === win) {
       mainWindow = null;
       for (const w of allWindows) { if (!w.isDestroyed()) { mainWindow = w; break; } }
@@ -2382,51 +2296,46 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   return win;
 }
 
-/** Open a new floor window — gated by the multiWindow flag. Returns the window,
- *  or null when the feature is off (the entry points are hidden in that case,
- *  but the IPC stays defensive). */
+/** 打开一个新楼层窗口——由 multiWindow 标志门控。返回窗口，功能关闭时返回
+ *  null（该情况下入口点已隐藏，但 IPC 保持防御性）。 */
 function openFloor(): BrowserWindow | null {
   if (!readConfig().multiWindow) return null;
   return createWindow({ floor: true });
 }
 
-/** Build + install the application menu. Only called when multiWindow is on, so
- *  flag-off keeps Electron's default menu (zero behavior change). Uses standard
- *  role-based items so copy/paste/quit/etc. work per-platform, and adds the
- *  "New Floor" item (Cmd/Ctrl+Shift+N). */
+/** 构建并安装应用菜单。仅在 multiWindow 开启时调用，所以关掉标志时 Electron
+ *  使用默认菜单（零行为变化）。使用标准基于角色的菜单项，让复制/粘贴/退出等
+ *  跨平台可用，并添加“新建楼层”项（Cmd/Ctrl+Shift+N）。 */
 function installAppMenu(): void {
   const isMac = process.platform === 'darwin';
   const newFloorItem = {
-    label: 'New Floor',
+    label: l10n('New Floor', '新建楼层'),
     accelerator: 'CmdOrCtrl+Shift+N',
     click: () => { openFloor(); }
   };
   const template: Electron.MenuItemConstructorOptions[] = [
     ...(isMac ? [{ role: 'appMenu' as const }] : []),
     {
-      label: 'File',
+      label: l10n('File', '文件'),
       submenu: isMac
         ? [newFloorItem, { type: 'separator' as const }, { role: 'close' as const }]
         : [newFloorItem, { type: 'separator' as const }, { role: 'quit' as const }]
     },
-    // The Edit menu is spelled out rather than `{ role: 'editMenu' }` for one
-    // reason: `registerAccelerator: false` on the clipboard items.
+    // Edit 菜单被显式展开而不是用 `{ role: 'editMenu' }`，原因只有一个：
+    // 剪贴板项上的 `registerAccelerator: false`。
     //
-    // A registered accelerator is claimed by the MENU, which then replays the
-    // action through `webContents.paste()` — an async hop that runs a beat after
-    // the keystroke. Dictation tools (Muesli, Wispr Flow, …) insert text by
-    // stashing the clipboard, writing the transcript, sending the paste key, and
-    // restoring the old clipboard immediately; the menu's late paste therefore
-    // read the RESTORED clipboard and typed the user's previous copy instead of
-    // what they had just said. It hit the terminal and the composer alike,
-    // because both were downstream of the same replay.
+    // 已注册的加速键会被菜单认领，然后通过 `webContents.paste()` 重放动作——
+    // 这是比按键晚一拍的异步跳转。听写工具（Muesli、Wispr Flow 等）通过
+    // 暂存剪贴板、写入转录、发送粘贴键、然后立即恢复旧剪贴板来插入文本；
+    // 因此菜单的迟到粘贴读到的是一秒前恢复后的剪贴板，敲出的不是用户刚说的
+    // 内容，而是他上一次复制的内容。它同时命中终端和 composer，因为两者都
+    // 在这个重放的下游。
     //
-    // With registerAccelerator false the item still shows its shortcut, but the
-    // key is left for the focused element to handle inline — xterm's own paste
-    // handler and the textarea's native paste event both read the clipboard
-    // synchronously, inside the keystroke, before any restore can land.
+    // registerAccelerator 为 false 时，菜单项仍显示其快捷键，但按键留给聚焦
+    // 元素内联处理——xterm 自己的粘贴处理器和 textarea 的原生粘贴事件都在
+    // 按键内部同步读取剪贴板，早于任何恢复落地。
     {
-      label: 'Edit',
+      label: l10n('Edit', '编辑'),
       submenu: [
         { role: 'undo' as const, registerAccelerator: false },
         { role: 'redo' as const, registerAccelerator: false },
@@ -2444,23 +2353,21 @@ function installAppMenu(): void {
 }
 
 
-// ─── IPC: pty lifecycle ─────────────────────────────────────────────────────
-/** Codex stores its rollout transcripts under a PER-AGENT CODEX_HOME
- *  (<hive>/agents/<id>/.codex/sessions/<Y>/<M>/<D>/rollout-*-<sessionId>.jsonl).
- *  A NEWLY added agent gets an empty CODEX_HOME, so `codex resume <sid>` finds
- *  nothing and silently opens a BLANK session — which is exactly what the Add
- *  Agent "resume session" field looked like it was doing. Find the agent whose
- *  CODEX_HOME owns this rollout and RETURN that home so the resumed agent can be
- *  pointed at it (the rollout AND its state_5.sqlite index live there together). */
+// ─── IPC: pty 生命周期 ─────────────────────────────────────────────────────
+/** Codex 把其卷展转录存放在按代理隔离的 CODEX_HOME 下
+ *  （<hive>/agents/<id>/.codex/sessions/<Y>/<M>/<D>/rollout-*-<sessionId>.jsonl）。
+ *  新加入的代理拿到空的 CODEX_HOME，因此 `codex resume <sid>` 什么也找不到，
+ *  静默打开一个空白会话——这正像是 Add Agent“恢复会话”字段在做什么。找到
+ *  拥有该卷展的代理 CODEX_HOME，返回那个 home，让被恢复的代理可以指向它
+ *  （卷展和它的 state_5.sqlite 索引一起住在那里）。 */
 function findCodexHomeForSession(sessionId: string, siblingsRoot: string): string | null {
   try {
     if (!sessionId || !/^[0-9a-fA-F][0-9a-fA-F-]{15,}$/.test(sessionId)) return null;
     let fallbackHome: string | null = null;
-    // Walk each sibling agent's CODEX_HOME (<agent>/.codex) looking for the
-    // rollout that owns this session. We RETURN that home rather than copy the
-    // rollout out of it: Codex indexes sessions in its state_5.sqlite, so a lone
-    // rollout file in a fresh home is invisible to `codex resume`. Pointing the
-    // resumed agent at the OWNING home gives it the rollout AND the index.
+    // 遍历每个兄弟代理的 CODEX_HOME（<agent>/.codex），查找拥有这个会话的
+    // 卷展。我们返回那个 home 而不是把卷展复制出来：Codex 在 state_5.sqlite
+    // 里给会话建索引，所以新 home 里孤立的一份卷展对 `codex resume` 不可见。
+    // 把被恢复的代理指向所属 home，就同时给了它卷展和索引。
     let agents: Array<{ name: string; isDirectory(): boolean }>;
     try {
       agents = readdirSync(siblingsRoot, { withFileTypes: true }) as unknown as Array<{ name: string; isDirectory(): boolean }>;
@@ -2485,14 +2392,14 @@ function findCodexHomeForSession(sessionId: string, siblingsRoot: string): strin
         }
       }
       if (!hasRollout) continue;
-      // Prefer the home whose Codex state DB actually INDEXES this session — a
-      // fresh/seeded home may carry only a stray rollout copy (no index), which
-      // `codex resume` can't open. Match the id as raw bytes in state_5.sqlite
-      // (+ its WAL). Homes with the rollout but no index are a last-resort fallback.
+      // 优先选择其 Codex 状态数据库确实索引了此会话的 home——刚播种的 home
+      // 可能只带一份孤立的卷展副本（无索引），`codex resume` 打不开。在
+      // state_5.sqlite（及其 WAL）中按原始字节匹配 id。有卷展但无索引的 home
+      // 作为最后手段的回退。
       const idBuf = Buffer.from(sessionId);
       let indexed = false;
       for (const db of ['state_5.sqlite', 'state_5.sqlite-wal']) {
-        try { if (readFileSync(join(home, db)).includes(idBuf)) { indexed = true; break; } } catch { /* no db */ }
+        try { if (readFileSync(join(home, db)).includes(idBuf)) { indexed = true; break; } } catch { /* 无 db */ }
       }
       if (indexed) return home;
       if (!fallbackHome) fallbackHome = home;
@@ -2504,14 +2411,12 @@ function findCodexHomeForSession(sessionId: string, siblingsRoot: string): strin
   }
 }
 
-/** Spawn options shared by the `pty:spawn` IPC handler and the god-triggered
- *  ephemeral-worker watcher. */
+/** `pty:spawn` IPC 处理器与 god 触发的临时 worker 观察器共享的生成选项。 */
 type AgentSpawnOptions = SpawnOptions & { hive?: AgentMeta; isolate?: boolean; resume?: boolean; requireResume?: boolean; resumeSessionId?: string; provider?: AgentProvider; noAutoInstall?: boolean };
 
-/** Map a `ptyManager.spawn` failure string to the closed `agent_spawn_failed.reason`
- *  enum (analytics.ts). The two known strings come from PtyManager.spawn; anything
- *  else is a generic `spawn_error`. The raw message never leaves the machine — only
- *  the enum value does, per TELEMETRY.md. */
+/** 把 `ptyManager.spawn` 的失败字符串映射到封闭的 `agent_spawn_failed.reason`
+ *  枚举（analytics.ts）。两个已知字符串来自 PtyManager.spawn；其他都是通用
+ *  `spawn_error`。原始消息绝不出机器——只有枚举值出，按 TELEMETRY.md。 */
 function spawnFailReason(error?: string): SpawnFailReason {
   if (error?.startsWith('cwd does not exist')) return 'cwd_missing';
   if (error?.includes('already exists')) return 'already_running';
@@ -2522,72 +2427,66 @@ ipcMain.handle('pty:spawn', async (evt, opts: AgentSpawnOptions) => {
   if (!opts || typeof opts.id !== 'string' || typeof opts.cwd !== 'string' || typeof opts.command !== 'string') {
     return { ok: false, error: 'invalid SpawnOptions' };
   }
-  // Record the spawning window as the PTY's owner so its output routes ONLY back
-  // to that floor, then run the shared spawn core.
+  // 把生成窗口记录为该 PTY 的所有者，让它的输出只路由回那个楼层，然后运行
+  // 共享的生成核心。
   const owner = BrowserWindow.fromWebContents(evt.sender)?.webContents ?? null;
   return spawnAgentCore(opts, owner);
 });
 
-/** Core agent-spawn logic — provider inference, the missing-CLI installer
- *  short-circuit, git-worktree isolation, hive provisioning, model/resume flags,
- *  and the final PTY spawn. Extracted VERBATIM from the `pty:spawn` IPC handler so
- *  it can ALSO be invoked by the god-triggered ephemeral-worker watcher (which has
- *  no renderer `evt`). `owner` is the window that should receive this PTY's output
- *  (null → the primary window). Behavior-identical to the prior inline handler. */
+/** 核心代理生成逻辑——provider 推断、缺 CLI 安装器短路、git 工作树隔离、
+ *  hive 供给、模型/恢复标志、最终 PTY 生成。从 `pty:spawn` IPC 处理器
+ *  逐字提取出来，以便 god 触发的临时 worker 观察器（没有渲染器 `evt`）也能
+ *  调用它。`owner` 是应接收该 PTY 输出的窗口（null → 主窗口）。与此前内联
+ *  处理器行为一致。 */
 async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebContents | null): Promise<{ ok: boolean; error?: string; cwd?: string; worktreePath?: string; resumeNotFound?: boolean; resumed?: boolean; seedPrompt?: string }> {
-  // ── cwd INGESTION — expand `~` exactly once, here ───────────────────────────
-  // This is the single door every agent spawn comes through (`pty:spawn` IPC and
-  // the god-triggered ephemeral-worker watcher), so it is where a user-typed
-  // `~/dev/foo` becomes an absolute path. Only a shell expands `~`; Node treats it
-  // as a literal dir, so without this every downstream existsSync/statSync fails
-  // with `cwd does not exist`. Expanding BEFORE hive provisioning is what makes the
-  // registry store an ABSOLUTE cwd (and `cwdValid: true`). The resolved value is
-  // returned to the caller so the renderer records the same absolute path.
+  // ── cwd 摄取——在这里把 `~` 恰好展开一次 ───────────────────────────────
+  // 这是每个代理生成的唯一入口（`pty:spawn` IPC 和 god 触发的临时 worker
+  // 观察器），所以用户输入的 `~/dev/foo` 在这里变成绝对路径。只有 shell 会
+  // 展开 `~`；Node 把它当普通目录，因此没有这一步，下游每个 existsSync/
+  // statSync 都会以 `cwd does not exist` 失败。在 hive 供给之前展开，正是
+  // 让注册表存绝对 cwd（且 `cwdValid: true`）的原因。解析后的值返回给调用方，
+  // 让渲染器记录同一绝对路径。
   opts.cwd = expandTilde(opts.cwd);
   if (opts.hive) opts.hive = { ...opts.hive, cwd: expandTilde(opts.hive.cwd) };
-  // Which CLI is this? Explicit wins; else inferred from the binary
-  // (claude/codex/grok/agy). Non-Claude providers skip every Claude-only spawn step
-  // below. Persist the resolved provider onto opts (+ hive meta) so the registry
-  // record and downstream provider-aware steps agree on one value.
+  // 是哪个 CLI？显式优先；否则从二进制名推断（claude/codex/grok/agy）。
+  // 非 Claude provider 跳过下面所有 Claude 专属的生成步骤。把解析出的 provider
+  // 持久化到 opts（+ hive 元数据）上，让注册表记录与下游感知 provider 的
+  // 步骤对同一个值达成一致。
   const provider = inferAgentProvider(opts.command, opts.provider ?? opts.hive?.provider);
   const claudeProvider = isClaudeProvider(provider);
   opts.provider = provider;
   if (opts.hive) opts.hive = { ...opts.hive, provider };
-  // Activation-funnel entry (v0.4.6): every spawn REQUEST, so (attempted − spawned)
-  // measures the fallout the whole rebuild exists to see. Gated on !noAutoInstall so
-  // the missing-CLI relaunch (the only re-entry, index.ts install-exit handler) does
-  // NOT double-count a single user attempt — it is the SAME attempt continuing.
+  // 激活漏斗入口（v0.4.6）：记录每个生成 REQUEST，这样（attempted − spawned）
+  // 就能度量这次整体重建想要看到的结果。以 !noAutoInstall 为门——让缺 CLI
+  // 重启（唯一的重入点，index.ts 安装退出处理器）不会把同一次用户尝试算两次
+  // ——它就是同一次尝试的延续。
   if (!opts.noAutoInstall) analytics.track('agent_spawn_attempted', { provider });
-  // ── Missing engine CLI → run its installer visibly (pre-spawn) ───────────────
-  // If the agent's engine binary (claude/codex/…) isn't installed, spawning it
-  // just dies with "— process exited (code 1) —" and the user has no idea why.
-  // Detect the absent binary BEFORE spawning and, in this SAME terminal, print a
-  // banner + RUN the provider's install command so the user can watch it (and
-  // complete any interactive sign-in). On a CLEAN install exit the PTY-exit handler
-  // auto restart-and-continues — it re-runs THIS spawn (with noAutoInstall) so the
-  // freshly-installed CLI launches in the SAME pty/window, no user click. STRICTLY
-  // pre-spawn: a non-zero exit from a CLI that DID start never reaches here, so there
-  // is no install loop; and the relaunch's noAutoInstall guarantees the installer
-  // can't fire twice. Providers with no known installer get a manual hint only (and
-  // are NOT armed for relaunch) — nothing arbitrary is ever auto-run. We short-circuit
-  // BEFORE worktree/hive/Claude-flag setup: ptyToAgent + worktreePaths stay unset for
-  // this id, so when the install PTY exits teardownPty is a harmless no-op (the agent
-  // isn't archived and no worktree is torn down) before the relaunch takes over.
+  // ── 缺引擎 CLI → 先运行其安装器（生成前可见）────────────────────────
+  // 如果代理的引擎二进制（claude/codex/…）未安装，生成它只会以
+  // “— process exited (code 1) —” 死掉，用户完全不知道为什么。在生成前检测
+  // 缺失的二进制，并在同一个终端里打印横幅 + 运行 provider 的安装命令，
+  // 让用户能看到（并完成任何交互式登录）。安装器干净退出后，PTY 退出处理器
+  // 会自动“重启并继续”——它重跑本次生成（带 noAutoInstall），让刚装好的 CLI
+  // 在同一个 pty/窗口里启动，无需用户点击。严格在生成前：已启动的 CLI 的非零
+  // 退出永远不会到这里，所以不存在安装循环；而重启携带的 noAutoInstall 保证
+  // 安装器不会跑两次。没有已知安装器的 provider 只得到手动提示（且不会被武装
+  // 用于重启）——绝不自动运行任何随意的东西。我们在工作树/hive/Claude 标志
+  // 设置之前短路：本 id 的 ptyToAgent + worktreePaths 保持未设置，所以安装
+  // PTY 退出时 teardownPty 是无害的空操作（代理不会被归档、没有工作树被拆），
+  // 之后才由重启接管。
   {
     const bin = opts.command.trim().split(/\s+/)[0] || opts.command;
     if (bin && !opts.noAutoInstall && !ptyManager.isCommandAvailable(bin)) {
-      // The installer commands are `npm install -g …`. Probe for npm the same way
-      // we probe for the engine CLI, so a no-Node machine gets the node-free rung
-      // (or an honest manual hint) instead of watching `npm: not found` scroll by.
-      // An npm whose Node is BELOW the floor counts as unavailable: founder rule
-      // (2026-08-07) is "their Node newer than ours → leave it alone; absent or
-      // older → install the latest stable for them".
+      // 安装命令是 `npm install -g …`。像探测引擎 CLI 一样探测 npm，
+      // 让没有 Node 的机器走无 Node 档（或诚实的手动提示），而不是看着
+      // `npm: not found` 滚屏。npm 的 Node 低于底线算不可用：创始人规则
+      // （2026-08-07）是“他们的 Node 比我们的新 → 别动；缺失或更旧 →
+      // 为他们装最新稳定版”。
       const npmAvailable =
         ptyManager.isCommandAvailable('npm') &&
         nodeIsUsable(detectNodeVersion(ptyManager.commandPath('node')));
-      // Only reach the network when we actually need to (npm missing/too old);
-      // resolveNodeInstaller is timeout-bounded and returns null offline, which
-      // simply drops the ladder to the native/manual rung.
+      // 只在确实需要时才联网（npm 缺失/太旧）；resolveNodeInstaller 有超时
+      // 上限，离线时返回 null，只是把档位降到 native/manual。
       const nodeInstaller = npmAvailable ? null : await resolveNodeInstaller();
       const rung = chooseInstallRung(installInfoForProvider(provider), npmAvailable, nodeInstaller);
       const res = ptyManager.spawn(
@@ -2601,50 +2500,45 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
         },
         owner
       );
-      // Arm auto restart-and-continue: when this installer PTY exits cleanly, the
-      // exit handler re-runs the spawn so the just-installed CLI launches in place
-      // (no user click). Only when an installer actually RAN (a provider with no
-      // bundled installer just prints a manual hint and exits 0 — relaunching there
-      // would spawn the still-missing binary and die) and the PTY actually started.
-      // …keyed on the RUNG, not on `installCommand`: the manual rung prints a hint
-      // and exits 0, and relaunching there would just respawn the still-missing
-      // binary and die with the bare "process exited (code 1)" this whole path exists
-      // to replace.
+      // 武装自动“重启并继续”：安装 PTY 干净退出时，退出处理器重跑生成，
+      // 让刚装好的 CLI 就地启动（无需用户点击）。只在安装器实际运行时才武装
+      // （没有内置安装器的 provider 只打印手动提示并退出 0——在那里重启会
+      // 生成仍然缺失的二进制然后死掉）且 PTY 确实启动了。
+      // …按 RUNG 而不是 `installCommand` 作键：manual 档打印提示并退出 0，
+      // 在那里重启只会重新生成缺失的二进制、带着这条路径本要取代的裸
+      // “process exited (code 1)” 死掉。
       if (res.ok && rung.command) {
         pendingInstallRelaunch.set(opts.id, { opts, owner, bin, rung: rung.kind });
-        // The auto-installer PTY is running; agent_install_finished on its exit says
-        // whether it actually produced an agent (rung is non-manual here by construction).
+        // 自动安装 PTY 正在运行；它的退出会通过 agent_install_finished 说明
+        // 是否真的产出了一个代理（此处构造上 rung 是非 manual 档）。
         analytics.track('agent_install_started', { provider, rung: rung.kind });
       } else if (res.ok) {
-        // Manual rung: the PTY only printed a hint (no installer to run, no relaunch
-        // armed), so no agent will start. This is the Mode 2 case that used to send
-        // NOTHING — an absent engine with no unattended install path.
+        // Manual 档：PTY 只打印了提示（没有可运行的安装器，未武装重启），
+        // 所以不会有代理启动。这就是过去什么都没发送的 Mode 2 情形——
+        // 引擎缺失且没有无人值守安装路径。
         analytics.track('agent_spawn_failed', { provider, reason: 'cli_missing' });
       } else {
-        // The install PTY itself failed to spawn (cwd gone, id clash, throw).
+        // 安装 PTY 本身生成失败（cwd 消失、id 冲突、抛出）。
         analytics.track('agent_spawn_failed', { provider, reason: spawnFailReason(res.error) });
       }
       syncKeepAwake();
       return res;
     }
   }
-  // Git isolation: when requested and the cwd is a real repo, give this agent
-  // its own worktree on an `agent/<id>` branch so it can't clobber other agents'
-  // (or the user's) working tree. Best-effort — a failure falls back to the
-  // shared cwd rather than blocking the spawn.
-  // NOTE (tracked, not yet hardened): the restore flow passes isolate:false and
-  // re-enters the existing worktree by cwd, so it never reaches here. But a stale
-  // `isolate:true` recipe spawned against an already-existing worktree path would
-  // make addWorktree below conflict (path/branch exists) and fall back to the base
-  // cwd — reuse-existing-worktree handling here is the follow-up.
+  // Git 隔离：请求时且 cwd 是真实仓库时，给该代理一个基于 `agent/<id>` 分支的
+  // 独立工作树，让它不会践踏其他代理（或用户）的工作树。尽力而为——失败时
+  // 回退到共享 cwd 而不是阻塞生成。
+  // 注意（已跟踪、尚未加固）：restore 流程传 isolate:false 并按 cwd 重入现有
+  // 工作树，所以它永远到不了这里。但一个陈旧的 `isolate:true` 配方针对已存在
+  // 的工作树路径生成时，会让下面的 addWorktree 冲突（路径/分支已存在）并回退
+  // 到基础 cwd——复用既有工作树的处理是后续工作。
   if (opts.isolate === true && await isRepo(opts.cwd)) {
     try {
       const origCwd = opts.cwd;
       const wtRoot = join(readConfig().harnessHome ?? origCwd, 'worktrees');
-      // The id is renderer-supplied (validated only as a string). Slugify it so a
-      // crafted id can't inject path separators, then assert the resolved path
-      // stays under the worktrees root (defends against bare '..' that slugify
-      // leaves intact). If it would escape, bail isolation → fall back to cwd.
+      // id 由渲染器提供（只校验为字符串）。slug 化它，让精心构造的 id 无法
+      // 注入路径分隔符，然后断言解析后的路径仍位于工作树根之下（抵御 slug 化
+      // 会原样留下的裸 '..'）。若会逃逸，则放弃隔离 → 回退到 cwd。
       const seg = (opts.hive?.id ?? opts.id).replace(/[^A-Za-z0-9._-]/g, '-');
       const wtPath = join(wtRoot, seg);
       if (!resolve(wtPath).startsWith(resolve(wtRoot) + sep)) {
@@ -2665,23 +2559,22 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       console.error('[worktree] isolation failed:', e);
     }
   }
-  // Proxy-tier CLIs (qwen/crush) route their LLM traffic through a loopback sidecar
-  // whose UPSTREAM is read from the preset's bridge.baseUrlEnv inside hive.ensureAgent.
-  // For the local-LLM path, feed the user's configured base URL as that upstream so the
-  // proxy forwards to their endpoint (Ollama/LM Studio/vLLM). Set on process.env BEFORE
-  // ensureAgent reads it. (Crush's baseUrlEnv is an inert sentinel used ONLY as this
-  // upstream source; its real routing is the per-agent CRUSH_GLOBAL_CONFIG base_url.)
-  if (opts.hive && (provider === 'crush' || provider === 'qwen')) {
+  // 代理档 CLI（qwen）通过回环 sidecar 路由其 LLM 流量，sidecar 的
+  // UPSTREAM 在 hive.ensureAgent 内部从预设的 bridge.baseUrlEnv 读取。
+  // 对本地 LLM 路径，把用户配置的 base URL 喂给该 upstream，让代理转发到
+  // 他们的端点（Ollama/LM Studio/vLLM）。在 ensureAgent 读取它之前设置到
+  // process.env 上。
+  if (opts.hive && provider === 'qwen') {
     const bridge = providerPreset(provider).bridge;
     const baseUrl = readConfig().providerBaseUrls?.[provider];
     if (bridge && bridge.kind === 'proxy' && baseUrl) process.env[bridge.baseUrlEnv] = baseUrl;
   }
-  // If the agent carries hive metadata, provision its workspace and add
-  // provider-specific spawn injection. Non-Claude providers get shared AGENT_*
-  // env only; Claude Code also gets prompt/settings hook args.
-  // Protocol seed that must be TYPED into a bare TUI after boot (Crush —
-  // seedDelivery:'type-into-tui') rather than passed on argv. Surfaced in the spawn
-  // result so the renderer types it through the per-pty write-chain. (ondev-b)
+  // 若代理携带 hive 元数据，供给其工作区并注入 provider 专属的生成参数。
+  // 非 Claude provider 只获得共享的 AGENT_* 环境变量；Claude Code 还会获得
+  // prompt/settings 钩子参数。
+  // 必须在启动后敲进裸 TUI 的协议种子（Crush——seedDelivery:'type-into-tui'）
+  // 而不是经 argv 传入。在生成结果中带出，让渲染器通过每条 pty 的写入链
+  // 把它敲进去。（ondev-b）
   let seedPrompt: string | undefined;
   if (opts.hive && hive.enabled()) {
     try {
@@ -2690,92 +2583,86 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
         {
           semanticMemory: memory.active(),
           knowledgeGraph: knowledge.active(),
-          // Bake the ABSOLUTE KG CLI path into the agent's prompt. The prompt used
-          // to spell it `$KG_CLI`, which is POSIX-only: under cmd.exe/PowerShell it
-          // expands to nothing, so every knowledge-graph instruction was dead on a
-          // Windows floor. Empty when the KG is off (the line isn't emitted then).
+          // 把绝对的 KG CLI 路径烘焙进代理的 prompt。prompt 过去写成
+          // `$KG_CLI`，那只是 POSIX 的写法：在 cmd.exe/PowerShell 下会展开成
+          // 空，所以 Windows 楼层上的每条知识图谱指令都是死的。KG 关闭时为空
+          // （那时不发出该行）。
           kgCliPath: knowledge.env().KG_CLI,
           theme: readConfig().terminalTheme ?? 'light',
-          // W3 — default-MCP consent state + the bundled skills source dir.
+          // W3 — 默认 MCP 同意状态 + 打包技能源目录。
           mcpDefaults: readConfig().mcpDefaults,
           skillsDir: skillsResourceDir(),
-          // The shared palace is mutated by the agent's own `mempalace` calls, so
-          // the OS sandbox must let it through (empty when memory is off).
+          // 共享宫殿由代理自己的 `mempalace` 调用修改，所以 OS 沙箱必须放行
+          // （内存关闭时为空）。
           extraWritableDirs: [memory.env().MEMPALACE_PALACE_PATH].filter((p): p is string => !!p)
         }
       );
       opts.args = [...(opts.args ?? []), ...inj.args];
       seedPrompt = inj.seedPrompt;
-      // A degraded spawn (proxy bridge never bound) is told to the user the same
-      // way breaker escalations are: a native toast, gated on the notifications
-      // setting. The hive already logged it and pushed hive:degraded to the floor.
-      if (inj.degraded) breakerToast('Agent running degraded', inj.degraded);
-      // Point the agent's mempalace CLI at the shared palace + the `kg` CLI at the
-      // enterprise knowledge store (both no-ops / empty when their flags are off).
+      // 降级生成（代理桥从未绑定）以与熔断器升级相同的方式告知用户：原生
+      // 提示，以通知设置为门。hive 已记录它并推送 hive:degraded 到楼层。
+      if (inj.degraded) breakerToast(l10n('Agent running degraded', '代理运行降级'), inj.degraded);
+      // 把代理的 mempalace CLI 指向共享宫殿、`kg` CLI 指向企业知识库
+      // （各自标志关闭时都为空操作/为空）。
       opts.env = { ...(opts.env ?? {}), ...inj.env, ...memory.env(), ...knowledge.env() };
     } catch (e) {
-      // Hive provisioning is best-effort; never block a spawn on it.
+      // hive 供给是尽力而为的；绝不让它阻塞生成。
       console.error('[hive] ensureAgent failed:', e);
     }
   }
-  // Long-run guardrails + tiering (Lane A #6.4/#6.6). All additive to the args
-  // already assembled (incl. the hive injection); an explicit choice always wins.
-  // Set when an explicit Add Agent "resume session" id couldn't be located and we
-  // silently fell back to a fresh session — returned so the dialog can surface it.
+  // 长跑护栏 + 分档（Lane A #6.4/#6.6）。都附加到已组装好的 args 上
+  // （含 hive 注入）；显式选择总是优先。
+  // 当显式填写的 Add Agent“恢复会话”id 找不到、我们静默回退到新会话时置位
+  // ——返回给对话框以便把它浮出来。
   let resumeNotFound = false;
-  // Set when `--resume` was actually attached (explicit id or restore-on-restart),
-  // so the renderer can skip re-orienting a god/assistant that resumed its thread.
+  // 当 `--resume` 实际被附加（显式 id 或重启恢复）时置位，让渲染器可以跳过
+  // 对已恢复其线程的 god/助理重新定位。
   let didResume = false;
-  // Claude-only — these are Claude Code flags; other CLIs carry their own flags
-  // in the command string the renderer already built.
+  // Claude 专属——这些是 Claude Code 标志；其他 CLI 在渲染器已构建的命令
+  // 字符串里带自己的标志。
   if (opts.hive && claudeProvider) {
     const cfg = readConfig();
-    // Permission posture (D9): only a GUI hire (Add Agent) builds its command
-    // through buildSpawnCommand, which bakes autoMode's bypass flag into the
-    // command STRING before this function ever sees it. A main-only spawn (the
-    // ephemeral-worker watcher, a voice hire) skips that step entirely, so it
-    // previously reached here with neither the flag nor any equivalent — every
-    // other Claude spawn path got the user's autoMode posture and this one
-    // didn't. argsWithAutoModeFlag is idempotent (a GUI spawn's args already has
-    // the flag, so this is a no-op for it) and is the SAME check spawnAgentCore
-    // already applies for opencode/crush et al a few lines below via
-    // HIVE_AUTO_APPROVE — one global toggle, one posture, every spawn path.
-    // Confirmed live: a worker spawned without this flag deadlocked — a
-    // cross-session message to it came back "held for the recipient user's
-    // approval" with no surface for anyone to ever grant that approval.
+    // 权限姿态（D9）：只有 GUI 招聘（Add Agent）通过 buildSpawnCommand 构建
+    // 命令，它把 autoMode 的绕过标志烘进命令 STRING，早于本函数见到它。
+    // 仅主进程的生成（临时 worker 观察器、语音招聘）完全跳过那一步，所以它
+    // 之前到达这里时既没有标志也没有等价物——其他每个 Claude 生成路径都得到
+    // 用户 autoMode 的姿态，唯独这条没有。argsWithAutoModeFlag 是幂等的
+    // （GUI 生成的 args 已带标志，对它来说是空操作），并且与 spawnAgentCore
+    // 几行后为 opencode/crush 等经 HIVE_AUTO_APPROVE 应用的检查相同——一个
+    // 全局开关、一个姿态、每条生成路径。
+    // 实盘确认：没有这个标志生成的 worker 死锁——发给它的跨会话消息返回
+    // “held for the recipient user's approval”，却没有任何人可授予该批准的界面。
     const args = argsWithAutoModeFlag(opts.args ?? [], cfg.autoMode, provider);
-    // Model precedence: an explicit per-agent --model (from the renderer) wins;
-    // else the user's global defaultModel; else the role-based default tier. The
-    // GOD is special-cased: it has its own engine config (godProvider/godModel), so
-    // modelForRole resolves it and that wins over the worker-oriented defaultModel.
+    // 模型优先级：显式的逐代理 --model（来自渲染器）优先；否则用户全局
+    // defaultModel；否则基于角色的默认档。GOD 特殊处理：它有自己的引擎配置
+    // （godProvider/godModel），所以 modelForRole 解析它，优先于面向 worker
+    // 的 defaultModel。
     if (!args.includes('--model')) {
       const m = opts.hive.isGod
         ? modelForRole(opts.hive, cfg)
         : cfg.defaultModel ?? modelForRole(opts.hive, cfg);
       if (m) args.push('--model', m);
     }
-    // Name the Remote Control session after the agent (Michael, Jim, Dev1…) so it
-    // is identifiable in claude.ai / the mobile app. Otherwise Claude defaults the
-    // prefix to the machine hostname (e.g. "vyapaks-macbook-pro-…"), which is
-    // opaque when several agents run at once — especially with remoteControlAtStartup
-    // on, where RC auto-enables for every session. Slugify the friendly name into a
-    // single safe token; Claude still appends its own random suffix for uniqueness.
+    // 用代理的名字命名 Remote Control 会话（Michael、Jim、Dev1…），好让它在
+    // claude.ai / 手机端可辨认。否则 Claude 默认用机器主机名做前缀
+    // （如 "vyapaks-macbook-pro-…"），几个代理同时跑时完全无法区分——
+    // 尤其在 remoteControlAtStartup 开启、RC 对每个会话都自动启用时。
+    // 把友好名字 slug 成单个安全 token；Claude 仍会加上自己的随机后缀保证唯一。
     if (!args.includes('--remote-control-session-name-prefix')) {
       const label = (opts.hive.name || opts.hive.id || '')
         .trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
       if (label) args.push('--remote-control-session-name-prefix', label);
     }
-    // Coarse runaway cap.
+    // 粗略的失控上限。
     if (typeof cfg.maxTurns === 'number' && cfg.maxTurns > 0 && !args.includes('--max-turns')) {
       args.push('--max-turns', String(cfg.maxTurns));
     }
-    // Resume: an explicit session id (Add Agent "resume session" field, #2) wins,
-    // else this agent's last recorded session (#1 restore-on-restart / #6.6a).
-    // Seed the transcript into the target cwd's Claude project dir first — Claude
-    // keys sessions by cwd, so a session started elsewhere is invisible until its
-    // `.jsonl` is copied across. Only attach `--resume` if the transcript is
-    // actually present (already or after the copy); otherwise fall back to a fresh
-    // session rather than launching a `--resume` against a missing id.
+    // 恢复：显式的会话 id（Add Agent“恢复会话”字段，#2）优先，否则用该代理
+    // 最后一次记录的会话（#1 重启即恢复 / #6.6a）。先把 transcript 播种到目标
+    // cwd 的 Claude 项目目录——Claude 按键 cwd 组织会话，所以在别处启动的
+    // 会话直到其 `.jsonl` 被拷过来前都是不可见的。只有在 transcript 实际存在
+    // 时（无论原本就在还是拷贝后）才附加 `--resume`；否则回退到新会话，而不是
+    // 对着缺失的 id 启动 `--resume`。
     const explicitSid = typeof opts.resumeSessionId === 'string' ? opts.resumeSessionId.trim() : '';
     const sid = explicitSid || (opts.resume === true ? hive.lastSession(opts.hive.id) : undefined);
     if (sid && !args.includes('--resume')) {
@@ -2783,44 +2670,39 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
         args.push('--resume', sid);
         didResume = true;
       } else if (explicitSid) {
-        // The user typed a session id in the Add Agent dialog but it isn't in any
-        // Claude project dir — we fall back to a FRESH session rather than a broken
-        // `--resume`. Make that non-silent: warn on the floor and flag it back to
-        // the renderer so the dialog can tell the user 'started fresh'.
+        // 用户在 Add Agent 对话框里敲了会话 id，但它不在任何 Claude 项目目录
+        // 里——我们回退到一个全新会话，而不是坏掉的 `--resume`。不静默处理：
+        // 在楼层上警告并把标志回传给渲染器，让对话框能告诉用户“已全新开始”。
         console.warn(`[resume] session "${explicitSid}" not found in any Claude project dir — starting a fresh session`);
         resumeNotFound = true;
       }
     }
     opts.args = args;
   }
-  // Idempotent session resume on respawn (#6.6a) — provider-aware: Claude
-  // `--resume <sid>`, Grok `--resume <sid>`, Antigravity `--conversation <id>`.
-  // The recorded session id comes from hook payloads, so
-  // a restored worker continues its prior CLI session. Only when requested AND a
-  // prior id exists for this agent.
-  // Claude resume — incl. transcript seeding + only-attach-when-present — is
-  // handled in the Claude-only block above; this generic flag path covers the
-  // other CLIs (it must not blindly attach `--resume` when the seed failed).
+  // 重启即恢复的幂等会话恢复（#6.6a），provider 感知：Claude `--resume <sid>`、
+  // Grok `--resume <sid>`、Antigravity `--conversation <id>`。记录的会话 id 来自
+  // 钩子载荷，所以被恢复的 worker 会继续它之前的 CLI 会话。仅在请求了恢复且该
+  // 代理存在先前 id 时。Claude 版恢复——含 transcript 播种与仅在有内容时附加
+  // ——在上面的 Claude 专属块里处理；这个通用标志路径覆盖其他 CLI（播种失败
+  // 时绝不能盲目附加 `--resume`）。
   if (opts.hive && !claudeProvider) {
     const preset = providerPreset(provider);
     const rf = preset.resumeFlag;
     const rsub = preset.resumeSubcommand;
-    // An id typed into Add Agent's "resume session" field wins; otherwise fall
-    // back to this agent's own recorded session (restart-in-place). Previously
-    // resumeSessionId was read ONLY in the Claude branch, so a Codex agent
-    // silently ignored it and started a brand-new empty session.
+    // 用户在 Add Agent“恢复会话”字段里敲的 id 优先；否则回退到该代理自己记录
+    // 的会话（原地重启）。之前 resumeSessionId 只在 Claude 分支里读，所以 Codex
+    // 代理会静默忽略它并启动一个全新的空会话。
     const typedSid = typeof opts.resumeSessionId === 'string' ? opts.resumeSessionId.trim() : '';
     const sid = typedSid || (opts.resume === true ? hive.lastSession(opts.hive.id) : undefined);
     if (sid && rf) {
       const args = opts.args ?? [];
       if (!args.includes(rf)) { args.push(rf, sid); opts.args = args; didResume = true; }
     } else if (sid && rsub) {
-      // Subcommand form (Codex): `codex resume [OPTIONS] [SESSION_ID]` — the
-      // subcommand MUST be argv[0], the id trails the flags. Codex indexes
-      // sessions in state_5.sqlite, so a fresh agent's empty CODEX_HOME can't
-      // resume by id. If this agent's own home already has the session, resume in
-      // place; otherwise point CODEX_HOME at the agent home that OWNS it (that
-      // home has both the rollout and the sqlite index).
+      // 子命令形式（Codex）：`codex resume [OPTIONS] [SESSION_ID]`——子命令必须
+      // 是 argv[0]，id 跟在标志后面。Codex 在 state_5.sqlite 里给会话建索引，
+      // 所以新代理的空 CODEX_HOME 无法按 id 恢复。如果该代理自己的 home 已有
+      // 该会话，就原地恢复；否则把 CODEX_HOME 指向拥有它的代理 home（那里同时
+      // 有卷展和 sqlite 索引）。
       const myHome = (opts.env ?? {}).CODEX_HOME;
       const agentsRoot = myHome ? dirname(dirname(myHome)) : '';
       const ownerHome = agentsRoot ? findCodexHomeForSession(sid, agentsRoot) : null;
@@ -2830,11 +2712,10 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       } else {
         if (ownerHome !== myHome) opts.env = { ...(opts.env ?? {}), CODEX_HOME: ownerHome };
         const args = opts.args ?? [];
-        // Positional order matters: `codex resume [OPTIONS] [SESSION_ID] [PROMPT]`.
-        // The hive identity prompt rides in `args` as a POSITIONAL (codex has no
-        // prompt flag), so the id must come BEFORE it — appending the id last made
-        // codex read the prompt as SESSION_ID ("No saved session found with ID
-        // You are \"Dev2\"…") and the id as the prompt.
+        // 位置顺序很关键：`codex resume [OPTIONS] [SESSION_ID] [PROMPT]`。hive
+        // 身份提示以位置参数形式骑在 `args` 里（codex 没有 prompt 标志），所以
+        // id 必须在它之前——把 id 追加到最后会让 codex 把提示当 SESSION_ID 读
+        // （"No saved session found with ID You are \"Dev2\"…"）而把 id 当提示。
         if (args[0] !== rsub) { opts.args = [rsub, sid, ...args]; didResume = true; }
         console.log('[resume] codex resume', sid, 'in', ownerHome);
       }
@@ -2847,40 +2728,38 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       ...(resumeNotFound ? { resumeNotFound: true } : {})
     };
   }
-  // Remember which agent owns this PTY so closing the tab can archive it. A
-  // live terminal means active — ensureAgent above already cleared `archived`.
+  // 记住哪个代理拥有这个 PTY，这样关闭标签页时可以归档它。活的终端意味着
+  // 活跃——上面的 ensureAgent 已经清掉了 `archived`。
   if (opts.hive?.id) {
     ptyToAgent.set(opts.id, opts.hive.id);
-    // Worker inbox-wake watchdog (#151): boot grace starts at spawn so the
-    // initial orientation prompt is never mistaken for an idle agent.
+    // Worker 收件箱唤醒看门狗（#151）：启动宽限期从生成时开始，让最初的
+    // 定向提示永远不会被误判为闲置代理。
     workerWake.noteSpawn(opts.id);
   }
-  // Pre-accept Claude Code's bypass-mode warning + folder-trust dialog so the
-  // agent (spawned with --permission-mode bypassPermissions) doesn't stall on an
-  // interactive prompt it can't answer and exit code 1. Best-effort, never blocks.
-  // Claude-only — other CLIs handle their own permission UX.
+  // 预先接受 Claude Code 的绕过模式警告 + 文件夹信任对话框，让代理（以
+  // --permission-mode bypassPermissions 生成）不会卡在它无法回答的交互式
+  // 提示上然后以退出码 1 结束。尽力而为，绝不阻塞。仅 Claude——其他 CLI
+  // 处理自己的权限 UX。
   if (claudeProvider) {
-    try { ensureClaudePermissionsAccepted(opts.cwd); } catch { /* never block spawn */ }
+    try { ensureClaudePermissionsAccepted(opts.cwd); } catch { /* 绝不阻塞 spawn */ }
   }
-  // Suppress first-run interactive prompts for providers that need it (e.g. Codex
-  // directory-trust gate via CODEX_NON_INTERACTIVE). Merges into any env already
-  // set on opts.
+  // 静默掉 provider 需要的首次运行交互提示（如 Codex 的目录信任闸门经
+  // CODEX_NON_INTERACTIVE）。合并进 opts 上已有的任何 env。
   const nonInteractiveEnv = nonInteractiveEnvForProvider(provider);
   if (Object.keys(nonInteractiveEnv).length > 0) {
     opts.env = { ...(opts.env ?? {}), ...nonInteractiveEnv };
   }
-  // ── BYOK keys + per-provider config for the non-Claude CLI engines (v0.3.1) ──
-  // OpenCode / Crush / pi / qwen read BYOK API keys from standard env vars and, for
-  // the local-LLM path, a per-provider base URL. Keys are write-only in the broker
-  // (read MAIN-ONLY here, never logged); base URLs ride HarnessConfig. Claude/codex
-  // use their own login, so they skip this. Pam guardrails #3/#4/#5.
-  if (opts.hive && (provider === 'opencode' || provider === 'crush' || provider === 'pi' || provider === 'qwen')) {
+  // ── 非 Claude 引擎的 BYOK 键 + 逐 provider 配置（v0.3.1）──────────────
+  // qwen 从标准 env 变量读 BYOK API 键，并且在本地 LLM 路径下读逐 provider 的
+  // base URL。键在 broker 里只写（这里仅在主进程读取，从不记日志）；
+  // base URL 放在 HarnessConfig 里。Claude/codex 用自己的登录，所以跳过这里。
+  if (opts.hive && provider === 'qwen') {
     const cfg = readConfig();
     const extra: Record<string, string> = {};
-    // 1) BYOK keys — LEAST-PRIVILEGE (Pam/Jim NIT-2): inject ONLY the key for the
-    //    spawned model's provider prefix when we can identify it; fall back to all
-    //    stored keys when the model/prefix is unknown (default model, qwen slugs,
-    //    custom). Reduces the blast radius vs handing every CLI all keys.
+    // 1) BYOK 键——最小权限（Pam/Jim NIT-2）：能识别出所生成模型的 provider
+    //    前缀时，只注入该 provider 的那一个键；模型/前缀未知时（默认模型、
+    //    qwen 别名、自定义）回退到全部已存键。相比把每个键都发给每个 CLI，
+    //    这缩小了爆炸半径。
     const modelIdx = (opts.args ?? []).indexOf('--model');
     const modelSlug = modelIdx >= 0 ? (opts.args?.[modelIdx + 1] ?? '') : '';
     const prefix = modelSlug.includes('/') ? modelSlug.split('/')[0].toLowerCase() : '';
@@ -2893,51 +2772,52 @@ async function spawnAgentCore(opts: AgentSpawnOptions, owner: Electron.WebConten
       const key = integrations.getSecret(providerKeyRef(backend));
       if (!key) continue;
       extra[BACKEND_KEY_ENV[backend]] = key;
-      // OpenCode/AI-SDK's Google provider reads GOOGLE_GENERATIVE_AI_API_KEY, not
-      // GEMINI_API_KEY — inject both so google/* authenticates (Jim NIT #1).
+      // OpenCode/AI-SDK 的 Google provider 读的是 GOOGLE_GENERATIVE_AI_API_KEY
+      // 而不是 GEMINI_API_KEY——两个都注入，好让 google/* 能认证（Jim NIT #1）。
       if (backend === 'google') extra.GOOGLE_GENERATIVE_AI_API_KEY = key;
     }
-    // 2) Floor auto-state for pi's bundled extension auto-allow (guardrail #5): it
-    //    only auto-approves tool calls when this is '1' (i.e. floor auto mode on).
+    // 2) pi 的内置扩展自动放行的楼层自动态（guardrail #5）：只有这个值为 '1'
+    //    时它才自动批准工具调用（即楼层自动模式开启）。
     extra.HIVE_AUTO_APPROVE = cfg.autoMode ? '1' : '0';
-    // 3) OpenCode's auto-approve + local provider live in its single config-injection
-    //    env var, built dynamically so permission:allow is GATED on autoMode (#2).
-    if (provider === 'opencode') {
-      const oc: Record<string, unknown> = { autoupdate: false };
-      if (cfg.autoMode) oc.permission = { edit: 'allow', bash: 'allow', webfetch: 'allow' };
-      const baseUrl = cfg.providerBaseUrls?.opencode;
-      if (baseUrl) {
-        // Register the model id the user actually selects (the part after 'local/')
-        // so `--model local/<id>` resolves; default to 'local'. Without this the
-        // dropdown's `local/llama3` failed against a config that only declared model
-        // 'local' (Jim verify-opencode MUST-FIX #2).
-        const localModel = (prefix === 'local' && modelSlug.slice(6)) || 'local';
-        oc.provider = {
-          local: { npm: '@ai-sdk/openai-compatible', name: 'Local (self-hosted)', options: { baseURL: baseUrl }, models: { [localModel]: { name: localModel } } }
-        };
-      }
-      extra.OPENCODE_CONFIG_CONTENT = JSON.stringify(oc);
-    }
+    // 3) 强制 qwen 的 getShellConfiguration 命中 Git Bash 分支：qwen 在
+    //    Windows 上按 MSYSTEM（MINGW/MSYS 前缀）→ Git Bash、ComSpec 以
+    //    powershell 结尾 → -NoProfile -Command、否则 cmd 三级判定。本机
+    //    ComSpec=cmd.exe，qwen 会落 cmd 分支并用 `chcp 65001` 前缀——那只改
+    //    控制台代码页，管不到 PowerShell 5.1 Get-Content 的 ANSI/GBK 读取
+    //    解码，UTF-8 文件在 agent 读文件时乱码（璧氶挶）。设 MSYSTEM 让 qwen
+    //    走 findGitBashPath 找到的 D:\Git\bin\bash.exe（在 PATH 里），bash
+    //    读文件按字节流透传，UTF-8 无转换。双通道之一：本注入是 spawn 级兜底，
+    //    与 ~/.qwen/settings.json 的 env.MSYSTEM（qwen 自加载）互为备份。
+    extra.MSYSTEM = 'MINGW64';
+    // 4) qwen 的终端擦除优化（installTerminalRedrawOptimizer）在 ConPTY 下
+    //    把多行擦除序列重写为光标序列，导致大量重复行/截断帧/视觉乱码。
+    //    设 legacy 擦除开关为 '1'，走逐行擦除路径。
+    extra.QWEN_CODE_LEGACY_ERASE_LINES = '1';
+    // 5) qwen 的 resize-reflow 优化（installTerminalResizeReflow）在窗口
+    //    缩窄时向输出流注入 CLEAR_VIEWPORT（ESC[2J ESC[H）并重绘整屏。
+    //    该序列经 node-pty 的 ConPTY 通道转发时若被拆分/时序错位，旧帧
+    //    不会真正清除，新帧直接叠加在其后——窄窗口（列数 < 80，首帧即
+    //    视为 shrink）下启动横幅会重复 3 份。设 legacy 开关为 '1' 禁用。
+    extra.QWEN_CODE_LEGACY_RESIZE_ERASE = '1';
     opts.env = { ...(opts.env ?? {}), ...extra };
   }
-  // Codex Remote is daemon-based (there is no `/remote-control` slash command).
-  // Start/enable the daemon under this agent's isolated CODEX_HOME and connect
-  // the TUI to it so the thread is visible in ChatGPT mobile. Best-effort: an
-  // unavailable/older Codex install still gets a normal local terminal.
+  // Codex Remote 是基于守护进程的（没有 `/remote-control` 斜杠命令）。
+  // 在该代理隔离的 CODEX_HOME 下启动/启用守护进程并把 TUI 连上去，让线程
+  // 在 ChatGPT 手机端可见。尽力而为：不可用/更旧的 Codex 安装仍会得到一个
+  // 普通本地终端。
   if (provider === 'codex' && opts.hive?.id) {
     await enableCodexRemoteForSpawn(opts, opts.hive.id);
   }
   const res = ptyManager.spawn(opts, owner);
   if (res.ok) analytics.track('agent_spawned', { provider });
   else analytics.track('agent_spawn_failed', { provider, reason: spawnFailReason(res.error) });
-  syncKeepAwake(); // arm the power-save blocker while ≥1 agent PTY is alive (#18)
-  // Hand the resolved worktree path back to the renderer so it can persist it on
-  // the agent (only set when isolation actually provisioned a worktree above).
-  // The restore flow re-enters this exact worktree (cwd = worktreePath) so a
-  // restored isolated agent resumes in the CORRECT checkout, not the base repo.
+  syncKeepAwake(); // 只要有 ≥1 个代理 PTY 活着就武装省电拦截器（#18）
+  // 把解析出的工作树路径交回渲染器，让它持久化到代理上（只有在上面真的
+  // 供给出工作树时才设置）。restore 流程按 cwd == worktreePath 精确重入这个
+  // 工作树，所以被恢复的隔离代理回到的是正确的检出，而不是基础仓库。
   const worktreePath = worktreePaths.get(opts.id);
-  // `cwd` echoes back the TILDE-EXPANDED absolute path so the renderer's agent
-  // record matches what the registry and the PTY actually used.
+  // `cwd` 把展开过 ~ 的绝对路径回传，让渲染器的代理记录与注册表和 PTY
+  // 实际使用的路径一致。
   return { ...res, cwd: opts.cwd, ...(worktreePath ? { worktreePath } : {}), ...(resumeNotFound ? { resumeNotFound: true } : {}), ...(didResume ? { resumed: true } : {}), ...(seedPrompt ? { seedPrompt } : {}) };
 }
 ipcMain.handle('pty:write', (_evt, id: string, data: string) => {
@@ -2954,41 +2834,38 @@ ipcMain.handle('pty:redraw', (_evt, id: string) => {
 });
 ipcMain.handle('pty:kill', (_evt, id: string) => {
   if (typeof id !== 'string') return { ok: false, error: 'invalid id' };
-  // Kill the process, then run the shared lifecycle teardown (archive the agent,
-  // remove its isolated worktree, drop the maps). teardownPty is idempotent, so
-  // node-pty firing onExit once the child actually dies is a harmless no-op.
+  // 先杀进程，再执行共享的生命周期拆解（归档 agent、移除其隔离的 worktree、
+  // 清空各映射）。teardownPty 是幂等的，所以子进程真正死后 node-pty 再触发
+  // onExit 也只是无害的空操作。
   const res = ptyManager.kill(id);
   teardownPty(id);
   return res;
 });
 ipcMain.handle('pty:list', () => ptyManager.list());
 
-// ─── IPC: analytics (the ONE renderer-facing seam) ──────────────────────────
-/** Count one human-sent message (TELEMETRY.md → `message_sent`). A COUNT, and
- *  nothing else: this channel takes no text, no length and no id, so there is
- *  no shape in which message content could cross it.
+// ─── IPC: analytics（渲染器面向外界的唯一接缝）────────────────────────────────
+/** 计数一条人工发送的消息（TELEMETRY.md → `message_sent`）。这只是一个 COUNT，
+ *  仅此而已：该通道不接收文本、长度或 id，因此消息内容无论如何都无法从这里流出。
  *
- *  This is the only analytics event the renderer can cause. It exists because
- *  two of the four send surfaces — a line typed into the agent's terminal, and
- *  the queue composer — are submits main cannot observe: the `pty:write` handler
- *  above fires on EVERY KEYSTROKE, so counting there would produce a keystroke
- *  meter, not a message count. `steer` and `hive` are counted at their own IPC
- *  handlers in this file and are rejected here (isRendererMessageSurface) so
- *  they can never be counted twice. The event name is fixed here, not passed
- *  in: the renderer chooses a surface, never an event. */
+ *  这是渲染器能引发的唯一一个 analytics 事件。之所以存在它，是因为四个发送面中有
+ *  两个——输入到 agent 终端里的一行，以及队列 composer——是 main 无法观测到的
+ *  submit：上面的 `pty:write` handler 在每次按键都会触发，所以在那里计数得到的是
+ *  按键计数，而不是消息计数。`steer` 和 `hive` 在本文件各自的 IPC handler 里计数，
+ *  并在这里被拒绝（isRendererMessageSurface），因此它们永远不会被计两次。事件名在
+ *  这里固定，而非传入：渲染器选择的是一个 surface，而不是一个事件。 */
 ipcMain.handle('analytics:messageSent', (_evt, surface: unknown) => {
   if (!isRendererMessageSurface(surface)) return { ok: false };
   analytics.trackMessageSent(surface);
   return { ok: true };
 });
 
-// Resolve a pasted Claude session id to the cwd it originally ran in, so the Add
-// Agent dialog can auto-fill the folder for a resume (#2 zero-step resume). Reads
-// the cwd from a transcript record; null when the id is invalid/unknown.
+// 把粘贴进来的 Claude session id 解析回它最初运行时的 cwd，以便 Add Agent 对话框
+// 能为恢复会话（#2 零步骤恢复）自动填充文件夹。从 transcript 记录里读取 cwd；
+// 当 id 无效/未知时返回 null。
 ipcMain.handle('session:resolveCwd', (_evt, sessionId: unknown) =>
   (typeof sessionId === 'string' ? resolveSessionCwd(sessionId) : null));
 
-// ─── IPC: clipboard ─────────────────────────────────────────────────────────
+// ─── IPC: 剪贴板 ───────────────────────────────────────────────────────────
 ipcMain.handle('app:copyToClipboard', (_evt, text: unknown) => {
   if (typeof text !== 'string') return { ok: false, error: 'invalid text' };
   try { clipboard.writeText(text); return { ok: true }; }
@@ -2997,35 +2874,32 @@ ipcMain.handle('app:copyToClipboard', (_evt, text: unknown) => {
 ipcMain.handle('app:readClipboard', () => {
   try { return clipboard.readText(); } catch { return ''; }
 });
-// Same read, SYNCHRONOUS, for the terminal's paste shortcut.
+// 同样的读取，但为终端的粘贴快捷键做成 SYNCHRONOUS（同步）版本。
 //
-// Dictation tools (muesli.works, Wispr Flow, …) type by stashing the user's
-// clipboard, writing the transcript, sending the paste key, then restoring the
-// old clipboard immediately. An `invoke` read returns a tick or two later — by
-// which point the restore has already landed and we paste the PREVIOUS text.
-// A `sendSync` read completes inside the keydown handler, before the tool gets
-// a chance to put the old contents back.
+// 听写工具（muesli.works、Wispr Flow 等）的输入方式是：先把用户的剪贴板内容
+// 藏起来、写入识别文本、发送粘贴按键，然后立刻恢复旧的剪贴板。`invoke` 读取会
+// 晚一到两个 tick 才返回——到那时恢复已经完成，我们会粘贴到的是「之前」的文本。
+// `sendSync` 读取则在 keydown handler 内部完成，趁工具还没来得及把旧内容放回去。
 ipcMain.on('app:readClipboardSync', (evt) => {
   try { evt.returnValue = clipboard.readText(); } catch { evt.returnValue = ''; }
 });
-// NOTE: the terminal theme is mirrored into each agent's per-session Claude
-// settings at spawn (hive.ensureAgent theme option) — deliberately NOT via
-// `claude config set -g theme`, which would also restyle the user's own
-// Claude sessions outside the app.
+// 注意：终端主题会在 spawn 时镜像进每个 agent 的 per-session Claude 设置
+// （hive.ensureAgent 的 theme 选项）——特意不用 `claude config set -g theme`，
+// 因为那会把应用之外的、用户自己的 Claude 会话也一并重设主题。
 
-// ─── IPC: folder picker ─────────────────────────────────────────────────────
+// ─── IPC: 文件夹选择器 ──────────────────────────────────────────────────────
 ipcMain.handle('dialog:chooseFolder', async (evt) => {
   const win = BrowserWindow.fromWebContents(evt.sender);
   if (!win) return { ok: false as const, error: 'no window' };
   const res = await dialog.showOpenDialog(win, {
     properties: ['openDirectory', 'createDirectory'],
-    title: 'Pick a folder'
+    title: l10n('Pick a folder', '选择文件夹')
   });
   if (res.canceled || res.filePaths.length === 0) return { ok: false as const, error: 'cancelled' };
   return { ok: true as const, path: res.filePaths[0] };
 });
 
-// ─── IPC: Terminal.app at a folder ──────────────────────────────────────────
+// ─── IPC: 在某个文件夹处打开 Terminal.app ───────────────────────────────────
 ipcMain.handle('terminal:openAtFolder', async (_evt, cwd: unknown) => {
   if (typeof cwd !== 'string' || cwd.length === 0) return { ok: false, error: 'invalid cwd' };
   return new Promise<{ ok: boolean; error?: string }>((resolve) => {
@@ -3040,9 +2914,9 @@ ipcMain.handle('terminal:openAtFolder', async (_evt, cwd: unknown) => {
   });
 });
 
-// ─── IPC: integrations (Phase 2 registry — backend for Ryan's Settings UI) ────
-// Records are metadata only (config-backed); secrets are encrypted at rest and NEVER
-// returned over IPC. `list` redacts secretRef to a `hasSecret` boolean.
+// ─── IPC: integrations（Phase 2 注册表——Ryan 的 Settings UI 的后端）──────────
+// 记录只是元数据（基于 config）；密钥在静止时加密，且绝不会经 IPC 返回。
+// `list` 会把 secretRef 脱敏为 `hasSecret` 布尔值。
 ipcMain.handle('integrations:list', () => integrations.listRecordsRedacted());
 ipcMain.handle('integrations:templates', () => INTEGRATION_TEMPLATES);
 ipcMain.handle('integrations:upsert', (_evt, record: unknown) => integrations.upsertRecord(record));
@@ -3057,12 +2931,12 @@ ipcMain.handle('integrations:remove', (_evt, payload: unknown) => {
   if (typeof p.id !== 'string' || !p.id) return { ok: false, error: 'id required' };
   return integrations.removeRecord(p.id);
 });
-// ─── IPC: per-CLI-provider BYOK keys (write-only) ────────────────────────────
-// API keys for the backend model-providers the non-Claude CLIs use are stored
-// WRITE-ONLY under `apikey:<backend>` in the same encrypted broker. The renderer
-// can SET a key and ASK whether one is set (boolean) — it can never read the
-// plaintext back. Keys are materialized MAIN-ONLY at spawn (spawnAgentCore). Base
-// URLs are non-secret and ride HarnessConfig.providerBaseUrls (normal config save).
+// ─── IPC: 每个 CLI provider 的 BYOK 密钥（只写）──────────────────────────────
+// 非 Claude CLI 所用的后端模型 provider 的 API 密钥，以「只写」方式存于同一个
+// 加密 broker 下的 `apikey:<backend>`。渲染器可以 SET（设置）一个密钥、或询问
+// 是否已设置（布尔值）——它永远无法读回明文。密钥只在 spawn 时（spawnAgentCore）
+// 于 MAIN 侧物化。Base URL 并非机密，随 HarnessConfig.providerBaseUrls 走
+// （普通的 config 保存）。
 ipcMain.handle('providerKey:set', (_evt, payload: unknown) => {
   const p = (payload ?? {}) as { backend?: unknown; key?: unknown };
   if (typeof p.backend !== 'string' || !(p.backend in BACKEND_KEY_ENV)) return { ok: false, error: 'unknown backend' };
@@ -3076,8 +2950,8 @@ ipcMain.handle('providerKey:clear', (_evt, backend: unknown) => {
   try { integrations.deleteSecret(providerKeyRef(backend)); return { ok: true }; }
   catch (e) { return { ok: false, error: e instanceof Error ? e.message : String(e) }; }
 });
-// Probe an integration's reachability through the broker's own auth path (admin-only;
-// runs in main, so the secret is used but never returned — only the upstream status).
+// 经 broker 自己的认证路径探测一个集成是否可达（仅管理员；在 main 中运行，
+// 因此密钥被使用但从不返回——只回上游状态）。
 ipcMain.handle('integrations:test', async (_evt, payload: unknown) => {
   const p = (payload ?? {}) as { id?: unknown; path?: unknown };
   if (typeof p.id !== 'string' || !p.id) return { ok: false, error: 'id required' };
@@ -3085,10 +2959,9 @@ ipcMain.handle('integrations:test', async (_evt, payload: unknown) => {
   if (!rec) return { ok: false, error: 'unknown integration' };
   const probe = validateBaseUrl(rec.baseUrl);
   if (!probe.ok) return { ok: false, error: probe.error };
-  // Confine the probe path through the SAME gate as the worker forward() path, so an
-  // absolute URL / backslash-host / traversal in p.path can't override the origin and
-  // exfiltrate the secret to an attacker host. Resolve (and reject) BEFORE the secret
-  // is ever materialized, so a bad path never even decrypts it.
+  // 让探测路径与 worker 的 forward() 路径走同一个门禁，从而 p.path 中的绝对
+  // URL / 反斜杠主机 / 目录穿越无法覆盖 origin 或把密钥外泄给攻击者主机。在密钥
+  // 物化之前就完成解析（并拒绝），因此一个坏路径甚至根本不会触发解密。
   const target = resolveUpstreamUrl(rec.baseUrl, typeof p.path === 'string' ? p.path : '');
   if (!target) return { ok: false, error: 'path escapes the integration baseUrl', code: 'bad_request' };
   const secret = integrations.getSecret(rec.secretRef);
@@ -3107,36 +2980,36 @@ ipcMain.handle('integrations:test', async (_evt, payload: unknown) => {
 // ─── IPC: config ────────────────────────────────────────────────────────────
 ipcMain.handle('config:get', (): HarnessConfig => readConfig());
 ipcMain.handle('config:update', (_evt, patch: Partial<HarnessConfig>) => {
-  // FIRST RUN: every hive-bound service is started by bootstrapHiveServices(),
-  // which runs once at app-ready and early-returns on `!hive.enabled()` — i.e.
-  // whenever harnessHome is still null, which is exactly the state a fresh
-  // install boots in. Onboarding then sets harnessHome through THIS handler and
-  // nothing re-bootstrapped, so the hook server, message router, telemetry
-  // collector and mission scheduler all stayed dead for the rest of the session.
+  // 首次运行：所有绑定 hive 的服务都由 bootstrapHiveServices() 启动，它只在
+  // app-ready 时运行一次，并且在 `!hive.enabled()` 时提前返回——也就是说只要
+  // harnessHome 仍为 null（这正是全新安装启动时的状态），就会这样。之后引导流程
+  // 通过「本 handler」设置 harnessHome，但没有任何东西重新启动服务，于是 hook
+  // server、消息 router、telemetry collector 和 mission scheduler 在整个会话的
+  // 剩余时间里都保持死寂。
   //
-  // Symptom: agents spawn and run (the PTY is not hive-bound), but no hook ever
-  // reaches the app — no `hooks.sock` on disk, so no SessionStart, which means
-  // recordSession() is never called and "Restart & Continue" fails with "No
-  // recorded session ID"; the cards also sit on "ctx no status tick yet" and 0
-  // tool calls. Everything healed on the next app launch, which is what hid it.
+  // 症状：agent 能 spawn 并运行（PTY 并不绑定 hive），但没有任何 hook 能到达应用
+  // ——磁盘上没有 `hooks.sock`，所以没有 SessionStart，也就意味着 recordSession()
+  // 永远不会被调用，「Restart & Continue」会报「No recorded session ID」；卡片
+  // 也会停在「ctx no status tick yet」且 0 次工具调用。下一次启动应用时一切自愈，
+  // 这正是问题被掩盖的原因。
   //
-  // changeHome() has always handled this by relaunching; onboarding does not
-  // relaunch, so bootstrap here on the null → set transition. Gated on the
-  // transition so ordinary config writes never re-enter it.
+  // changeHome() 一直通过重启来解决这一点；引导流程不重启，所以这里要在
+  // null → set 的转换上做 bootstrap。以该转换作为门禁，普通 config 写入就不会
+  // 再次进入它。
   const hiveWasEnabled = hive.enabled();
   const wasOnboarded = readConfig().onboardingComplete;
   const next = writeConfig(patch);
-  // Live opt-in/out from Settings → Privacy (TELEMETRY.md).
+  // 从 Settings → Privacy 实时选择启用/停用（TELEMETRY.md）。
   if (typeof patch?.telemetryEnabled === 'boolean') analytics.setEnabled(patch.telemetryEnabled);
-  // Activation funnel (v0.4.6): onboarding just finished (false → true) — the top of
-  // the launch → first-agent funnel. `provider` is the engine chosen in the wizard.
-  // Fired here (main), not in the renderer, so it rides the same allowlist as the rest.
+  // 激活漏斗（v0.4.6）：引导刚刚完成（false → true）——位于「启动 → 首个 agent」
+  // 漏斗的顶端。`provider` 是向导中选择的引擎。
+  // 在这里（main）触发而不是在渲染器里，以便与其余事件共用同一个 allowlist。
   if (!wasOnboarded && next.onboardingComplete) {
     analytics.track('onboarding_completed', { provider: next.godProvider ?? 'claude' });
   }
-  // Keep the hive's mirror of the spawn gate current. The queue itself reads
-  // config per tick so it gates immediately; this is for the PROMPT, which is
-  // built per spawn, so flipping the toggle reaches god the next time he starts.
+  // 让 hive 对 spawn 门禁的镜像保持最新。队列本身每个 tick 都会读 config，
+  // 因此它即时生效；这里针对的是 PROMPT——它按每次 spawn 构建，所以翻转该开关
+  // 会在 god 下次启动时生效。
   if (typeof patch?.orchestratorMaySpawn === 'boolean') hive.setOrchestratorMaySpawn(patch.orchestratorMaySpawn);
   if (!hiveWasEnabled && hive.enabled()) {
     console.log('[hive] harnessHome configured — bootstrapping hive services');
@@ -3152,25 +3025,23 @@ ipcMain.handle('config:ensureHome', (_evt, path: unknown) => {
   return ensureHarnessHome(path);
 });
 
-// Change the harnessHome folder. Because every derived path (hive root, palace,
-// sock, agent dirs) resolves lazily through getHome(), the only real work is
-// optionally MOVING the existing hive + palace and relaunching so every service
-// re-binds against the new root. mode: 'move' copies the data (old kept as a
-// safety net), 'fresh' just re-points and bootstraps an empty home.
+// 更换 harnessHome 文件夹。由于所有派生路径（hive 根、palace、sock、agent 目录）
+// 都通过 getHome() 惰性解析，唯一真正的工作是：可选地「移动」现有 hive + palace 并
+// 重启，让每个服务都重新绑定到新根上。mode: 'move' 会复制数据（旧数据保留作为
+// 安全网），'fresh' 则只重新指向并引导一个空 home。
 ipcMain.handle('config:changeHome', async (_evt, payload: unknown) => {
   const p = (payload ?? {}) as { newHome?: unknown; mode?: unknown };
   if (typeof p.newHome !== 'string' || !p.newHome) return { ok: false, error: 'invalid newHome' };
   const mode: 'move' | 'fresh' = p.mode === 'fresh' ? 'fresh' : 'move';
-  // expandTilde BEFORE resolve: both UI callers feed a folder-dialog result
-  // (always absolute), but the hive picker's recents list can serve a literal
-  // "~/…" persisted by a pre-#140 build — resolve() would anchor that at cwd
-  // and the app would relaunch against a real directory named "~". Same
-  // defence-in-depth-at-the-consumer rule as expandTilde's own doc.
+  // 在 resolve 之前先 expandTilde：两个 UI 调用方传入的都是文件夹对话框的结果
+  // （总是绝对路径），但 hive 选择器的 recents 列表可能给出一个由 pre-#140 构建
+  // 持久化下来的字面量 "~/…"——resolve() 会把它锚定到 cwd，应用就会重启到一个
+  // 真的叫 "~" 的目录。这与 expandTilde 自身文档里「在消费端做纵深防御」的规则一致。
   const newHome = resolve(expandTilde(p.newHome));
   const oldRaw = readConfig().harnessHome;
   const oldHome = oldRaw ? resolve(oldRaw) : null;
 
-  // Guard against same-folder / nested-folder (a move would self-copy forever).
+  // 防止同一文件夹 / 嵌套文件夹（移动会无限自我复制）。
   if (oldHome) {
     if (newHome === oldHome) return { ok: false, error: 'That is already the current home folder.' };
     const a = newHome + sep, b = oldHome + sep;
@@ -3182,9 +3053,8 @@ ipcMain.handle('config:changeHome', async (_evt, payload: unknown) => {
   const ensured = ensureHarnessHome(newHome);
   if (!ensured.ok) return ensured;
 
-  // Tear down everything bound to the OLD root before copying, so nothing writes
-  // mid-copy — a live git commit into hive/.git would otherwise be copied as a
-  // half-written object and corrupt the moved repo.
+  // 复制前先把所有绑定到旧根的东西拆掉，避免复制中途有写入——否则一个正在进行的
+  // hive/.git 提交会被当成只写了一半的对象复制走，从而损坏被移动的仓库。
   try { clearMissionTimers(); } catch (e) { console.error('[changeHome] clearMissionTimers:', e); }
   try { clearContextTimers(); } catch (e) { console.error('[changeHome] clearContextTimers:', e); }
   try { stopWebhookDoneObserver(); } catch (e) { console.error('[changeHome] stopWebhookDoneObserver:', e); }
@@ -3199,21 +3069,20 @@ ipcMain.handle('config:changeHome', async (_evt, payload: unknown) => {
 
   if (mode === 'move' && oldHome) {
     try {
-      // roster.json + its backups ride along with hive/palace: the roster is the
-      // renderer's half of the same state, and leaving it behind would move the
-      // agents' sessions and memory to the new home while their names, notes and
-      // worktree paths stayed at the old one.
+      // roster.json 及其备份随 hive/palace 一起走：roster 是同一状态的渲染器端一半，
+      // 把它留下就意味着把 agent 的会话和记忆移到新家，而它们的名字、备注和 worktree
+      // 路径仍留在旧家。
       for (const sub of ['hive', 'palace', 'roster.json', 'roster-backups']) {
         const src = join(oldHome, sub);
         if (!existsSync(src)) continue;
-        // cpSync copies the whole tree incl. .git and is cross-device safe (unlike
-        // renameSync, which throws EXDEV across volumes). We COPY, never delete —
-        // the old folder stays as a safety net the user removes manually.
+        // cpSync 会复制整棵树（含 .git），并且跨设备安全（不同于 renameSync——
+        // 跨卷时会抛 EXDEV）。我们只复制、绝不删除——旧文件夹保留下来，作为用户
+        // 手动移除的安全网。
         cpSync(src, join(newHome, sub), { recursive: true, force: true, dereference: false });
       }
     } catch (e) {
-      // Copy failed: recover IN PLACE against the unchanged old home (config never
-      // repointed) so the user loses nothing, and surface the error — no relaunch.
+      // 复制失败：针对未改变的旧 home 原地恢复（config 从未重新指向），让用户什么
+      // 都不损失，并把错误暴露出来——不重启。
       bootstrapHiveServices();
       const cfg = readConfig();
       if (cfg.slackEnabled && cfg.slackSigningSecret) void startSlackServer();
@@ -3222,17 +3091,17 @@ ipcMain.handle('config:changeHome', async (_evt, payload: unknown) => {
     }
   }
 
-  // Repoint config and relaunch so every service re-bootstraps against newHome.
-  // (Identical recovery path to resetAll — relaunch is the clean re-bind.)
+  // 重新指向 config 并重启，让每个服务都针对 newHome 重新引导。
+  // （与 resetAll 相同的恢复路径——重启就是干净的重新绑定。）
   allowQuit = true;
   writeConfig({ harnessHome: newHome });
   try { ptyManager.killAll(); } catch (e) { console.error('[changeHome] killAll:', e); }
   app.relaunch();
   app.exit(0);
-  return { ok: true as const }; // unreachable (process exits) — typed for the renderer
+  return { ok: true as const }; // 不可达（进程已退出）——仅为渲染器做类型标注
 });
 
-// ─── IPC: filesystem (sandboxed to a root) ──────────────────────────────────
+// ─── IPC: 文件系统（沙箱化到某个根）─────────────────────────────────────────
 ipcMain.handle('fs:listDir', (_evt, root: unknown, rel: unknown) => {
   if (typeof root !== 'string' || typeof rel !== 'string') return { ok: false, error: 'invalid args' };
   return listDir(root, rel);
@@ -3241,10 +3110,9 @@ ipcMain.handle('fs:readFile', (_evt, root: unknown, rel: unknown) => {
   if (typeof root !== 'string' || typeof rel !== 'string') return { ok: false, error: 'invalid args' };
   return readFileText(root, rel);
 });
-// Raw bytes for files the text reader refuses (images). The renderer cannot
-// load them off disk itself — the CSP has no `file:` source and no file
-// protocol is registered — so the bytes come through here and become a `blob:`
-// URL on the other side. Same root confinement as every other fs handler.
+// 文本读取器拒绝的文件（如图片）的原始字节。渲染器无法自行从磁盘加载它们——
+// CSP 没有 `file:` 源，也没有注册 file 协议——所以字节经这里流转，在另一端变成
+// `blob:` URL。与所有其他 fs handler 一样受同一根约束限制。
 ipcMain.handle('fs:readBinary', (_evt, root: unknown, rel: unknown) => {
   if (typeof root !== 'string' || typeof rel !== 'string') return { ok: false, error: 'invalid args' };
   return readFileBinary(root, rel);
@@ -3255,7 +3123,7 @@ ipcMain.handle('fs:writeFile', (_evt, root: unknown, rel: unknown, content: unkn
   }
   return writeFileText(root, rel, content);
 });
-// v0.3.4: existence check for the terminal ⌘-click markdown flow (metadata only).
+// v0.3.4: 终端 ⌘-点击 markdown 流程的存在性检查（仅元数据）。
 ipcMain.handle('fs:statAbs', (_evt, p: unknown) => {
   if (typeof p !== 'string' || p.length > 4096 || p.includes('\0')) {
     return { exists: false, isFile: false, path: '' };
@@ -3263,21 +3131,18 @@ ipcMain.handle('fs:statAbs', (_evt, p: unknown) => {
   return statAbs(p);
 });
 
-/** Reveal a path in the OS file browser — Finder, Explorer, or whatever the
- *  Linux desktop registers. Backs ⌘-click on a terminal path we cannot open
- *  ourselves (an image, an archive, an unknown extension).
+/** 在操作系统的文件浏览器中显示某个路径——Finder、Explorer 或 Linux 桌面注册的
+ *  任何程序。支撑在终端中对那些我们无法自行打开的路径（图片、压缩包、未知扩展名）
+ *  的 ⌘-点击。
  *
- *  `showItemInFolder`, NEVER `shell.openPath`, for a file. The path arrives
- *  from agent output, and openPath hands an arbitrary file to its default
- *  application: a printed `installer.dmg` or `.desktop` would be one click from
- *  executing. Revealing only ever opens a file browser, so the worst an agent
- *  can achieve by printing a path is a window at a folder the user could
- *  already open themselves.
+ *  对文件，用 `showItemInFolder`，绝不用 `shell.openPath`。路径来自 agent 输出，
+ *  openPath 会把任意文件交给它的默认应用：一段打印出来的 `installer.dmg` 或
+ *  `.desktop` 距执行只差一次点击。reveal 永远只会打开一个文件浏览器，所以 agent
+ *  打印路径所能造成的最大后果，也就是打开一个用户本来就能自己打开的文件夹窗口。
  *
- *  openPath IS used for a directory, and only after statAbs has confirmed it is
- *  one — a directory has no default application to launch, so the execution
- *  argument above does not apply, and revealing a folder inside its parent is
- *  not what "open this folder" means to anyone. */
+ *  openPath 只用于目录，而且仅在 statAbs 确认它是目录之后——目录没有可启动的
+ *  默认应用，所以上面的执行论证不适用；而且在父目录里 reveal 一个文件夹，也不是
+ *  「打开这个文件夹」对任何人而言的含义。 */
 ipcMain.handle('fs:revealPath', async (_evt, p: unknown) => {
   if (typeof p !== 'string' || !p.length || p.length > 4096 || p.includes('\0')) {
     return { ok: false, error: 'bad request' };
@@ -3295,8 +3160,8 @@ ipcMain.handle('git:isRepo', (_evt, cwd: unknown) => {
   return isRepo(cwd);
 });
 
-// The repo a cwd belongs to, following a linked worktree back to its main
-// checkout — the renderer groups the agent roster by this.
+// cwd 所属的仓库——沿链接的 worktree 回溯到它的主 checkout；渲染器据此对
+// agent roster 分组。
 ipcMain.handle('git:mainRepo', (_evt, cwd: unknown) => {
   if (typeof cwd !== 'string' || !cwd) return null;
   return mainRepoRoot(cwd);
@@ -3328,7 +3193,7 @@ ipcMain.handle('git:diff', (_evt, cwd: unknown, relPath: unknown) => {
   }
   return getDiff(cwd, relPath);
 });
-// ─── v0.3.4: history / compare / checkout (git visualization) ───────────────
+// ─── v0.3.4: 历史 / 对比 / checkout（git 可视化）────────────────────────────
 ipcMain.handle('git:logGraph', (_evt, cwd: unknown, n: unknown, skip: unknown) => {
   if (typeof cwd !== 'string') return { error: 'invalid args' };
   const count = Math.min(500, Math.max(1, typeof n === 'number' ? n : 200));
@@ -3357,11 +3222,10 @@ ipcMain.handle('git:worktrees', (_evt, cwd: unknown) => {
 });
 ipcMain.handle('git:checkout', async (_evt, cwd: unknown, ref: unknown, detach: unknown) => {
   if (typeof cwd !== 'string' || typeof ref !== 'string') return { ok: false, error: 'invalid args' };
-  // Guard: never swap files under an actively-working agent. Objective signal
-  // owned by main — any live pty whose cwd sits in this tree and emitted output
-  // in the last 10s is treated as mid-run. (Idle-but-open terminals are fine:
-  // checkoutRef additionally requires a clean tree, and TUIs redraw on fs
-  // changes gracefully.)
+  // 守卫：绝不在正在工作的 agent 下交换文件。客观信号由 main 持有——任何
+  // cwd 位于该目录树内、并且在最近 10 秒内输出过的存活 pty 都被视为运行中。
+  // （空闲但打开的终端没问题：checkoutRef 还要求工作树干净，TUI 会优雅地
+  // 重绘以响应文件系统变化。）
   const busy = ptyManager.list().find((p) =>
     (p.cwd === cwd || p.cwd.startsWith(cwd.endsWith('/') ? cwd : `${cwd}/`)) &&
     Date.now() - p.lastOutputAt < 10_000
@@ -3372,18 +3236,46 @@ ipcMain.handle('git:checkout', async (_evt, cwd: unknown, ref: unknown, detach: 
   return checkoutRef(cwd, ref, detach === true);
 });
 
-// ─── IPC: roster mirror (shared between dev and a packaged build) ───────────
-// The renderer's store is built synchronously at module load, before any async
-// IPC could resolve, so the read is `ipcMain.on` + `returnValue` — one blocking
-// round trip at boot, in exchange for the roster being correct on first paint
-// instead of flashing an empty floor and then filling in.
-// (`roster` itself is constructed earlier so HookServer can read standing goals.)
+// ─── IPC: roster mirror（开发版与打包构建共享）─────────────────────────
+// 渲染进程的 store 在模块加载时就同步构建，早于任何异步 IPC 解析，因此读取走
+// `ipcMain.on` + `returnValue`——启动时一次阻塞往返，换来的是首次绘制时 roster
+// 即为正确，而不是先闪烁一片空楼层再填上。
+// （`roster` 本身更早构建，HookServer 因此能读取常驻目标。）
+/**
+ * roster 名称跟随 registry。roster 由 RENDERER 写入
+ * （`persistAgents` -> 500ms 防抖 -> `roster:write`），渲染进程在自己的
+ * memory/localStorage 里保存显示名。一旦它们与 hive 身份（registry.json 是权威，
+ * 例如 god 侧改名为中文后）漂移，渲染进程的写入会把正确的名字悄悄覆盖回去。
+ * 所以在每次 `roster:write` 落盘前，我们都用 registry 重新盖印每条记录的 `name`
+ * ——渲染进程继续管理其余一切（role、status、order、queues、selectedId），
+ * 但 name 始终镜像 registry。
+ */
+function withRegistryNames(snap: unknown): unknown {
+  if (!snap || typeof snap !== 'object') return snap;
+  const s = snap as { agents?: unknown[]; archived?: unknown[]; restorable?: unknown[] };
+  const reg = hive.registry();
+  const fix = (list: unknown[] | undefined): unknown[] | undefined =>
+    Array.isArray(list)
+      ? list.map((a) => {
+          if (!a || typeof a !== 'object') return a;
+          const entry = a as { id?: unknown; name?: unknown };
+          if (typeof entry.id !== 'string') return a;
+          const regName = reg.agents?.[entry.id]?.name;
+          return regName ? { ...entry, name: regName } : a;
+        })
+      : list;
+  return { ...s, agents: fix(s.agents), archived: fix(s.archived), restorable: fix(s.restorable) };
+}
+
 ipcMain.on('roster:readSync', (evt) => { evt.returnValue = roster.read(); });
 ipcMain.on('config:homeSync', (evt) => { evt.returnValue = readConfig().harnessHome ?? null; });
 ipcMain.handle('roster:read', () => roster.read());
-ipcMain.handle('roster:write', (_evt, snap: unknown) => roster.write(snap));
+ipcMain.handle(
+  'roster:write',
+  (_evt, snap: unknown) => roster.write(withRegistryNames(snap)),
+);
 
-// ─── IPC: hive (multi-agent coordination) ───────────────────────────────────
+// ─── IPC: hive（多 agent 协调）───────────────────────────────────────
 ipcMain.handle('hive:registry', () => hive.registry());
 ipcMain.handle('hive:renameAgent', (_evt, id: unknown, name: unknown) => {
   if (typeof id !== 'string' || typeof name !== 'string') {
@@ -3402,9 +3294,9 @@ ipcMain.handle('hive:tasks', () => hive.tasks());
 ipcMain.handle('hive:log', (_evt, n: unknown) => hive.logTail(typeof n === 'number' ? n : 200));
 ipcMain.handle('hive:memory', (_evt, id: unknown) => (typeof id === 'string' ? hive.memory(id) : ''));
 ipcMain.handle('hive:inbox', (_evt, id: unknown) => (typeof id === 'string' ? hive.inbox(id) : []));
-// Voice read-layer: recent message CONTENT (inbox/outbox bodies), REDACTED
-// main-side by hive.voiceMessages(). The renderer/voice layer never sees a raw
-// body — secrets are stripped here, before the result crosses IPC.
+// 语音读取层：最近消息 CONTENT（inbox/outbox 正文），已在主进程侧由
+// hive.voiceMessages() 脱敏。渲染进程/语音层永远看不到原始正文——机密在结果
+// 跨过 IPC 之前就在这里被剥离。
 ipcMain.handle('hive:messages', (_evt, opts: unknown) =>
   hive.voiceMessages(opts && typeof opts === 'object' ? (opts as Parameters<typeof hive.voiceMessages>[0]) : {})
 );
@@ -3412,10 +3304,9 @@ ipcMain.handle('hive:send', (_evt, partial: Partial<HiveMessage>, from: unknown)
   if (!hive.enabled()) return { ok: false, error: 'hive disabled (no harnessHome)' };
   const sender = typeof from === 'string' ? from : 'system';
   const msg = hive.send(partial ?? {}, sender);
-  // Count only what a PERSON sent. Every renderer surface that dispatches on a
-  // human's behalf passes 'human' (Command Center dispatch, thread replies, ASK
-  // ME answers); agent-to-agent traffic passes the agent id and would swamp the
-  // number. Counted AFTER the send so a rejected message is never counted.
+  // 只统计 PERSON 发送的。每个以人类名义分发的渲染进程界面都传 'human'
+  // （Command Center 派发、线程回复、ASK ME 答复）；agent 间流量传的是 agent id，
+  // 会把数字淹没。在发送之后才统计，因此被拒绝的消息永远不会被计入。
   if (sender === 'human') analytics.trackMessageSent('hive');
   return { ok: true, message: msg };
 });
@@ -3452,15 +3343,15 @@ ipcMain.handle('hive:patchAgentRole', (_evt, id: unknown, role: unknown) => {
   return hive.patchAgentRole(id, role);
 });
 
-// ─── IPC: Settings hero payload (remote data, cached) ───────────────────────
-/** Plan copy and sponsor, fetched from the repo so they can change without a
- *  release. Validated in shared/heroPayload before it reaches the renderer. */
+// ─── IPC: Settings hero payload（远程数据，已缓存）─────────────────────────
+/** Plan 文案与 sponsor，从仓库获取，以便无需发版即可变更。在到达渲染进程前
+ *  于 shared/heroPayload 中校验。 */
 ipcMain.handle('hero:payload', async (_evt, force: unknown) =>
   loadHero(join(app.getPath('userData'), 'hero.json'), { force: force === true }));
 
-// ─── IPC: skills (installed locally, and the browsable catalog) ─────────────
-/** Skills the CLIs on this machine can already use. Scans the registered repos
- *  plus the agent's own cwd, so a project-scoped skill shows up where it applies. */
+// ─── IPC: skills（本地安装 + 可浏览的目录）────────────────────────────────
+/** 本机 CLI 已能使用的 skills。扫描已注册仓库外加 agent 自己的 cwd，因此
+ *  项目级 skill 会在其适用处出现。 */
 ipcMain.handle('skills:local', (_evt, cwd: unknown): LocalSkill[] => {
   const cfg = readConfig();
   const cwds = [
@@ -3474,34 +3365,34 @@ ipcMain.handle('skills:local', (_evt, cwd: unknown): LocalSkill[] => {
     return [];
   }
 });
-/** The skills catalog, parsed from its README and cached in userData.
- *  `force` is the explicit refresh button; everything else is served from a
- *  day-old cache so opening the tab never waits on the network. */
+/** skills 目录，从 README 解析并缓存在 userData。
+ *  `force` 是显式刷新按钮；其余都从一天前的缓存提供，打开标签页因此从不
+ *  等待网络。 */
 ipcMain.handle('skills:catalog', async (_evt, force: unknown) => {
   const cachePath = join(app.getPath('userData'), 'skill-catalog.json');
   return loadCatalog(cachePath, { force: force === true });
 });
 
-/** Install one catalog skill into ~/.claude/skills. Structured refusals, never a
- *  throw: the UI distinguishes "not installable" from "install failed". */
+/** 把一个目录 skill 安装进 ~/.claude/skills。结构化拒绝而非抛异常：
+ *  UI 得以区分「无法安装」与「安装失败」。 */
 ipcMain.handle('skills:install', async (_evt, url: unknown, name: unknown) => {
   if (typeof url !== 'string' || typeof name !== 'string') {
     return { ok: false as const, error: 'bad request' };
   }
   return installSkill(url, name);
 });
-/** Delete an installed skill. The guard rails live in uninstallSkill — it refuses
- *  any path it cannot prove is a skill folder inside a skills root. */
+/** 删除一个已安装的 skill。护栏在 uninstallSkill 里——它拒绝任何无法证明是
+ *  某个 skills 根目录内 skill 文件夹的路径。 */
 ipcMain.handle('skills:uninstall', (_evt, path: unknown) => {
   if (typeof path !== 'string') return { ok: false as const, error: 'bad request' };
   const cfg = readConfig();
   return uninstallSkill(path, { cwds: cfg.registeredRepos ?? [] });
 });
-/** Reveal a skill on disk. `openExternal` is deliberately https-only, so a
- *  file:// URL cannot (and should not) be smuggled through it. */
+/** 在磁盘上揭示一个 skill。`openExternal` 刻意只允许 https，因此 file:// URL
+ *  无法（也不应该）借它偷渡。 */
 ipcMain.handle('skills:reveal', (_evt, path: unknown) => {
   if (typeof path !== 'string' || !path.trim()) return { ok: false, error: 'bad request' };
-  const skillRoots = [join(homedir(), '.claude', 'skills'), join(homedir(), '.config', 'opencode')];
+  const skillRoots = [join(homedir(), '.claude', 'skills')];
   const target = resolve(path);
   const inRoot = skillRoots.some((r) => target.startsWith(resolve(r) + sep))
     || (readConfig().registeredRepos ?? []).some((c) => target.startsWith(resolve(c) + sep));
@@ -3510,20 +3401,18 @@ ipcMain.handle('skills:reveal', (_evt, path: unknown) => {
   return { ok: true };
 });
 
-// ─── IPC: setup catalog (which external tools are actually here) ────────────
+// ─── IPC: setup catalog（本机实际装了哪些外部工具）────────────────────────
 /**
- * Probe every catalog row against THIS machine.
+ * 针对本机探测目录中的每一行。
  *
- * Presence is a PATH resolution, not a spawn: running each candidate to read a
- * --version would be a dozen process launches on every panel open, and several of
- * these CLIs boot a TUI when invoked bare. `resolveCommand` returns its input
- * unchanged when it finds nothing, so "resolved to a real, existing path that is
- * not just the bare name" is the found test.
+ * 存在性是一次 PATH 解析，而非 spawn：为读 --version 而运行每个候选，等于每次
+ * 打开面板都要发起十几个进程启动，而且其中好几个 CLI 裸调用会启动 TUI。
+ * `resolveCommand` 找不到时原样返回输入，所以「解析到真实存在的路径、而不是
+ * 只有裸名字」就是找到的判据。
  *
- * mempalace is the one row that does NOT come from PATH: the memory subsystem
- * already resolves it (including uv/pip locations PATH may not carry for a
- * Finder-launched app) and knows whether the palace is initialised, so it is
- * authoritative and reused rather than re-probed differently here.
+ * mempalace 是唯一不来自 PATH 的行：memory 子系统已经解析过它（包括 PATH 对
+ * Finder 启动的应用可能不携带的 uv/pip 位置），并且知道 palace 是否已初始化，
+ * 因此这里以其为准直接复用，而不是用另一种方式重新探测。
  */
 ipcMain.handle('tools:status', (): ToolStatus[] => {
   const win = process.platform === 'win32';
@@ -3546,16 +3435,15 @@ ipcMain.handle('tools:status', (): ToolStatus[] => {
     try {
       const resolved = resolveCliCommand(spec.bin);
       if (resolved !== spec.bin && existsSync(resolved)) path = resolved;
-    } catch { /* a probe must never take the panel down */ }
+    } catch { /* 探测绝不能拖垮面板 */ }
     return { ...spec, installCommand, found: !!path, path };
   });
 });
 
-// ─── IPC: semantic memory (MemPalace CLI) ───────────────────────────────────
-// refresh() = resetBinCache + an idempotent start(). The poll is the one thing
-// that reliably notices mempalace being installed after boot, so it is what arms
-// the mine loop that boot's start() had to skip — otherwise the pill reads
-// "getting ready" until the app is restarted.
+// ─── IPC: semantic memory（MemPalace CLI）───────────────────────────────────
+// refresh() = resetBinCache + 幂等 start()。轮询是唯一能可靠察觉 mempalace
+// 在启动后被安装的机制，因此由它来武装 boot 的 start() 不得不跳过的 mine
+// 循环——否则那个状态点会一直显示 "getting ready" 直到应用重启。
 ipcMain.handle('hive:memoryStatus', () => memory.refresh());
 ipcMain.handle('hive:searchMemory', (_evt, query: unknown, wing: unknown) => {
   if (typeof query !== 'string' || !query.trim()) return { ok: false, output: '', error: 'empty query' };
@@ -3564,12 +3452,12 @@ ipcMain.handle('hive:searchMemory', (_evt, query: unknown, wing: unknown) => {
 ipcMain.handle('hive:memoryWakeUp', (_evt, wing: unknown) =>
   memory.wakeUp(typeof wing === 'string' ? wing : undefined));
 ipcMain.handle('hive:mineNow', () => { memory.mineNow(); return { ok: true }; });
-// Condense memory.md on demand: an explicit id condenses that one agent (skips
-// the size trigger — a "condense now" button); no id runs a full threshold scan.
+// 按需压缩 memory.md：显式 id 压缩那一个 agent（跳过大小触发——「立即压缩」
+// 按钮）；无 id 则运行完整阈值扫描。
 ipcMain.handle('memory:reflectNow', (_evt, id: unknown) =>
   reflector.reflectNow(typeof id === 'string' && id ? id : undefined));
 
-// ─── IPC: enterprise Knowledge Graph (multimodal context for agents) ─────────
+// ─── IPC: enterprise Knowledge Graph（面向 agent 的多模态上下文）────────────
 ipcMain.handle('kg:status', () => knowledge.status());
 ipcMain.handle('kg:list', () => knowledge.list());
 ipcMain.handle('kg:search', (_evt, query: unknown, limit: unknown) => {
@@ -3580,8 +3468,8 @@ ipcMain.handle('kg:get', (_evt, id: unknown) =>
   (typeof id === 'string' && id ? knowledge.get(id) : null));
 ipcMain.handle('kg:remove', (_evt, id: unknown) =>
   ({ ok: typeof id === 'string' && id ? knowledge.remove(id) : false }));
-// Ingest one or more files from disk. Best-effort per file; returns per-file
-// results so the UI can report partial success.
+// 从磁盘摄取一个或多个文件。逐文件尽力而为；返回逐文件结果，UI 因此能
+// 报告部分成功。
 ipcMain.handle('kg:ingestFiles', (_evt, payload: unknown) => {
   const p = (payload ?? {}) as { paths?: unknown; tags?: unknown };
   const paths = Array.isArray(p.paths) ? p.paths.filter((x): x is string => typeof x === 'string') : [];
@@ -3596,13 +3484,13 @@ ipcMain.handle('kg:ingestFiles', (_evt, payload: unknown) => {
   });
   return { results };
 });
-// Open a multi-file picker and ingest the chosen artifacts in one round-trip.
+// 打开一个多文件选择器，并在一次往返中摄取所选工件。
 ipcMain.handle('kg:addFiles', async (evt) => {
   const win = BrowserWindow.fromWebContents(evt.sender);
   if (!win) return { ok: false as const, error: 'no window' };
   const res = await dialog.showOpenDialog(win, {
     properties: ['openFile', 'multiSelections'],
-    title: 'Add documents to the Knowledge Graph'
+    title: l10n('Add documents to the Knowledge Graph', '向知识图谱添加文档')
   });
   if (res.canceled || res.filePaths.length === 0) return { ok: false as const, error: 'cancelled' };
   const results = res.filePaths.map((srcPath) => {
@@ -3616,28 +3504,26 @@ ipcMain.handle('kg:addFiles', async (evt) => {
   return { ok: true as const, results };
 });
 
-// ─── IPC: composer attachments (images + arbitrary files, attached by PATH) ──
-// The message queue pipes raw text into a Claude CLI PTY, so attachments travel
-// as a file PATH the agent reads with its Read tool (same convention as Slack).
-// Picker offers an Images group + All Files.
+// ─── IPC: composer 附件（图片 + 任意文件，按 PATH 附加）────────────────────
+// 消息队列把原始文本送进 Claude CLI PTY，因此附件以文件 PATH 随行，agent 用
+// 其 Read 工具读取（与 Slack 同约定）。选择器提供 Images 组 + All Files。
 ipcMain.handle('dialog:attachFiles', async (evt) => {
   const win = BrowserWindow.fromWebContents(evt.sender);
   if (!win) return { ok: false as const, error: 'no window' };
   const res = await dialog.showOpenDialog(win, {
     properties: ['openFile', 'multiSelections'],
-    title: 'Attach images or files',
+    title: l10n('Attach images or files', '附加图片或文件'),
     filters: [
-      { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg', 'heic', 'tiff', 'avif'] },
-      { name: 'All Files', extensions: ['*'] }
+      { name: l10n('Images', '图片'), extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg', 'heic', 'tiff', 'avif'] },
+      { name: l10n('All Files', '所有文件'), extensions: ['*'] }
     ]
   });
   if (res.canceled || res.filePaths.length === 0) return { ok: false as const, error: 'cancelled' };
   return { ok: true as const, files: res.filePaths.map((p) => ({ path: p, name: basename(p) })) };
 });
 
-// Persist the current native clipboard image to a temp PNG so a pasted
-// screenshot can be attached by PATH. Returns an error result when the
-// clipboard holds no image (e.g. a normal text paste).
+// 把当前系统剪贴板图片持久化为临时 PNG，让粘贴的截图可以按 PATH 附加。
+// 剪贴板没有图片时（例如普通文本粘贴）返回错误结果。
 ipcMain.handle('clipboard:saveImage', async () => {
   try {
     const img = clipboard.readImage();
@@ -3653,7 +3539,7 @@ ipcMain.handle('clipboard:saveImage', async () => {
   }
 });
 
-// ─── IPC: command history (SQLite — every prompt submitted to an agent) ──────
+// ─── IPC: command history（SQLite——提交给 agent 的每条提示）─────────────────
 ipcMain.handle('history:add', (_evt, payload: unknown) => {
   const p = (payload ?? {}) as { agentId?: unknown; cwd?: unknown; text?: unknown };
   if (typeof p.agentId !== 'string' || typeof p.text !== 'string') return { ok: false, error: 'invalid args' };
@@ -3670,13 +3556,13 @@ ipcMain.handle('history:list', (_evt, agentId: unknown, limit: unknown) =>
 ipcMain.handle('history:search', (_evt, query: unknown, limit: unknown) =>
   persist.searchHistory(typeof query === 'string' ? query : '', typeof limit === 'number' ? limit : undefined));
 
-// ─── IPC: quit confirmation ─────────────────────────────────────────────────
-/** Tear the harness down and quit. Shared by the hard "kill all & quit" path
- *  and the closing-time conclusion (after the god confirmed the floor saved). */
+// ─── IPC: 退出确认 ────────────────────────────────────────────────────────
+/** 拆除 harness 并退出。被硬「kill all & quit」路径与 closing-time 收尾
+ *  （god 确认楼层已保存之后）共用。 */
 function teardownAndQuit(): void {
   allowQuit = true;
-  // Each teardown step is best-effort: a throw here (e.g. a dying child or a
-  // half-torn-down socket) must never abort the quit or pop a crash dialog.
+  // 每个拆除步骤都是尽力而为：这里抛出的异常（例如垂死的子进程或拆到一半的
+  // socket）绝不能中止退出或弹出崩溃对话框。
   try { clearMissionTimers(); } catch (e) { console.error('[quit] clearMissionTimers:', e); }
   try { clearContextTimers(); } catch (e) { console.error('[quit] clearContextTimers:', e); }
   try { stopWebhookDoneObserver(); } catch (e) { console.error('[quit] stopWebhookDoneObserver:', e); }
@@ -3695,49 +3581,48 @@ function teardownAndQuit(): void {
   app.quit();
 }
 ipcMain.handle('app:confirmClose', () => {
-  closingTime.cancel(); // a hard quit overrides a closing time in progress
+  closingTime.cancel(); // 硬退出会覆盖正在进行的 closing time
   teardownAndQuit();
 });
 ipcMain.handle('app:cancelClose', () => {
-  // The modal closes on the renderer side. The one thing main owes anybody here
-  // is the truth about a restart-to-install: if this quit was one, it has just
-  // been called off, and whoever is waiting on it needs to hear that rather than
-  // sit disabled forever waiting for a process that is not going to die.
+  // 模态框在渲染进程侧关闭。main 在这里对任何人只欠一个真相：关于
+  // restart-to-install——如果这次退出就是其中的一次，它刚刚被取消，而等待它
+  // 的人需要听到这一点，而不是永远被禁用、傻等一个不会死掉的进程。
   abortPendingRestart();
 });
 
-// Open a new floor (independent office window). Gated by the multiWindow flag
-// inside openFloor(); returns whether a window opened so a renderer button can
-// reflect availability. The app-menu "New Floor" item calls openFloor() directly.
+// 打开一个新楼层（独立办公室窗口）。由 openFloor() 内的 multiWindow 标志
+// 门控；返回是否已打开窗口，渲染进程按钮据此反映可用性。应用菜单的
+// "New Floor" 项直接调用 openFloor()。
 ipcMain.handle('window:newFloor', () => {
   const win = openFloor();
   return { ok: win != null };
 });
 
-// ─── IPC: closing time (graceful, data-loss-free shutdown) ──────────────────
-// The third quit-dialog button. The god broadcasts closing time, every worker
-// saves its memory and ACKs, the god concludes with CLOSING-TIME-COMPLETE —
-// only then does the harness tear down. See closingTime.ts for the protocol.
+// ─── IPC: closing time（优雅、不丢数据的关机）───────────────────────────────
+// 第三个退出对话框按钮。god 广播 closing time，每个 worker 保存记忆并 ACK，
+// god 以 CLOSING-TIME-COMPLETE 收尾——只有到那时 harness 才拆除。协议见
+// closingTime.ts。
 const closingTime = new ClosingTimeController(
   hive,
-  // Roster source: agents with a live PTY right now (ptyToAgent is pruned on
-  // every teardown). The registry alone would include ghost workers from
-  // sessions that ended with a hard quit — never archived, never able to ACK.
+  // roster 来源：此刻持有存活 PTY 的 agent（ptyToAgent 在每次拆除时清理）。
+  // 单看 registry 会把硬退出结束的会话里那些 ghost worker 也算进来——它们
+  // 从未被归档，也永远无法 ACK。
   () => [...new Set(ptyToAgent.values())],
   () => liveWebContents(),
   () => teardownAndQuit(),
-  // #7C.2 steering — the graceful interrupt that reaches deeply busy agents
-  // at their next hook boundary instead of waiting for a Stop.
+  // #7C.2 steering——那种能在深度忙碌的 agent 到达下一个 hook 边界时触达它、
+  // 而不是等一个 Stop 的优雅中断。
   control
 );
 hive.setRoutedObserver((msg, targets) => closingTime.onRouted(msg, targets));
 ipcMain.handle('app:startClosingTime', () => closingTime.start());
 ipcMain.handle('app:cancelClosingTime', () => closingTime.cancel());
 
-// ─── IPC: full reset (wipe data + config, relaunch into onboarding) ──────────
+// ─── IPC: full reset（清除数据 + 配置，重启进入 onboarding）───────────────
 ipcMain.handle('app:resetAll', () => {
   allowQuit = true;
-  // Tear everything down first so nothing writes back into the dirs we wipe.
+  // 先拆除一切，这样就不会有任何东西写回我们要清空的目录。
   try { clearMissionTimers(); } catch (e) { console.error('[reset] clearMissionTimers:', e); }
   try { clearContextTimers(); } catch (e) { console.error('[reset] clearContextTimers:', e); }
   try { stopWebhookDoneObserver(); } catch (e) { console.error('[reset] stopWebhookDoneObserver:', e); }
@@ -3752,37 +3637,35 @@ ipcMain.handle('app:resetAll', () => {
   try { persist.close(); } catch (e) { console.error('[reset] persist.close:', e); }
   try { ptyManager.killAll(); } catch (e) { console.error('[reset] killAll:', e); }
   try { hive.removeExposedCodexData(); } catch (e) { console.error('[reset] removeExposedCodexData:', e); }
-  // Erase the hive (Michael's + every agent's memory, inboxes, tasks, board,
-  // git history) and the semantic-memory palace. Only these harness-created
-  // subdirs are removed — never the user's whole harnessHome folder.
+  // 抹除 hive（Michael 与每个 agent 的 memory、inbox、tasks、board、git 历史）
+  // 以及语义记忆 palace。只移除这些由 harness 创建的子目录——绝不动用户整个
+  // harnessHome 文件夹。
   for (const dir of [hive.root(), memory.palacePath()]) {
     if (!dir) continue;
     try { rmSync(dir, { recursive: true, force: true }); }
     catch (e) { console.error('[reset] rm', dir, e); }
   }
-  // The roster is the renderer's half of the same state, so it retires with the
-  // hive — archived into roster-backups/ rather than deleted, and cleared as the
-  // active file so re-selecting this folder later doesn't resurrect agents whose
-  // sessions and memory are gone.
+  // roster 是同一状态的渲染进程半边，因此它随 hive 一起退役——归档到
+  // roster-backups/ 而不是删除，并清空为活动文件，这样之后重新选择该文件夹
+  // 不会复活那些会话与记忆都已消失的 agent。
   try { roster.archive(); }
   catch (e) { console.error('[reset] roster.archive:', e); }
-  // Back to first-run defaults, then relaunch clean so all in-memory services
-  // re-bootstrap from scratch and the renderer lands on onboarding.
+  // 回到首次运行默认值，然后干净地重启，让所有内存中的服务从零重新引导，
+  // 渲染进程落到 onboarding。
   resetConfig();
   app.relaunch();
   app.exit(0);
 });
 
-// ─── IPC: token telemetry (real usage + est. cost from CC transcripts) ───────
-// Reconciler/fallback path: per-cwd transcript sum, now priced PER MODEL (cost
-// bug #1 fixed in pricing.ts). Kept for back-compat with the existing UsageRow.
+// ─── IPC: token telemetry（CC transcript 的真实用量 + 估算成本）─────────────
+// Reconciler/fallback 路径：按 cwd 汇总 transcript，现在按 MODEL 计价（cost
+// bug #1 已在 pricing.ts 修复）。为与既有 UsageRow 向后兼容而保留。
 ipcMain.handle('hive:agentUsage', (_evt, cwd: unknown) =>
   typeof cwd === 'string' ? readAgentUsage(cwd) : null);
-// Current context size (tokens) of an agent's LIVE session — the transcript
-// path is learned from the agent's hook payloads (SessionStart fires right at
-// spawn), so this works even when several agents share one cwd. Null until the
-// first hook fires; a known-but-empty transcript reads as 0 so a freshly
-// (re)started session zeroes the gauge instead of leaving a stale value up.
+// agent LIVE 会话的当前上下文大小（tokens）——transcript 路径从 agent 的
+// hook 负载习得（SessionStart 在 spawn 时立即触发），因此即使几个 agent 共享
+// 同一个 cwd 也能工作。首个 hook 触发前为 null；已知但为空的 transcript 读作
+// 0，因此新（重）启动的会话会把仪表清零，而不是留一个过期值在上面。
 ipcMain.handle('hive:agentContext', (_evt, agentId: unknown) => {
   if (typeof agentId !== 'string') return null;
   const tp = hookServer.transcriptPath(agentId);
@@ -3790,15 +3673,15 @@ ipcMain.handle('hive:agentContext', (_evt, agentId: unknown) => {
   return readContextTokens(tp) ?? 0;
 });
 
-// A consolidated, NON-SENSITIVE per-agent directory for the voice read-layer
-// (Realtime Michael's get_agent_detail / list_agents). One read that joins
-// everything the office-floor sidebar + telemetry know per agent: the registry
-// record (name/role/provider/cwd/status/archived/isGod/isAssistant/sessionId/
-// cwdValid), live token + breaker + last-tool telemetry, and the current context
-// window fill. Includes ARCHIVED agents (unlike the heartbeat's fleet.json, which
-// is live-only) so Michael can speak to inactive agents — their cwd and memory
-// stay reachable. PII-free: no secrets, env, or API keys ever leave main; cost is
-// carried as tokens (+ a usd field the voice layer deliberately never speaks).
+// 一个合并的、NON-SENSITIVE 的按-agent 目录，供语音读取层使用
+// （Realtime Michael 的 get_agent_detail / list_agents）。一次读取即联接
+// 办公室侧栏 + telemetry 对每个 agent 所知的一切：registry 记录
+// （name/role/provider/cwd/status/archived/isGod/isAssistant/sessionId/
+// cwdValid）、实时 token + breaker + 最近工具 telemetry，以及当前上下文窗口
+// 占用。包含 ARCHIVED agent（不同于 heartbeat 的 fleet.json——它只含存活），
+// 因此 Michael 能对不活跃 agent 讲话——它们的 cwd 与记忆保持可达。无 PII：
+// 机密、env、API keys 不会离开 main；成本以 tokens 承载（外加一个语音层刻意
+// 从不提及的 usd 字段）。
 ipcMain.handle('hive:agentDirectory', () => {
   if (!hive.enabled()) return { godId: null, agents: [] };
   const reg = hive.registry();
@@ -3838,27 +3721,27 @@ ipcMain.handle('hive:agentDirectory', () => {
   return { godId: reg.godId, agents };
 });
 
-// ─── IPC: live telemetry (the OTel collector — the locked usage-provider seam) ─
-// The fleet grid + span waterfall (#7B) read these; Lane A's breaker (#6)
-// consumes getAgentUsage in-process via the provider, not over IPC.
+// ─── IPC: live telemetry（OTel collector——被锁定的 usage-provider 接缝）────
+// fleet 网格 + span waterfall（#7B）读取这些；Lane A 的 breaker（#6）经 provider
+// 在进程内消费 getAgentUsage，而非走 IPC。
 ipcMain.handle('telemetry:usage', (_evt, agentId: unknown) =>
   typeof agentId === 'string' ? telemetry.getAgentUsage(agentId) : null);
 ipcMain.handle('telemetry:spans', (_evt, agentId: unknown) =>
   typeof agentId === 'string' ? telemetry.getSpans(agentId) : []);
 ipcMain.handle('telemetry:snapshot', () => telemetry.snapshot());
 
-// ─── IPC: circuit-breaker state (Lane A #6 policy → this lane's avatars/meter) ─
-// Lane A's breaker calls this with a BreakerState; we fan it out to the renderer
-// on `control:breakerState`, where the avatar adapter gives it precedence over
-// hook-derived status (#5C looping/zombie). Defined here so the channel exists
-// before Jim's policy lands; he produces, this lane consumes.
+// ─── IPC: circuit-breaker state（Lane A #6 策略 → 本 lane 的 avatars/meter）──
+// Lane A 的 breaker 以 BreakerState 调用它；我们在 `control:breakerState` 上
+// 扇出给渲染进程，avatar 适配器在那里让它优先于 hook 派生的状态
+// （#5C looping/zombie）。在此定义是为了让通道在 Jim 的策略落地之前就存在；
+// 他生产，本 lane 消费。
 ipcMain.handle('control:setBreakerState', (_evt, state: unknown) => {
-  try { liveWebContents()?.send('control:breakerState', state); } catch { /* window tore down */ }
+  try { liveWebContents()?.send('control:breakerState', state); } catch { /* 窗口已拆除 */ }
   return { ok: true };
 });
 
-// ─── IPC: operator control over agents (#7C.1–7C.3) ─────────────────────────
-// All return the agent's fresh control snapshot so the UI can reflect state.
+// ─── IPC: operator control over agents（#7C.1–7C.3）─────────────────────────
+// 全部返回 agent 最新的 control 快照，UI 因此能反映状态。
 ipcMain.handle('control:pause', (_evt, agentId: unknown, on: unknown) => {
   if (typeof agentId !== 'string') return null;
   control.pause(agentId, on === true);
@@ -3886,9 +3769,9 @@ ipcMain.handle('control:gateTool', (_evt, agentId: unknown, tool: unknown, on: u
 ipcMain.handle('control:steer', (_evt, agentId: unknown, text: unknown) => {
   if (typeof agentId !== 'string' || typeof text !== 'string') return null;
   control.steer(agentId, text);
-  // A steer typed into the control strip is a human message. Counted HERE, at
-  // the IPC seam, and deliberately not inside control.steer(): closingTime and
-  // the voice action layer call that directly, and neither is a person typing.
+  // 在控制条里输入的一条 steer 是人类消息。在这里、IPC 接缝处统计，刻意不放在
+  // control.steer() 内部：closingTime 与语音动作层直接调用它，而两者都不是人
+  // 在打字。
   analytics.trackMessageSent('steer');
   return control.snapshot(agentId);
 });
@@ -3900,13 +3783,12 @@ ipcMain.handle('control:halt', (_evt, agentId: unknown) => {
 ipcMain.handle('control:snapshot', (_evt, agentId: unknown) =>
   typeof agentId === 'string' ? control.snapshot(agentId) : null);
 
-// ─── IPC: scheduled missions (recurring auto-dispatch) ──────────────────────
+// ─── IPC: scheduled missions（周期性自动派发）────────────────────────
 ipcMain.handle('missions:list', () => readConfig().missions ?? []);
 ipcMain.handle('missions:save', (_evt, missions) => {
-  // lastFiredAt is scheduler-owned. The renderer loads missions once and later
-  // sends back a STALE array, so a wholesale write would clobber every
-  // lastFiredAt the scheduler has stamped since. Merge by id and keep the newer
-  // lastFiredAt (almost always the persisted one) so the UI can never erase it.
+  // lastFiredAt 归调度器所有。渲染进程只加载一次 missions，之后发回的是过期的
+  // 数组，因此整体写入会抹掉调度器此后打上的每一个 lastFiredAt。按 id 合并并
+  // 保留较新的 lastFiredAt（几乎总是已持久化的那个），UI 因此永远无法擦掉它。
   const incoming = (Array.isArray(missions) ? missions : []) as ScheduledMission[];
   const persistedById = new Map(
     (readConfig().missions ?? []).map((m) => [m.id, m] as const)
@@ -3921,14 +3803,14 @@ ipcMain.handle('missions:save', (_evt, missions) => {
   return { ok: true };
 });
 
-// ─── IPC: full-text search across hive files (board, tasks, memory) ──────────
+// ─── IPC: 跨 hive 文件全文搜索（board、tasks、memory）──────────────────────
 ipcMain.handle('hive:textSearch', (_evt, query: unknown) => {
   if (typeof query !== 'string' || !query.trim()) return { ok: false, results: [] };
   const root = hive.root();
   if (!root) return { ok: false, results: [] };
   const q = query.toLowerCase();
   const results: Array<{ source: string; excerpt: string }> = [];
-  // Each target file is (path, readable label). agents/<id>/memory.md is expanded below.
+  // 每个目标文件是（path, 可读标签）。agents/<id>/memory.md 在下方展开。
   const targets: Array<{ path: string; source: string }> = [
     { path: join(root, 'board.md'), source: 'board.md' },
     { path: join(root, 'tasks.json'), source: 'tasks.json' }
@@ -3946,7 +3828,7 @@ ipcMain.handle('hive:textSearch', (_evt, query: unknown) => {
       if (hits >= 3) break;
       const idx = line.toLowerCase().indexOf(q);
       if (idx === -1) continue;
-      // ~40 chars of context on either side of the match.
+      // 匹配处两侧各约 40 个字符的上下文。
       const excerpt = line.slice(Math.max(0, idx - 40), idx + q.length + 40).trim();
       results.push({ source, excerpt });
       hits++;
@@ -3955,23 +3837,23 @@ ipcMain.handle('hive:textSearch', (_evt, query: unknown) => {
   return { ok: true, results };
 });
 
-// ─── IPC: GitHub issue ingestion (gh CLI) ────────────────────────────────────
+// ─── IPC: GitHub issue 摄取（gh CLI）───────────────────────────────────
 ipcMain.handle('github:issues', (_evt, cwd: unknown) =>
   typeof cwd === 'string' ? listIssues(cwd) : { ok: false, error: 'no cwd' }
 );
 
-// ─── IPC: GitHub CI status watcher (gh CLI) ──────────────────────────────────
+// ─── IPC: GitHub CI 状态监听（gh CLI）─────────────────────────────────
 ipcMain.handle('github:ciRuns', (_evt, cwd: unknown) =>
   typeof cwd === 'string' ? listCIRuns(cwd) : { ok: false, error: 'no cwd' }
 );
 
-// ─── IPC: desktop notifications toggle ──────────────────────────────────────
+// ─── IPC: 桌面通知开关 ─────────────────────────────────────────────────
 ipcMain.handle('app:setNotifications', (_evt, val) => writeConfig({ notifications: val === true }));
 
-// ─── IPC: onboarding reliability — open Settings deep-link + login-item toggle ─
-/** Open a System Settings deep-link (or https URL) in the OS default handler.
- *  Restricted to Settings panes / https so the renderer can't shell arbitrary
- *  schemes. Used by the onboarding "Permissions & reliability" step. */
+// ─── IPC: onboarding 可靠性——打开 Settings 深链 + login-item 切换 ──────────
+/** 在系统默认处理器中打开一个 System Settings 深链（或 https URL）。
+ *  限定 Settings 面板 / https，渲染进程因此无法执行任意 scheme。用于 onboarding
+ *  的「Permissions & reliability」步骤。 */
 ipcMain.handle('app:openExternal', async (_evt, url: unknown) => {
   if (typeof url !== 'string' || !/^(x-apple\.systempreferences:|https:\/\/)/.test(url)) {
     return { ok: false, error: 'blocked url' };
@@ -3979,41 +3861,39 @@ ipcMain.handle('app:openExternal', async (_evt, url: unknown) => {
   await shell.openExternal(url);
   return { ok: true };
 });
-/** Toggle macOS "Open at Login" — fully programmatic, no permission prompt.
- *  Returns the resulting state so the renderer toggle reflects reality. */
+/** 切换 macOS「Open at Login」——完全编程式，无权限提示。
+ *  返回结果状态，渲染进程开关因此反映现实。 */
 ipcMain.handle('app:setLoginItem', (_evt, enabled: unknown) => {
   app.setLoginItemSettings({ openAtLogin: enabled === true });
   return app.getLoginItemSettings().openAtLogin;
 });
 
-// ─── IPC: Slack integration ─────────────────────────────────────────────────
+// ─── IPC: Slack 集成 ───────────────────────────────────────────────────────
 ipcMain.handle('slack:start', () => startSlackServer());
 ipcMain.handle('slack:stop', () => { stopSlackServer(); return { ok: true }; });
-/** Current connection state + last Request URL — lets Settings hydrate the
- *  "Connected" badge and re-show the persisted tunnel URL on reopen. */
+/** 当前连接状态 + 最近一次 Request URL——让 Settings 填充「Connected」徽章，
+ *  并在重开时重新显示持久化的隧道 URL。 */
 ipcMain.handle('slack:status', () => ({ running: slackServer != null, url: lastSlackUrl }));
-/** Absolute path to the bundled reply helper, for the prompt the office worker
- *  runs to post its summary back in-thread. No secret crosses this boundary. */
+/** 捆绑的回复助手的绝对路径，供办公室 worker 运行以把摘要发回线程内。
+ *  没有机密跨越此边界。 */
 ipcMain.handle('slack:replyScriptPath', () => slackReplyScriptPath());
-/** Renderer's immediate "queued" ack into the triggering Slack thread. The bot
- *  token stays in main — only channel/thread/text cross IPC. */
+/** 渲染进程立即发回触发线程的「queued」确认。机器人 token 留在 main——
+ *  只有 channel/thread/text 跨过 IPC。 */
 ipcMain.handle('slack:reply', (_evt, arg: unknown) => {
   const p = (arg ?? {}) as { channel?: unknown; thread_ts?: unknown; text?: unknown };
   const cfg = readConfig();
-  // CLAUSE-3 (human: "stop posting into Slack by default"): this is the ONLY
-  // app/voice-INITIATED proactive Slack post (the renderer's "queued" ack). It is
-  // OFF unless the user opts in via Settings → Slack. The Slack-ORIGIN done-reply
-  // round-trip (done-poller) and an agent's own direct /reply are NOT routed
-  // through here, so they are unaffected and always stay on.
+  // CLAUSE-3（人类：「默认不要往 Slack 发帖」）：这是唯一的 app/voice 主动发起的
+  // Slack 帖子（渲染进程的「queued」确认）。除非用户在 Settings → Slack 里选择
+  // 开启，否则保持关闭。Slack 来源的 done-reply 往返（done-poller）以及 agent
+  // 自己的直接 /reply 不经过这里，因此它们不受影响、始终开启。
   if (!cfg.slackProactivePosting) return { ok: false, error: 'app-initiated Slack posting disabled (enable in Settings → Slack)' };
   const botToken = cfg.slackBotToken;
   if (!botToken) return { ok: false, error: 'no bot token' };
   if (typeof p.channel !== 'string' || typeof p.thread_ts !== 'string' || typeof p.text !== 'string') {
     return { ok: false, error: 'channel, thread_ts, text required' };
   }
-  // CLAUSE-1 (fix-slack-integration): an app-initiated send must target an
-  // EXPLICIT thread — reject a blank/whitespace channel or thread rather than
-  // letting it fall through to an implicit destination (the channel root).
+  // CLAUSE-1（fix-slack-integration）：app 发起的发送必须指向显式线程——拒绝
+  // 空白/纯空白的 channel 或 thread，而不是让它落到隐式目标（channel 根）。
   if (!p.channel.trim() || !p.thread_ts.trim()) {
     return { ok: false, error: 'explicit channel + thread_ts required' };
   }
@@ -4025,7 +3905,7 @@ ipcMain.handle('slack:setConfig', (_evt, patch: unknown) => {
     proactivePosting?: unknown;
   };
   const next: Partial<HarnessConfig> = {};
-  // Trim string fields; an emptied field clears back to undefined.
+  // 裁剪字符串字段；被清空的字段回到 undefined。
   if (typeof p.signingSecret === 'string') next.slackSigningSecret = p.signingSecret.trim() || undefined;
   if (typeof p.botToken === 'string') next.slackBotToken = p.botToken.trim() || undefined;
   if (typeof p.channelId === 'string') next.slackChannelId = p.channelId.trim() || undefined;
@@ -4033,15 +3913,14 @@ ipcMain.handle('slack:setConfig', (_evt, patch: unknown) => {
   if (typeof p.enabled === 'boolean') next.slackEnabled = p.enabled;
   if (typeof p.proactivePosting === 'boolean') next.slackProactivePosting = p.proactivePosting;
   writeConfig(next);
-  // Reconcile the running server: disabling (or clearing the secret) stops it. We
-  // deliberately do NOT auto-(re)start here — the user presses Start in Settings
-  // to fetch the fresh (ephemeral) tunnel URL.
+  // 协调运行中的服务器：禁用（或清空 secret）会停止它。此处刻意不自动（重新）
+  // 启动——用户在 Settings 里按 Start 以获取全新的（临时）隧道 URL。
   const cfg = readConfig();
   if (!cfg.slackEnabled || !cfg.slackSigningSecret) stopSlackServer();
   return { ok: true };
 });
 
-// ─── IPC: Triggers — context (auto-compact / auto-clear) ────────────────────
+// ─── IPC: Triggers——context（auto-compact / auto-clear）─────────────────────
 ipcMain.handle('triggers:getContext', () => readConfig().contextTrigger ?? DEFAULT_CONTEXT_TRIGGER);
 ipcMain.handle('triggers:setContext', (_evt, arg: unknown) => {
   const current = readConfig().contextTrigger ?? DEFAULT_CONTEXT_TRIGGER;
@@ -4051,16 +3930,15 @@ ipcMain.handle('triggers:setContext', (_evt, arg: unknown) => {
     clear: sanitizeContextRule(p.clear, current.clear)
   };
   writeConfig({ contextTrigger: next });
-  // The timers ARE the setting — a cadence saved but not re-armed would keep
-  // firing on the old rhythm until the next boot.
+  // 定时器本身就是设置——保存了节奏却没有重新武装，就会一直按旧节奏触发
+  // 直到下次启动。
   syncContextTriggers();
   return next;
 });
 
-/** Clamp one half of the context trigger. The renderer is not trusted with the
- *  arming maths: a zero/negative/NaN `everyMs` would arm a runaway timer, and an
- *  out-of-range percentage would silently disable (or permanently trip) the
- *  pressure gate. */
+/** 钳制 context trigger 的一半。渲染进程不得参与武装计算：零/负/NaN 的
+ *  `everyMs` 会武装一个失控的定时器，而越界的百分比会静默禁用（或永久触发）
+ *  压力闸门。 */
 function sanitizeContextRule(patch: Partial<ContextRule> | undefined, current: ContextRule): ContextRule {
   const p = (patch ?? {}) as Partial<ContextRule>;
   const num = (v: unknown, fallback: number, min: number, max: number): number =>
@@ -4074,7 +3952,7 @@ function sanitizeContextRule(patch: Partial<ContextRule> | undefined, current: C
   };
 }
 
-// ─── IPC: Triggers — webhooks (many endpoints, one server, one tunnel) ──────
+// ─── IPC: Triggers——webhooks（多端点、单服务器、单隧道）────────────────────
 ipcMain.handle('webhooks:list', () => readConfig().webhookTriggers ?? []);
 ipcMain.handle('webhooks:save', (_evt, arg: unknown) => {
   const incoming = Array.isArray(arg) ? arg : [];
@@ -4083,7 +3961,7 @@ ipcMain.handle('webhooks:save', (_evt, arg: unknown) => {
   const seen = new Set<string>();
   for (const raw of incoming) {
     const t = sanitizeWebhookTrigger(raw, existing);
-    if (!t || seen.has(t.id)) continue; // an id is a URL path segment — one owner each
+    if (!t || seen.has(t.id)) continue; // id 是 URL 路径段——每个 id 只有一个所有者
     seen.add(t.id);
     list.push(t);
   }
@@ -4095,32 +3973,31 @@ ipcMain.handle('webhooks:delete', (_evt, arg: unknown) => {
   const id = typeof arg === 'string' ? arg : '';
   const list = (readConfig().webhookTriggers ?? []).filter((t) => t.id !== id);
   writeConfig({ webhookTriggers: list });
-  // Revoking one endpoint must not disturb the others: the live server is
-  // re-pointed, not restarted, so every remaining caller's URL keeps working.
+  // 撤销一个端点不得打扰其他端点：在线服务器被重新指向而非重启，因此其余
+  // 调用方的 URL 继续工作。
   reconcileWebhookServer();
   return list;
 });
-/** Mint a strong (256-bit) secret for the operator to paste into their caller.
- *  Not persisted here — it belongs to whichever endpoint the UI saves it onto. */
+/** 为操作者铸一枚强（256 位）secret，供其粘贴进调用方。
+ *  此处不持久化——它属于 UI 保存到的那个端点。 */
 ipcMain.handle('webhooks:generateSecret', () => randomBytes(32).toString('hex'));
-/** Server state + the tunnel root + one public URL per configured endpoint (the
- *  UI offers a copy button per webhook, so the root alone isn't enough). */
+/** 服务器状态 + 隧道根 + 每个已配置端点一个公开 URL（UI 对每个 webhook
+ *  提供复制按钮，因此单有根不够）。 */
 ipcMain.handle('webhooks:status', () => ({
   running: webhookServer != null,
   url: lastWebhookUrl,
   endpoints: webhookEndpointUrls()
 }));
 
-/** Normalise one endpoint coming back from the renderer. Unknown/blank fields
- *  fall back to what is already persisted, so a UI that round-trips a partially
- *  filled row can never blank a live secret or silently widen a mode. */
+/** 规范化一个从渲染进程回来的端点。未知/空字段回退到已持久化的值，因此
+ *  往返部分填充行的 UI 永远无法清空一个活的 secret 或静默放宽某种模式。 */
 function sanitizeWebhookTrigger(raw: unknown, existing: WebhookTrigger[]): WebhookTrigger | null {
   if (!raw || typeof raw !== 'object') return null;
   const r = raw as Partial<WebhookTrigger>;
   const id = typeof r.id === 'string' ? r.id.trim() : '';
-  // The id is spliced into a public URL path. Restrict it to a boring charset
-  // rather than escaping later: no slashes (which would forge a nested route),
-  // no encoded traversal, nothing that could make two endpoints alias.
+  // 该 id 会被拼进一个公开 URL 路径。限制为朴素的字符集，而不是事后转义：
+  // 无斜杠（会伪造嵌套路由）、无编码穿越、没有任何能让两个端点互为别名的
+  // 内容。
   if (!/^[A-Za-z0-9._-]{1,64}$/.test(id)) return null;
   const prior = existing.find((t) => t.id === id);
   const secret = typeof r.secret === 'string' && r.secret.trim() ? r.secret.trim() : prior?.secret ?? '';
@@ -4129,7 +4006,7 @@ function sanitizeWebhookTrigger(raw: unknown, existing: WebhookTrigger[]): Webho
     id,
     name: typeof r.name === 'string' && r.name.trim() ? r.name.trim() : prior?.name ?? id,
     secret,
-    // A secretless endpoint can never be enabled — it would be an open door.
+    // 没有 secret 的端点永远无法启用——那会是一扇敞开的大门。
     enabled: secret ? (typeof r.enabled === 'boolean' ? r.enabled : prior?.enabled ?? false) : false,
     mode,
     schema: typeof r.schema === 'string' && r.schema.trim() ? r.schema : prior?.schema ?? DEFAULT_WEBHOOK_SCHEMA,
@@ -4141,14 +4018,13 @@ function isTriggerMode(v: unknown): v is TriggerMode {
   return v === 'strict' || v === 'allow-all' || v === 'communication-only';
 }
 
-// ─── IPC: Triggers — organisation (persistence only; no transport yet) ──────
+// ─── IPC: Triggers——organisation（仅持久化；尚无传输）──────────────────────
 ipcMain.handle('org:getTrigger', () => readConfig().orgTrigger ?? DEFAULT_ORG_TRIGGER);
 ipcMain.handle('org:setTrigger', (_evt, arg: unknown) => {
   const current = readConfig().orgTrigger ?? DEFAULT_ORG_TRIGGER;
   const p = (arg ?? {}) as Partial<OrgTriggerConfig>;
-  // PERSIST ONLY — the peer messaging service does not exist yet, so nothing
-  // reads `apiKey` beyond the settings surface that shows it. Deliberately no
-  // start/stop, no network, no side effect of any kind.
+  // 仅持久化——对等消息服务还不存在，因此除了显示它的设置界面外，没有人
+  // 读取 `apiKey`。刻意没有 start/stop、没有网络、没有任何副作用。
   const next: OrgTriggerConfig = {
     apiKey: typeof p.apiKey === 'string' ? p.apiKey.trim() : current.apiKey,
     enabled: typeof p.enabled === 'boolean' ? p.enabled : current.enabled,
@@ -4158,7 +4034,7 @@ ipcMain.handle('org:setTrigger', (_evt, arg: unknown) => {
   return next;
 });
 
-// ─── IPC: Triggers — history ledger + the approval gate ─────────────────────
+// ─── IPC: Triggers——history ledger + approval gate───────────────────────────
 ipcMain.handle('triggerHistory:list', () => listTriggerHistory());
 ipcMain.handle('triggerHistory:clear', (_evt, arg: unknown) => {
   const source = arg === 'webhook' || arg === 'org' ? arg : undefined;
@@ -4168,15 +4044,13 @@ ipcMain.handle('triggerHistory:clear', (_evt, arg: unknown) => {
   return { ok: true };
 });
 /**
- * The operator's verdict on a held message.
+ * 操作者对一个被扣住消息的裁决。
  *
- * 'approved' RELEASES it: it takes the identical path an auto-allowed message
- * would have taken (card + god request), then the entry flips. 'rejected' just
- * flips — nothing is ever dispatched.
+ * 'approved' 释放它：它走一条自动放行消息本会走的完全相同的路径（card + god
+ * request），然后条目翻转。'rejected' 只是翻转——什么都不会被派发。
  *
- * Idempotent by construction: only an entry still sitting at `pending` can be
- * decided, so a double-click (or two windows deciding at once) cannot dispatch
- * the same message twice.
+ * 构造上幂等：只有仍停在 `pending` 的条目可以被裁决，因此双击（或两个窗口
+ * 同时裁决）无法把同一条消息派发两次。
  */
 ipcMain.handle('triggerHistory:decide', (_evt, arg: unknown) => {
   const p = (arg ?? {}) as { id?: unknown; decision?: unknown };
@@ -4185,7 +4059,7 @@ ipcMain.handle('triggerHistory:decide', (_evt, arg: unknown) => {
   if (!id || !decision) return null;
   const entry: TriggerHistoryEntry | undefined = listTriggerHistory().find((e) => e.id === id);
   if (!entry) return null;
-  if (entry.decision !== 'pending') return entry; // already decided → no-op, not a re-dispatch
+  if (entry.decision !== 'pending') return entry; // 已裁决 → 空操作，而非重新派发
 
   if (decision === 'rejected') {
     const next = updateTriggerHistory(id, { decision: 'rejected' });
@@ -4197,12 +4071,11 @@ ipcMain.handle('triggerHistory:decide', (_evt, arg: unknown) => {
   const tokenHash = heldTokenHashFor(id);
   const title = entry.title ?? (entry.body.length > 80 ? `${entry.body.slice(0, 79)}…` : entry.body);
   if (!dispatchWebhookWork({ taskId, title, message: entry.body, tokenHash, origin: entry.source })) {
-    // The card is what the caller polls and what god works from. Leave the entry
-    // pending so the operator can approve again once the hive is writable.
+    // card 是调用方轮询、也是 god 据以工作的东西。让条目保持 pending，这样
+    // 一旦 hive 可写，操作者就能再次批准。
     return entry;
   }
-  // The hash now lives on the card, so the caller's GET resolves through the
-  // normal task lookup from here on.
+  // hash 现在在 card 上，因此调用方的 GET 从此刻起经由正常的任务查找解析。
   if (tokenHash) { heldTokens().delete(tokenHash); persistHeldTokens(); }
   const next = updateTriggerHistory(id, { decision: 'approved', taskId });
   pruneHeldTokens();
@@ -4210,17 +4083,16 @@ ipcMain.handle('triggerHistory:decide', (_evt, arg: unknown) => {
   return next;
 });
 
-// ─── IPC: Generic webhook (LEGACY single-endpoint channels) ─────────────────
-// Kept alive for Settings → Webhook, which still speaks the one-secret shape.
-// They are now THIN SHIMS over the multi-endpoint engine: the legacy secret and
-// enabled flag map onto the `legacy` WebhookTrigger the config migration created,
-// so the two surfaces can never disagree about whether the endpoint is live.
+// ─── IPC: Generic webhook（LEGACY 单端点通道）───────────────────────────────
+// 为 Settings → Webhook 而保留，它仍使用单 secret 形态。它们现在是多端点引擎
+// 之上的薄垫片：遗留 secret 与 enabled 标志映射到配置迁移创建的 `legacy`
+// WebhookTrigger，因此两个界面永远不会对端点是否在线产生分歧。
 ipcMain.handle('webhook:start', () => startWebhookServer());
 ipcMain.handle('webhook:stop', () => { stopWebhookServer(); return { ok: true }; });
-/** Current state + last public endpoint URL, for the Settings badge/URL field. */
+/** 当前状态 + 最近一个公开端点 URL，供 Settings 徽章/URL 字段使用。 */
 ipcMain.handle('webhook:status', () => ({ running: webhookServer != null, url: lastWebhookUrl }));
-/** Mint a strong (256-bit) secret, persist it, and return it so Settings can show
- *  it for the user to copy into their client. The previous secret is replaced. */
+/** 铸一枚强（256 位）secret、持久化并返回，以便 Settings 展示给用户复制进
+ *  客户端。之前的 secret 被替换。 */
 ipcMain.handle('webhook:generateSecret', () => {
   const secret = randomBytes(32).toString('hex');
   writeConfig({ webhookSecret: secret });
@@ -4238,17 +4110,16 @@ ipcMain.handle('webhook:setConfig', (_evt, patch: unknown) => {
     secret: typeof p.secret === 'string' ? p.secret.trim() : undefined,
     enabled: typeof p.enabled === 'boolean' ? p.enabled : undefined
   });
-  // Disabling (or clearing the secret) stops the public surface immediately; the
-  // reconcile also picks up the case where OTHER endpoints are still enabled, in
-  // which case the server stays up minus the legacy one.
+  // 禁用（或清空 secret）会立即停止公开面；reconcile 也接手其他端点仍启用
+  // 的情形——此时服务器继续运行，只是少掉 legacy 那一个。
   reconcileWebhookServer();
   return { ok: true };
 });
 
-/** Mirror a legacy `webhook:setConfig` / `webhook:generateSecret` edit onto the
- *  `legacy` WebhookTrigger. Creates the row only once a secret exists — an
- *  enabled endpoint without a secret would be an open door, so a bare "enable"
- *  against a never-configured webhook is deliberately a no-op. */
+/** 把一次遗留的 `webhook:setConfig` / `webhook:generateSecret` 编辑镜像到
+ *  `legacy` WebhookTrigger。只在 secret 存在后才创建该行——没有 secret 的
+ *  启用端点等于敞开的大门，因此对从未配置过的 webhook 做裸「enable」刻意是
+ *  空操作。 */
 function upsertLegacyWebhookTrigger(patch: { secret?: string; enabled?: boolean }): void {
   const list = readConfig().webhookTriggers ?? [];
   const prior = list.find((t) => t.id === 'legacy');
@@ -4268,26 +4139,25 @@ function upsertLegacyWebhookTrigger(patch: { secret?: string; enabled?: boolean 
   });
 }
 
-// ─── IPC: Free Flow (voice dictation → message queue) ────────────────────────
-// Entry point B is hold-Option-to-talk, handled entirely in the renderer
-// (capture-phase key listeners) — no globalShortcut here. macOS doesn't deliver
-// the Fn key to Electron (electron#16714) and a faithful native Fn helper
-// (CGEventTap) is deferred; hold-Option is the human-chosen v1 activation.
+// ─── IPC: Free Flow（语音听写 → 消息队列）──────────────────────────────────
+// 入口 B 是按住 Option 说话，完全在渲染进程处理（捕获阶段按键监听）——这里
+// 没有 globalShortcut。macOS 不把 Fn 键交给 Electron（electron#16714），而忠实的
+// 原生 Fn 助手（CGEventTap）被推迟；按住 Option 是人类选择的 v1 激活方式。
 
 ipcMain.handle('freeflow:setConfig', (_evt, patch: unknown) => {
   const p = (patch ?? {}) as { enabled?: unknown; apiKey?: unknown; model?: unknown };
   const next: Partial<HarnessConfig> = {};
   if (typeof p.enabled === 'boolean') next.freeflowEnabled = p.enabled;
-  // Trim string fields; an emptied key clears back to undefined.
+  // 裁剪字符串字段；被清空的键回到 undefined。
   if (typeof p.apiKey === 'string') next.groqApiKey = p.apiKey.trim() || undefined;
   if (typeof p.model === 'string') next.freeflowModel = p.model.trim() || DEFAULT_GROQ_MODEL;
   writeConfig(next);
   return { ok: true };
 });
 
-/** Transcribe one captured audio clip via Groq. Gated on the flag + a key being
- *  present, so a disabled feature can NEVER reach the network. The Groq key stays
- *  in main — only the audio bytes cross IPC inbound and the transcript outbound. */
+/** 通过 Groq 转写一段捕获的音频。由标志 + 存在 key 门控，因此被禁用的功能
+ *  永远无法触达网络。Groq key 留在 main——入站只有音频字节跨过 IPC，出站只有
+ *  transcript。 */
 ipcMain.handle('freeflow:transcribe', async (_evt, arg: unknown) => {
   const cfg = readConfig();
   if (!cfg.freeflowEnabled) return { ok: false, error: 'Free Flow is disabled' };
@@ -4308,30 +4178,29 @@ ipcMain.handle('freeflow:transcribe', async (_evt, arg: unknown) => {
   return out;
 });
 
-// ─── IPC: Realtime Michael (voice orchestrator — ephemeral token mint, rt-1) ──
-// MAIN owns the BYOK OpenAI key (encrypted broker, apikey:openai) and mints a
-// short-lived EPHEMERAL client secret; the real key never crosses IPC. All wiring
-// lives in ./realtime so this stays a single registration line.
+// ─── IPC: Realtime Michael（语音编排器——临时 token mint，rt-1）──────────────
+// MAIN 持有 BYOK OpenAI key（加密 broker，apikey:openai），并铸一枚短命的
+// EPHEMERAL 客户端 secret；真实 key 绝不跨过 IPC。所有接线都在 ./realtime 里，
+// 因此这里只是一行注册。
 registerRealtimeIpc();
 
-// ─── IPC: Realtime Michael voice ACTIONS (rt-5, Phase 2) ─────────────────────
-// Thin adapters over the SAME main fns the god PTY already uses. ALL of the safety
-// spine — soft-vs-destructive tiering, the two-step verbal echo-back confirm, the
-// distinct-token rule, the hard allowlist (kill-god / mass-ops forbidden), and the
-// michael-voice attribution — lives in ./realtimeActions. This site only injects
-// the existing functions; it adds NO new orchestration logic.
-// ─── IPC: Realtime Michael completion watcher (rt-12, Phase 2) ───────────────
-// Jim's net-new engine (realtimeCompletionWatcher.ts) detects a voice-dispatched
-// task finishing (card→done OR a done-reply in michael-voice's inbox) and EMITS it;
-// I own the seam — inject the hive read deps, push completions to the live session
-// (so Michael speaks them unprompted), and bridge waitFor / queue-drain over IPC.
+// ─── IPC: Realtime Michael voice ACTIONS（rt-5，Phase 2）─────────────────────
+// 是对 god PTY 已用的同一批 main 函数的薄适配器。整条安全脊——软 vs 破坏性
+// 分级、两步口头回显确认、独立 token 规则、硬允许列表（禁止 kill-god / 批量
+// 操作）、以及 michael-voice 归属——都在 ./realtimeActions 里。此处只注入
+// 既有函数；不新增任何编排逻辑。
+// ─── IPC: Realtime Michael completion watcher（rt-12，Phase 2）───────────────
+// Jim 的全新引擎（realtimeCompletionWatcher.ts）检测语音派发的任务完成
+// （card→done 或 michael-voice 收件箱里的 done-reply）并 EMITS 它；我拥有这个
+// 接缝——注入 hive 读取依赖，把完成事件推给活跃会话（于是 Michael 会主动说出
+// 它们），并在 IPC 上桥接 waitFor / queue-drain。
 const completionWatcher = initCompletionWatcher({
   readTasks: () => { const t = hive.tasks() as { tasks?: TaskCard[] }; return Array.isArray(t?.tasks) ? t.tasks : []; },
-  // Voice dispatches go out as from:michael-voice, so assignee done-replies land here.
+  // 语音派发以 from:michael-voice 发出，因此被指派人的 done-reply 落在这里。
   readInbox: () => {
-    // Voice dispatches go out from:michael-voice, so done-replies normally land in its
-    // inbox — but an assignee may address god out of habit. Merge both inboxes (de-dupe
-    // by id) so a god-addressed completion isn't missed; the detector filters by sender.
+    // 语音派发以 from:michael-voice 发出，因此 done-reply 通常落进它的收件箱，
+    // ——但被指派人可能出于习惯发给 god。合并两个收件箱（按 id 去重），发往
+    // god 的完成事件因此也不会漏掉；检测器按发送者过滤。
     try {
       const mv = hive.inbox('michael-voice') as unknown as InboxMessage[];
       const godId = hive.registry().godId;
@@ -4348,7 +4217,7 @@ const completionWatcher = initCompletionWatcher({
       const reg = hive.registry();
       const title = resolveGodName(reg.agents[reg.godId ?? 'god']?.name);
       new Notification({ title, body: evt.summary }).show();
-    } catch { /* best-effort */ }
+    } catch { /* 尽力而为 */ }
   }
 });
 
@@ -4366,18 +4235,18 @@ registerRealtimeActionIpc({
   killAgent: (id) => {
     const r = ptyManager.kill(id);
     teardownPty(id);
-    // A voice (MAIN-initiated) kill: the renderer never removed the card itself
-    // (unlike a UI kill), so tell the floor to archive it. Mirrors hive:agentSpawned.
-    try { liveWebContents()?.send('hive:agentArchived', { id }); } catch { /* window torn down */ }
+    // 语音（MAIN 发起）的 kill：渲染进程没有自己移除卡片（与 UI kill 不同），
+    // 所以告诉楼层归档它。镜像 hive:agentSpawned。
+    try { liveWebContents()?.send('hive:agentArchived', { id }); } catch { /* 窗口已拆除 */ }
     return r;
   },
   spawnAgent: async (opts) => {
     const o = opts as AgentSpawnOptions;
     const res = await spawnAgentCore(o, null);
-    // The renderer roster is only mutated by renderer-initiated hires (AddAgentModal),
-    // so a MAIN-initiated spawn is invisible on the floor until we broadcast it. The
-    // renderer (useHive) builds the Agent card from this descriptor; addAgent is
-    // idempotent so a renderer-initiated hire is never double-carded.
+    // 渲染进程 roster 只被渲染进程发起的 hiring（AddAgentModal）改变，因此
+    // MAIN 发起的 spawn 在广播前对楼层不可见。渲染进程（useHive）用这个
+    // 描述符构建 Agent 卡片；addAgent 幂等，因此渲染进程发起的 hire 绝不会
+    // 被重复建卡。
     if (res.ok) {
       try {
         liveWebContents()?.send('hive:agentSpawned', {
@@ -4389,47 +4258,46 @@ registerRealtimeActionIpc({
           role: o.hive?.role,
           worktreePath: res.worktreePath
         });
-      } catch { /* window torn down */ }
+      } catch { /* 窗口已拆除 */ }
     }
     return res;
   },
   listMissions: () => readConfig().missions ?? [],
-  // The spec carries lastFiredAt through from listMissions(), so a wholesale write
-  // preserves the scheduler's stamps; edit_schedule is deliberate + rare.
+  // spec 经 listMissions() 带着 lastFiredAt 一路传来，因此整体写入会保留
+  // 调度器的时间戳；edit_schedule 是刻意且罕见的操作。
   saveMissions: (missions) => { writeConfig({ missions }); },
-  // rt-12: register each voice dispatch so the watcher can detect its completion.
-  trackDispatch: (d) => { try { completionWatcher.track({ ...d, kind: 'dispatch' }); } catch { /* watcher unavailable */ } },
-  // ── v0.3.4 full-control extensions ──
+  // rt-12：注册每次语音派发，让 watcher 能检测到它的完成。
+  trackDispatch: (d) => { try { completionWatcher.track({ ...d, kind: 'dispatch' }); } catch { /* watcher 不可用 */ } },
+  // ── v0.3.4 全权控制扩展 ──
   controlResume: (id) => control.resume(id),
   controlAutoDelivery: (id, paused) => control.pauseAutoDelivery(id, paused),
   controlGateTool: (id, toolName, on) => control.gateTool(id, toolName, on),
   setArchived: (id, archived) => {
     if (!hive.enabled()) return { ok: false, error: 'hive disabled' };
     hive.setArchived(id, archived);
-    try { liveWebContents()?.send(archived ? 'hive:agentArchived' : 'hive:agentSpawned', { id }); } catch { /* window gone */ }
+    try { liveWebContents()?.send(archived ? 'hive:agentArchived' : 'hive:agentSpawned', { id }); } catch { /* 窗口已消失 */ }
     return { ok: true };
   },
-  // clear_context: hand the text to the renderer's queue so delivery rides every
-  // existing gate (idle-only, boot grace, draft/picker safety).
+  // clear_context：把文本交给渲染进程的队列，投递因此借用每道既有闸门
+  // （仅空闲、启动宽限、草稿/选择器安全）。
   enqueueToAgent: (id, text) => {
-    try { liveWebContents()?.send('realtime:enqueue', { agentId: id, text }); } catch { /* window gone */ }
+    try { liveWebContents()?.send('realtime:enqueue', { agentId: id, text }); } catch { /* 窗口已消失 */ }
   },
   getConfigValue: (key) => (readConfig() as unknown as Record<string, unknown>)[key],
   patchConfig: (patch) => { writeConfig(patch as Partial<HarnessConfig>); }
 });
 
-// rt-12 seam: push detected completions to the live floor; bridge live-flag, queue
-// drain (closed-session warm-start), and wait_for over IPC. Then start polling.
-completionWatcher.onCompletion((evt) => { try { liveWebContents()?.send('realtime:completion', evt); } catch { /* window gone */ } });
-// v0.3.4: the floor delta watcher shares the session-live flag — while a voice
-// session is open it pushes coalesced floor updates the renderer injects as
-// silent conversation items (snapshot-at-connect + append-only deltas).
+// rt-12 接缝：把检测到的完成推给活跃楼层；在 IPC 上桥接 live 标志、队列排空
+// （关闭会话的暖启动）与 wait_for。然后开始轮询。
+completionWatcher.onCompletion((evt) => { try { liveWebContents()?.send('realtime:completion', evt); } catch { /* 窗口已消失 */ } });
+// v0.3.4：floor delta watcher 共享会话 live 标志——语音会话打开期间，它推送
+// 合并后的楼层更新，渲染进程将其注入为静默对话条目（连接时快照 + 只追加增量）。
 const floorWatcher = new RealtimeFloorWatcher({
   enabled: () => hive.enabled(),
   registry: () => hive.registry(),
   tasks: () => hive.tasks(),
   ptys: () => ptyManager.list().map((p) => ({ id: p.id, lastOutputAt: p.lastOutputAt })),
-  push: (text) => { try { liveWebContents()?.send('realtime:floorDelta', { text }); } catch { /* window gone */ } }
+  push: (text) => { try { liveWebContents()?.send('realtime:floorDelta', { text }); } catch { /* 窗口已消失 */ } }
 });
 floorWatcher.start();
 ipcMain.handle('realtime:setSessionLive', (_e, live: unknown) => {
@@ -4437,12 +4305,12 @@ ipcMain.handle('realtime:setSessionLive', (_e, live: unknown) => {
   floorWatcher.setSessionLive(live === true);
   return { ok: true };
 });
-// v0.3.4: app self-knowledge for the voice get_app_info tool — version + the
-// newest CHANGELOG sections. Read-only; ships CHANGELOG.md with the app.
+// v0.3.4：语音 get_app_info 工具的应用自知——版本 + 最新 CHANGELOG 片段。
+// 只读；随应用携带 CHANGELOG.md。
 ipcMain.handle('app:info', () => {
   let changelog = '';
   for (const p of [join(app.getAppPath(), 'CHANGELOG.md'), join(process.cwd(), 'CHANGELOG.md')]) {
-    try { changelog = readFileSync(p, 'utf8'); if (changelog) break; } catch { /* try next */ }
+    try { changelog = readFileSync(p, 'utf8'); if (changelog) break; } catch { /* 尝试下一个 */ }
   }
   const top = changelog
     ? changelog.split(/\n## /).slice(1, 3).map((s) => `## ${s}`).join('\n').slice(0, 8000)
@@ -4456,56 +4324,52 @@ ipcMain.handle('realtime:waitFor', (_e, taskId: unknown, timeoutMs: unknown) =>
     : Promise.resolve({ timedOut: true as const, taskId: '' }));
 completionWatcher.start();
 
-// ─── god-triggered ephemeral Slack workers ──────────────────────────────────
-// god drops a spawn-request JSON into HIVE_ROOT/spawn-requests/; MAIN polls that
-// queue (same cadence + atomic-rename archival as the hive router — reliability
-// over latency, no fs.watch/dedup needed), spins up a FRESH ISOLATED worker via
-// the shared spawnAgentCore, dispatches the objective through the standard inbox
-// path, then watches each worker for a terminal `act:"done"` (success → release)
-// or excessive idleness (reap). All teardown flows through teardownPty's
-// safety-gate, so a worker's worktree is never auto-removed while it holds
-// unintegrated work. Every terminal failure informs god WITH the Slack coords so
-// god closes the Slack loop; the success path is the worker replying in-thread.
+// ─── god 触发的临时 Slack worker ────────────────────────────────────────────
+// god 将 spawn-request JSON 投递到 HIVE_ROOT/spawn-requests/；MAIN 轮询该队列
+// （与 hive router 相同的节奏 + 原子重命名归档 —— 可靠性优先于延迟，无需
+// fs.watch/dedup），通过共享的 spawnAgentCore 启动一个全新的隔离 worker，
+// 通过标准 inbox 路径派发目标，然后监视每个 worker 是否给出终态 `act:"done"`
+// （成功 → 释放）或过度闲置（回收）。所有 teardown 都流经 teardownPty 的
+// safety-gate，因此只要 worker 还持有未整合的工作，其 worktree 就绝不会被自动移除。
+// 每个终态失败都会连同 Slack 坐标一并通知 god，让 god 关闭 Slack 循环；成功路径
+// 则是 worker 在 thread 内回复。
 
-/** A spawn-request god drops into HIVE_ROOT/spawn-requests/<id>.json. god authors
- *  these directly; `objective` and `cwd` are the only required fields. */
+/** god 投递到 HIVE_ROOT/spawn-requests/<id>.json 的 spawn-request。由 god 直接
+ *  编写；`objective` 和 `cwd` 是仅有的必填字段。 */
 interface SpawnRequest {
   id?: string;
   objective?: string;
-  command?: string;                                   // engine CLI; default = config.defaultCommand
-  provider?: AgentProvider;                           // optional explicit provider
-  model?: string;                                     // optional --model override (Claude)
-  cwd?: string;                                        // repo the worker (and its worktree) runs in
-  name?: string;                                       // display name
-  slack?: { channel: string; thread_ts: string };     // reply target + where failures surface
-  isolate?: boolean;                                   // default true (fresh worktree)
-  tokenCap?: number;                                   // optional per-worker token cap (advisory P1)
-  // Appearance on the office floor. Both optional and both validated renderer-side
-  // against the real cast and accent lists, so a bad value degrades to the default
-  // rather than breaking the card.
+  command?: string;                                   // 引擎 CLI；默认 = config.defaultCommand
+  provider?: AgentProvider;                           // 可选显式 provider
+  model?: string;                                     // 可选 --model 覆盖（Claude）
+  cwd?: string;                                        // worker（及其 worktree）运行的仓库
+  name?: string;                                       // 显示名称
+  slack?: { channel: string; thread_ts: string };     // 回复目标 + 失败浮现的位置
+  isolate?: boolean;                                   // 默认 true（全新 worktree）
+  tokenCap?: number;                                   // 可选按 worker 的 token 上限（advisory P1）
+  // 办公室楼层上的外观。二者皆可选，且均在 renderer 侧对照真实的 cast 与 accent
+  // 列表校验，因此坏值会退化为默认值，而不会破坏卡片。
   //
-  // Naming a worker after a cast member ALREADY gets you their avatar: the floor
-  // card infers it from the name. These two exist for the case that inference
-  // cannot express, an agent called something else that should still look like a
-  // particular character, and picking the accent instead of taking the one hashed
-  // from the worker id.
+  // 用 cast 成员的名字来命名 worker，本就会获得该成员的头像：楼层卡片会根据名字
+  // 推断出来。这两个字段用于处理推断无法表达的情况——一个叫别的名字、却仍应看起来
+  // 像某个特定角色的 agent，以及选用 accent 而非取用从 worker id 哈希得到的那个。
   character?: string;
   accent?: string;
 }
 
-/** Polling cadence — matches the hive router. */
+/** 轮询节奏 —— 与 hive router 一致。 */
 const WORKER_TICK_MS = 1500;
 let workerWatchTimer: ReturnType<typeof setInterval> | null = null;
-/** Re-entrancy guard so a slow tick (await spawn / git checks) never overlaps. */
+/** 重入保护，确保慢速 tick（await spawn / git 检查）永不重叠。 */
 let workerTickRunning = false;
 
-/** HIVE_ROOT/spawn-requests — the queue dir god drops requests into. */
+/** HIVE_ROOT/spawn-requests —— god 投递请求的队列目录。 */
 function spawnRequestsDir(): string | null {
   const root = hive.root();
   return root ? join(root, 'spawn-requests') : null;
 }
 
-/** Move a processed request out of the queue so it's never reprocessed. */
+/** 将已处理的请求移出队列，确保它永不被重复处理。 */
 function archiveRequest(filePath: string, sub: '.done' | '.failed'): void {
   const queue = spawnRequestsDir();
   try {
@@ -4514,24 +4378,22 @@ function archiveRequest(filePath: string, sub: '.done' | '.failed'): void {
     mkdirSync(dir, { recursive: true });
     renameSync(filePath, join(dir, basename(filePath)));
   } catch (e) {
-    // Last resort: delete it so a poison file can't loop forever.
-    try { unlinkSync(filePath); } catch { /* noop */ }
+    // 最后手段：删除它，这样投毒文件就不会无限循环。
+    try { unlinkSync(filePath); } catch { /* 无操作 */ }
     console.error('[worker] archiveRequest failed:', e);
   }
 }
 
-/** Did this worker post a terminal `act:"done"` yet? Scans its own outbox AND
- *  outbox/.sent (the router archives delivered mail there ~every 1.5s), so the
- *  signal is caught whether or not it's been routed out yet.
+/** 该 worker 是否已给出终态 `act:"done"`？扫描它自己的 outbox 以及
+ *  outbox/.sent（router 约每 1.5s 会把已投递的邮件归档到那里），因此无论信号
+ *  是否已被路由出去，都能捕获到。
  *
- *  Stale-done guard: agent dirs persist after teardown, so REUSING a reqId would
- *  leave a PRIOR worker's `done` sitting in this same dir. Without a guard that
- *  stale signal would release the new worker on its very first tick — before it
- *  does anything or replies — causing a silent Slack hang. So we only count a
- *  `done` authored AFTER this worker spawned: by its `created_at` (the message's
- *  own timestamp), falling back to the file's mtime when `created_at` is missing
- *  or unparseable. When neither yields a usable timestamp we DON'T count it
- *  (fail toward keeping the worker alive — the idle reaper is the backstop). */
+ *  陈旧-done 防护：agent 目录在 teardown 后会保留，所以复用 reqId 会让先前
+ *  worker 的 `done` 残留在同一目录里。若无防护，那个陈旧信号会在新 worker 的
+ *  首个 tick 就释放它——在它做任何事或回复之前——从而造成静默的 Slack 挂起。
+ *  因此我们只统计在该 worker 启动之后产生的 `done`：依据其 `created_at`（消息
+ *  自带的时间戳），当 `created_at` 缺失或不可解析时回退到文件的 mtime。当二者
+ *  都无法给出可用时间戳时，我们不计入（倾向于让 worker 存活——闲置回收器是兜底）。 */
 function workerSignaledDone(workerId: string, spawnedAt: number): boolean {
   const root = hive.root();
   if (!root) return false;
@@ -4551,17 +4413,16 @@ function workerSignaledDone(workerId: string, spawnedAt: number): boolean {
           try { ts = statSync(fp).mtimeMs; } catch { ts = NaN; }
         }
         if (Number.isFinite(ts) && ts > spawnedAt) return true;
-      } catch { /* skip unreadable/partial */ }
+      } catch { /* 跳过不可读/不完整的 */ }
     }
   }
   return false;
 }
 
-/** Spin up one ephemeral worker from a spawn-request. Terminal failures (bad
- *  request, missing CLI, spawn error) archive to .failed and inform god WITH the
- *  Slack coords so god can post a 'couldn't start' reply. On success the worker is
- *  registered (for done-scan / reaping / safe teardown) and dispatched its
- *  objective via the standard inbox path. */
+/** 从一份 spawn-request 启动一个临时 worker。终态失败（坏请求、缺少 CLI、spawn
+ *  错误）会归档到 .failed，并连同 Slack 坐标通知 god，让 god 能发布一条
+ *  “无法启动”的回复。成功后，worker 会被注册（用于 done 扫描 / 回收 / 安全
+ *  teardown），并通过标准 inbox 路径派发其目标。 */
 async function processSpawnRequest(filePath: string): Promise<void> {
   let raw: SpawnRequest;
   try {
@@ -4575,26 +4436,25 @@ async function processSpawnRequest(filePath: string): Promise<void> {
   const slack = raw.slack && typeof raw.slack.channel === 'string' && typeof raw.slack.thread_ts === 'string'
     ? { channel: raw.slack.channel, thread_ts: raw.slack.thread_ts } : undefined;
   const fail = (reason: string): void => {
-    informGod(`[worker spawn rejected] ${reason}`, `Spawn-request ${basename(filePath)} rejected: ${reason}.`, slack);
+    informGod(`[worker 生成被拒] ${reason}`, `生成请求 ${basename(filePath)} 被拒绝: ${reason}。`, slack);
     archiveRequest(filePath, '.failed');
   };
 
   const objective = typeof raw.objective === 'string' ? raw.objective.trim() : '';
-  if (!objective) { fail('missing "objective"'); return; }
+  if (!objective) { fail('缺少 "objective"'); return; }
 
   const reqId = (typeof raw.id === 'string' && raw.id.trim() ? raw.id.trim() : basename(filePath).replace(/\.json$/i, ''))
     .replace(/[^A-Za-z0-9._-]/g, '-');
   const workerId = `worker-${reqId}`;
-  if (liveWorkers.has(workerId)) { fail(`worker "${workerId}" already running`); return; }
+  if (liveWorkers.has(workerId)) { fail(`worker "${workerId}" 已在运行`); return; }
 
-  // Worker request files are hand/LLM-authored, so `~/…` shows up here too — expand
-  // before the existence check (Node reads `~` literally).
+  // Worker 请求文件是手写 / LLM 编写的，所以这里也会出现 `~/…` —— 在存在性检查
+  // 之前展开（Node 会按字面读取 `~`）。
   const cwd = typeof raw.cwd === 'string' && raw.cwd.trim() ? expandTilde(raw.cwd) : '';
-  if (!cwd || !existsSync(cwd)) { fail(`"cwd" missing or not found (${cwd || 'unset'})`); return; }
+  if (!cwd || !existsSync(cwd)) { fail(`"cwd" 缺失或未找到 (${cwd || '未设置'})`); return; }
 
-  // Request line → executable + argv (auto-mode inheritance, tokenization,
-  // model-flag dedupe). Pure and unit-tested — see workerLaunch.ts for why this
-  // translation earned a test.
+  // 请求行 → 可执行文件 + argv（auto 模式继承、token 化、model 标志去重）。纯函数
+  // 且经过单测 —— 至于为何这层转换值得写测试，见 workerLaunch.ts。
   const cfgSpawn = readConfig();
   const launch = buildWorkerLaunch({
     requestCommand: raw.command,
@@ -4604,24 +4464,22 @@ async function processSpawnRequest(filePath: string): Promise<void> {
     autoMode: !!cfgSpawn.autoMode
   });
   const bin = launch.bin;
-  // Validate the executable name on the spawn path. A spawn-request file is
-  // untrusted input (authored by the orchestrator, reachable by anything that can
-  // write HIVE_ROOT/spawn-requests), so the bin must be a plain command token or
-  // an absolute path — never a string a downstream shell `which`/`where` could
-  // reinterpret. Rejected here, before any resolution; the resolver guards behind
-  // it validate the same thing in depth.
+  // 在 spawn 路径上校验可执行文件名。spawn-request 文件是不可信输入（由编排器编写，
+  // 任何能写 HIVE_ROOT/spawn-requests 的东西都能触达），因此 bin 必须是纯命令 token
+  // 或绝对路径 —— 绝不能是下游 shell `which`/`where` 可能重新解释的字符串。在这里、
+  // 任何解析之前就拒绝；其后层层的 resolver 守卫也会做同样的深度校验。
   if (!isSafeCommandName(bin) && !isAbsolute(bin)) {
-    fail(`refusing spawn: engine command "${bin}" is not a plain command name or an absolute path`);
+    fail(`拒绝生成: 引擎命令 "${bin}" 不是纯命令名或绝对路径`);
     return;
   }
-  // Missing-CLI → FAIL FAST. A headless worker has no human to watch an installer,
-  // so we never run the cc49e1e install banner here — we reject and tell god.
-  if (!ptyManager.isCommandAvailable(bin)) { fail(`engine CLI "${bin}" is not installed`); return; }
+  // 缺少 CLI → 快速失败。无头 worker 没有人类来看安装程序，所以我们在这里从不运行
+  // cc49e1e 安装横幅 —— 直接拒绝并告知 god。
+  if (!ptyManager.isCommandAvailable(bin)) { fail(`引擎 CLI "${bin}" 未安装`); return; }
 
-  const isolate = raw.isolate !== false; // default true
-  // Base branch the worktree will be cut from (for the ahead-of-base safety check).
+  const isolate = raw.isolate !== false; // 默认 true
+  // worktree 将从其上切出的基分支（用于 ahead-of-base 安全检查）。
   let baseBranch = 'main';
-  try { const br = await getBranch(cwd); if ('current' in br && br.current) baseBranch = br.current; } catch { /* keep default */ }
+  try { const br = await getBranch(cwd); if ('current' in br && br.current) baseBranch = br.current; } catch { /* 保留默认 */ }
 
   const meta: AgentMeta = {
     id: workerId,
@@ -4630,11 +4488,10 @@ async function processSpawnRequest(filePath: string): Promise<void> {
     role: 'worker',
     cwd
   };
-  // Phase 2: grant this worker a broker capability over the currently-enabled
-  // integrations and inject the broker URL + a per-worker capability TOKEN (a handle,
-  // never a secret) into its env, so it can reach registered REST integrations through
-  // the loopback secret broker without ever seeing a credential. Only when the broker
-  // is up; the grant is revoked in teardownPty (and below if the spawn fails).
+  // 阶段 2：为这个 worker 授予一个对当前已启用集成的 broker 能力，并把 broker URL +
+  // 每 worker 的能力 TOKEN（一个句柄，绝非机密）注入其 env，这样它就能经由回环
+  // 机密 broker 触达已注册的 REST 集成，而永远看不到任何凭据。仅在 broker 处于运行
+  // 状态时进行；该授权会在 teardownPty（以及下面 spawn 失败时）中被吊销。
   const brokerEnv: Record<string, string> = {};
   if (integrationBroker.running()) {
     const token = integrationBroker.grant(workerId, integrations.enabledIds());
@@ -4655,14 +4512,12 @@ async function processSpawnRequest(filePath: string): Promise<void> {
   }
   if (!res.ok) { integrationBroker.revoke(workerId); fail(`spawn failed — ${res.error ?? 'unknown error'}`); return; }
 
-  // A god-hired worker is a MAIN-initiated spawn, so the renderer would never
-  // card it on its own (same reason as the voice-spawn broadcast): without this
-  // the worker is invisible on the floor, never enters the roster, and after a
-  // restart nothing offers to restore it. The card rides the normal agent
-  // lifecycle from here — teardownPty broadcasts the matching archive. A card
-  // RESTORED after an app quit revives through the renderer's normal spawn path
-  // and never re-enters liveWorkers: ephemerality is a property of the hiring,
-  // not of the card, so a restored worker is a regular agent (no reaping).
+  // 由 god 雇佣的 worker 是 MAIN 发起的 spawn，所以 renderer 自己永远不会给它
+  // 建卡片（与 voice-spawn 广播同样的原因）：没有这个广播，worker 在楼层上不可见、
+  // 永远不会进入 roster，重启后也没有任何东西提议恢复它。卡片从这里起走正常的
+  // agent 生命周期 —— teardownPty 广播对应的归档。应用退出后恢复的卡片，会经由
+  // renderer 的正常 spawn 路径复活，且永远不会重新进入 liveWorkers：临时性属于雇佣
+  // 这个动作，而非卡片本身，所以恢复的 worker 就是普通 agent（不再回收）。
   try {
     liveWebContents()?.send('hive:agentSpawned', {
       id: workerId,
@@ -4675,18 +4530,16 @@ async function processSpawnRequest(filePath: string): Promise<void> {
       character: typeof raw.character === 'string' ? raw.character : undefined,
       accent: typeof raw.accent === 'string' ? raw.accent : undefined
     });
-  } catch { /* window torn down */ }
+  } catch { /* 窗口已拆除 */ }
 
-  // Register for done-scan / idle-reap / token-cap / safe teardown (pty id == workerId).
-  // tokenCap is optional plumbing (default unlimited) — only a positive finite cap is kept.
+  // 注册以用于 done 扫描 / 闲置回收 / token 上限 / 安全 teardown（pty id == workerId）。
+  // tokenCap 是可选管道（默认不限）—— 只保留正的有限上限。
   const tokenCap = typeof raw.tokenCap === 'number' && Number.isFinite(raw.tokenCap) && raw.tokenCap > 0
     ? raw.tokenCap : undefined;
   liveWorkers.set(workerId, { workerId, reqId, name: meta.name, slack, baseBranch, spawnedAt: Date.now(), tokenCap });
 
-  // Dispatch the objective via the standard inbox path (zero new transport),
-  // reusing the autonomous-request preamble so the worker gets the exact Slack
-  // reply command + autonomy policy. `from: god` so the worker treats it as a god
-  // dispatch per its protocol.
+  // 通过标准 inbox 路径派发目标（零新增传输），复用自主请求的前言，让 worker 拿到
+  // 精确的 Slack 回复命令 + 自主策略。`from: god`，使 worker 依其协议把它当作 god 派发。
   try {
     const prefix = slack
       ? buildAutonomousRequestProtocol(slack.channel, slack.thread_ts, slackReplyScriptPath())
@@ -4701,46 +4554,44 @@ async function processSpawnRequest(filePath: string): Promise<void> {
   archiveRequest(filePath, '.done');
 }
 
-/** Total tokens (input+output+cache) a worker has burned so far, from the usage
- *  provider — 0 when unknown. Mirrors the breaker's `tokensOf`. Used only by the
- *  (default-off) per-worker token cap. */
+/** 一个 worker 迄今累计消耗的 token（输入+输出+缓存），取自 usage provider ——
+ *  未知时为 0。镜像了 breaker 的 `tokensOf`。仅由（默认关闭的）每 worker token 上限使用。 */
 function workerTokensUsed(workerId: string): number {
   const s = usageProvider.getAgentUsage(workerId);
   return s ? s.input + s.output + s.cacheRead + s.cacheCreation : 0;
 }
 
-/** Throttle for the GC sweep — git checks are cheap but pointless every 1.5s tick. */
+/** GC 清扫的节流 —— git 检查很廉价，但没必要每个 1.5s tick 都跑。 */
 const GC_SWEEP_MS = 60_000;
 let lastGcSweepAt = 0;
 let gcSweepRunning = false;
 
-/** Reclaim preserved worker worktrees (+ their scratch dirs) whose work is now
- *  integrated, or whose worktree was already removed by hand. Fail-safe: a worktree
- *  is removed ONLY when `worktreeIsGcSafe` proves it clean AND integrated; any doubt
- *  KEEPS it (never discards un-integrated work — god is the sole integrator). Runs
- *  inside the worker tick, throttled to GC_SWEEP_MS, and is a no-op when nothing is
- *  preserved (the common case → zero cost). */
+/** 回收那些工作现已整合、或其 worktree 已被手工移除的保留 worker worktree（连同
+ *  其 scratch 目录）。故障安全：仅当 `worktreeIsGcSafe` 证明它既干净又已整合时才
+ *  移除 worktree；任何存疑都会保留（绝不丢弃未整合的工作 —— god 是唯一整合者）。
+ *  在 worker tick 内运行，按 GC_SWEEP_MS 节流；当没有保留项时是无操作（常见情况
+ *  → 零成本）。 */
 async function gcPreservedWorktrees(): Promise<void> {
   if (gcSweepRunning || preservedWorktrees.size === 0) return;
   gcSweepRunning = true;
   try {
     for (const [key, e] of [...preservedWorktrees]) {
-      // A worker id that is live again (reqId reuse) → never GC its worktree or
-      // scratch out from under the new run; leave the stale entry for a later sweep.
+      // 一个再次活跃的 worker id（reqId 复用）→ 绝不在新运行下方回收其 worktree 或
+      // scratch；把陈旧条目留给后续清扫。
       if (liveWorkers.has(e.workerId)) continue;
-      // (a) Worktree already gone (removed at clean teardown, or god removed it by
-      //     hand per the preserve note) → just reclaim the scratch dir + drop tracking.
+      // (a) worktree 已消失（干净 teardown 时移除，或 god 依保留说明手工移除）
+      //     → 只回收 scratch 目录并停止跟踪。
       if (!existsSync(e.wtPath)) {
         removeWorkerScratch(e.workerId);
         preservedWorktrees.delete(key);
         console.log(`[worker gc] ${e.workerId}: worktree already gone — reclaimed scratch`);
         continue;
       }
-      // (b) Still on disk → reclaim ONLY when provably integrated + clean.
+      // (b) 仍在磁盘上 → 仅当可证明已整合且干净时才回收。
       let safe: { gc: boolean; detail: string };
       try { safe = await worktreeIsGcSafe(e.wtPath, e.baseBranch); }
       catch (err) { console.error('[worker gc] gc-safe check threw (keeping):', err); continue; }
-      if (!safe.gc) continue; // keep — fail-safe
+      if (!safe.gc) continue; // 保留 —— 故障安全
       const r = await removeWorktree(e.origCwd, e.wtPath);
       if (!r.ok) { console.error(`[worker gc] removeWorktree failed (keeping ${e.workerId}):`, r.error); continue; }
       removeWorkerScratch(e.workerId);
@@ -4757,9 +4608,8 @@ async function gcPreservedWorktrees(): Promise<void> {
   }
 }
 
-/** One controller tick: (1) finish/reap live workers (frees slots), then (2) pull
- *  new requests up to the concurrency cap. Order matters so a freed slot is reused
- *  the same tick. */
+/** 一次控制器 tick：(1) 结束/回收正在运行的 worker（释放槽位），然后 (2) 拉取新请求
+ *  直至并发上限。顺序很重要，这样释放的槽位能在同一个 tick 内被复用。 */
 async function ephemeralWorkerTick(): Promise<void> {
   if (workerTickRunning) return;
   workerTickRunning = true;
@@ -4767,31 +4617,30 @@ async function ephemeralWorkerTick(): Promise<void> {
     const cfg = readConfig();
     const maxWorkers = Math.max(1, cfg.maxConcurrentWorkers ?? 4);
     const idleTimeoutMs = Math.max(1, cfg.workerIdleTimeoutMinutes ?? 20) * 60_000;
-    // Per-worker token cap. 0 = UNLIMITED (the default — wired but never throttles
-    // unless a positive cap is set per-request or via defaultWorkerTokenCap).
+    // 每 worker token 上限。0 = 不限（默认 —— 已接线但从不节流，除非按请求或通过
+    // defaultWorkerTokenCap 设置了正上限）。
     const defaultTokenCap = typeof cfg.defaultWorkerTokenCap === 'number' && cfg.defaultWorkerTokenCap > 0
       ? cfg.defaultWorkerTokenCap : 0;
 
-    // (1) Finish or reap. Each release calls teardownPty EXPLICITLY after the
-    //     kill, like every other kill site: ptyManager.kill() deletes the session
-    //     synchronously, so when node-pty's async onExit later fires it fails the
-    //     session-identity guard and the global exit handler (→ teardownPty)
-    //     never runs. Relying on onExit here left released workers un-torn-down:
-    //     no hive archive, no hive:agentArchived, frozen floor cards, and god
-    //     kept mailing dead agents (seen live 2026-08-16 with worker-business/
-    //     worker-qa/worker-bizreview). A double teardown is a harmless no-op.
+    // (1) 结束或回收。每次释放都在 kill 之后显式调用 teardownPty，与其它所有 kill
+    //     点一致：ptyManager.kill() 会同步删除会话，所以当 node-pty 的异步 onExit
+    //     稍后触发时，会失败于会话身份守卫，全局退出处理器（→ teardownPty）永远不会
+    //     运行。在此依赖 onExit 会让已释放的 worker 无法完成 teardown：没有 hive
+    //     归档、没有 hive:agentArchived、楼层卡片冻结，而且 god 会继续向死掉的 agent
+    //     投递邮件（2026-08-16 实测，涉及 worker-business/worker-qa/worker-bizreview）。
+    //     双重 teardown 是无害的 no-op。
     for (const [workerId, rec] of [...liveWorkers]) {
       if (rec.releasing) continue;
       if (workerSignaledDone(workerId, rec.spawnedAt)) {
-        // Success: the worker already replied in-thread; just release it.
+        // 成功：worker 已在 thread 内回复；只需释放它。
         rec.releasing = true;
         console.log(`[worker] ${workerId} signaled done — releasing`);
         ptyManager.kill(workerId);
         teardownPty(workerId);
         continue;
       }
-      // Token-cap reap (default-off plumbing). An effective cap > 0 → reap when the
-      // worker's cumulative token use exceeds it; its committed work is preserved.
+      // token 上限回收（默认关闭的管道）。有效上限 > 0 → 当 worker 累计 token 用量
+      // 超过它时回收；其已提交的工作会被保留。
       const tokenCap = (rec.tokenCap && rec.tokenCap > 0) ? rec.tokenCap : defaultTokenCap;
       if (tokenCap > 0) {
         const used = workerTokensUsed(workerId);
@@ -4809,7 +4658,7 @@ async function ephemeralWorkerTick(): Promise<void> {
         }
       }
       const idleMs = ptyManager.idleFor(workerId);
-      if (idleMs === undefined) continue; // PTY already gone; teardownPty cleans up
+      if (idleMs === undefined) continue; // PTY 已消失；teardownPty 会清理
       if (idleMs > idleTimeoutMs) {
         rec.releasing = true;
         console.warn(`[worker] reaping idle ${workerId} (${Math.round(idleMs / 60000)}min idle)`);
@@ -4823,31 +4672,27 @@ async function ephemeralWorkerTick(): Promise<void> {
       }
     }
 
-    // (2) Process new requests, honoring the concurrency cap (backpressure: leave
-    //     the rest in the queue for a later tick).
+    // (2) 处理新请求，遵守并发上限（背压：把其余的留在队列里，留给后面的 tick）。
     //
-    //     Gated on config.orchestratorMaySpawn (default OFF): letting the
-    //     orchestrator spin up agents unprompted is a SPEND decision, so the
-    //     operator opts in. The gate sits HERE, on intake, and not on the watcher
-    //     itself, because step (1) above owns the lifecycle of workers that are
-    //     already running — reaping, teardown, the Slack failure notice — and
-    //     turning the toggle off mid-flight must not strand them.
+    //     受 config.orchestratorMaySpawn（默认关）门控：让编排器未经提示就启动 agent
+    //     是一项 SPEND 决策，所以由操作员选择开启。这个门放在这里、放在 intake 上，
+    //     而不是放在 watcher 本身，因为上面的步骤 (1) 掌管着已在运行的 worker 的
+    //     生命周期 —— 回收、teardown、Slack 失败通知 —— 中途关掉开关不能把它们搁浅。
     //
-    //     Declining also means declining to CONSUME. A request dropped in while
-    //     this is off stays in the queue and runs when it is turned on, rather
-    //     than being eaten and failed for a reason god never asked about.
+    //     拒绝也意味着拒绝消费。在关闭期间被投入的请求会留在队列里，等到开启时再运行，
+    //     而不是被吃掉并以一个 god 从未问及的理由而失败。
     const dir = readConfig().orchestratorMaySpawn ? spawnRequestsDir() : null;
     if (dir && existsSync(dir)) {
       let files: string[] = [];
-      try { files = readdirSync(dir).filter(f => f.endsWith('.json')).sort(); } catch { /* dir vanished */ }
+      try { files = readdirSync(dir).filter(f => f.endsWith('.json')).sort(); } catch { /* 目录已消失 */ }
       for (const f of files) {
         if (liveWorkers.size >= maxWorkers) break;
         await processSpawnRequest(join(dir, f));
       }
     }
 
-    // (3) GC preserved worktrees whose work has since integrated. Throttled to
-    //     GC_SWEEP_MS and a no-op when nothing is preserved (the common case).
+    // (3) 回收那些工作此后已整合的保留 worktree。按 GC_SWEEP_MS 节流，当没有保留项
+    //     时是无操作（常见情况）。
     const now = Date.now();
     if (preservedWorktrees.size > 0 && now - lastGcSweepAt >= GC_SWEEP_MS) {
       lastGcSweepAt = now;
@@ -4863,7 +4708,7 @@ async function ephemeralWorkerTick(): Promise<void> {
 function startEphemeralWorkerWatcher(): void {
   if (workerWatchTimer || !hive.enabled()) return;
   const dir = spawnRequestsDir();
-  if (dir) { try { mkdirSync(dir, { recursive: true }); } catch { /* noop */ } }
+  if (dir) { try { mkdirSync(dir, { recursive: true }); } catch { /* 空操作 */ } }
   workerWatchTimer = setInterval(() => { void ephemeralWorkerTick(); }, WORKER_TICK_MS);
 }
 
@@ -4871,7 +4716,7 @@ function stopEphemeralWorkerWatcher(): void {
   if (workerWatchTimer) { clearInterval(workerWatchTimer); workerWatchTimer = null; }
 }
 
-/** Snapshot of one live ephemeral worker for the renderer Workers tab. */
+/** 供 renderer 的 Workers 标签页使用的单个活动临时 worker 快照。 */
 interface WorkerSnapshot {
   workerId: string;
   reqId: string;
@@ -4879,14 +4724,14 @@ interface WorkerSnapshot {
   baseBranch: string;
   spawnedAt: number;
   ageMs: number;
-  idleMs: number | null;        // null = PTY already gone
+  idleMs: number | null;        // null = PTY 已消失
   tokensUsed: number;
-  tokenCap: number | null;      // effective cap (per-request or config default); null = unlimited
+  tokenCap: number | null;      // 有效上限（按请求或配置默认）；null = 不限
   hasSlack: boolean;
   releasing: boolean;
   status: 'releasing' | 'working';
 }
-/** Snapshot of a preserved-but-not-yet-GC'd worktree for the tab. */
+/** 供标签页使用的、已保留但尚未 GC 的 worktree 快照。 */
 interface PreservedSnapshot {
   workerId: string;
   wtPath: string;
@@ -4894,7 +4739,7 @@ interface PreservedSnapshot {
   preservedAt: number;
 }
 
-/** List live ephemeral workers (+ preserved worktrees awaiting GC) for the tab. */
+/** 列出活动临时 worker（+ 等待 GC 的保留 worktree），供标签页使用。 */
 ipcMain.handle('workers:list', (): { live: WorkerSnapshot[]; preserved: PreservedSnapshot[]; maxWorkers: number } => {
   const cfg = readConfig();
   const defaultCap = typeof cfg.defaultWorkerTokenCap === 'number' && cfg.defaultWorkerTokenCap > 0
@@ -4924,19 +4769,17 @@ ipcMain.handle('workers:list', (): { live: WorkerSnapshot[]; preserved: Preserve
   return { live, preserved, maxWorkers: Math.max(1, cfg.maxConcurrentWorkers ?? 4) };
 });
 
-/** Manually stop a live ephemeral worker. Mirrors the done-release path: mark
- *  releasing, then kill + teardownPty runs the SAFETY-GATED worktree teardown
- *  (committed work is preserved, never force-discarded). Idempotent. teardownPty
- *  is called explicitly (D10) rather than left to the PTY's natural exit: kill()
- *  frees the manager's id slot synchronously, so by the time the process's real
- *  exit arrives the exit-handler's stale-id guard already misreads it as a
- *  reclaimed id and skips teardown — the worker would stay "live" in registry.json
- *  and fleet.json forever after this call. */
+/** 手动停止一个活动临时 worker。镜像 done-释放路径：标记 releasing，然后 kill +
+ *  teardownPty 运行经 SAFETY-GATED 的 worktree teardown（已提交的工作会被保留，
+ *  绝不强制丢弃）。幂等。teardownPty 被显式调用（D10），而不是交给 PTY 的自然退出：
+ *  kill() 会同步释放管理器的 id 槽位，所以当进程真正的退出到达时，退出处理器的
+ *  陈旧-id 守卫已把它误判为已回收的 id 并跳过 teardown —— 之后这个 worker 会永远
+ *  以 “live” 状态留在 registry.json 和 fleet.json 里。 */
 ipcMain.handle('workers:stop', (_evt, workerId: string): { ok: boolean; error?: string } => {
   if (typeof workerId !== 'string' || !workerId) return { ok: false, error: 'invalid worker id' };
   const rec = liveWorkers.get(workerId);
   if (!rec) return { ok: false, error: 'no such live worker' };
-  if (rec.releasing) return { ok: true }; // already stopping
+  if (rec.releasing) return { ok: true }; // 已在停止
   rec.releasing = true;
   console.log(`[worker] manual stop requested for ${workerId}`);
   try { ptyManager.kill(workerId); } catch (e) { return { ok: false, error: String(e) }; }
@@ -4944,82 +4787,85 @@ ipcMain.handle('workers:stop', (_evt, workerId: string): { ok: boolean; error?: 
   return { ok: true };
 });
 
-/** Start every hive-bound background service against the current harnessHome.
- *  Called on boot, and again to recover in place if a folder-change copy fails
- *  (config:changeHome tears these down before copying). No-op without a home. */
+/** 针对当前 harnessHome 启动每个与 hive 绑定的后台服务。在启动时调用，若文件夹变更
+ *  复制失败则再次调用以就地恢复（config:changeHome 会在复制前把这些全部 teardown）。
+ *  无 home 时为无操作。 */
 function bootstrapHiveServices(): void {
   if (!hive.enabled()) return;
   hive.ensureHive();
-  // Tell the hive what it is running inside, BEFORE anything spawns: the prompt
-  // builder reads this, so an agent spawned earlier would never learn it.
+  // 在任何东西 spawn 之前，告诉 hive 它运行在什么环境中：prompt 构建器会读取这个，
+  // 所以更早 spawn 的 agent 永远不会得知。
   hive.setRuntimeInfo({ version: app.getVersion(), packaged: app.isPackaged, appPath: app.getAppPath() });
   hive.setOrchestratorMaySpawn(readConfig().orchestratorMaySpawn === true);
-  // An app-start marker in the event log. log.jsonl had twelve event kinds and
-  // none of them meant "the app restarted", so a relaunch, and more importantly a
-  // switch between a packaged build and a local one, was invisible to every agent
-  // reading the feed. That gap cost a multi-hour investigation whose answer was
-  // exactly this: a local build inherits the launching shell's umask, a
-  // Finder-launched app does not.
+  // 事件日志中的应用启动标记。log.jsonl 曾有十二种事件类型，但没有一种表示“应用
+  // 重启了”，因此一次重启——更重要的是打包构建与本地构建之间的切换——对读取该
+  // 数据流的每个 agent 都不可见。这个缺口导致了一次数小时的排查，答案恰恰就是：
+  // 本地构建继承启动 shell 的 umask，而 Finder 启动的应用不会。
   hive.appendLog({
     kind: 'app-start',
     version: app.getVersion(),
     packaged: app.isPackaged,
-    // WHICH bundle, not just which version. Version plus packaged is not enough
-    // to tell two builds apart: a stale copy in /Applications and a fresh one in
-    // dist/ can report the same version and both be packaged, and picking the
-    // wrong one by habit looks exactly like the new build being broken. Cost us
-    // twice before this line existed.
+    // 是哪一个 bundle，而不只是哪个版本。版本加 packaged 不足以区分两个构建：
+    // /Applications 里的陈旧副本与 dist/ 里的新副本可以报告相同版本且同为打包，
+    // 而凭习惯拿错的那个，看起来恰好就像新构建坏了。在这一行存在之前，我们已经
+    // 为此吃过两次亏。
     appPath: app.getAppPath(),
     exePath: process.execPath,
     electron: process.versions.electron,
     platform: process.platform
   });
   control.replaceAutoDeliveryPauses(readConfig().autoDeliveryPausedAgents ?? []);
-  archiveOrphanedAgents(); // #57/#58: archive stale archived:false entries with no live PTY
+  archiveOrphanedAgents(); // #57/#58: 归档无活动 PTY 的陈旧 archived:false 条目
+  // Roster 名称始终镜像 registry（方案 B, #roster-name-sync）：如果先前 renderer
+  // 的写入在 roster.json 里留下了英文/localStorage 名称，就在启动时把 registry 的
+  // 权威名称盖回去，使 UI 以正确的显示名称打开（例如中文团队名）。RosterStore.write
+  // 会先做备份。
+  try {
+    const boot = roster.read();
+    if (boot) roster.write(withRegistryNames(boot));
+  } catch (e) { console.error('[roster] boot name-sync failed:', e); }
   hive.startRouter();
-  startEphemeralWorkerWatcher(); // poll HIVE_ROOT/spawn-requests → ephemeral workers
-  // Phase 2: the loopback secret broker. Bind it BEFORE workers spawn so each spawn can
-  // be granted a capability token + the broker URL in its env. Loopback-only, idempotent.
+  startEphemeralWorkerWatcher(); // 轮询 HIVE_ROOT/spawn-requests → 临时 worker
+  // 阶段 2：回环机密 broker。在 worker spawn 之前绑定，这样每次 spawn 都能在其 env
+  // 中获授一个能力 token + broker URL。仅回环、幂等。
   void integrationBroker.start().then((r) => {
     if (r.ok) console.log('[broker] integration broker listening on', integrationBroker.url());
     else console.error('[broker] failed to start:', r.error);
   });
-  ensureDefaultMissions(); // one-time: seed the built-in hourly ops standup
-  syncMissions(); // arm recurring auto-dispatch missions now the router is live
-  syncContextTriggers(); // …and the context trigger's own compact/clear cadences
-  // Pair replies to inbound webhook messages in the ledger. Tied to the FEATURE
-  // (any endpoint configured), not to the server: an approved message's card can
-  // finish long after the operator switched the public surface back off, and its
-  // reply still belongs in the history.
+  ensureDefaultMissions(); // 一次性：植入内置的每小时 ops 站会
+  syncMissions(); // 现在 router 已上线，为循环自动派发任务布防
+  syncContextTriggers(); // ……以及 context trigger 自身的 compact/clear 节奏
+  // 把入站 webhook 消息的回复配对到 ledger 中。绑定的是 FEATURE（任何已配置的
+  // endpoint），而不是服务器：一条已批准消息的卡片可以在操作员关掉公共表面很久之后
+  // 才完成，其回复仍应属于历史记录。
   if ((readConfig().webhookTriggers ?? []).length > 0) startWebhookDoneObserver();
   hookServer.start();
-  // Bind the telemetry collector BEFORE the renderer spawns any agent, then point
-  // the hive at it so every subsequent spawn is instrumented. Best-effort — a bind
-  // failure just leaves telemetry off (transcript reconciler stays). No breaker.start():
-  // the breaker is POLICY-only, ticked by the heartbeat beat (#1, ships disabled).
+  // 在 renderer spawn 任何 agent 之前绑定遥测收集器，然后把 hive 指向它，这样之后
+  // 每次 spawn 都会被插桩。尽力而为 —— 绑定失败只是让遥测保持关闭（transcript
+  // reconciler 仍会保留）。无 breaker.start()：breaker 只做策略，由心跳 beat 驱动
+  // （#1，随产品默认关闭）。
   void telemetry.start().then((r) => {
     if (r.ok && r.endpoint) { hive.setOtelEndpoint(r.endpoint); console.log('[telemetry] collector listening', r.endpoint); }
     else console.error('[telemetry] collector failed to start:', r.error);
   });
-  memory.start(); // init shared palace + mine loop (no-op without mempalace)
-  reflector.start(); // bound oversized memory.md files on a timer (no-op until threshold)
+  memory.start(); // 初始化共享 palace + 挖掘循环（无 mempalace 时为无操作）
+  reflector.start(); // 定时约束过大的 memory.md 文件（阈值前为无操作）
 
   armAlwaysOnBeats();
 }
 
-/** Cadence of the worker inbox-wake watchdog (#151). Well under the renderer's
- *  own nudge cooldown so a throttled window is caught within ~15s of a stall. */
+/** worker inbox-wake watchdog 的节奏（#151）。远低于 renderer 自身的 nudge
+ *  冷却，因此节流的窗口能在停滞约 15s 内被捕捉到。 */
 const WORKER_WAKE_POLL_MS = 15_000;
 let workerWakeTimer: ReturnType<typeof setInterval> | null = null;
 
-/** Type the renderer's guarded nudge into one worker's PTY — text first, Enter a
- *  tick later (the exact submitToPty pattern: a single-chunk write would land the
- *  "\r" inside the input box and never submit). Best-effort + never throws. */
+/** 把 renderer 的受保护 nudge 键入一个 worker 的 PTY —— 先文本、稍后一个 tick 再
+ *  回车（正是 submitToPty 的模式：单块写入会把 “\r” 落到输入框内而永不提交）。
+ *  尽力而为 + 从不抛出。 */
 function nudgeWorker(ptyId: string, ids: string[] = []): void {
-  // Same text the renderer queues (#187's inboxNudgeText), so the two wake paths
-  // produce byte-identical nudges: the queue's one-pending rule recognises either
-  // via isInboxNudge, and a watchdog nudge names its ids so the agent can still
-  // tell "I filed this last turn" from "woken for nothing".
+  // 与 renderer 排队的文本相同（#187 的 inboxNudgeText），因此两条唤醒路径产生的
+  // nudge 逐字节一致：队列的单待处理规则可经 isInboxNudge 识别任一条，且 watchdog
+  // nudge 会点名其 ids，使 agent 仍能区分“我上一轮已提交”与“被无缘无故唤醒”。
   const wrote = ptyManager.write(ptyId, inboxNudgeText(ids));
   if (!wrote.ok) { console.warn(`[worker-wake] write failed for ${ptyId}: ${wrote.error}`); return; }
   setTimeout(() => {
@@ -5030,15 +4876,13 @@ function nudgeWorker(ptyId: string, ids: string[] = []): void {
   }, 140);
 }
 
-/** Main-process inbox-wake beat (issue #151, fix A): the renderer's idle nudge
- *  (useHive.ts) is the only path that wakes a worker parked on an undrained
- *  inbox — and it lives on a setInterval in the renderer, which a throttled or
- *  occluded window stops honoring. This beat is the renderer-INDEPENDENT fallback:
- *  it gathers live-worker facts (PTY quiescence, inbox depth, control flags) and
- *  lets WorkerWakeWatchdog.decide apply the exact renderer guards (idle-only,
- *  post-boot-grace, not paused/halted, no pending HITL, cooldown), then types the
- *  same nudge the renderer would have. God is never a candidate (its heartbeat
- *  path already re-engages it). */
+/** 主进程 inbox-wake beat（issue #151，方案 A）：renderer 的闲置 nudge
+ *  （useHive.ts）是唤醒停靠在未排空 inbox 上的 worker 的唯一路径——而它生活在
+ *  renderer 的一个 setInterval 上，被节流或遮挡的窗口会停止履行它。这个 beat 是
+ *  独立于 renderer 的兜底：它收集活动 worker 的事实（PTY 静止、inbox 深度、控制
+ *  标志），让 WorkerWakeWatchdog.decide 应用与 renderer 完全相同的守卫（仅闲置、
+ *  启动宽限期后、未暂停/未停止、无待处理的 HITL、冷却），然后键入 renderer 本会
+ *  键入的同一个 nudge。god 永不是候选（其心跳路径已重新接合它）。 */
 function runWorkerWakeBeat(): void {
   if (!hive.enabled()) return;
   const reg = hive.registry();
@@ -5064,9 +4908,8 @@ function runWorkerWakeBeat(): void {
   for (const agentId of workerWake.decide(facts, now)) {
     const ptyId = ptyForAgent(agentId);
     if (!ptyId) continue;
-    // Re-read at delivery time, not from the facts snapshot: the agent may have
-    // drained the mail during the beat, and a nudge naming ids it already filed
-    // is the exact staleness #187 exists to stop.
+    // 在投递时刻重新读取，而不是用 facts 快照：agent 可能已在本 beat 期间排空了
+    // 邮件，而点名它已提交的 ids 的 nudge，正是 #187 存在所要阻止的那种陈旧。
     const ids = hive.inbox(agentId).map((m) => m.id).filter(Boolean);
     if (!ids.length) { console.log(`[worker-wake] ${agentId} drained before delivery, skipping`); continue; }
     console.log(`[worker-wake] nudging ${agentId} on ${ptyId} (${ids.length} pending)`);
@@ -5074,11 +4917,10 @@ function runWorkerWakeBeat(): void {
   }
 }
 
-/** (Re)arm the always-on beats (decoupled from the optional heartbeat): the live
- *  fleet snapshot Michael reads (~8s) + the breaker/cost-ledger beat (~30s).
- *  Guarded (clear-then-set) so a re-bootstrap (changeHome recovery) OR a
- *  powerMonitor resume can't stack duplicate timers — these are setInterval
- *  handles that freeze during true system sleep and must be re-armed on wake. */
+/** （重新）布防 always-on beats（与可选心跳解耦）：Michael 读取的实时 fleet 快照
+ *  （约 8s）+ breaker/成本 ledger beat（约 30s）。受保护（先清后设），因此重新
+ *  bootstrap（changeHome 恢复）或 powerMonitor resume 都不会堆积重复定时器——这些
+ *  setInterval 句柄在真正的系统休眠期间会冻结，必须在唤醒时重新布防。 */
 function armAlwaysOnBeats(): void {
   if (fleetTimer) clearInterval(fleetTimer);
   writeFleetSnapshot();
@@ -5087,73 +4929,65 @@ function armAlwaysOnBeats(): void {
   breakerBeatTimer = setInterval(() => { try { runBreakerBeat(300_000); } catch (e) { console.error('[breaker beat]', e); } }, 30_000);
   if (workerWakeTimer) clearInterval(workerWakeTimer);
   workerWakeTimer = setInterval(() => { try { runWorkerWakeBeat(); } catch (e) { console.error('[worker-wake beat]', e); } }, WORKER_WAKE_POLL_MS);
-  runWorkerWakeBeat(); // catch-up on arm — power-resume re-arms and drains the backlog
+  runWorkerWakeBeat(); // 布防时追赶 —— power-resume 会重新布防并排空积压
 }
 
-/** Wall-clock instant we last observed the machine suspend or lock, so a resume
- *  can report how long we were out. Best-effort context for the renderer follow-on
- *  (auto-revive); null until the first suspend/lock of the session. */
+/** 我们最后一次观察到机器挂起或锁屏的墙上时钟时刻，使 resume 能报告我们离线了多久。
+ *  为 renderer 后续操作（auto-revive）提供尽力而为的上下文；在会话第一次挂起/锁屏前
+ *  为 null。 */
 let lastSuspendAt: number | null = null;
-/** Single pending post-resume PTY health check, so overlapping resume+unlock
- *  events collapse to ONE check (the latest) instead of stacking. */
+/** 单个待处理的 resume 后 PTY 健康检查，使重叠的 resume+unlock 事件折叠为一次检查
+ *  （最近一次），而不是叠加。 */
 let resumeHealthTimer: NodeJS.Timeout | null = null;
 
-/** After the machine wakes, probe each live PTY for liveness and surface any that
- *  didn't survive. macOS can wedge a child `claude` process/socket across a long
- *  sleep while node-pty still holds the fd (its exit event never fired) — so a
- *  dead PTY can linger in our list. `process.kill(pid, 0)` is a pure existence
- *  probe (signal 0 never touches the process); ESRCH means the process is gone.
- *  We only LOG + NOTIFY here (no auto-kill/respawn — true revive is renderer-owned
- *  via pty:spawn) and emit `power:resume` as the integration point for the
- *  follow-on renderer auto-revive card. */
+/** 机器唤醒后，探测每个活动 PTY 的活性，并暴露任何未能存活的 PTY。macOS 可能在长
+ *  时间休眠期间卡住子 `claude` 进程/套接字，而 node-pty 仍持有该 fd（其 exit 事件
+ *  从未触发）——所以一个已死的 PTY 可能滞留在我们的列表里。`process.kill(pid, 0)`
+ *  是纯粹的存活性探测（信号 0 从不触碰进程）；ESRCH 表示进程已消失。这里我们只
+ *  记录 + 通知（不自动 kill/重生——真正的复活由 renderer 经 pty:spawn 负责），并把
+ *  `power:resume` 作为后续 renderer 自动复活卡片的集成点发出。 */
 function healthCheckPtys(reason: string, awayMs: number | null): void {
   const ptys = ptyManager.list();
   const dead: string[] = [];
   for (const p of ptys) {
     if (typeof p.pid === 'number' && p.pid > 0) {
-      try { process.kill(p.pid, 0); }   // liveness probe only — never kills
-      catch { dead.push(p.id); }        // ESRCH: process gone but PTY still registered
+      try { process.kill(p.pid, 0); }   // 仅为活性探测 —— 绝不 kill
+      catch { dead.push(p.id); }        // ESRCH：进程已消失但 PTY 仍被注册
     }
   }
   const away = awayMs != null ? ` (away ~${Math.round(awayMs / 1000)}s)` : '';
   if (dead.length) {
     console.warn(`[power] ${reason}${away}: ${dead.length}/${ptys.length} PTY(s) look wedged (process gone):`, dead.join(', '));
-    breakerToast('Agents need a restart', `${dead.length} agent terminal(s) didn't survive sleep — re-open them to resume.`);
+    breakerToast(l10n('Agents need a restart', '代理需要重启'), l10n(`${dead.length} agent terminal(s) didn't survive sleep — re-open them to resume.`, `${dead.length} 个代理终端在休眠后未能恢复——请重新打开以继续。`));
   } else {
     console.log(`[power] ${reason}${away}: ${ptys.length} PTY(s) healthy`);
   }
-  // Single integration point for the (separate) renderer auto-revive card: it can
-  // listen for 'power:resume' and respawn the `dead` PTYs with --resume.
-  try { liveWebContents()?.send('power:resume', { reason, awayMs, dead, total: ptys.length }); } catch { /* window gone */ }
+  // （独立的）renderer 自动复活卡片的唯一集成点：它可以监听 'power:resume' 并用
+  // --resume 重生这些 `dead` PTY。
+  try { liveWebContents()?.send('power:resume', { reason, awayMs, dead, total: ptys.length }); } catch { /* 窗口已销毁 */ }
 }
 
-/** Re-arm everything that runs on a frozen libuv timer after the machine slept,
- *  and surface any PTY that didn't survive. macOS pauses setTimeout/setInterval
- *  during true system sleep (the monotonic clock halts) — on wake they resume
- *  where they paused, shifted by the whole sleep, so missions due during sleep
- *  never fired and never replay. We rebuild the scheduler (syncMissions reuses its
- *  remaining=max(0,…) semantics → each overdue mission fires exactly ONCE then
- *  re-settles, never N replays), re-arm the always-on beats, re-evaluate the
- *  power blocker, then — after a short grace for PTYs to wake their pipes —
- *  health-check the terminals. Idempotent: overlapping resume+unlock events
- *  collapse safely (clear-then-arm everywhere; at most one catch-up fire). */
+/** 机器休眠后，重新布防每个运行在冻结的 libuv 定时器上的东西，并暴露任何未能存活的
+ *  PTY。macOS 在真正的系统休眠期间会暂停 setTimeout/setInterval（单调时钟停止）——
+ *  唤醒后它们从暂停处继续，整体偏移整个休眠时长，因此休眠期间到期的任务从未触发、
+ *  也从未重放。我们重建调度器（syncMissions 复用其 remaining=max(0,…) 语义 → 每个
+ *  逾期的任务恰好触发一次后重新归位，绝不 N 次重放），重新布防 always-on beats，
+ *  重新评估 power blocker，然后——在给 PTY 一个唤醒其管道的短暂宽限期之后——健康
+ *  检查终端。幂等：重叠的 resume+unlock 事件安全折叠（处处先清后设；至多一次追赶触发）。 */
 function onSystemResume(reason: string): void {
   console.log(`[power] ${reason} — re-arming scheduler, beats, router, keep-awake`);
   try { syncMissions(); } catch (e) { console.error('[power] syncMissions on resume', e); }
-  // Same freeze, same catch-up: the context timers honour elapsed-time-since-last-
-  // run, so a compact/clear that came due while the machine slept fires ONCE here
-  // rather than being lost or replayed N times.
+  // 同样的冻结、同样的追赶：context 定时器尊重距上次运行的经过时间，因此在机器休眠
+  // 期间到期的 compact/clear 在这里恰好触发一次，而不是丢失或重放 N 次。
   try { syncContextTriggers(); } catch (e) { console.error('[power] syncContextTriggers on resume', e); }
   try { armAlwaysOnBeats(); } catch (e) { console.error('[power] armAlwaysOnBeats on resume', e); }
-  // The hive message router (outbox→inbox drain) is a setInterval that freezes
-  // during true system sleep exactly like the beats above — but it was the one
-  // always-on timer never re-armed on wake. Symptom: after a long sleep the
-  // scheduler→god path recovered (it injects straight into god's inbox), while
-  // every agent's outbox silently stopped draining, so god→worker and
-  // worker↔worker mail piled up undelivered. Re-arm the poll loop (clear-then-set,
-  // idempotent) and immediately drain the backlog that accrued while we were out
-  // instead of waiting for the first post-wake tick. The renderer's idle inbox-wake
-  // nudge (useHive.ts) then wakes each parked recipient once its mail lands.
+  // hive 消息 router（outbox→inbox 排空）是与上面那些 beat 一样的 setInterval，在
+  // 真正的系统休眠期间冻结——但它是唯一从未在唤醒时重新布防的 always-on 定时器。
+  // 症状：长时间休眠后，scheduler→god 路径恢复（它直接注入 god 的 inbox），而每个
+  // agent 的 outbox 静默停止排空，导致 god→worker 和 worker↔worker 邮件积压未送达。
+  // 重新布防轮询循环（先清后设、幂等）并立即排空我们离线期间累积的积压，而不是等待
+  // 唤醒后的第一个 tick。然后 renderer 的闲置 inbox-wake nudge（useHive.ts）会在
+  // 邮件落地的瞬间唤醒每个停靠的收件人。
   try {
     hive.stopRouter();
     hive.startRouter();
@@ -5162,8 +4996,8 @@ function onSystemResume(reason: string): void {
   } catch (e) { console.error('[power] router re-arm on resume', e); }
   try { syncKeepAwake(); } catch (e) { console.error('[power] syncKeepAwake on resume', e); }
   const awayMs = lastSuspendAt != null ? Date.now() - lastSuspendAt : null;
-  // Give PTYs a beat to resume their pipes before judging them wedged; reset any
-  // pending check so a resume quickly followed by unlock runs the probe just once.
+  // 在判定终端异常前，给 PTY 一个恢复管道的节拍；重置任何待处理检查，使快速 resume
+  // 后紧接 unlock 只运行一次探测。
   if (resumeHealthTimer) clearTimeout(resumeHealthTimer);
   resumeHealthTimer = setTimeout(() => {
     resumeHealthTimer = null;
@@ -5172,59 +5006,53 @@ function onSystemResume(reason: string): void {
 }
 
 app.whenReady().then(() => {
-  // Realtime Michael mic-gate hygiene (rt-8 / Pam rt-10 nit): the voice session
-  // opens the mic permission gate by persisting realtimeVoiceEnabled=true and
-  // closes it on disconnect — but a hard crash/reload mid-session skips that
-  // teardown, leaving the flag stuck true so the gate would boot PRE-OPEN with no
-  // live session. Force it closed at startup (a real session re-opens it via
-  // setMicGate(true)); macOS TCC stays a second gate regardless.
+  // Realtime Michael 麦克风门控卫生（rt-8 / Pam rt-10 nit）：语音会话通过持久化
+  // realtimeVoiceEnabled=true 打开麦克风权限门，并在断开时关闭它——但会话中途硬崩溃/
+  // 重载会跳过该 teardown，使标志卡在 true，导致门控以无活动会话的 PRE-OPEN 状态
+  // 启动。在启动时强制关闭它（真正的会话会经 setMicGate(true) 重新打开）；macOS TCC
+  // 无论如何仍是第二道门。
   if (readConfig().realtimeVoiceEnabled) writeConfig({ realtimeVoiceEnabled: false });
 
-  // Anonymous product analytics (PostHog) — the full contract lives in
-  // TELEMETRY.md. No-op unless a build-time key was injected (official releases
-  // only), and gated on DO_NOT_TRACK + the telemetryEnabled config (opt-out).
+  // 匿名产品分析（PostHog）——完整约定见 TELEMETRY.md。除非注入了构建时密钥（仅官方
+  // 发布），否则为无操作，并受 DO_NOT_TRACK + telemetryEnabled 配置门控（可退出）。
   analytics.init({
     stateDir: app.getPath('userData'),
     appVersion: app.getVersion(),
     enabled: readConfig().telemetryEnabled !== false
   });
 
-  // A cold-start deep link (Windows/Linux) rides in on OUR argv.
+  // 冷启动深链（Windows/Linux）搭载在我们自己的 argv 上。
   const startupHireLink = process.argv.find((a) => a.startsWith('munderdifflin://'));
   if (startupHireLink) void handleHireLink(startupHireLink);
 
-  // Hand every spawned agent the path to the Slack reply discovery file via the
-  // inherited env (pty merges process.env). The path is stable whether or not the
-  // server is running; the FILE only exists while it is, so the helper degrades
-  // to "endpoint not running" cleanly. NO secret is in the env — only the path.
+  // 通过继承的 env（pty 合并 process.env）把 Slack 回复发现文件的路径交给每个已
+  // spawn 的 agent。无论服务器是否在运行，该路径都稳定；而文件只在服务器运行期间
+  // 存在，因此辅助函数会干净地退化为“endpoint 未运行”。env 中没有任何机密——只有路径。
   process.env.MD_SLACK_REPLY_CONFIG = slackReplyConfigPath();
-  // Open the durable store first — createWindow() reads the saved window bounds.
-  // Guarded: a DB failure (e.g. a bad native build) must degrade to defaults,
-  // never block app startup.
+  // 先打开持久化存储——createWindow() 会读取保存的窗口边界。受保护：数据库故障
+  // （例如原生构建损坏）必须退化为默认值，绝不让应用启动阻塞。
   try { persist.open(); } catch (e) { console.error('[db] open failed:', e); }
-  // Auto-update from GitHub releases (packaged builds only; gated on the
-  // `autoUpdate` config flag). Download-in-background + restart-to-apply toast;
-  // never restarts on its own. Falls back to a notify-only releases/latest
-  // check where native updating isn't possible (win-portable, dev-ish builds).
+  // 从 GitHub releases 自动更新（仅打包构建；受 `autoUpdate` 配置标志门控）。
+  // 后台下载 + 重启应用 toast；从不自行重启。在无法进行原生更新的地方（win-portable、
+  // 类 dev 构建）回退为仅通知的 releases/latest 检查。
   initAutoUpdater(() => liveWebContents());
-  // Bootstrap the hive (if harnessHome is configured) and start the message router.
+  // 启动 hive（若已配置 harnessHome）并启动消息 router。
   bootstrapHiveServices();
-  // Survive sleep/lock. macOS freezes libuv timers during true system sleep, so a
-  // locked/idle/slept Mac stops firing schedules and can wedge PTYs. On wake we
-  // re-arm the scheduler (catching up missed missions ONCE) + beats + keep-awake,
-  // then health-check terminals. App-lifetime listeners — powerMonitor outlives
-  // every window, so there is nothing to tear down on quit.
+  // 挺过休眠/锁屏。macOS 在真正的系统休眠期间冻结 libuv 定时器，因此锁屏/闲置/休眠的
+  // Mac 会停止触发调度并可能卡住 PTY。唤醒时我们重新布防调度器（一次性追赶错过的
+  // 任务）+ beats + keep-awake，然后健康检查终端。应用生命周期监听器——powerMonitor
+  // 比每个窗口都活得久，因此退出时无需拆除任何东西。
   powerMonitor.on('resume', () => onSystemResume('resume'));
   powerMonitor.on('unlock-screen', () => onSystemResume('unlock-screen'));
   powerMonitor.on('suspend', () => { lastSuspendAt = Date.now(); console.log('[power] suspend — system sleeping'); });
   powerMonitor.on('lock-screen', () => { lastSuspendAt = Date.now(); console.log('[power] lock-screen'); });
-  // Multi-window floors (opt-in): install the menu carrying "New Floor". When
-  // off, the app keeps Electron's default menu — zero behavior change.
+  // 多窗口楼层（可选加入）：安装携带 “New Floor” 的菜单。关闭时，应用保留 Electron
+  // 的默认菜单——零行为变化。
   if (readConfig().multiWindow) installAppMenu();
   createWindow();
-  // Auto-start the Slack webhook server when configured. Best-effort: a tunnel
-  // failure (offline) is logged, not fatal. The tunnel URL is ephemeral and
-  // changes per restart, so the user re-pastes it via Settings → Start.
+  // 配置时自动启动 Slack webhook 服务器。尽力而为：tunnel 失败（离线）只记日志，
+  // 不致命。tunnel URL 是临时的、每次重启都会变化，因此用户经 Settings → Start
+  // 重新粘贴。
   const slackCfg = readConfig();
   if (slackCfg.slackEnabled && slackCfg.slackSigningSecret) {
     void startSlackServer().then((r) => {
@@ -5232,9 +5060,8 @@ app.whenReady().then(() => {
       else console.log('[slack] webhook listening', r.url ? `(tunnel: ${r.url})` : '(no tunnel)');
     });
   }
-  // Auto-start the generic webhook only for endpoints the user has explicitly
-  // enabled (each with its own secret) — never a default-on public surface.
-  // Opt-in, like Slack; an install with no enabled endpoint opens no tunnel.
+  // 只为用户显式启用的 endpoint（各有其独立密钥）自动启动通用 webhook——绝不默认
+  // 开启公共表面。与 Slack 一样是可选的；未启用任何 endpoint 的安装不会打开 tunnel。
   if (enabledWebhookEndpoints().length > 0) {
     void startWebhookServer().then((r) => {
       if (!r.ok) console.error('[webhook] auto-start failed:', r.error);
@@ -5246,8 +5073,8 @@ app.whenReady().then(() => {
   });
 });
 
-// before-quit covers Cmd-Q / dock-quit; the per-window close handler covers
-// the red close button. Both routes hit the same warning UX.
+// before-quit 覆盖 Cmd-Q / dock 退出；每窗口的关闭处理器覆盖红色关闭按钮。两条路径
+// 都命中同一个警告 UX。
 app.on('before-quit', (e) => {
   if (allowQuit) return;
   const count = ptyManager.list().length;
@@ -5259,8 +5086,8 @@ app.on('before-quit', (e) => {
   }
 });
 
-// Every window loads the config once at start-up, so tell them all when a
-// setting is saved — a floor left out would keep showing what it opened with.
+// 每个窗口都在启动时加载一次配置，所以在设置被保存时告知它们全部——被漏掉的楼层
+// 会一直显示它打开时的旧配置。
 onConfigWritten((config) => {
   for (const w of allWindows) {
     if (w.isDestroyed() || w.webContents.isDestroyed()) continue;
@@ -5270,27 +5097,24 @@ onConfigWritten((config) => {
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    // Full teardown, not a bare killAll: this path must also stop the proxy
-    // sidecars and helper servers — on Windows a child is NOT killed when its
-    // parent exits, so anything skipped here outlives the app.
+    // 完整 teardown，而非单纯的 killAll：这条路径还必须停止 proxy 侧车和辅助服务器
+    // ——在 Windows 上，子进程不会随父进程退出而被杀掉，所以任何在这里被跳过的东西
+    // 都会比应用活得更久。
     teardownAndQuit();
   }
 });
 
-// Final analytics flush (session_ended + drain the send queue), bounded so a
-// hung network can never wedge quit: preventDefault ONCE, race the flush
-// against a short timeout, then exit hard.
+// 最终的分析 flush（session_ended + 排空发送队列），设有界，使挂起的网络永远不会
+// 卡死退出：preventDefault 一次，让 flush 与一个短超时竞速，然后硬退出。
 //
-// finish MUST be app.exit(), not a re-entrant app.quit(): when the quit was
-// initiated while a window was still open (the "kill all & quit" confirm path
-// calls teardownAndQuit → app.quit() and the window closes DURING that quit),
-// Electron is left with its internal is-quitting state set after this
-// preventDefault, and the later app.quit() is silently a no-op — no before-quit,
-// no will-quit, no quit; the main process idles forever with zero windows. On
-// Windows that stranded the whole Electron process group (main + GPU + network
-// service) after every agents-running quit. By this point teardown has already
-// run and the flush has finished or timed out, so an unconditional exit is
-// exactly what's left to do.
+// finish 必须是 app.exit()，而不是可重入的 app.quit()：当退出是在窗口仍打开时发起
+// 的（“kill all & quit” 确认路径调用 teardownAndQuit → app.quit()，而窗口在退出
+// 过程中关闭），Electron 会在这次 preventDefault 之后把内部 is-quitting 状态置位，
+// 之后再次调用 app.quit() 会静默地成为 no-op——没有 before-quit、没有 will-quit、
+// 没有 quit；主进程在零窗口的情况下永远空转。在 Windows 上，这让整个 Electron
+// 进程组（main + GPU + network service）在每次 agents-running 退出后都被搁浅。到
+// 这一步，teardown 已经运行完毕，flush 也已结束或超时，所以无条件的退出正是剩下
+// 要做的事。
 let analyticsFlushed = false;
 app.on('will-quit', (e) => {
   if (analyticsFlushed) return;

--- a/src/main/integrationBroker.ts
+++ b/src/main/integrationBroker.ts
@@ -1,27 +1,24 @@
 /**
- * Loopback secret broker (Phase 2 foundation, main process).
+ * 回环地址秘密代理（Phase 2 基础，主进程）。
  *
- * A 127.0.0.1-only HTTP proxy. An ephemeral worker calls
+ * 一个仅限 127.0.0.1 的 HTTP 代理。临时 worker 调用
  *   <METHOD> http://127.0.0.1:<port>/i/<integrationId>/<path...>
- * authenticating with a PER-WORKER CAPABILITY TOKEN (a handle, NOT any secret) in the
- * `Authorization: Bearer` / `X-MD-Broker-Token` header. The broker validates the token,
- * authorizes the integration, decrypts the integration's real secret, injects it as the
- * upstream auth header, forwards to the integration's baseUrl, and streams the response
- * back. The worker uses the integration WITHOUT EVER SEEING the credential.
+ * 在 `Authorization: Bearer` / `X-MD-Broker-Token` 头中携带“每个 worker 的
+ * 能力令牌”（一个句柄，不是任何秘密）认证。代理校验令牌、授权该集成、
+ * 解密集成真实的秘密，把它作为上游认证头注入，转发到集成的 baseUrl，
+ * 并把响应流式返回。worker 使用该集成但“从未看到凭证”。
  *
- * Generalizes the existing src/main/slack.ts `SlackReplyServer` (a loopback broker that
- * posts Slack replies without the agent seeing the bot token) to an N-integration proxy.
+ * 把现有 src/main/slack.ts 的 `SlackReplyServer`（一个在不暴露 bot token 的
+ * 情况下发 Slack 回复的回环代理）泛化为 N 集成代理。
  *
- * DEPENDENCY-FREE of electron by design: `getRecord` + `getSecret` are injected, so this
- * module is unit-testable under plain node. The secret is materialized ONLY here, at
- * forward-time, and is NEVER logged, NEVER returned to the worker, NEVER echoed in an
- * error.
+ * 设计上对 electron 零依赖：`getRecord` + `getSecret` 由注入提供，因此本模块
+ * 可以在纯 node 下做单元测试。秘密只在转发时刻于此处实体化，绝不记录日志、
+ * 绝不返回给 worker、绝不在错误里回显。
  *
- * NOT an open proxy: a worker can only reach baseUrls the user registered (it selects an
- * integration by id, never a host), and the path is confined under the integration
- * origin (see resolveUpstreamUrl).
+ * 不是开放代理：worker 只能访问用户注册的 baseUrl（它按 id 选择集成，
+ * 从不选择主机），路径也被限制在集成源站之下（见 resolveUpstreamUrl）。
  *
- * Contract: hive/docs/integrations-spec.md.
+ * 契约：hive/docs/integrations-spec.md。
  */
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
@@ -33,21 +30,21 @@ import {
   authTypeNeedsSecret
 } from '../shared/integrations';
 
-const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB request-body cap
+const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB 请求体上限
 const UPSTREAM_TIMEOUT_MS = 30_000;
 const DEFAULT_USER_AGENT = 'munder-difflin-broker/1';
 
-/** Hop-by-hop headers never forwarded in either direction. */
+/** 逐跳（hop-by-hop）头，两个方向都绝不转发。 */
 const HOP_BY_HOP = new Set([
   'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
   'te', 'trailer', 'transfer-encoding', 'upgrade'
 ]);
-/** Request headers the worker is NEVER allowed to pass upstream. */
+/** 绝不允许 worker 传给上游的请求头。 */
 const STRIP_REQUEST = new Set([
   'authorization', 'x-md-broker-token', 'host', 'cookie', 'content-length', ...HOP_BY_HOP
 ]);
-/** Response headers never forwarded back (fetch already decodes the body, so the
- *  upstream content-encoding/length would be wrong). */
+/** 绝不转发回给下游的响应头（fetch 已经解码了响应体，因此上游的
+ *  content-encoding/length 会是错的）。 */
 const STRIP_RESPONSE = new Set([
   'content-encoding', 'content-length', 'set-cookie', ...HOP_BY_HOP
 ]);
@@ -59,13 +56,13 @@ interface Capability {
 }
 
 export interface IntegrationBrokerDeps {
-  /** Resolve an integration record by id (injected — the registry). */
+  /** 按 id 解析集成记录（注入——注册表）。 */
   getRecord: (id: string) => IntegrationRecord | undefined;
-  /** Decrypt a secret by ref (injected — the secret store). Main-internal. */
+  /** 按 ref 解密秘密（注入——秘密存储）。仅供主进程内部。 */
   getSecret: (secretRef: string | undefined) => string | undefined;
 }
 
-/** True for IPv4 loopback (127.0.0.0/8) and IPv6 ::1 (incl. v4-mapped). Mirrors slack.ts. */
+/** 对 IPv4 回环（127.0.0.0/8）和 IPv6 ::1（含 v4 映射）返回 true。与 slack.ts 一致。 */
 function isLoopback(addr: string): boolean {
   const a = addr.replace(/^::ffff:/, '');
   return a === '::1' || a.startsWith('127.');
@@ -75,16 +72,16 @@ export class IntegrationBroker {
   private server: Server | null = null;
   private port = 0;
   private readonly deps: IntegrationBrokerDeps;
-  /** token -> capability. In-memory only; NEVER persisted. */
+  /** token → 能力。仅存内存；绝不持久化。 */
   private readonly byToken = new Map<string, Capability>();
-  /** workerId -> token, for revoke. */
+  /** workerId → token，用于撤销。 */
   private readonly byWorker = new Map<string, string>();
 
   constructor(deps: IntegrationBrokerDeps) {
     this.deps = deps;
   }
 
-  /** Bind a loopback port (0 ⇒ OS-assigned). Resolves the bound port. */
+  /** 绑定一个回环端口（0 ⇒ 由操作系统分配）。resolve 出已绑定的端口。 */
   start(preferredPort = 0): Promise<{ ok: boolean; port?: number; error?: string }> {
     return new Promise((resolve) => {
       if (this.server) { resolve({ ok: true, port: this.port }); return; }
@@ -99,33 +96,33 @@ export class IntegrationBroker {
       };
       server.once('error', onError);
       server.once('listening', onListening);
-      // 127.0.0.1 ONLY — never bound to a routable interface, never tunneled.
+      // 仅限 127.0.0.1——绝不绑定到可路由接口，绝不隧道化。
       server.listen(preferredPort, '127.0.0.1');
     });
   }
 
-  /** Close the broker. Idempotent and best-effort. Clears all capabilities. */
+  /** 关闭代理。幂等且尽力而为。清除全部能力。 */
   stop(): void {
-    try { this.server?.close(); } catch { /* noop */ }
+    try { this.server?.close(); } catch { /* 空操作 */ }
     this.server = null;
     this.port = 0;
     this.byToken.clear();
     this.byWorker.clear();
   }
 
-  /** Whether the broker is bound and serving. */
+  /** 代理是否已绑定并对外服务。 */
   running(): boolean {
     return !!this.server && this.port > 0;
   }
 
-  /** The base URL workers use (only valid while running). */
+  /** worker 使用的基础 URL（仅在运行期间有效）。 */
   url(): string {
     return `http://127.0.0.1:${this.port}`;
   }
 
-  /** Mint a per-worker capability token granting access to `allowedIds`. Any prior
-   *  token for this worker is revoked first. The token is a random handle — never a
-   *  secret, never persisted. */
+  /** 铸造一个授予 `allowedIds` 访问权的、每 worker 的能力令牌。该 worker
+   *  先前的任何令牌都会先行撤销。令牌是一个随机句柄——绝不是秘密、
+   *  绝不持久化。 */
   grant(workerId: string, allowedIds: string[]): string {
     this.revoke(workerId);
     const token = randomBytes(32).toString('base64url');
@@ -134,13 +131,13 @@ export class IntegrationBroker {
     return token;
   }
 
-  /** Revoke a worker's capability (called on teardown). Idempotent. */
+  /** 撤销 worker 的能力（拆除时调用）。幂等。 */
   revoke(workerId: string): void {
     const token = this.byWorker.get(workerId);
     if (token) { this.byToken.delete(token); this.byWorker.delete(workerId); }
   }
 
-  /** Constant-time-ish lookup of a presented token against live capabilities. */
+  /** 对出示的令牌对照现存能力做“近似恒定时间”的查找。 */
   private resolveCapability(provided: string | undefined): Capability | undefined {
     if (!provided) return undefined;
     const a = Buffer.from(provided);
@@ -152,12 +149,12 @@ export class IntegrationBroker {
   }
 
   private static sendError(res: ServerResponse, status: number, code: string, message: string): void {
-    if (res.headersSent) { try { res.end(); } catch { /* noop */ } return; }
+    if (res.headersSent) { try { res.end(); } catch { /* 空操作 */ } return; }
     res.writeHead(status, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ error: message, code }));
   }
 
-  /** Extract the bearer/x-md-broker-token from the request. */
+  /** 从请求中提取 bearer/x-md-broker-token。 */
   private static tokenFrom(req: IncomingMessage): string | undefined {
     const x = req.headers['x-md-broker-token'];
     if (typeof x === 'string' && x) return x;
@@ -170,15 +167,15 @@ export class IntegrationBroker {
   }
 
   private handle(req: IncomingMessage, res: ServerResponse): void {
-    // 1) Loopback — defense in depth even though the bind already excludes others.
+    // 1) 回环——虽然是纵深防御，绑定本身已排除其他来源。
     if (!isLoopback(req.socket.remoteAddress ?? '')) {
       return IntegrationBroker.sendError(res, 403, 'forbidden', 'loopback callers only');
     }
-    // 2) Capability token.
+    // 2) 能力令牌。
     const cap = this.resolveCapability(IntegrationBroker.tokenFrom(req));
     if (!cap) return IntegrationBroker.sendError(res, 401, 'unauthorized', 'missing or invalid capability token');
 
-    // 3) Parse /i/<integrationId>/<path...>.
+    // 3) 解析 /i/<integrationId>/<path...>。
     const rawUrl = req.url ?? '';
     const m = /^\/i\/([^/?#]+)(?:\/([^?#]*))?(\?[^#]*)?$/.exec(rawUrl);
     if (!m) return IntegrationBroker.sendError(res, 404, 'not_found', 'expected /i/<integrationId>/<path>');
@@ -186,20 +183,20 @@ export class IntegrationBroker {
     const path = m[2] ?? '';
     const query = m[3] ?? '';
 
-    // 4) Authorize against this worker's capability.
+    // 4) 对照该 worker 的能力做授权。
     if (!cap.allowedIds.has(integrationId)) {
       return IntegrationBroker.sendError(res, 403, 'forbidden', 'integration not in this worker capability');
     }
-    // 5) Resolve the record (still enabled?).
+    // 5) 解析记录（仍然启用？）。
     const rec = this.deps.getRecord(integrationId);
     if (!rec) return IntegrationBroker.sendError(res, 404, 'not_found', 'unknown integration');
     if (!rec.enabled) return IntegrationBroker.sendError(res, 403, 'forbidden', 'integration is disabled');
 
-    // 6) Confine the upstream URL under the integration origin (NOT an open proxy).
+    // 6) 把上游 URL 限制在集成源站之下（不是开放代理）。
     const upstream = resolveUpstreamUrl(rec.baseUrl, path + query);
     if (!upstream) return IntegrationBroker.sendError(res, 400, 'bad_request', 'invalid or out-of-bounds path');
 
-    // 7) Secret (decrypted ONLY here, used ONLY to inject the upstream header).
+    // 7) 秘密（只在此处解密，只用于注入上游头）。
     let secret: string | undefined;
     if (authTypeNeedsSecret(rec.authType)) {
       secret = this.deps.getSecret(rec.secretRef);
@@ -216,7 +213,7 @@ export class IntegrationBroker {
     upstream: URL,
     secret: string | undefined
   ): Promise<void> {
-    // Buffer the request body with a hard cap (write methods).
+    // 带硬上限缓冲请求体（写方法）。
     const method = (req.method ?? 'GET').toUpperCase();
     const hasBody = method !== 'GET' && method !== 'HEAD';
     let body: Buffer | undefined;
@@ -231,8 +228,8 @@ export class IntegrationBroker {
       }
     }
 
-    // Sanitize worker headers, then inject the auth header(s). Injected auth ALWAYS
-    // wins: the strip list removes any worker-supplied authorization/auth header.
+    // 清洗 worker 头，然后注入认证头。注入的认证“总是”
+    // 生效：清洗清单会移除任何 worker 提供的 authorization/auth 头。
     const outHeaders: Record<string, string> = {};
     for (const [k, v] of Object.entries(req.headers)) {
       const key = k.toLowerCase();
@@ -243,7 +240,7 @@ export class IntegrationBroker {
     if (!outHeaders['user-agent']) outHeaders['user-agent'] = DEFAULT_USER_AGENT;
     const injected = buildAuthHeaders(rec.authType, rec.authHeader, secret);
     for (const [k, v] of Object.entries(injected)) {
-      delete outHeaders[k]; // ensure the worker can't shadow an injected header
+      delete outHeaders[k]; // 确保 worker 无法遮蔽已注入的头
       outHeaders[k] = v;
     }
 
@@ -260,11 +257,11 @@ export class IntegrationBroker {
       });
     } catch (e) {
       clearTimeout(timer);
-      // The message could in theory contain the URL but never the secret.
+      // 理论上消息可以包含 URL，但绝不能包含秘密。
       return IntegrationBroker.sendError(res, 502, 'bad_gateway', `upstream request failed: ${(e as Error).message}`);
     }
 
-    // Stream the response back (status + sanitized headers + body).
+    // 把响应流式返回（状态 + 已清洗的头 + 响应体）。
     const respHeaders: Record<string, string> = {};
     upstreamRes.headers.forEach((value, key) => {
       if (!STRIP_RESPONSE.has(key.toLowerCase())) respHeaders[key] = value;
@@ -277,14 +274,14 @@ export class IntegrationBroker {
         res.end();
       }
     } catch {
-      try { res.end(); } catch { /* socket gone */ }
+      try { res.end(); } catch { /* 套接字已消失 */ }
     } finally {
       clearTimeout(timer);
     }
   }
 }
 
-/** Read a request body into a Buffer, aborting past MAX_BODY_BYTES (throws 'too_large'). */
+/** 把请求体读入 Buffer，超过 MAX_BODY_BYTES 即中止（抛 'too_large'）。 */
 function readBodyCapped(req: IncomingMessage): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -299,7 +296,7 @@ function readBodyCapped(req: IncomingMessage): Promise<Buffer> {
   });
 }
 
-/** Pipe a web ReadableStream (fetch response body) to a node ServerResponse. */
+/** 把 web ReadableStream（fetch 响应体）管道到 node ServerResponse。 */
 function pipeWebStream(web: ReadableStream<Uint8Array>, res: ServerResponse): Promise<void> {
   return new Promise((resolve, reject) => {
     const node = Readable.fromWeb(web as Parameters<typeof Readable.fromWeb>[0]);

--- a/src/main/integrations.ts
+++ b/src/main/integrations.ts
@@ -1,20 +1,20 @@
 /**
- * Integrations registry + encrypted secret store (Phase 2 foundation, main process).
+ * 集成注册表 + 加密秘密存储（Phase 2 基础，主进程）。
  *
- * Two responsibilities, deliberately separated from the broker:
- *   1. Registry — config-backed CRUD over IntegrationRecord metadata (NO secrets).
- *   2. Secret store — secrets ENCRYPTED AT REST via Electron `safeStorage`, kept in a
- *      file SEPARATE from config.json, decrypted only here, only in main.
+ * 两个职责，刻意与代理分离：
+ *   1. 注册表——对 IntegrationRecord 元数据的、基于 config 的 CRUD（无秘密）。
+ *   2. 秘密存储——通过 Electron `safeStorage` 在静态时加密的秘密，存放在
+ *      与 config.json “分开”的文件里，只在这里、只在主进程中解密。
  *
- * The broker (src/main/integrationBroker.ts) is electron-free and receives `getRecord`
- * + `getSecret` from here by injection, so it stays unit-testable without electron.
+ * 代理（src/main/integrationBroker.ts）不依赖 electron，通过注入从这里拿到
+ * `getRecord` + `getSecret`，因此它在没有 electron 的情况下仍可单元测试。
  *
- * SECURITY: a secret is never written unless `safeStorage.isEncryptionAvailable()`
- * (fail closed — no plaintext fallback), never returned to the renderer, never logged,
- * never placed in agent env/transcript, never echoed in any response. Records carry
- * only a `secretRef` handle.
+ * 安全：除非 `safeStorage.isEncryptionAvailable()`（关闭即失败——没有明文
+ * 回退），否则绝不写入秘密；绝不移交给渲染进程、绝不记录日志、绝不放进
+ * agent 的 env/transcript、绝不在任何响应中回显。记录只携带一个
+ * `secretRef` 句柄。
  *
- * Contract: hive/docs/integrations-spec.md.
+ * 契约：hive/docs/integrations-spec.md。
  */
 import { app, safeStorage } from 'electron';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
@@ -27,29 +27,28 @@ import {
 } from '../shared/integrations';
 import { readConfig, writeConfig } from './config';
 
-// ─── Registry (config-backed) ────────────────────────────────────────────────
+// ─── 注册表（基于 config）───────────────────────────────────────────────────
 
-/** All registered integration records (metadata only). */
+/** 全部已注册的集成记录（仅元数据）。 */
 export function listRecords(): IntegrationRecord[] {
   return readConfig().integrations ?? [];
 }
 
-/** Look up one record by id. */
+/** 按 id 查找一条记录。 */
 export function getRecord(id: string): IntegrationRecord | undefined {
   return listRecords().find((r) => r.id === id);
 }
 
-/** Ids of integrations a worker may use right now (enabled, and — for secret auth —
- *  actually holding a stored secret). This is the default capability scope granted to
- *  every ephemeral worker. */
+/** worker 当前可以用到的集成 id（已启用，且——对于秘密认证——确实持有
+ *  已存储的秘密）。这是授予每个临时 worker 的默认能力范围。 */
 export function enabledIds(): string[] {
   return listRecords()
     .filter((r) => r.enabled && (!authTypeNeedsSecret(r.authType) || hasSecret(r.secretRef)))
     .map((r) => r.id);
 }
 
-/** Create or replace a record (validated). Stamps createdAt/updatedAt; preserves the
- *  original createdAt on update. Does NOT touch the secret store. */
+/** 创建或替换一条记录（已校验）。打上 createdAt/updatedAt 时间戳；更新时
+ *  保留原始的 createdAt。不碰秘密存储。 */
 export function upsertRecord(input: unknown): { ok: true; record: IntegrationRecord } | { ok: false; error: string } {
   const v = validateIntegrationRecord(input);
   if (!v.ok) return v;
@@ -66,7 +65,7 @@ export function upsertRecord(input: unknown): { ok: true; record: IntegrationRec
   return { ok: true, record };
 }
 
-/** Remove a record AND its stored secret. */
+/** 移除一条记录及其存储的秘密。 */
 export function removeRecord(id: string): { ok: boolean } {
   const next = listRecords().filter((r) => r.id !== id);
   writeConfig({ integrations: next });
@@ -74,12 +73,12 @@ export function removeRecord(id: string): { ok: boolean } {
   return { ok: true };
 }
 
-/** Records with the secretRef redacted to a boolean — the renderer-safe shape. */
+/** 把 secretRef 隐去为布尔值的记录——渲染进程安全的形状。 */
 export function listRecordsRedacted(): Array<Omit<IntegrationRecord, 'secretRef'> & { hasSecret: boolean }> {
   return listRecords().map(({ secretRef, ...rest }) => ({ ...rest, hasSecret: !!secretRef && hasSecret(secretRef) }));
 }
 
-// ─── Secret store (encrypted at rest) ────────────────────────────────────────
+// ─── 秘密存储（静态加密）───────────────────────────────────────────────────
 
 function secretsPath(): string {
   return join(app.getPath('userData'), 'integration-secrets.json');
@@ -102,8 +101,8 @@ function writeSecretBlob(blob: Record<string, string>): void {
   writeFileSync(p, JSON.stringify(blob, null, 2), { encoding: 'utf8', mode: 0o600 });
 }
 
-/** Store a secret ENCRYPTED. Fail closed if OS encryption is unavailable (never
- *  writes plaintext). The plaintext is used only to encrypt and is not retained. */
+/** 以加密形式存储秘密。若 OS 加密不可用则关闭即失败（绝不写入明文）。
+ *  明文只用于加密，不会保留。 */
 export function setSecret(secretRef: string, plaintext: string): { ok: boolean; error?: string } {
   if (!secretRef) return { ok: false, error: 'secretRef required' };
   if (typeof plaintext !== 'string' || plaintext === '') return { ok: false, error: 'secret required' };
@@ -121,8 +120,8 @@ export function setSecret(secretRef: string, plaintext: string): { ok: boolean; 
   }
 }
 
-/** Decrypt a secret. MAIN-INTERNAL ONLY — never expose this over IPC. Returns
- *  undefined if absent or undecryptable (the broker maps that to 503 no_secret). */
+/** 解密一条秘密。仅供主进程内部——绝不经 IPC 暴露。不存在或无法解密时
+ *  返回 undefined（代理把它映射为 503 no_secret）。 */
 export function getSecret(secretRef: string | undefined): string | undefined {
   if (!secretRef) return undefined;
   const cipher = readSecretBlob()[secretRef];
@@ -135,20 +134,20 @@ export function getSecret(secretRef: string | undefined): string | undefined {
   }
 }
 
-/** Whether a secret is stored for this ref (no decryption). */
+/** 该 ref 是否已存储秘密（不解密）。 */
 export function hasSecret(secretRef: string | undefined): boolean {
   if (!secretRef) return false;
   return !!readSecretBlob()[secretRef];
 }
 
-/** Delete a stored secret. Idempotent. */
+/** 删除已存储的秘密。幂等。 */
 export function deleteSecret(secretRef: string | undefined): void {
   if (!secretRef) return;
   const blob = readSecretBlob();
   if (secretRef in blob) {
     delete blob[secretRef];
     if (Object.keys(blob).length === 0) {
-      try { rmSync(secretsPath(), { force: true }); } catch { /* best-effort */ }
+      try { rmSync(secretsPath(), { force: true }); } catch { /* 尽力而为 */ }
     } else {
       writeSecretBlob(blob);
     }

--- a/src/main/knowledge.ts
+++ b/src/main/knowledge.ts
@@ -1,21 +1,21 @@
 /**
- * KnowledgeManager — the Electron-main façade over the file-backed enterprise
- * Knowledge Graph store. Owns ingestion (in-app, over IPC) and exposes the same
- * keyword search the agent CLI uses; agents themselves query out-of-process via
- * `resources/kg.cjs` (see docs/design/knowledge-graph.md).
+ * KnowledgeManager —— 文件后端企业知识图谱存储的 Electron 主进程门面。
+ * 负责摄取（应用内、经 IPC），并暴露 agent CLI 所用的同一套关键字搜索；
+ * agent 自身则经 `resources/kg.cjs` 在进程外查询（见
+ * docs/design/knowledge-graph.md）。
  *
- * All heavy lifting lives in the pure-JS `kg-core.cjs` sidecar (no native deps),
- * required the same way `slack.ts` requires `slack-trigger.cjs`. Mirrors the
- * MemoryManager surface (`active()` / `env()` / `status()`) so it slots into the
- * existing spawn-injection flow.
+ * 所有重活都在纯 JS 的 `kg-core.cjs` sidecar 里（无原生依赖），像
+ * `slack.ts` require `slack-trigger.cjs` 那样引入。镜像 MemoryManager 的
+ * 表面（`active()` / `env()` / `status()`），以便嵌入现有的
+ * spawn 注入流程。
  */
 import { app } from 'electron';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { readConfig } from './config';
 
-// Pure-JS core, copied to out/main at build (like slack-trigger.cjs) and shipped
-// to process.resourcesPath for the agent CLI (electron-builder extraResources).
+// 纯 JS 核心，构建时复制到 out/main（与 slack-trigger.cjs 相同），并随
+// process.resourcesPath 交付给 agent CLI（electron-builder extraResources）。
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const core = require('./kg-core.cjs') as KgCore;
 
@@ -50,34 +50,34 @@ export interface KnowledgeStatus {
 }
 
 export class KnowledgeManager {
-  /** Whether the feature flag is on. */
+  /** 功能开关是否开启。 */
   active(): boolean {
     return readConfig().knowledgeGraph?.enabled === true;
   }
 
-  /** The store directory (config override or <userData>/knowledge). */
+  /** 存储目录（config 覆盖值或 <userData>/knowledge）。 */
   root(): string {
     const override = readConfig().knowledgeGraph?.rootPath;
     if (override && override.trim()) return override;
     return join(app.getPath('userData'), 'knowledge');
   }
 
-  /** Absolute path to the agent CLI (dev: repo resources/; packaged: resourcesPath). */
+  /** agent CLI 的绝对路径（开发：仓库 resources/；打包后：resourcesPath）。 */
   private cliPath(): string {
     return app.isPackaged
       ? join(process.resourcesPath, 'kg.cjs')
       : join(app.getAppPath(), 'resources', 'kg.cjs');
   }
 
-  /** Absolute path to the pure-JS core for the out-of-process CLI to require. */
+  /** 供进程外 CLI require 的纯 JS 核心的绝对路径。 */
   private corePath(): string {
     return app.isPackaged
       ? join(process.resourcesPath, 'kg-core.cjs')
       : join(app.getAppPath(), 'src', 'main', 'kg-core.cjs');
   }
 
-  /** Env merged into each agent's spawn so its `kg` CLI hits this store. Empty
-   *  when off — so a default install injects nothing (zero behaviour change). */
+  /** 并入每个 agent spawn 的 env，让它的 `kg` CLI 命中本存储。关闭时为空——
+   *  因此默认安装不注入任何东西（零行为变化）。 */
   env(): Record<string, string> {
     if (!this.active()) return {};
     return { KG_ROOT: this.root(), KG_CLI: this.cliPath(), KG_CORE: this.corePath() };
@@ -92,12 +92,12 @@ export class KnowledgeManager {
     return { enabled, root, docCount: s.docCount, chunkCount: s.chunkCount, byModality: s.byModality };
   }
 
-  /** Ingest a file from disk. No-op-safe when off (callers gate on status). */
+  /** 从磁盘摄取一个文件。关闭时安全地空操作（调用方按 status 把关）。 */
   ingestFile(srcPath: string, opts: { title?: string; tags?: string[]; caption?: string } = {}) {
     return core.ingest(this.root(), { srcPath, ...opts });
   }
 
-  /** Ingest inline text (e.g. pasted content). */
+  /** 摄取内联文本（例如粘贴的内容）。 */
   ingestText(text: string, opts: { title?: string; tags?: string[] } = {}) {
     return core.ingest(this.root(), { text, ...opts });
   }

--- a/src/main/l10n.ts
+++ b/src/main/l10n.ts
@@ -1,0 +1,28 @@
+/**
+ * 最小化的主进程本地化器。
+ *
+ * 渲染进程拥有完整的 i18next 配置（设置里的语言选择器，存放在 localStorage）。
+ * 主进程读不到那份存储，因此它以操作系统区域设置（OS locale）为依据——这与
+ * 渲染进程默认语言检测所用的信号一致。用户在设置里特意选择与系统不同的
+ * 语言时，渲染进程仍完全使用该语言；原生菜单/对话框跟随系统区域设置，
+ * 这本来就是 Electron 惯例行为。
+ */
+import { app } from 'electron';
+
+let cached: 'zh' | 'other' | null = null;
+
+function lang(): 'zh' | 'other' {
+  if (cached) return cached;
+  try {
+    const loc = (app.getLocale() ?? '').toLowerCase();
+    cached = loc.startsWith('zh') ? 'zh' : 'other';
+  } catch {
+    cached = 'other';
+  }
+  return cached;
+}
+
+/** 为 UI 标签/对话框/菜单项选取中文或英文字符串。 */
+export function l10n(en: string, zh: string): string {
+  return lang() === 'zh' ? zh : en;
+}

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -1,17 +1,17 @@
 /**
- * MemoryManager — semantic memory for the hive, backed by the MemPalace CLI.
+ * MemoryManager —— hive 的语义记忆，由 MemPalace CLI 支撑。
  *
- * CLI-only (no MCP): the harness keeps a single shared palace under harnessHome,
- * points every agent's `MEMPALACE_PALACE_PATH` at it, and mines each agent's
- * `memory.md` into its own wing so the whole team can recall by meaning via
- * `mempalace search` / `mempalace wake-up`. Degrades silently to no-op when the
- * `mempalace` CLI isn't installed — the markdown memory still works.
+ * 仅 CLI（无 MCP）：harness 在 harnessHome 下维护一个共享宫殿，
+ * 把每个 agent 的 `MEMPALACE_PALACE_PATH` 指向它，并把每个 agent 的
+ * `memory.md` 挖掘进它自己的侧翼（wing），这样整个团队可以通过
+ * `mempalace search` / `mempalace wake-up` 按语义回忆。当 `mempalace`
+ * CLI 未安装时静默降级为空操作——markdown 记忆仍然可用。
  *
- *   init    : mempalace init <home> --yes --no-llm        (heuristics-only, no LLM)
+ *   init    : mempalace init <home> --yes --no-llm        （仅启发式，无 LLM）
  *   store   : mempalace mine <agentDir> --wing <id> --agent <id>
  *   recall  : mempalace search "<q>" --results N   /   mempalace wake-up
  *
- * Runs in the Electron main process.
+ * 运行在 Electron 主进程。
  */
 import { existsSync, statSync, readdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -19,30 +19,30 @@ import { spawn, spawnSync } from 'node:child_process';
 import { ensureKilled } from './procKill';
 import { quarantineDirsToReap, quarantineStampMs, nextMineDelayMs } from './palaceReap';
 
-/** Non-memory files `mempalace mine` must not ingest: the Claude Code hooks
- *  config (a large JSON blob that swamps the wake-up digest), the cursor, raw
- *  inbox/outbox message JSON, and a Codex worker's private CODEX_HOME. `mempalace
- *  mine` honors .gitignore, so we drop one in each agent dir rather than touch the
- *  mine command.
+/** `mempalace mine` 绝不能摄取的“非记忆”文件：Claude Code hooks 配置
+ *  （一块会淹没 wake-up 摘要的大 JSON）、光标位置、原始 inbox/outbox
+ *  消息 JSON，以及 Codex worker 私有的 CODEX_HOME。`mempalace
+ *  mine` 遵守 .gitignore，所以我们在每个 agent 目录放一份，而不是去改
+ *  mine 命令。
  *
- *  MUST STAY IN SYNC with MINE_IGNORE_LINES in hive.ts — that copy is written when
- *  an agent spawns, this one on every mine cycle, and only this one reaches agents
- *  that are not currently running. See hive.ts for why `.codex/` matters beyond
- *  mempalace: it is also what stopped the hive's git repo from versioning every
- *  Codex transcript and sqlite log into a 7.5GB history. */
+ *  必须与 hive.ts 中的 MINE_IGNORE_LINES 保持同步——那份在 agent spawn
+ *  时写入，这份在每次 mine 周期写入，而且只有这份能到达当前未运行的
+ *  agent。关于 `.codex/` 为什么比 mempalace 更重要，见 hive.ts：它也正是
+ *  阻止 hive 的 git 仓库把每一份 Codex transcript 和 sqlite 日志都纳入
+ *  版本管理、变成 7.5GB 历史的原因。 */
 const MINE_IGNORE_LINES = ['settings.json', 'cursor.json', 'inbox/', 'outbox/', '.codex/'];
 
-/** Idempotently ensure `<agentDir>/.gitignore` excludes the non-memory files.
- *  Writes only the missing lines (append-only) so it's safe to call every cycle. */
+/** 幂等地确保 `<agentDir>/.gitignore` 排除这些非记忆文件。
+ *  只写入缺失的行（只追加），因此每个周期调用都安全。 */
 function ensureMineIgnore(agentDir: string): void {
   const path = join(agentDir, '.gitignore');
   let existing = '';
   try { if (existsSync(path)) existing = readFileSync(path, 'utf8'); } catch { return; }
   const have = new Set(existing.split('\n').map((l) => l.trim()));
   const missing = MINE_IGNORE_LINES.filter((l) => !have.has(l));
-  if (missing.length === 0) return; // already covered — don't rewrite every cycle
+  if (missing.length === 0) return; // 已覆盖——不必每个周期重写
   const prefix = existing && !existing.endsWith('\n') ? existing + '\n' : existing;
-  try { writeFileSync(path, prefix + missing.join('\n') + '\n', 'utf8'); } catch { /* best-effort */ }
+  try { writeFileSync(path, prefix + missing.join('\n') + '\n', 'utf8'); } catch { /* 尽力而为 */ }
 }
 
 export type EmbeddingModel = 'minilm' | 'embeddinggemma';
@@ -53,59 +53,57 @@ export interface MemorySettings {
 }
 
 export interface MemoryStatus {
-  available: boolean;        // mempalace CLI found on PATH
-  enabled: boolean;          // user setting
-  active: boolean;           // available && enabled && have a home
-  initialized: boolean;      // palace directory exists
+  available: boolean;        // 在 PATH 上找到了 mempalace CLI
+  enabled: boolean;          // 用户设置
+  active: boolean;           // 可用 && 已启用 && 有 home
+  initialized: boolean;      // 宫殿目录存在
   palacePath: string | null;
   model: EmbeddingModel;
   bin: string | null;
 }
 
-// Re-mine changed memories every 10 min, up from 3.
+// 每 10 分钟重新挖掘一遍变化的记忆，由原来的 3 分钟延长而来。
 //
-// Every `mempalace mine` opens the palace, and every open runs MemPalace's
-// quarantine gate — which on a palace stuck in the rename loop means another
-// full-size copy of the segment left on disk. The gate is not ours to fix, but
-// how often we invoke it is. Mining is already skipped for agents whose
-// memory.md has not changed, so this only affects an agent editing its notes
-// repeatedly: its changes are batched into one mine instead of three. A memory
-// written now is searchable within ten minutes rather than three, which no one
-// is waiting on. `reapPalace` handles the copies that still get made.
+// 每次 `mempalace mine` 都会打开宫殿，而每次打开都会运行 MemPalace 的
+// 隔离门——对卡在重命名循环里的宫殿来说，这意味着磁盘上又多一份
+// 完整尺寸的段拷贝。那道门不归我们修，但“多久触发一次”归我们管。
+// 对于 memory.md 未变化的 agent，挖掘本来就会跳过，所以这只影响
+// 反复编辑笔记的 agent：它的改动会被合并成一次挖掘而不是三次。
+// 现在写入的记忆十分钟后可搜索，而不是三分钟——没有人会等这三分钟。
+// `reapPalace` 负责处理仍然产生的拷贝。
 const MINE_INTERVAL_MS = 600_000;
-// Ceiling for the quarantine backoff below. Low on purpose: a memory is not
-// searchable until it has been mined, and the reaper already handles the disk,
-// so there is nothing here worth making recall half an hour stale for.
+// 下面隔离退避的上限。刻意设低：记忆在挖掘之前不可被搜索，
+// 而磁盘已经由收割器处理，因此这里没有任何值得让 recall
+// 过期半小时来换的东西。
 const MINE_BACKOFF_MAX_MS = 1_800_000;
-const MINE_TIMEOUT_MS = 10 * 60_000; // hard cap per mine (first run downloads the embedding model)
-/** mempalace's device "auto" picks the CoreML execution provider on Apple
- *  Silicon, and CoreML runs the quantized embeddinggemma ONNX graph partially
- *  (330/1647 nodes) with fp16 partitions that overflow → EVERY vector comes
- *  back NaN and chroma rejects every upsert ("Embeddings must not contain NaN
- *  or Infinity values"), so no memory ever gets indexed. Reproduced + verified
- *  2026-08-16: same input is NaN under CoreMLExecutionProvider and clean under
- *  CPU. Pin cpu for BOTH the mine loop and the agents' own `mempalace search`
- *  (a query embedded to NaN breaks recall the same way).
+const MINE_TIMEOUT_MS = 10 * 60_000; // 每次挖掘的硬上限（首次运行会下载嵌入模型）
+/** mempalace 的设备 "auto" 在 Apple Silicon 上会选择 CoreML 执行提供方，
+ *  而 CoreML 只能部分运行量化后的 embeddinggemma ONNX 图
+ *  （330/1647 个节点），fp16 分区会溢出 → 每个向量都返回 NaN，
+ *  chroma 拒绝每一次 upsert（“Embeddings must not contain NaN or
+ *  Infinity values”），于是没有任何记忆被索引。2026-08-16 复现并验证：
+ *  相同的输入在 CoreMLExecutionProvider 下是 NaN，在 CPU 下干净。
+ *  把 mine 循环和 agent 自己的 `mempalace search` 都钉在 cpu 上
+ *  （查询被嵌入成 NaN 会以同样的方式破坏 recall）。
  *
- *  Scope, deliberately macOS-WIDE rather than per-model: the pin costs the
- *  other model nothing. minilm rides chromadb's ONNXMiniLM_L6_V2, whose model
- *  build UNCONDITIONALLY removes CoreMLExecutionProvider ("not as well
- *  optimized as CPU" — chromadb's words), so minilm never runs on CoreML with
- *  or without this pin; embeddinggemma (mempalace's own ONNX class, no such
- *  pruning) is the only path that would reach CoreML, and that path is the NaN
- *  bug. Other platforms keep mempalace's own default ("auto").
+ *  范围刻意是“整个 macOS”而不是按模型：这个钉扎对另一个模型毫无代价。
+ *  minilm 走 chromadb 的 ONNXMiniLM_L6_V2，它构建模型时无条件移除
+ *  CoreMLExecutionProvider（“不如 CPU 优化得好”——chromadb 原话），
+ *  因此无论有没有这个钉扎，minilm 都绝不会跑在 CoreML 上；
+ *  embeddinggemma（mempalace 自己的 ONNX 类，没有这种裁剪）是唯一
+ *  会触及 CoreML 的路径，而那正是 NaN bug。其他平台保留 mempalace
+ *  自己的默认（"auto"）。
  *
- *  A user's OWN device choice wins: if MEMPALACE_EMBEDDING_DEVICE is already
- *  exported we emit nothing, so the inherited value flows through untouched —
- *  which also leaves a one-command way to reproduce the NaN behaviour
- *  (`MEMPALACE_EMBEDDING_DEVICE=coreml`). Exported as a function of
- *  (platform, envOverride) so every branch is reachable from a test on any
- *  platform — same trick as `buildMissingCliScript`. */
+ *  用户自己的设备选择优先：若 MEMPALACE_EMBEDDING_DEVICE 已导出，
+ *  我们就不输出任何东西，让继承的值原样流过——这也留下了一条复现
+ *  NaN 行为的单命令途径（`MEMPALACE_EMBEDDING_DEVICE=coreml`）。
+ *  以 (platform, envOverride) 的函数形式导出，让每个分支都能从任何
+ *  平台上的测试触达——与 `buildMissingCliScript` 相同的手法。 */
 export function mempalaceDevice(
   platform: NodeJS.Platform,
   envOverride: string | undefined
 ): string | undefined {
-  if (envOverride) return undefined; // explicit user choice — never override
+  if (envOverride) return undefined; // 用户显式选择——绝不覆盖
   return platform === 'darwin' ? 'cpu' : undefined;
 }
 const MEMPALACE_DEVICE = mempalaceDevice(process.platform, process.env.MEMPALACE_EMBEDDING_DEVICE);
@@ -114,15 +112,15 @@ export class MemoryManager {
   private binCache: string | null | undefined;
   private mineTimer: NodeJS.Timeout | null = null;
   private mineStopped = false;
-  /** Current gap between mine passes. Widens while the palace is quarantining. */
+  /** 当前两次挖掘之间的间隔。宫殿在隔离期间会变宽。 */
   private mineDelayMs = MINE_INTERVAL_MS;
-  /** Newest quarantine stamp seen so far, so a LATER one means the palace
-   *  quarantined again. A count would be useless: the reaper deletes them. */
+  /** 目前见过的最新隔离时间戳，因此“更晚”的一个意味着宫殿再次隔离。
+   *  计数没有用：收割器会删掉它们。 */
   private lastQuarantineTs = 0;
   private initStarted = false;
-  /** True while a mineNow() pass is in flight — serializes palace writers. */
+  /** 当一次 mineNow() 正在执行时为 true——让宫殿写入者串行化。 */
   private mining = false;
-  /** agentId → memory.md mtimeMs at last successful mine (skip unchanged). */
+  /** agentId → 上次成功挖掘时 memory.md 的 mtimeMs（跳过未变化的）。 */
   private lastMined = new Map<string, number>();
 
   constructor(
@@ -135,13 +133,13 @@ export class MemoryManager {
     return h ? join(h, 'palace') : null;
   }
 
-  /** Resolve the mempalace CLI against the user's PATH + common uv/pip spots. */
+  /** 按用户的 PATH + 常见的 uv/pip 安装位置解析 mempalace CLI。 */
   bin(): string | null {
     if (this.binCache !== undefined) return this.binCache;
     let found: string | null = null;
     const isWin = process.platform === 'win32';
-    // 1) Ask the shell/PATH resolver. Windows has no POSIX shell + uses `where`
-    //    and a `.exe` suffix; everything else goes through the login shell.
+    // 1) 询问 shell/PATH 解析器。Windows 没有 POSIX shell，用 `where`
+    //    和 `.exe` 后缀；其余平台都走登录 shell。
     try {
       if (isWin) {
         const res = spawnSync('where', ['mempalace'], { encoding: 'utf8', timeout: 3000 });
@@ -154,8 +152,8 @@ export class MemoryManager {
         const p = res.stdout.trim().split('\n').pop();
         if (p && existsSync(p)) found = p;
       }
-    } catch { /* fall through */ }
-    // 2) Probe common install locations (uv tool / homebrew / pip).
+    } catch { /* 继续往下 */ }
+    // 2) 探测常见安装位置（uv tool / homebrew / pip）。
     if (!found) {
       const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
       const candidates = isWin
@@ -173,7 +171,7 @@ export class MemoryManager {
     this.binCache = found;
     return found;
   }
-  /** Force re-resolution (e.g. after the user installs mempalace). */
+  /** 强制重新解析（例如在用户安装 mempalace 之后）。 */
   resetBinCache(): void { this.binCache = undefined; }
 
   available(): boolean { return this.bin() !== null; }
@@ -194,7 +192,7 @@ export class MemoryManager {
     };
   }
 
-  /** Env merged into each agent's spawn so its `mempalace` CLI hits the shared palace. */
+  /** 并入每个 agent spawn 的 env，让它的 `mempalace` CLI 命中共享宫殿。 */
   env(): Record<string, string> {
     const palace = this.palacePath();
     if (!this.active() || !palace) return {};
@@ -214,21 +212,20 @@ export class MemoryManager {
     };
   }
 
-  // — lifecycle —
+  // —— 生命周期 ——
 
-  /** Start the mine loop. `mempalace mine` auto-creates the palace on first run
-   *  (lazily downloading the embedding model, one-time). We deliberately do NOT
-   *  run `mempalace init`: it ends in an interactive "Mine now? [Y/n]" prompt
-   *  that --yes doesn't cover, so a spawned child would hang forever. */
+  /** 启动挖掘循环。`mempalace mine` 在首次运行时自动创建宫殿
+   *  （一次性懒下载嵌入模型）。我们刻意不运行 `mempalace init`：
+   *  它最终会停在交互式 "Mine now? [Y/n]" 提示上，--yes 覆盖不到，
+   *  于是派生的子进程会永远挂起。 */
   start(): void {
     if (!this.active() || this.initStarted) return;
     if (!this.bin() || !this.getHome() || !this.palacePath()) return;
     this.initStarted = true;
-    // Sweep once at boot, before the first mine. An app updating into this fix
-    // arrives at a palace that has been accumulating copies for as long as it
-    // has been running — 357 of them here — and waiting for the first agent to
-    // edit its memory.md would leave all of that on disk for an arbitrary
-    // while. This is the pass that makes the existing pile go away by itself.
+    // 启动时先清扫一次，在第一次挖掘之前。升级到这个修复的应用，
+    // 面对的是一个从运行起就一直在累积拷贝的宫殿——这里有 357 个——
+    // 而等着第一个 agent 去编辑它的 memory.md，会让这些拷贝在磁盘上
+    // 任意逗留。正是这一趟让既有的一大堆自行消失。
     this.reapPalace();
     this.startMineLoop();
   }
@@ -239,21 +236,19 @@ export class MemoryManager {
   }
 
   /**
-   * Re-resolve the CLI, arm the mine loop if it is only now possible, and report.
+   * 重新解析 CLI；若直到现在才可行，就武装挖掘循环，并汇报。
    *
-   * `start()` runs once at boot and bails when mempalace isn't on PATH yet. If the
-   * user installs it AFTER that — the common case, since the settings panel is
-   * where they find out they need it — nothing re-invoked `start()`, so the mine
-   * loop never ran. The palace is created by the first `mempalace mine`, so it
-   * never appeared either, and `initialized` (existsSync(palace)) stayed false
-   * while `available` flipped true: the status pill read "On — getting ready…"
-   * forever and only an app restart cleared it.
+   * `start()` 在启动时运行一次，当 mempalace 还不在 PATH 上时就退出。如果
+   * 用户在那之后才安装（常见情况，因为设置面板正是他们发现自己需要它的
+   * 地方）——没有任何东西会再次调用 `start()`，于是挖掘循环从未运行。
+   * 宫殿由第一次 `mempalace mine` 创建，所以它也从未出现；`initialized`
+   * （existsSync(palace)）保持 false，而 `available` 已翻成 true：状态胶囊
+   * 永远显示 "On — getting ready…"，只有重启应用才能清除。
    *
-   * The status poll is the one thing that reliably notices the install, so it is
-   * where the re-arm belongs. `start()` is idempotent (initStarted), so repeated
-   * polls never start a second loop — and it still deliberately does NOT run
-   * `mempalace init`, which ends in an interactive "Mine now? [Y/n]" that `--yes`
-   * doesn't cover and that hangs a spawned child.
+   * 状态轮询是唯一可靠察觉安装的东西，所以重新武装应当发生在这里。
+   * `start()` 是幂等的（initStarted），重复轮询绝不会启动第二个循环——
+   * 而且它仍然刻意不运行 `mempalace init`，那会停在交互式
+   * "Mine now? [Y/n]" 上，`--yes` 覆盖不到，还会挂住派生的子进程。
    */
   refresh(): MemoryStatus {
     this.resetBinCache();
@@ -261,8 +256,8 @@ export class MemoryManager {
     return this.status();
   }
 
-  /** Self-scheduling rather than `setInterval`, so the gap can widen when the
-   *  palace is quarantining and snap back the moment it stops. */
+  /** 自我调度而不是用 `setInterval`，这样宫殿隔离期间间隔可以变宽，
+   *  隔离一停止就立刻弹回。 */
   private startMineLoop(): void {
     if (this.mineTimer) return;
     const tick = () => {
@@ -272,25 +267,25 @@ export class MemoryManager {
         this.mineTimer.unref?.();
       });
     };
-    // Armed synchronously. `mineTimer` is the "is the loop running" signal that
-    // `refresh()` reports on right after `start()`, and setting it only once the
-    // first mine resolves would report the loop as dead for a whole pass —
-    // which is exactly the re-arm-after-install case that has its own test.
+    // 同步武装。`mineTimer` 是“循环在跑吗”的信号，`refresh()` 在 `start()`
+    // 之后紧跟着上报它；如果等到第一次挖掘完成才设置它，
+    // 就会在整整一个周期内把循环报成死的——
+    // 这正是“安装后重新武装”的情形，它有自己的测试。
     this.mineTimer = setTimeout(tick, 0);
     this.mineTimer.unref?.();
   }
 
-  // — mining (store) —
+  // —— 挖掘（store）——
 
-  /** Mine every agent whose memory changed since last time, one at a time.
-   *  The palace permits a single writer, so mines MUST be serialized — firing
-   *  them concurrently makes all but one fail with "held by another writer".
-   *  `mining` guards against a slow pass overlapping the next interval tick. */
+  /** 逐个挖掘自上次以来记忆发生变化的每个 agent。
+   *  宫殿只允许一个写入者，因此挖掘必须串行化——并发触发会让
+   *  除一个之外全部以 "held by another writer" 失败。
+   *  `mining` 防止慢速的一趟与下一个间隔滴答重叠。 */
   async mineNow(): Promise<void> {
     const home = this.getHome();
     const bin = this.bin();
     if (!this.active() || !home || !bin) return;
-    if (this.mining) return; // a previous pass is still running — let it finish
+    if (this.mining) return; // 上一趟还在运行——让它完成
     const agentsDir = join(home, 'hive', 'agents');
     if (!existsSync(agentsDir)) return;
     let ids: string[];
@@ -303,15 +298,15 @@ export class MemoryManager {
         if (!existsSync(mem)) continue;
         let mtime = 0;
         try { mtime = statSync(mem).mtimeMs; } catch { continue; }
-        if (this.lastMined.get(id) === mtime) continue; // unchanged — skip the model load
+        if (this.lastMined.get(id) === mtime) continue; // 未变化——跳过模型加载
         this.lastMined.set(id, mtime);
-        await this.mineAgent(agentDir, id); // one writer at a time
+        await this.mineAgent(agentDir, id); // 一次一个写入者
       }
     } finally {
       this.mining = false;
     }
-    // Every pass above may have left another copy behind, and whether it did
-    // decides how long we wait before the next one.
+    // 上面的每一趟都可能又留下一份拷贝，而是否留下
+    // 决定了我们等多久再跑下一趟。
     const quarantined = this.reapPalace();
     this.mineDelayMs = nextMineDelayMs(
       this.mineDelayMs, MINE_INTERVAL_MS, MINE_BACKOFF_MAX_MS, quarantined
@@ -319,17 +314,15 @@ export class MemoryManager {
   }
 
   /**
-   * Delete quarantined segment copies MemPalace renamed aside and never removed.
+   * 删除 MemPalace 改名挪开、却从未移除的被隔离段拷贝。
    *
-   * Safe to delete: the rename is precisely what takes them OUT of the palace's
-   * live set, and Chroma has already rebuilt by the time we see one. They are
-   * diagnostic residue. `quarantineDirsToReap` keeps the newest couple so there
-   * is still something to look at, and refuses to touch anything recent enough
-   * to still be mid-recovery.
+   * 可以安全删除：改名正是把它们从宫殿“在线集合”中拿出去的动作，
+   * 而且我们见到一个时 Chroma 早已重建完毕。它们是诊断残渣。
+   * `quarantineDirsToReap` 保留最新的几个，这样总还有东西可看，
+   * 并且拒绝碰任何仍在恢复期、太新的目录。
    *
-   * Best-effort throughout. A palace we cannot read, or a directory we cannot
-   * remove, must never take down the mine loop — this is disk hygiene, not a
-   * correctness path.
+   * 全程尽力而为。一个读不了的宫殿，或一个删不掉的目录，
+   * 绝不能拖垮挖掘循环——这是磁盘卫生，不是正确性路径。
    */
   private reapPalace(): boolean {
     const palace = this.palacePath();
@@ -342,9 +335,9 @@ export class MemoryManager {
       const ts = quarantineStampMs(name);
       if (ts !== null && ts > newest) newest = ts;
     }
-    // The boot sweep runs before the first mine precisely so it can seed this:
-    // otherwise a palace that arrives with a backlog would read as "just
-    // quarantined" and back the loop off before it has mined anything.
+    // 启动清扫恰好在第一次挖掘前运行，正是为了给这里播种：
+    // 否则一个带着积压而来的宫殿会被读成“刚刚隔离过”，
+    // 在挖掘任何东西之前就把循环退避了。
     const fresh = this.lastQuarantineTs > 0 && newest > this.lastQuarantineTs;
     if (newest > this.lastQuarantineTs) this.lastQuarantineTs = newest;
 
@@ -353,7 +346,7 @@ export class MemoryManager {
     let removed = 0;
     for (const name of doomed) {
       try { rmSync(join(palace, name), { recursive: true, force: true }); removed += 1; }
-      catch { /* locked, gone, or not ours — leave it and try again next pass */ }
+      catch { /* 被锁、已消失或不是我们的——留着它，下一趟再试 */ }
     }
     if (removed) console.log(`[memory] reaped ${removed} quarantined palace segment(s)`);
     return fresh;
@@ -363,27 +356,27 @@ export class MemoryManager {
     return new Promise((resolve) => {
       const bin = this.bin();
       if (!bin) { resolve(); return; }
-      ensureMineIgnore(agentDir); // keep settings.json / cursor / messages out of the index
-      // stdin closed (mempalace can prompt); mempalace dedups so re-mining is safe.
+      ensureMineIgnore(agentDir); // 让 settings.json / 光标 / 消息不进入索引
+      // stdin 已关闭（mempalace 可能会提示）；mempalace 会去重，重挖安全。
       const proc = spawn(bin, ['mine', agentDir, '--wing', id, '--agent', id], {
         env: this.childEnv(), stdio: ['ignore', 'ignore', 'pipe']
       });
       let err = '';
       proc.stderr?.on('data', (d) => { err += d.toString(); });
-      // Hard ceiling: a wedged mine used to hold its PID forever AND leave
-      // `mining` stuck true, silently stopping all future passes. Generous cap
-      // because the first run may lazily download the embedding model.
+      // 硬上限：卡死的挖掘过去会永远占着 PID，还把 `mining` 卡在 true，
+      // 静默地停掉所有后续趟次。上限给得宽，
+      // 因为首次运行可能要懒下载嵌入模型。
       const timer = setTimeout(() => {
         console.error(`[memory] mine ${id} timed out after ${MINE_TIMEOUT_MS / 60000}min — killing`);
-        try { proc.kill('SIGTERM'); } catch { /* gone */ }
-        ensureKilled(proc.pid); // SIGKILL sweep if SIGTERM is ignored
+        try { proc.kill('SIGTERM'); } catch { /* 已消失 */ }
+        ensureKilled(proc.pid); // SIGTERM 被忽略时用 SIGKILL 清扫
       }, MINE_TIMEOUT_MS);
       timer.unref?.();
       proc.on('close', (code) => {
         clearTimeout(timer);
         if (code !== 0) {
           console.error(`[memory] mine ${id} exited ${code}: ${err.slice(-300)}`);
-          this.lastMined.delete(id); // let the next tick retry
+          this.lastMined.delete(id); // 让下一个滴答重试
         }
         resolve();
       });
@@ -391,12 +384,11 @@ export class MemoryManager {
     });
   }
 
-  // — recall (read) —
+  // —— 回忆（read）——
 
-  /** Run one mempalace read command asynchronously. These used to be spawnSync
-   *  with a 120s timeout — on a cold model load that BLOCKED the Electron main
-   *  process (renderer IPC, timers, every window) for up to two minutes. Same
-   *  contract, but the event loop keeps breathing and a wedged CLI is swept. */
+  /** 异步运行一条 mempalace 读取命令。过去它们是带 120 秒超时的 spawnSync——
+ *  冷模型加载时会阻塞 Electron 主进程（渲染进程 IPC、定时器、每个窗口）
+ *  长达两分钟。契约相同，但事件循环保持呼吸，卡死的 CLI 会被清扫。 */
   private runCli(args: string[], label: string): Promise<{ ok: boolean; output: string; error?: string }> {
     return new Promise((resolve) => {
       const bin = this.bin();
@@ -418,7 +410,7 @@ export class MemoryManager {
       proc.stdout?.on('data', (d: string) => { out += d; });
       proc.stderr?.on('data', (d: string) => { err += d; });
       const timer = setTimeout(() => {
-        try { proc.kill('SIGTERM'); } catch { /* gone */ }
+        try { proc.kill('SIGTERM'); } catch { /* 已消失 */ }
         ensureKilled(proc.pid);
         settle({ ok: false, output: out, error: `${label} timed out` });
       }, 120_000);
@@ -431,14 +423,14 @@ export class MemoryManager {
     });
   }
 
-  /** Semantic search across the shared palace. Returns the CLI's text output. */
+  /** 跨共享宫殿的语义搜索。返回 CLI 的文本输出。 */
   search(query: string, opts: { wing?: string; results?: number } = {}): Promise<{ ok: boolean; output: string; error?: string }> {
     const args = ['search', query, '--results', String(opts.results ?? 5)];
     if (opts.wing) args.push('--wing', opts.wing);
     return this.runCli(args, 'search');
   }
 
-  /** Session-start digest (~600-900 tokens). */
+  /** 会话开始摘要（约 600-900 token）。 */
   wakeUp(wing?: string): Promise<{ ok: boolean; output: string; error?: string }> {
     const args = ['wake-up'];
     if (wing) args.push('--wing', wing);

--- a/src/main/nodeInstall.ts
+++ b/src/main/nodeInstall.ts
@@ -1,26 +1,23 @@
 /**
- * Installing Node.js itself, so a machine with nothing on it can still run agents.
+ * 安装 Node.js 本身，让一台什么都没有的机器也能运行 agent。
  *
- * Founder decision (2026-08-07), superseding the earlier "never auto-install a
- * system Node" constraint: by DEFAULT we install the real thing — latest stable
- * (LTS) Node + the npm that ships with it — into the user's system. Electron's
- * bundled Node stays as a last-resort fallback only (see hive.runtimeBinDir).
+ * 创始人决策（2026-08-07），取代早先“绝不自动安装系统 Node”的约束：默认
+ * 情况下我们把真东西——最新稳定（LTS）版 Node + 随附的 npm——装进用户的
+ * 系统。Electron 自带的 Node 只作为最后的兜底备用（见 hive.runtimeBinDir）。
  *
- * The user has to type their password: every official installer writes outside the
- * home directory. That happens VISIBLY in the same terminal as every other
- * installer in this app — we never elevate silently.
+ * 用户必须输入密码：每个官方安装程序都会写到 home 目录之外。这发生在
+ * 与本应用其他所有安装程序相同的终端里，且对用户可见——我们从不静默提权。
  *
- * Because we run an installer as root, the download is CHECKSUM-VERIFIED against
- * nodejs.org's own SHASUMS256.txt before anything executes. A mismatch aborts.
+ * 因为我们以 root 运行安装程序，所以在任何东西执行之前，下载都会对照
+ * nodejs.org 自己的 SHASUMS256.txt 做校验和验证。不匹配即中止。
  *
- * Nothing here imports electron: the URL/artifact/script logic is all pure, so it
- * is testable without booting an app.
+ * 这里不 import electron：URL/产物/脚本逻辑全是纯函数，
+ * 无需启动应用即可测试。
  */
 
-/** Lowest Node major we consider usable. Below this we offer the upgrade; at or
- *  above it we leave the user's own install completely alone — an existing,
- *  working toolchain is never "upgraded" out from under them. Chosen as Electron's
- *  own bundled line, i.e. the floor we already know every code path tolerates. */
+/** 我们认为可用的最低 Node 主版本。低于它就提供升级；达到或高于它则完全
+ *  不去动用户自己的安装——一套已有、可用的工具链绝不会被“升级”到用户
+ *  脚下。选 Electron 自带的同代版本，即我们已知所有代码路径都能容忍的下限。 */
 export const NODE_FLOOR_MAJOR = 20;
 
 const DIST = 'https://nodejs.org/dist';
@@ -40,13 +37,13 @@ export interface NodeInstaller {
   kind: 'pkg' | 'msi' | 'tar';
 }
 
-/** Major version of `v24.19.0` / `24.19.0`, or null if unparseable. */
+/** `v24.19.0` / `24.19.0` 的主版本号，无法解析时为 null。 */
 export function nodeMajor(version: string | null | undefined): number | null {
   const m = /^v?(\d+)\./.exec((version ?? '').trim());
   return m ? Number(m[1]) : null;
 }
 
-/** Whether the user's own Node is good enough to be left alone. */
+/** 用户自己的 Node 是否好到可以不去动它。 */
 export function nodeIsUsable(version: string | null | undefined): boolean {
   const major = nodeMajor(version);
   return major !== null && major >= NODE_FLOOR_MAJOR;
@@ -59,10 +56,9 @@ const execNodeVersion: VersionProbe = (nodePath) =>
   require('node:child_process')
     .execFileSync(nodePath, ['--version'], { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] });
 
-/** `node --version` from the binary the user's PATH actually resolves (see
- *  pty.commandPath). Null when node is absent or the probe fails at all — both
- *  mean "we cannot vouch for this runtime", which routes into the install rung
- *  rather than silently assuming it is fine. */
+/** 取自用户 PATH 实际解析到的二进制（见 pty.commandPath）的 `node --version`。
+ *  当 node 缺失或探测完全失败时为 null——两者都意味着“我们无法为这个运行时
+ *  背书”，于是进入安装阶梯，而不是静默地假设它没问题。 */
 export function detectNodeVersion(
   nodePath: string | null | undefined,
   probe: VersionProbe = execNodeVersion
@@ -76,23 +72,23 @@ export function detectNodeVersion(
   }
 }
 
-/** Newest LTS in nodejs.org's index.json. The index is newest-first, and `lts` is
- *  the codename (or false), so the first truthy one is the latest stable line.
- *  We deliberately do NOT take index[0] — that is the current/odd release, which
- *  is not what "latest stable" means to a user who just wants things to work. */
+/** nodejs.org 的 index.json 中最新的 LTS。索引按从新到旧排列，`lts` 是
+ *  代号（或 false），所以第一个真值就是最新的稳定线。
+ *  我们刻意不取 index[0]——那是当前/奇数版本发布，对只想让东西跑起来的
+ *  用户来说那不是“最新稳定版”的意思。 */
 export function pickLatestLts(index: NodeDistEntry[]): NodeDistEntry | null {
   return index.find((e) => e && e.lts) ?? null;
 }
 
-/** The installer artifact for a platform/arch.
+/** 某个平台/架构的安装包产物。
  *
- *  Names are derived here but VALIDATED against SHASUMS256.txt by the caller —
- *  index.json's `files` array is not trustworthy for this: it lists no
- *  `win-arm64-msi` even though `node-<v>-arm64.msi` is published, and its
- *  `osx-x64-pkg` entry actually denotes the single UNIVERSAL `node-<v>.pkg`.
+ *  名称在这里推导，但由调用方对照 SHASUMS256.txt 校验——index.json 的
+ *  `files` 数组在这方面不可信：尽管 `node-<v>-arm64.msi` 确实发布，
+ *  它却不列出 `win-arm64-msi`，而且它的 `osx-x64-pkg` 条目实际指的是
+ *  单个 UNIVERSAL `node-<v>.pkg`。
  *
- *  Linux has no official installer package — only tarballs — so it gets the
- *  tar kind, unpacked into /usr/local. */
+ *  Linux 没有官方安装包——只有 tarball——所以它用 tar 类型，解包到
+ *  /usr/local。 */
 export function nodeArtifactFor(
   version: string,
   platform: string,
@@ -111,7 +107,7 @@ export function nodeArtifactFor(
   return null;
 }
 
-/** Pull one file's digest out of a SHASUMS256.txt body ("<sha>  <file>" lines). */
+/** 从 SHASUMS256.txt 正文（"<sha>  <file>" 行）中取出某个文件的摘要。 */
 export function shaFor(shasums: string, file: string): string | null {
   for (const line of shasums.split('\n')) {
     const m = /^([0-9a-f]{64})\s+(\S+)\s*$/.exec(line.trim());
@@ -124,14 +120,14 @@ export const distUrl = (version: string, file: string): string => `${DIST}/${ver
 
 type Fetcher = (url: string) => Promise<{ ok: boolean; text: () => Promise<string> }>;
 
-/** This runs INSIDE a spawn, so it must never hang the launch: an unreachable
- *  nodejs.org has to fail fast and drop the ladder to its next rung. */
+/** 这在 spawn 内部运行，所以绝不能挂住启动：不可达的 nodejs.org 必须快速
+ *  失败，把阶梯降到下一级。 */
 const timedFetch: Fetcher = (url) =>
   fetch(url, { signal: AbortSignal.timeout(6000) }) as unknown as ReturnType<Fetcher>;
 
-/** Resolve the exact installer to run on THIS machine, checksum included.
- *  Returns null on any failure (offline, unsupported platform, artifact not in
- *  SHASUMS256) — callers then fall back down the ladder rather than guessing. */
+/** 解析本机要运行的精确安装包，包括校验和。
+ *  任何失败都返回 null（离线、不支持的平台、产物不在 SHASUMS256 中）——
+ *  调用方随后沿阶梯回退，而不是瞎猜。 */
 export async function resolveNodeInstaller(
   platform: string = process.platform,
   arch: string = process.arch,
@@ -150,7 +146,7 @@ export async function resolveNodeInstaller(
     const shaRes = await fetchImpl(`${DIST}/${lts.version}/SHASUMS256.txt`);
     if (!shaRes.ok) return null;
     const sha256 = shaFor(await shaRes.text(), artifact.file);
-    // No digest → we would be running an unverified installer as root. Refuse.
+    // 没有摘要 → 我们就要以 root 运行一个未经验证的安装包。拒绝。
     if (!sha256) return null;
 
     return {
@@ -166,58 +162,58 @@ export async function resolveNodeInstaller(
   }
 }
 
-/** The visible install script: download → VERIFY → install, aborting on any step.
+/** 可见的安装脚本：下载 → 校验 → 安装，任何一步失败即中止。
  *
- *  POSIX form is newline-separated statements for `$SHELL -lc`. Windows form is
- *  ONE `&`-chained cmd.exe line with NO double quotes — it is wrapped verbatim in
- *  `cmd /d /s /c "<script>"`, where a single embedded quote would end the command
- *  line early and execute the remainder as garbage. */
+ *  POSIX 形式是供 `$SHELL -lc` 使用的换行分隔语句。Windows 形式是
+ *  一条 `&` 串联、且不含双引号的 cmd.exe 命令——它会被原样包在
+ *  `cmd /d /s /c "<script>"` 里，其中任何一个内嵌引号都会提前结束命令
+ *  行，把剩余部分当垃圾执行。 */
 export function buildNodeInstallScript(installer: NodeInstaller, platform: string): string[] {
   const { version, url, sha256, file } = installer;
 
   if (platform === 'win32') {
-    // certutil is the only hashing tool guaranteed present; `findstr` does the
-    // compare because cmd has no string equality on command output. msiexec's
-    // own UAC prompt is the elevation — we never call it silently.
+    // certutil 是唯一保证存在的哈希工具；比较用 `findstr` 做，因为 cmd
+    // 对命令输出没有字符串相等判断。msiexec 自己的 UAC 提示就是提权——
+    // 我们从不静默调用它。
     const f = `%TEMP%\\${file}`;
     return [
-      `echo   Downloading Node.js ${version} ^(official installer^)...`,
+      `echo   正在下载 Node.js ${version} ^(官方安装器^)...`,
       `curl -fSL ${url} -o ${f}`,
       `if errorlevel 1 exit /b 1`,
-      `echo   Verifying checksum...`,
+      `echo   正在校验校验和...`,
       `certutil -hashfile ${f} SHA256 | findstr /i /c:${sha256} >nul`,
-      `if errorlevel 1 (echo   [x] CHECKSUM MISMATCH - refusing to install ^& exit /b 1)`,
-      `echo   Installing - approve the Windows prompt if it appears...`,
+      `if errorlevel 1 (echo   [x] 校验和不匹配——拒绝安装 ^& exit /b 1)`,
+      `echo   正在安装——如出现 Windows 提示，请确认...`,
       `msiexec /i ${f} /passive /norestart`,
       `if errorlevel 1 exit /b 1`,
       `set PATH=%ProgramFiles%\\nodejs;%PATH%`
     ];
   }
 
-  // macOS ships `shasum`; Linux ships `sha256sum`. Neither ships both.
+  // macOS 自带 `shasum`；Linux 自带 `sha256sum`。两者都不全带。
   const verify = platform === 'darwin'
     ? `echo "${sha256}  $__f" | shasum -a 256 -c - >/dev/null`
     : `echo "${sha256}  $__f" | sha256sum -c - >/dev/null`;
   const install = platform === 'darwin'
     ? `sudo installer -pkg "$__f" -target /`
-    // No official Linux package — the tarball IS the distribution. --strip-components
-    // drops the versioned top dir so bin/ lands directly in /usr/local/bin.
+    // Linux 没有官方安装包——tarball 就是发行物。--strip-components
+    // 去掉带版本的顶层目录，让 bin/ 直接落在 /usr/local/bin。
     : `sudo tar -xJf "$__f" -C /usr/local --strip-components=1`;
 
   return [
-    `echo '  Downloading Node.js ${version} (official installer)...'`,
+    `echo '  正在下载 Node.js ${version}（官方安装器）...'`,
     `__tmp=$(mktemp -d)`,
     `__f=$__tmp/${file}`,
-    `curl -fSL --progress-bar ${url} -o "$__f" || { echo '  [x] Download failed.'; exit 1; }`,
-    `echo '  Verifying checksum...'`,
-    `${verify} || { echo '  [x] CHECKSUM MISMATCH - refusing to install.'; rm -rf "$__tmp"; exit 1; }`,
+    `curl -fSL --progress-bar ${url} -o "$__f" || { echo '  [x] 下载失败。'; exit 1; }`,
+    `echo '  正在校验校验和...'`,
+    `${verify} || { echo '  [x] 校验和不匹配——拒绝安装。'; rm -rf "$__tmp"; exit 1; }`,
     `echo ''`,
-    `echo '  Installing Node.js. Enter your password if prompted -'`,
-    `echo '  the official installer writes outside your home directory.'`,
+    `echo '  正在安装 Node.js。如提示请输入密码——'`,
+    `echo '  官方安装器会写入你的主目录之外。'`,
     `echo ''`,
-    `${install} || { echo '  [x] Node install failed.'; rm -rf "$__tmp"; exit 1; }`,
+    `${install} || { echo '  [x] Node 安装失败。'; rm -rf "$__tmp"; exit 1; }`,
     `rm -rf "$__tmp"`,
-    // The shell that is running this script captured PATH before node existed.
+    // 正在运行此脚本的 shell 是在 node 存在之前捕获的 PATH。
     `PATH=/usr/local/bin:$PATH`,
     `export PATH`
   ];

--- a/src/main/palaceReap.ts
+++ b/src/main/palaceReap.ts
@@ -1,54 +1,48 @@
 /**
- * Which quarantined MemPalace segments to delete.
+ * 要删除哪些被隔离的 MemPalace 段。
  *
- * MemPalace recovers from a suspect ChromaDB HNSW segment by RENAMING the whole
- * segment directory out of the way — `<uuid>.drift-<stamp>` for mtime drift,
- * `<uuid>.corrupt-<stamp>` for unreadable metadata — and letting Chroma rebuild
- * a clean one. Sound recovery. What it never does, at any version we have read
- * (3.3.5 through the current 3.7.1), is DELETE the copy it renamed aside.
+ * MemPalace 从可疑的 ChromaDB HNSW 段恢复的方式是：把整个段目录改名挪开——
+ * mtime 漂移叫 `<uuid>.drift-<stamp>`，元数据不可读叫 `<uuid>.corrupt-<stamp>`
+ * ——然后让 Chroma 重建一个干净的段。恢复逻辑本身没问题。但它在我们读过的
+ * 任何版本（3.3.5 到当前的 3.7.1）都绝不会删除改名挪开的那份拷贝。
  *
- * That is fine for a one-off. It is not fine here, because on this palace the
- * quarantine is not a one-off: the drawers segment is one 100-vector batch
- * (167,600 bytes at 384 dims), which never reaches Chroma's sync threshold of
- * 1000, so no persist ever fires, so `index_metadata.pickle` is never written,
- * so the health gate fails and quarantines it again. Byte-identical, every few
- * minutes, forever. A user on Discord passed 100GB inside 8 hours this way.
+ * 一次性场景没问题；在这里不行，因为这座宫殿的隔离不是一次性的：drawers
+ * 段是单个 100 向量的批次（384 维、167,600 字节），永远达不到 Chroma 1000
+ * 的同步阈值，所以持久化永远不会触发，`index_metadata.pickle` 永远不会写入，
+ * 健康门因此失败并再次隔离它。字节完全相同，每隔几分钟一次，永远循环。
+ * Discord 上有用户因此 8 小时内攒了 100GB。
  *
- * The cure belongs upstream — MemPalace's "has real data" floor is 1024 bytes,
- * set for tiny test collections, and a normal vector batch clears it by 163x.
- * We cannot ship their fix and cannot make anyone upgrade. So we contain it:
- * sweep the copies and the disk stops growing on every version, with nothing
- * for the user to notice or do.
+ * 药方在上游——MemPalace 的“有真实数据”下限是 1024 字节，是为微型测试集合
+ * 设置的，普通向量批次超出它 163 倍。我们无法发布他们的修复，也无法强迫
+ * 任何人升级。所以我们遏制它：扫掉这些拷贝，磁盘在任意版本下都不再增长，
+ * 用户无需注意到任何事或做任何事。
  *
- * Pure and browser-global-free so the rules are unit-testable without a palace
- * on disk. Same split as `store/focusMode.ts`: the decision lives here, the
- * `rm` lives in `memory.ts`.
+ * 纯逻辑、不依赖浏览器全局，因此规则可以在没有磁盘上的宫殿时做单元测试。
+ * 与 `store/focusMode.ts` 相同的拆分：决策在这里，`rm` 在 `memory.ts`。
  */
 
-/** A palace directory entry, as far as these rules care. */
+/** 就这些规则关心的范围而言，一个宫殿目录条目。 */
 export interface PalaceEntry {
   name: string;
 }
 
 /**
- * Matches ONLY MemPalace's own quarantine suffix.
+ * 只匹配 MemPalace 自己的隔离后缀。
  *
- * Deliberately anchored and fully specified — `%Y%m%d-%H%M%S` from
- * `backends/chroma.py`, so exactly 8 digits, a dash, 6 digits, end of name. A
- * looser "contains .corrupt" test is the kind that one day matches a live
- * collection and deletes somebody's index. The live segments are bare UUIDs
- * with no suffix at all, so nothing without this exact shape is ever a
- * candidate.
+ * 刻意锚定并完全限定——来自 `backends/chroma.py` 的 `%Y%m%d-%H%M%S`，
+ * 即恰好 8 位数字、一个短横线、6 位数字、然后是名称结尾。宽松的
+ * “包含 .corrupt”测试总有一天会匹配到在线集合，删掉某人的索引。
+ * 在线段是没有任何后缀的裸 UUID，因此没有这种精确形状的
+ * 条目永远不会成为候选。
  */
 const QUARANTINE = /\.(?:drift|corrupt)-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/;
 
-/** The quarantine stamp as local epoch ms, or null if this is not one.
+/** 隔离时间戳（本地 epoch 毫秒），若不是隔离目录则返回 null。
  *
- *  The stamp, not the directory's mtime: renaming a directory does not change
- *  its own mtime (only the parent's), so mtime still reports when the segment
- *  was last WRITTEN, not when it was quarantined. The stamp is written by
- *  MemPalace's `datetime.now()` on this same machine, so local time is the
- *  right reading of it. */
+ *  看时间戳，而不是目录的 mtime：重命名目录不会改变它自身的 mtime
+ *  （只会改父目录的），所以 mtime 仍然报告段最后一次被“写入”的时间，
+ *  而不是被隔离的时间。时间戳由 MemPalace 在同一台机器上调用
+ *  `datetime.now()` 写入，因此本地时间才是它的正确读法。 */
 export function quarantineStampMs(name: string): number | null {
   const m = QUARANTINE.exec(name);
   if (!m) return null;
@@ -58,23 +52,22 @@ export function quarantineStampMs(name: string): number | null {
 }
 
 export interface ReapOptions {
-  /** Newest N kept for diagnosis. Something has to survive for anyone to be
-   *  able to look at what was quarantined and why. */
+  /** 保留最新 N 个用于诊断。总得留下一些，让别人能查看
+   *  被隔离的是什么、为什么被隔离。 */
   keep?: number;
-  /** Never touch a quarantine younger than this. The rename and the rebuild are
-   *  not atomic with respect to us, so leave the freshest ones alone rather
-   *  than race a MemPalace process mid-recovery. */
+  /** 绝不碰比这个更年轻的隔离目录。重命名和重建对我们来说不是原子的，
+   *  因此宁可不碰最新的那些，也不要与恢复中的 MemPalace 进程竞争。 */
   minAgeMs?: number;
 }
 
 const DEFAULTS = { keep: 2, minAgeMs: 10 * 60_000 };
 
 /**
- * Names to delete, given everything currently in the palace directory.
+ * 给定宫殿目录当前的全部内容，返回要删除的名字。
  *
- * Newest-first by stamp, skip the newest `keep`, then drop whatever is left
- * that is also older than `minAgeMs`. Returns names, not paths — the caller
- * owns the palace path and the filesystem.
+ * 按时间戳从新到旧排序，跳过最新的 `keep` 个，然后丢弃其余
+ * 比 `minAgeMs` 更老的。返回名字而非路径——调用方拥有
+ * 宫殿路径和文件系统。
  */
 export function quarantineDirsToReap(
   entries: PalaceEntry[],
@@ -89,8 +82,8 @@ export function quarantineDirsToReap(
     const ts = quarantineStampMs(e.name);
     if (ts !== null) stamped.push({ name: e.name, ts });
   }
-  // Newest first. Tie-break on name so two quarantines inside the same second
-  // produce a stable, reproducible ordering rather than depending on readdir.
+  // 新的在前。同一秒内两个隔离目录用名字破平，这样能产生
+  // 稳定可复现的排序，而不是依赖 readdir 的顺序。
   stamped.sort((a, b) => (b.ts - a.ts) || b.name.localeCompare(a.name));
 
   return stamped
@@ -100,19 +93,17 @@ export function quarantineDirsToReap(
 }
 
 /**
- * How long to wait before the next mine pass.
+ * 下一次挖掘之前要等待多久。
  *
- * Mining into a palace that just quarantined buys nothing: the segment it
- * rebuilds is the same one the next open will quarantine again, so the only
- * product of a fast cadence is another copy for `quarantineDirsToReap` to
- * clean up. So each pass that sees a fresh quarantine doubles the wait, and
- * the first clean pass drops straight back to the base interval.
+ * 刚被隔离的宫殿立刻去挖没有任何收益：它重建的段正是下一次 open
+ * 会再次隔离的那一个，所以快速节奏的唯一产物是又一份让
+ * `quarantineDirsToReap` 清理的拷贝。因此每次遇到新鲜隔离目录的
+ * 挖掘都会把等待时间翻倍，而第一次干净的挖掘会直接回落到基础间隔。
  *
- * Capped deliberately, and not high. On a palace stuck in the loop the backoff
- * would otherwise climb forever, and the cost of waiting is real: a memory is
- * not searchable until it has been mined. The reaper already removes 100% of
- * the disk growth, so this is only trimming CPU and IO — not worth making
- * recall an hour stale to save.
+ * 刻意设置了上限，而且不高。陷在循环里的宫殿若不设上限，退避会无限
+ * 爬升；而等待的代价是真实的：记忆在挖掘之前不可被搜索。收割器已经
+ * 清除了 100% 的磁盘增长，所以这里只是在削减 CPU 和 IO——不值得为了
+ * 省这点而让 recall 数据旧上一小时。
  */
 export function nextMineDelayMs(
   currentMs: number,

--- a/src/main/pricing.ts
+++ b/src/main/pricing.ts
@@ -1,20 +1,18 @@
 /**
- * Fallback-only model → price table (USD per million tokens).
+ * 仅回退用的模型 → 价格表（每百万 token 的美元价格）。
  *
- * The LIVE telemetry path does NOT use this. Claude Code emits a pre-computed,
- * per-model `cost_usd` on every `api_request` log and a `claude_code.cost.usage`
- * metric (verified by the 7A.1 spike), so the collector (`telemetry.ts`) trusts
- * Claude's own figure. This table exists solely for the OFFLINE transcript
- * reconciler (`transcript.ts`), which runs when telemetry is off and must
- * estimate cost from raw token counts.
+ * 实时遥测路径并不使用此表。Claude Code 会在每条 `api_request` 日志上输出
+ * 预先算好的、按模型的 `cost_usd`，并输出 `claude_code.cost.usage` 指标
+ * （已由 7A.1 尖峰验证），因此采集器（`telemetry.ts`）信任 Claude 自己给出的
+ * 数字。本表仅服务于离线转录核对器（`transcript.ts`）——它只在遥测关闭时运行，
+ * 必须根据原始 token 计数估算成本。
  *
- * It supersedes the old hard-coded Sonnet-for-everyone constants that lived in
- * `transcript.ts` (cost bug #1 — Opus undercosted ~5×, Haiku overcosted). Prices
- * are now matched per model family. This is the ONE place per-model pricing
- * lives; both the transcript backend and the collector's fallback import it.
+ * 它取代了原先硬编码在 `transcript.ts` 里的“所有人都是 Sonnet”常量
+ * （成本 bug #1——Opus 被低估约 5 倍，Haiku 被高估）。现在价格按模型家族匹配。
+ * 这是按模型定价唯一存在的地方；转录后端与采集器的回退逻辑都从这里导入。
  */
 
-/** USD per million tokens for one model family. */
+/** 一个模型家族每百万 token 的美元价格。 */
 export interface ModelPrice {
   inputPerM: number;
   outputPerM: number;
@@ -22,26 +20,25 @@ export interface ModelPrice {
   cacheWritePerM: number;
 }
 
-// Anthropic list prices, USD per million tokens. Approximate, fallback-only —
-// the live path uses Claude's own per-model cost, so drift here is harmless.
+// Anthropic 公开价格，每百万 token 的美元价格。为近似值，仅用于回退——
+// 实时路径使用 Claude 自带的按模型成本，因此这里的偏差无害。
 const OPUS: ModelPrice = { inputPerM: 15, outputPerM: 75, cacheReadPerM: 1.5, cacheWritePerM: 18.75 };
 const SONNET: ModelPrice = { inputPerM: 3, outputPerM: 15, cacheReadPerM: 0.3, cacheWritePerM: 3.75 };
 const HAIKU: ModelPrice = { inputPerM: 0.8, outputPerM: 4, cacheReadPerM: 0.08, cacheWritePerM: 1.0 };
 
-/** When the model id is unknown, assume Sonnet (the historical default). */
+/** 模型 id 未知时，假定为 Sonnet（历史默认值）。 */
 const DEFAULT_PRICE: ModelPrice = SONNET;
 
 /**
- * Strip Claude Code's variant suffix so `claude-opus-4-8[1m]` (the form the
- * `token.usage` metric carries) and `claude-opus-4-8` (the base id the
- * `api_request` log carries) resolve to the same family. Case is preserved;
- * matching is done case-insensitively in `priceFor`.
+ * 去除 Claude Code 的变体后缀，让 `claude-opus-4-8[1m]`（`token.usage`
+ * 指标携带的形式）和 `claude-opus-4-8`（`api_request` 日志携带的基础 id）
+ * 解析到同一家族。保留大小写；匹配在 `priceFor` 中按不区分大小写进行。
  */
 export function normalizeModel(model: string | undefined | null): string {
   return (model ?? '').trim().replace(/\[[^\]]*\]\s*$/, '');
 }
 
-/** Resolve a model id to its price row by family, falling back to Sonnet. */
+/** 按家族将模型 id 解析到其价格行，回退到 Sonnet。 */
 export function priceFor(model: string | undefined | null): ModelPrice {
   const m = normalizeModel(model).toLowerCase();
   if (m.includes('opus')) return OPUS;
@@ -50,7 +47,7 @@ export function priceFor(model: string | undefined | null): ModelPrice {
   return DEFAULT_PRICE;
 }
 
-/** Token split used by the cost estimator (matches `AgentUsage` token fields). */
+/** 成本估算器使用的 token 拆分（与 `AgentUsage` 的 token 字段一致）。 */
 export interface TokenSplit {
   inputTokens: number;
   outputTokens: number;
@@ -59,8 +56,8 @@ export interface TokenSplit {
 }
 
 /**
- * Estimate USD cost for a token split using the model's fallback price row.
- * Used only by the transcript reconciler; the live path trusts Claude's cost.
+ * 使用模型的回退价格行，估算一个 token 拆分的美元成本。
+ * 仅供转录核对器使用；实时路径信任 Claude 给出的成本。
  */
 export function estimateCostUsd(model: string | undefined | null, tokens: TokenSplit): number {
   const p = priceFor(model);

--- a/src/main/procKill.ts
+++ b/src/main/procKill.ts
@@ -1,52 +1,47 @@
 /**
- * Process-tree termination helpers (PID-release hardening).
+ * 进程树终止辅助（PID 释放加固）。
  *
- * Every explicit kill path used to be a bare node-pty `proc.kill()` — SIGHUP to
- * the DIRECT child only. Two leaks follow: (1) a child that ignores/queues
- * SIGHUP never dies, so its PID lingers for the machine's uptime; (2) even when
- * the child dies, its own children (MCP servers, helper daemons the session
- * started) are orphaned to PID 1 and never released. With the breaker/heartbeat
- * spawning and killing sessions all day, PIDs accumulate steadily.
+ * 过去每条显式 kill 路径都是裸的 node-pty `proc.kill()`——只向直接子进程发
+ * SIGHUP。随之而来两个泄漏：(1) 忽略/排队 SIGHUP 的子进程永远不会死，它的
+ * PID 会一直残留到机器重启；(2) 即使子进程死了，它自己的子进程（MCP 服务器、
+ * 会话启动的辅助守护进程）会被孤养到 PID 1 下而永不释放。熔断器/心跳整天在
+ * 生成和杀掉会话，PID 因此稳步累积。
  *
- * The fix: the pty child is a session leader (forkpty does setsid), so its
- * process GROUP covers its descendants — after a graceful kill, verify and then
- * SIGKILL the whole group (POSIX) or `taskkill /T /F` the tree (Windows).
+ * 修复：pty 子进程是会话首领（forkpty 会 setsid），因此它的进程组覆盖其
+ * 全部后代——优雅终止后，先校验再对整个组 SIGKILL（POSIX），或在 Windows 上
+ * 用 `taskkill /T /F` 杀整棵树。
  *
- * Deliberate scope: callers apply this on EXPLICIT kills (breaker stop, archive,
- * respawn, app quit, hidden check sessions) — never on a natural exit, where a
- * daemon the agent intentionally left running (a dev server started via a Bash
- * tool) must survive its parent session.
+ * 刻意的范围：调用方只在“显式”终止时使用（熔断停止、归档、重生、应用退出、
+ * 隐藏式检查会话）——绝不在自然退出时使用；自然退出时，agent 有意留着运行的
+ * 守护进程（比如通过 Bash 工具启动的 dev server）必须能比其父会话活得更久。
  */
 import { spawnSync } from 'node:child_process';
 
-/** Grace between the polite signal and the SIGKILL escalation. */
+/** 礼貌信号与 SIGKILL 升级之间的宽限期。 */
 export const KILL_GRACE_MS = 4_000;
 
-/** Is the process still alive? Signal 0 probes without touching it. */
+/** 进程是否还活着？信号 0 只探测，不打扰它。 */
 export function isAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; } catch { return false; }
 }
 
-/** Forcefully kill pid and its descendants NOW. Group-SIGKILL on POSIX (falls
- *  back to the single pid when the group id is gone); `taskkill /T /F` on
- *  Windows. Killing the group of an already-dead leader is exactly the
- *  orphan-reaping case: any surviving members still hold the group id. */
+/** 立即强力杀死 pid 及其全部后代。POSIX 上对进程组 SIGKILL（组 id 已消失时
+ *  回退到单个 pid）；Windows 上 `taskkill /T /F`。对已死亡首领的组执行杀死
+ *  正是回收孤儿的情形：任何幸存的成员仍然持有该组 id。 */
 export function hardKillTree(pid: number): void {
   if (!Number.isInteger(pid) || pid <= 0) return;
   if (process.platform === 'win32') {
-    try { spawnSync('taskkill', ['/pid', String(pid), '/T', '/F'], { timeout: 10_000 }); } catch { /* gone */ }
+    try { spawnSync('taskkill', ['/pid', String(pid), '/T', '/F'], { timeout: 10_000 }); } catch { /* 已消失 */ }
     return;
   }
   try { process.kill(-pid, 'SIGKILL'); } catch {
-    try { process.kill(pid, 'SIGKILL'); } catch { /* gone */ }
+    try { process.kill(pid, 'SIGKILL'); } catch { /* 已消失 */ }
   }
 }
 
-/** After a graceful kill (node-pty's SIGHUP), make sure the PIDs actually get
- *  released: wait a short grace, then sweep the process tree. Runs even when
- *  the leader died promptly — the sweep is what reaps grandchildren the polite
- *  signal never reached. The timer is unref'd so it can never keep the app
- *  alive during quit. */
+/** 优雅终止（node-pty 的 SIGHUP）之后，确保 PID 真正被释放：等待短暂宽限期，
+ *  然后清扫进程树。即使首领及时死亡也会运行——清扫正是为了回收礼貌信号
+ *  从未触达的孙进程。定时器已 unref，因此它绝不可能在退出时拖住应用。 */
 export function ensureKilled(pid: number | undefined, graceMs = KILL_GRACE_MS): void {
   if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return;
   const t = setTimeout(() => hardKillTree(pid), graceMs);

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -8,24 +8,22 @@ import { expandTilde } from './fs';
 import { buildPtyEnv } from './ptyEnv';
 import { captureFromLoginShell, isSafeCommandName, userShellPath } from './shellEnv';
 
-/** APPEND the hive's bundled-node dir (`<HIVE_ROOT>/bin/runtime`, which holds a
- *  shim literally named `node`) to a child's PATH.
+/** 把 hive 自带的 node 目录（`<HIVE_ROOT>/bin/runtime`，其中放着一个字面名为 `node`
+ *  的垫片）APPEND 到子进程的 PATH 末尾。
  *
- *  Layer 1 routed the commands WE generate through `hive-node`. This covers the
- *  ones we don't: an MCP server declared as `node ./server.js`, a provider CLI
- *  that shells out to node, a helper script the agent wrote itself. With no
- *  system node those all die with 127 — the same bug, one level down.
+ *  第 1 层让 WE 生成的命令走 `hive-node`。这里覆盖的是我们不生成的命令：一个声明为
+ *  `node ./server.js` 的 MCP 服务器、一个向外调用 node 的 provider CLI、一个 agent
+ *  自己写的辅助脚本。没有系统级 node 时，它们都会以 127 退出——同一类 bug，只是又低了一层。
  *
- *  APPENDED, never prepended: a user who has their own node keeps it, and we are
- *  only the fallback. Prepending would silently swap the node version under the
- *  user's own projects for Electron's, which is a different (and wrong) product
- *  decision. No-ops when there is no hive root or the dir was never written. */
+ *  只 APPEND、绝不 PREPEND：用户自己装了 node 就保留它，我们只是兜底。若 PREPEND，
+ *  会在用户自己的项目里悄悄把 node 版本换成 Electron 自带的，这是另一个（而且是错误的）
+ *  产品决策。没有 hive 根目录或该目录从未写入时，本函数为 no-op。 */
 export function withHiveRuntimeFallback(path: string, hiveRoot?: string): string {
   if (!hiveRoot) return path;
   const dir = join(hiveRoot, 'bin', 'runtime');
   if (!existsSync(dir)) return path;
   const entries = path.split(delimiter).filter(Boolean);
-  if (entries.includes(dir)) return path; // re-spawn of a live agent
+  if (entries.includes(dir)) return path; // 正在重新生成活的 agent
   return [...entries, dir].join(delimiter);
 }
 
@@ -34,90 +32,79 @@ interface PtySession {
   proc: pty.IPty;
   cwd: string;
   command: string;
-  /** The window (webContents) that spawned this PTY and should receive its
-   *  output. Multi-window: each floor owns its own terminals, so `pty:data:<id>`
-   *  / `pty:exit:<id>` route ONLY here — never broadcast — so one floor's stream
-   *  never leaks into another. Null falls back to the default attached sink
-   *  (the primary window), preserving single-window behavior. */
+  /** 生成该 PTY 并应接收其输出的窗口（webContents）。多窗口场景下：每个楼层拥有自己的
+   *  终端，因此 `pty:data:<id>` / `pty:exit:<id>` 只路由到这里——绝不广播——这样
+   *  一个楼层的输出流不会泄漏到另一个楼层。为 null 时回退到默认的附加输出目标（主窗口），
+   *  保持单窗口行为不变。 */
   owner: WebContents | null;
-  /** Epoch ms of the most recent byte this PTY emitted (bumped in onData). The
-   *  heartbeat (Lane A #1) reads this for two things: floor-quiet detection (an
-   *  agent printing/thinking counts as activity even before it writes a hive
-   *  file) and the idle handshake that gates god's PTY nudge (never type into a
-   *  PTY that produced output in the last few seconds = mid-stream). */
+  /** 本 PTY 最近一次输出字节的 epoch 毫秒数（在 onData 中更新）。心跳（Lane A #1）
+   *  读取它用于两件事：楼层静默检测（agent 打印/思考即使还没写 hive 文件也算活跃）和
+   *  空闲握手——用来门控 god 的 PTY 轻推（绝不要向最近几秒内仍有输出的 PTY 键入内容 =
+   *  正处于输出流中间）。 */
   lastOutputAt: number;
-  /** True after the child has emitted at least one frame. Automation waits for
-   *  this before typing, so startup prompts cannot outrun the TUI subscription. */
+  /** 子进程至少输出过一帧后为 true。自动化在键入前会等待它，这样启动提示不会跑在
+   *  TUI 订阅之前。 */
   hasOutput: boolean;
 }
 
 export interface SpawnOptions {
   id: string;
   cwd: string;
-  command: string;       // e.g. 'claude'
+  command: string;       // 例如 'claude'
   args?: string[];
   cols?: number;
   rows?: number;
-  /** Extra environment for the child (merged over the resolved shell env). */
+  /** 子进程的额外环境变量（覆盖到已解析的 shell 环境之上）。 */
   env?: Record<string, string>;
-  /** When set, run this string as a VISIBLE shell script instead of resolving/
-   *  spawning `command`. Used by the missing-CLI auto-install path: the script
-   *  (a banner + an install command) streams to the same Terminal tab. Routed
-   *  through `$SHELL -lc` on unix and `cmd.exe /d /s /c` on Windows. The script
-   *  MUST contain no embedded double-quotes (it is wrapped verbatim on Windows).
-   *  `command` is still recorded for display but is not executed. */
+  /** 设置后，把该字符串当作一个可见的 shell 脚本来运行，而不是解析/生成 `command`。
+   *  用于缺少 CLI 的自动安装路径：该脚本（一条横幅 + 一条安装命令）会流式输出到同一个
+   *  Terminal 标签页。unix 下经 `$SHELL -lc` 运行，Windows 下经 `cmd.exe /d /s /c`
+   *  运行。脚本绝不能包含内嵌双引号（在 Windows 上会原样包裹）。`command` 仍会被记录
+   *  用于展示，但不会被执行。 */
   shellScript?: string;
 }
 
 /**
- * (#55) Build the single pre-escaped command-line STRING for routing a non-.exe
- * Windows target through cmd.exe. Returns the args portion only (everything after
- * `cmd.exe`), in Node's canonical `child_process` form:
+ * (#55) 构建单条预转义命令行 STRING，用于把非 .exe 的 Windows 目标经 cmd.exe 路由。
+ * 只返回 args 部分（`cmd.exe` 之后的一切），采用 Node 规范的 `child_process` 形式：
  *
  *   /d /s /c "<target> <arg> <arg> ..."
  *
- * Each token (the resolved target + every user arg) is double-quoted only when it
- * contains a space/tab/quote, then the WHOLE inner command is wrapped in one more
- * outer quote pair. cmd.exe's `/s` strips exactly that outer pair and executes the
- * remainder literally, so a `C:\Program Files\...` target survives its space.
+ * 每个 token（解析出的目标 + 每个用户参数）仅在包含空格/制表符/引号时加双引号，然后用
+ * 一对额外的外层引号包住整个内部命令。cmd.exe 的 `/s` 恰好剥掉那对外层引号并按字面执行
+ * 其余部分，所以 `C:\Program Files\...` 这样的目标能扛过它路径中的空格。
  *
- * This is handed to `pty.spawn(file, args, ...)` as a STRING, which node-pty treats
- * as a pre-escaped CommandLine and passes through VERBATIM (no per-arg re-escaping),
- * so the quoting here is never double-wrapped.
+ * 该字符串以 STRING 形式交给 `pty.spawn(file, args, ...)`，node-pty 会把它当作一条
+ * 预转义的 CommandLine 并 VERBATIM 透传（不再逐参数重新转义），所以这里的引号绝不会被
+ * 二次包裹。
  *
- * ⚠️ LAST-RESORT PATH — DO NOT PUT AN AGENT PROMPT THROUGH IT. Two hard limits of
- * cmd.exe's parser that no amount of escaping here can work around:
+ * ⚠️ 最后手段路径——绝不要把 agent 提示词塞进去。cmd.exe 解析器有两个硬限制，这里无论
+ * 怎样转义都无法绕过：
  *
- *  1. **cmd.exe has NO backslash escape.** An earlier version of this comment
- *     claimed `\"` was "cmd's quote-escape". It is not: to cmd, `\` is an ordinary
- *     character and every `"` TOGGLES quote state. So `\"` does not embed a quote —
- *     it closes (or opens) the quoted run and dumps everything after it back into
- *     bare, metacharacter-interpreting context. The `\"` produced below survives
- *     only because the CRT of the *final* program un-escapes it; the intermediate
- *     cmd.exe still mis-tracks quote state across it.
- *  2. **A newline can never survive.** cmd.exe treats CR/LF as a statement
- *     separator before quoting is even considered, so a multi-line argument is
- *     TRUNCATED at its first newline and the remainder is executed as commands.
- *     That is exactly how the Windows hive protocol prompt (multi-line, full of
- *     `(`/`)` which cmd reads as block delimiters) was being destroyed: the agent
- *     booted looking healthy but never received the HIVE PROTOCOL block, so it
- *     never knew its inbox/outbox existed and no agent could message another.
+ *  1. **cmd.exe 没有反斜杠转义。** 本注释的早期版本曾声称 `\"` 是 "cmd 的引号转义"。
+ *     其实不是：对 cmd 而言 `\` 只是普通字符，每个 `"` 都会 TOGGLE 引号状态。所以 `\"`
+ *     并不会嵌入一个引号——它只会关闭（或打开）带引号的一段，并把其后的一切重新丢回裸的、
+ *     按元字符解释的上下文。下面生成的 `\"` 之所以能存活，只是因为 *最终* 程序的 CRT
+ *     会反转义它；中间的 cmd.exe 仍会在它上面错误跟踪引号状态。
+ *  2. **换行永远无法存活。** cmd.exe 在考虑引号之前就把 CR/LF 当作语句分隔符，所以
+ *     多行参数会在第一个换行处被 TRUNCATED，剩余部分被当作命令执行。这正是 Windows 上
+ *     hive 协议提示词（多行、满是 cmd 视为块定界符的 `(`/`)`）被毁掉的方式：agent 启动
+ *     后看起来健康，却从未收到 HIVE PROTOCOL 块，于是永远不知道收件箱/发件箱存在，
+ *     没有任何 agent 能互发消息。
  *
- * There is also cmd.exe's ~8191-character command-line ceiling, which the injected
- * hive prompt (~6.1k chars) sits uncomfortably close to.
+ * 还有 cmd.exe 约 8191 字符的命令行上限，而注入的 hive 提示词（约 6.1k 字符）就紧贴着
+ * 这个上限。
  *
- * Prompt-carrying spawns therefore go through `parseNpmCmdShim` instead (spawn the
- * shim's real interpreter with an ARRAY of args, so node-pty's own CRT-correct
- * `argsToCommandLine` runs and no shell parser is involved). This function remains
- * the fallback for every target we cannot decode — strictly no worse than before.
+ * 因此携带提示词的 spawn 改走 `parseNpmCmdShim`（用 ARRAY 参数生成垫片的真实解释器，
+ * 这样 node-pty 自带的 CRT 正确的 `argsToCommandLine` 得以运行，全程不涉及 shell 解析器）。
+ * 本函数仍是所有我们无法解码目标的兜底——严格说不比从前更差。
  */
 export function buildCmdCommandLine(resolved: string, args: string[]): string {
   const quoteToken = (s: string): string => {
-    // Escape any embedded double-quote, then quote the token if it needs it.
-    // Quote on whitespace/quote AND on cmd.exe metacharacters (& | ^ < > ( ) % !):
-    // an unquoted `&`/`|`/etc. would let one token chain a second command once this
-    // string is executed by cmd.exe. Quoting neutralizes them — cmd does not
-    // interpret metacharacters inside a double-quoted run.
+    // 转义任何内嵌的双引号，然后在需要时给 token 加引号。
+    // 在空白/引号以及 cmd.exe 元字符（& | ^ < > ( ) % !）上加引号：
+    // 未加引号的 `&`/`|`/等一旦被 cmd.exe 执行，会让一个 token 串联出第二条命令。
+    // 加引号可以中和它们——cmd 不会解释双引号段内的元字符。
     const escaped = s.replace(/"/g, '\\"');
     return /[ \t"&|^<>()%!]/.test(s) ? `"${escaped}"` : escaped;
   };
@@ -125,101 +112,86 @@ export function buildCmdCommandLine(resolved: string, args: string[]): string {
   return `/d /s /c "${inner}"`;
 }
 
-/** What an npm-style Windows `.cmd` shim actually runs, decoded from its text. */
+/** 一个 npm 风格的 Windows `.cmd` 垫片实际运行的内容，从其文本中解码而来。 */
 export interface NpmShimTarget {
-  /** BARE interpreter name — `node`, `bun` or `deno` — to be resolved off PATH by
-   *  the caller (kept bare deliberately: see parseNpmCmdShim), or NULL when the
-   *  shim runs a native executable directly and there is no interpreter at all. */
+  /** BARE 解释器名——`node`、`bun` 或 `deno`——由调用方沿 PATH 解析（刻意保持裸名：
+   *  见 parseNpmCmdShim）；当垫片直接运行原生可执行文件、根本没有解释器时为 NULL。 */
   interpreter: string | null;
-  /** Absolute, normalized win32 path to the script that interpreter should run —
-   *  or to the executable itself when `interpreter` is null. */
+  /** 该解释器应运行的脚本的绝对、规范化 win32 路径——当 `interpreter` 为 null 时，
+   *  则指向可执行文件本身。 */
   scriptPath: string;
 }
 
-/** Interpreters we are willing to spawn directly. Deliberately a tiny allowlist:
- *  anything else (a hand-written batch file, a python/ruby shim, a shape we have
- *  not seen) resolves to null and falls back to the cmd.exe path — never worse
- *  than today's behaviour. */
+/** 我们愿意直接生成的解释器。刻意保持极小的白名单：任何其他东西（手写的批处理文件、
+ *  python/ruby 垫片、我们没见过形状的东西）都解析为 null 并回退到 cmd.exe 路径——绝不
+ *  比现在的行为更差。 */
 const SHIM_INTERPRETERS = new Set(['node', 'bun', 'deno']);
-/** The shim's target must look like a JS entry point. A shim that points at
- *  something else is not a shape we understand → null. */
+/** 垫片的目标必须看起来像 JS 入口点。指向其他东西的垫片不是我们能理解的形状 → null。 */
 const SHIM_SCRIPT_EXT = /\.(?:c|m)?js$/i;
 
 /**
- * Decode an npm-generated Windows `.cmd` shim into the interpreter + script it
- * would have run. PURE (no filesystem, no `process.platform`): it takes the shim's
- * path and its CONTENT so it is unit-testable on macOS/Linux, where every Windows
- * build is authored.
+ * 把一个 npm 生成的 Windows `.cmd` 垫片解码成它本会运行的解释器 + 脚本。PURE（不碰
+ * 文件系统、不碰 `process.platform`）：它接收垫片的路径及其 CONTENT，因此可以在
+ * macOS/Linux 上做单元测试，而所有 Windows 构建都在那里产出。
  *
- * WHY THIS EXISTS. On Windows a `.cmd`/`.bat` cannot be handed to CreateProcess,
- * so the spawn path used to route it through `cmd.exe /d /s /c "<line>"`. That
- * turns argv into a single string parsed by cmd.exe — which cannot carry a newline
- * (statement separator), reads `(`/`)` as block delimiters, has no backslash escape,
- * and caps out near 8191 chars. The hive protocol prompt is a ~6.1k-char, 11-line,
- * 62-paren argument, so on Windows it was truncated at its first newline: every
- * npm-installed CLI (OpenCode always; `claude.cmd` whenever there is no native
- * `claude.exe`) started up looking perfectly healthy but never received the HIVE
- * PROTOCOL block, never learned that `inbox/`/`outbox/` existed, and so no agent
- * ever heard from another. Claude appeared to work only because its native
- * `claude.exe` skipped cmd.exe entirely.
+ * 为什么存在。Windows 上 `.cmd`/`.bat` 不能直接交给 CreateProcess，所以 spawn 路径过去
+ * 把它经 `cmd.exe /d /s /c "<line>"` 路由。那会把 argv 变成由 cmd.exe 解析的单条字符串
+ * ——cmd.exe 无法承载换行（语句分隔符）、把 `(`/`)` 当作块定界符、没有反斜杠转义、上限
+ * 接近 8191 字符。hive 协议提示词是一个约 6.1k 字符、11 行、62 个括号的参数，所以在
+ * Windows 上它会在第一个换行处被截断：每个 npm 安装的 CLI（OpenCode 一直如此；只要没有
+ * 原生 `claude.exe`，`claude.cmd` 也如此）启动后看起来完全健康，却从未收到 HIVE PROTOCOL
+ * 块，从未得知 `inbox/`/`outbox/` 存在，于是没有任何 agent 能听到别的 agent 的声音。
+ * Claude 看起来正常，只是因为它的原生 `claude.exe` 完全绕过了 cmd.exe。
  *
- * Spawning the shim's own interpreter with an ARRAY of args removes cmd.exe from
- * the picture: node-pty's `argsToCommandLine` applies MSDN/CRT escaping (backslash
- * doubling before a quote, whole-arg quoting on whitespace) and hands the result
- * straight to CreateProcess, which passes the raw command line to the child. A
- * newline inside a quoted CRT argument is just a character there, and the limit
- * becomes CreateProcess's 32767 rather than cmd's 8191.
+ * 用 ARRAY 形式的参数直接生成垫片自己的解释器，就把 cmd.exe 从整条链路中移除了：
+ * node-pty 的 `argsToCommandLine` 会应用 MSDN/CRT 转义（引号前反斜杠加倍、遇空白时整参
+ * 加引号），并把结果直接交给 CreateProcess，由它把原始命令行传给子进程。带引号的 CRT
+ * 参数里的换行在那里只是一个字符，上限也变成 CreateProcess 的 32767，而不是 cmd 的 8191。
  *
- * SHAPES HANDLED (npm's cmd-shim, across its historical revisions; pnpm/yarn emit
- * the same families):
+ * SHAPES HANDLED（npm 的 cmd-shim，覆盖其历史各版本；pnpm/yarn 产出同一族形状）：
  *
- *   modern (cmd-shim ≥4 / npm ≥7) — dp0 captured into a variable, program chosen
- *   into %_prog%, single trailing exec line:
+ *   modern (cmd-shim ≥4 / npm ≥7) — dp0 被捕获进变量，程序选入 %_prog%，末尾单条 exec 行：
  *       SET dp0=%~dp0
  *       IF EXIST "%dp0%\node.exe" ( SET "_prog=%dp0%\node.exe" ) ELSE ( SET "_prog=node" … )
  *       endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\node_modules\pkg\bin\cli.js" %*
  *
- *   classic (cmd-shim 2/3, npm 5/6) — IF/ELSE with the exec inlined in both arms:
+ *   classic (cmd-shim 2/3, npm 5/6) — IF/ELSE，exec 在两个分支中都内联：
  *       @IF EXIST "%~dp0\node.exe" (
  *         "%~dp0\node.exe"  "%~dp0\node_modules\pkg\bin\cli.js" %*
  *       ) ELSE ( … node  "%~dp0\node_modules\pkg\bin\cli.js" %* )
  *
- *   ancient single-line:
+ *   ancient 单行:
  *       @"%~dp0\node.exe"  "%~dp0\node_modules\pkg\bin\cli.js" %*
  *
- * The interpreter is returned BARE (`node`), not as the shim's `%dp0%\node.exe`
- * candidate, on purpose: that candidate only exists for an npm install that ships a
- * colocated node, and that directory is on PATH by construction — so resolving the
- * bare name finds the same binary while also going through the caller's existing
- * PATH/candidate-dir resolution and cache.
+ * 解释器刻意以 BARE（`node`）形式返回，而不是垫片的 `%dp0%\node.exe` 候选：那个候选只
+ * 在 npm 安装自带同目录 node 时存在，而该目录按构造本来就在 PATH 上——所以解析裸名能
+ * 找到同一个二进制，同时仍会走调用方现有的 PATH/候选目录解析与缓存。
  *
- * Returns null — meaning "fall back to the cmd.exe path" — for ANY shape that is
- * not fully understood: unknown interpreter, unexpanded `%VAR%` left in the target,
- * a relative target, extra interpreter flags we would otherwise silently drop, a
- * non-JS target, a file too large to be a shim, or plain garbage.
+ * 对任何未完全理解的形状返回 null——含义是"回退到 cmd.exe 路径"：未知解释器、目标里
+ * 残留未展开的 `%VAR%`、相对目标、我们本会静默丢弃的多余解释器标志、非 JS 目标、大到
+ * 不可能是垫片的文件，或者纯垃圾内容。
  */
 export function parseNpmCmdShim(shimPath: string, content: string): NpmShimTarget | null {
   if (typeof shimPath !== 'string' || typeof content !== 'string') return null;
   if (!shimPath || !content) return null;
-  // A cmd-shim is ~1KB. Anything larger is somebody's real batch script (or a
-  // binary someone named `.cmd`) and is not ours to reinterpret.
+  // 一个 cmd-shim 约 1KB。更大的东西是某人的真实批处理脚本（或某个被命名为 `.cmd` 的
+  // 二进制），不该由我们重新解释。
   if (content.length > 8192 || content.includes('\0')) return null;
 
-  // win32.* explicitly — these paths are Windows paths regardless of the host we
-  // are running (or testing) on.
+  // 明确使用 win32.* ——无论我们在什么宿主机上运行（或测试），这些路径都是 Windows 路径。
   const dir = win32.dirname(shimPath);
   if (!dir || dir === '.') return null;
 
-  /** Expand a shim token's `%~dp0` / `%dp0%` (the shim's OWN directory, which cmd
-   *  expands WITH a trailing backslash) into an absolute, normalized path. Any
-   *  other surviving `%` means a variable we did not model → refuse. */
+  /** 把一个垫片 token 的 `%~dp0` / `%dp0%`（垫片自己的目录，cmd 展开时会带一个尾部
+   *  反斜杠）展开成绝对、规范化的路径。任何其他存留的 `%` 都意味着有一个我们没有建模的
+   *  变量 → 拒绝。 */
   const expand = (raw: string): string | null => {
     let s = raw.replace(/%~dp0%?|%dp0%/gi, `${dir}\\`);
     if (s.includes('%')) return null;
     if (!s.trim()) return null;
-    // `<dir>\` + `\node_modules\…` produces a doubled separator that Windows
-    // tolerates; collapse it so the path we hand to existsSync is clean. A leading
-    // UNC `\\server\share` prefix must survive that collapse.
+    // `<dir>\` + `\node_modules\…` 会产生一个 Windows 能容忍的双写分隔符；把它折叠掉，
+    // 这样交给 existsSync 的路径是干净的。开头的 UNC `\\server\share` 前缀必须在这种
+    // 折叠后仍然保留。
     const unc = /^[\\/]{2}/.test(s);
     s = s.replace(/[\\/]+/g, '\\');
     if (unc) s = `\\${s}`;
@@ -227,13 +199,13 @@ export function parseNpmCmdShim(shimPath: string, content: string): NpmShimTarge
     return win32.normalize(s);
   };
 
-  // Every `SET "_prog=…"` the shim performs (the IF-EXISTS arm and the PATH arm).
+  // 垫片执行的每个 `SET "_prog=…"`（IF-EXISTS 分支和 PATH 分支）。
   const progValues: string[] = [];
   for (const m of content.matchAll(/^\s*@?SET\s+"?_prog=([^"\r\n]*)"?/gim)) progValues.push(m[1]);
 
-  // The exec line is the LAST line carrying `%*` (cmd's "forward all args"): in the
-  // modern shim that is the single `endLocal & … & "%_prog%" "<script>" %*` line;
-  // in the classic IF/ELSE shim it is the ELSE arm, which runs the same script.
+  // exec 行是携带 `%*`（cmd 的"转发全部参数"）的最后一行：在 modern 垫片里就是那条
+  // 单独的 `endLocal & … & "%_prog%" "<script>" %*` 行；在 classic IF/ELSE 垫片里则是
+  // ELSE 分支，它运行同一个脚本。
   const lines = content.split(/\r?\n/);
   let execLine: string | null = null;
   for (let i = lines.length - 1; i >= 0; i--) {
@@ -250,46 +222,43 @@ export function parseNpmCmdShim(shimPath: string, content: string): NpmShimTarge
   if (quoted.length === 0) return null;
 
   const scriptTok = quoted[quoted.length - 1];
-  // Locate the program token and PROVE nothing sits between it and the script.
-  // Interpreter flags baked into a shebang (`#!/usr/bin/env node --flag`) land
-  // there; dropping them silently would change how the CLI runs, so we bail out
-  // to the cmd.exe fallback instead.
+  // 定位程序 token，并 PROVE 它和脚本之间没有任何东西。写死在 shebang（`#!/usr/bin/env
+  // node --flag`）里的解释器标志会落在这里；悄悄丢弃它们会改变 CLI 的运行方式，所以我们
+  // 改而退出到 cmd.exe 兜底。
   let progRaw: string;
   if (quoted.length >= 2) {
     const progTok = quoted[quoted.length - 2];
     if (head.slice(progTok.end, scriptTok.start).trim() !== '') return null;
     progRaw = progTok.text;
   } else {
-    // Two one-token shapes share this branch, told apart by what precedes the quote.
+    // 两种单 token 形状共用这个分支，靠引号前面是什么来区分。
     const before = head.slice(0, scriptTok.start).trim().replace(/^@/, '').trim();
     if (before === '') {
-      // DIRECT-EXECUTABLE shim: nothing before the quoted target, so there is no
-      // interpreter — the shim runs a native binary. npm writes this whenever the
-      // package's bin has no shebang, which is the norm for a compiled CLI:
+      // DIRECT-EXECUTABLE 垫片：带引号的目标前面什么都没有，因此没有解释器——垫片直接
+      // 运行一个原生二进制。npm 在包的 bin 没有 shebang 时会写出这种形式，而这正是编译型
+      // CLI 的常态：
       //
       //   "%dp0%\..\opencode-ai\bin\opencode.exe"   %*
       //
-      // opencode-ai is exactly that (its bin is ./bin/opencode.exe, a real
-      // binary), so EVERY Windows OpenCode install hit this shape, fell through to
-      // null, and got the cmd.exe fallback that truncates the hive protocol at its
-      // first newline. The agent then booted looking healthy with no idea it had
-      // an inbox. Handing the binary straight to CreateProcess with an argv array
-      // is strictly better than routing it through cmd.exe — same program, no
-      // shell parser in between.
+      // opencode-ai 正是如此（其 bin 是 ./bin/opencode.exe，一个真正的二进制），所以
+      // 每个 Windows OpenCode 安装都会命中这种形状、落回 null，然后走 cmd.exe 兜底，而
+      // cmd.exe 会在第一个换行处截断 hive 协议。agent 随后启动，看起来健康，却完全不知道
+      // 自己有收件箱。用 argv 数组把二进制直接交给 CreateProcess，严格优于经 cmd.exe
+      // 路由——同一个程序，中间没有 shell 解析器。
       const exe = expand(scriptTok.text);
       if (!exe) return null;
-      // Only a real executable. Anything else here is a shape we have not modelled.
+      // 只接受真正的可执行文件。这里的其他任何东西都是我们没有建模过的形状。
       if (!/\.(exe|com)$/i.test(exe)) return null;
       return { interpreter: null, scriptPath: exe };
     }
-    // Classic ELSE arm: `node  "<script>" %*` — the program is an unquoted word.
+    // Classic ELSE 分支：`node  "<script>" %*` —— 程序是一个未加引号的单词。
     const word = before.split(/\s+/).filter(Boolean).pop();
-    if (!word || word !== before) return null; // anything else before it → unknown shape
+    if (!word || word !== before) return null; // 它前面还有别的 → 未知形状
     progRaw = word;
   }
 
-  // `"%_prog%"` → the value the shim SET. Prefer the bare-name arm (the PATH
-  // fallback); a `%dp0%\node.exe` value still reduces to the same basename below.
+  // `"%_prog%"` → 垫片 SET 的那个值。优先取裸名分支（PATH 兜底）；`%dp0%\node.exe`
+  // 这种值下面仍会归约到同一个 basename。
   if (/^%_prog%$/i.test(progRaw)) {
     if (progValues.length === 0) return null;
     progRaw = progValues.find((v) => !/[%\\/]/.test(v)) ?? progValues[progValues.length - 1];
@@ -305,29 +274,28 @@ export function parseNpmCmdShim(shimPath: string, content: string): NpmShimTarge
 export class PtyManager {
   private sessions = new Map<string, PtySession>();
   private webContents: WebContents | null = null;
-  /** Fired when a PTY exits on its OWN (child finished/crashed/killed
-   *  externally), so the main process can run the SAME lifecycle teardown
-   *  (archive, worktree removal, map cleanup) that the explicit kill() path
-   *  runs. Best-effort — set once by the main process. */
+  /** 当 PTY 自行退出（子进程结束/崩溃/被外部杀死）时触发，这样主进程可以运行与显式
+   *  kill() 路径相同的生命周期清理（归档、worktree 移除、map 清理）。尽力而为——由主进程
+   *  设置一次。 */
   private exitHandler: ((id: string, exitCode?: number) => void) | null = null;
 
-  /** The default/fallback output sink — set to the PRIMARY window. Used only for
-   *  sessions with no recorded owner; owned sessions route to their owner. */
+  /** 默认/兜底的输出目标——设为主窗口。只用于没有记录 owner 的会话；有 owner 的会话
+   *  路由到各自的 owner。 */
   attachWebContents(wc: WebContents) {
     this.webContents = wc;
   }
 
-  /** Count live PTYs owned by a given window — used to scope a floor's
-   *  close-confirmation to its OWN terminals, not the whole app's. */
+  /** 统计某个窗口拥有的存活 PTY 数量——用于把楼层的关闭确认限定在它自己的终端上，
+   *  而不是整个应用的终端。 */
   countByOwner(wc: WebContents): number {
     let n = 0;
     for (const s of this.sessions.values()) if (s.owner === wc) n++;
     return n;
   }
 
-  /** Kill every PTY owned by a window (its onExit runs the normal teardown:
-   *  archive + worktree cleanup). Called when a floor window closes so its
-   *  terminals don't linger as orphaned processes writing to a dead webContents. */
+  /** 杀死一个窗口拥有的每个 PTY（其 onExit 会运行常规清理：归档 + worktree 清理）。
+   *  在楼层窗口关闭时调用，这样它的终端不会作为孤儿进程残留、继续向已死的 webContents
+   *  写入。 */
   killByOwner(wc: WebContents): void {
     for (const [id, s] of [...this.sessions.entries()]) {
       if (s.owner === wc) {
@@ -335,69 +303,60 @@ export class PtyManager {
           const pid = s.proc.pid;
           s.proc.kill();
           ensureKilled(pid);
-        } catch { /* already gone */ }
+        } catch { /* 已经不在了 */ }
         void id;
       }
     }
   }
 
-  /** Register the natural-exit teardown callback. Invoked from inside node-pty's
-   *  onExit after the session is cleaned up. The exit code is forwarded so the
-   *  handler can distinguish a clean exit (e.g. a successful first-time CLI
-   *  install → auto restart-and-continue) from a crash. */
+  /** 注册自然退出清理回调。在会话清理完成后，从 node-pty 的 onExit 内部调用。退出码会被
+   *  转发，这样处理器能区分干净退出（例如首次 CLI 安装成功 → 自动重启并继续）与崩溃。 */
   setExitHandler(handler: (id: string, exitCode?: number) => void): void {
     this.exitHandler = handler;
   }
 
-  /** Send to the renderer only if it's still alive. During app quit, killing a
-   *  PTY fires onExit asynchronously — by then app.quit() may have destroyed the
-   *  window, and `.send()` on a destroyed webContents throws "Object has been
-   *  destroyed", which surfaces as the main-process crash dialog. Guard it. */
+  /** 仅当渲染进程还活着时才发送给它。应用退出期间，杀死 PTY 会异步触发 onExit——到那时
+   *  app.quit() 可能已经销毁了窗口，对已销毁的 webContents 调用 `.send()` 会抛出 "Object
+   *  has been destroyed"，表现为主进程崩溃对话框。要加防护。 */
   private safeSend(channel: string, payload: unknown, target?: WebContents | null): void {
-    // Route to the session's owner window when known (multi-window: keeps each
-    // floor's stream private); fall back to the default attached sink otherwise.
+    // 已知时路由到会话的 owner 窗口（多窗口：让每个楼层的输出流保持私有）；否则回退到
+    // 默认附加的输出目标。
     const wc = target ?? this.webContents;
     if (!wc || wc.isDestroyed()) return;
-    try { wc.send(channel, payload); } catch { /* window tore down mid-send */ }
+    try { wc.send(channel, payload); } catch { /* 发送途中窗口被销毁 */ }
   }
 
-  /** Whether an engine CLI is actually installed/locatable on this machine.
-   *  Used PRE-SPAWN by the missing-CLI auto-install path: a bare `claude`/`codex`
-   *  that resolveCommand can't locate would otherwise be spawned and die with
-   *  "process exited (code 1)". Reuses the exact same `which`/`where` +
-   *  candidate-dir logic as spawn(), so detection and spawning never disagree. */
+  /** 引擎 CLI 是否真的安装/可定位在这台机器上。由缺少 CLI 的自动安装路径在 PRE-SPAWN
+   *  时使用：一个 resolveCommand 定位不到的裸 `claude`/`codex` 若被强行生成，会以
+   *  "process exited (code 1)" 死掉。复用与 spawn() 完全相同的 `which`/`where` +
+   *  候选目录逻辑，这样检测与生成永远不会不一致。 */
   isCommandAvailable(command: string): boolean {
     return this.resolveCommand(command).found;
   }
 
-  /** The absolute path a bare command resolves to for THIS user, or null when it
-   *  isn't installed. Same resolution + cache as spawn(), so a caller that probes
-   *  a binary (e.g. `node --version`, to decide whether it is too old to keep)
-   *  inspects exactly the executable an agent would have run. */
+  /** 裸命令为 THIS 用户解析出的绝对路径；未安装时为 null。与 spawn() 相同的解析 + 缓存，
+   *  因此探测某个二进制的调用方（例如 `node --version`，用来判断它是否太旧该弃用）检查的
+   *  正是 agent 本会运行的那个可执行文件。 */
   commandPath(command: string): string | null {
     const r = this.resolveCommand(command);
     return r.found ? r.path : null;
   }
 
-  /** Session cache of SUCCESSFUL command resolutions. Each miss costs a full
-   *  interactive-shell launch (`$SHELL -ilc which …` sources the user's whole
-   *  zshrc — nvm/asdf init is routinely ~1s) run synchronously on the main
-   *  process, and every agent spawn used to pay it TWICE (pre-check + spawn) —
-   *  a multi-second all-windows freeze per spawn, ×N on a team restore.
-   *  Negatives are deliberately NOT cached: the missing-CLI auto-install path
-   *  must see a just-installed binary on its re-check. */
+  /** 成功命令解析的会话缓存。每次 miss 都要在主进程上同步启动一次完整交互式 shell
+   *  （`$SHELL -ilc which …` 会 source 用户整个 zshrc——nvm/asdf 初始化通常约 1s），
+   *  而每次 agent 生成过去都要付两次（预检 + 生成）——每次生成造成全窗口数秒冻结，团队
+   *  恢复时再 ×N。负结果刻意不缓存：缺少 CLI 的自动安装路径在复检时必须能看到刚装好的
+   *  二进制。 */
   private readonly resolvedCommands = new Map<string, { path: string; found: boolean }>();
 
-  /** Resolve a bare command (e.g. 'claude') against the user's PATH +
-   *  common install locations. Needed because Electron's spawn env on
-   *  macOS launches without the user's interactive shell PATH. Returns the
-   *  best path AND whether an existing executable was actually located (`found`):
-   *  when nothing is found, `path` falls back to the bare command (spawn would
-   *  ENOENT) and `found` is false — the signal the missing-CLI path keys on. */
+  /** 沿用户的 PATH + 常见安装位置解析裸命令（例如 'claude'）。之所以需要，是因为
+   *  macOS 上 Electron 的 spawn 环境启动时没有用户的交互式 shell PATH。返回最佳路径以及
+   *  是否真的定位到了存在的可执行文件（`found`）：什么都没找到时，`path` 回退为裸命令
+   *  （spawn 会 ENOENT）且 `found` 为 false——这是缺少 CLI 路径所依赖的信号。 */
   private resolveCommand(command: string): { path: string; found: boolean } {
     const cached = this.resolvedCommands.get(command);
-    // Trust a positive hit only while the binary still exists (uninstall/update
-    // between spawns must re-probe rather than hand out a dead path).
+    // 只在二进制仍存在时信任正命中（两次生成之间的卸载/更新必须重新探测，而不是交出
+    // 一个已死的路径）。
     if (cached && existsSync(cached.path)) return cached;
     const res = this.resolveCommandUncached(command);
     if (res.found) this.resolvedCommands.set(command, res);
@@ -406,24 +365,22 @@ export class PtyManager {
   }
 
   private resolveCommandUncached(command: string): { path: string; found: boolean } {
-    // Already an absolute/relative path (Unix `/` or Windows `\`) — pass through;
-    // `found` reflects whether that path actually exists on disk.
+    // 已经是绝对/相对路径（Unix `/` 或 Windows `\`）——直接透传；`found` 反映该路径是否
+    // 真的存在于磁盘上。
     if (command.includes('/') || command.includes('\\')) return { path: command, found: existsSync(command) };
-    // Only a plain command name is resolved against PATH. Anything else is
-    // refused here so it never reaches `which`/`where`; `found:false` makes the
-    // caller treat it as missing.
+    // 只有纯命令名才会沿 PATH 解析。其他任何东西都在这里被拒绝，这样它永远不会到达
+    // `which`/`where`；`found:false` 让调用方把它当作缺失。
     if (!isSafeCommandName(command)) return { path: command, found: false };
     if (process.platform === 'win32') {
-      // `where` is the Windows equivalent of `which`.
-      // It can return MULTIPLE matches in PATH order; the first is often an
-      // EXTENSIONLESS shim (bare `claude`). Skip extensionless hits and take
-      // the first PATHEXT-eligible one (.CMD/.BAT/.EXE/…). NOTE: even .CMD/.BAT
-      // files are not directly spawnable by node-pty's CreateProcess (error 193);
-      // spawn() either decodes the shim to its real interpreter or, failing that,
-      // routes it through `cmd.exe /c` (see resolveWindowsShimSpawn below).
+      // `where` 是 `which` 的 Windows 等价物。
+      // 它可能按 PATH 顺序返回 MULTIPLE 个匹配；第一个往往是 EXTENSIONLESS 垫片（裸
+      // `claude`）。跳过无扩展名的命中，取第一个符合 PATHEXT 的（.CMD/.BAT/.EXE/…）。
+      // 注意：即使 .CMD/.BAT 文件也不能被 node-pty 的 CreateProcess 直接生成（错误 193）；
+      // spawn() 要么把垫片解码成其真实解释器，要么在失败时经 `cmd.exe /c` 路由
+      // （见下面的 resolveWindowsShimSpawn）。
       try {
-        // No `shell:true`: `command` is proven metacharacter-free above, and
-        // running `where` directly keeps cmd.exe from re-parsing the argument.
+        // 不用 `shell:true`：上面已证明 `command` 不含元字符，直接运行 `where` 能让
+        // cmd.exe 不去重新解析该参数。
         const res = spawnSync('where', [command], { encoding: 'utf8', timeout: 3000 });
         const lines = (res.stdout ?? '').trim().split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
         const pathExts = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
@@ -431,13 +388,13 @@ export class PtyManager {
         const isExecutable = (p: string): boolean => {
           const dot = p.lastIndexOf('.');
           const sep = Math.max(p.lastIndexOf('\\'), p.lastIndexOf('/'));
-          if (dot <= sep) return false; // no extension on the basename
+          if (dot <= sep) return false; // basename 没有扩展名
           return pathExts.includes(p.slice(dot).toUpperCase());
         };
         const exe = lines.find((p) => isExecutable(p) && existsSync(p));
         if (exe) return { path: exe, found: true };
-      } catch { /* fall through */ }
-      // Common Windows install locations (npm global = %APPDATA%\npm\<cmd>.cmd).
+      } catch { /* 继续向下 */ }
+      // 常见 Windows 安装位置（npm 全局 = %APPDATA%\npm\<cmd>.cmd）。
       const appData = process.env.APPDATA ?? '';
       const localAppData = process.env.LOCALAPPDATA ?? '';
       const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
@@ -449,17 +406,17 @@ export class PtyManager {
         `${home}\\.claude\\local\\${command}`
       ];
       for (const c of winCandidates) if (existsSync(c)) return { path: c, found: true };
-      // Last resort — let node-pty try; will fail with ENOENT if missing.
+      // 最后手段——让 node-pty 试一把；若缺失会以 ENOENT 失败。
       return { path: command, found: false };
     }
-    // macOS / Linux — `which` against an interactive shell so we pick up nvm/asdf/brew paths.
-    // Fenced capture (shellEnv): rc-file chatter can't poison the which output.
+    // macOS / Linux —— 对交互式 shell 运行 `which`，从而拿到 nvm/asdf/brew 的路径。
+    // 围栏式捕获（shellEnv）：rc 文件的碎语不会污染 which 的输出。
     const which = captureFromLoginShell(`which ${command}`);
     if (which) {
       const path = which.trim().split('\n').map((l) => l.trim()).filter(Boolean).pop();
       if (path && existsSync(path)) return { path, found: true };
     }
-    // Common explicit locations
+    // 常见显式安装位置
     const candidates = [
       `/opt/homebrew/bin/${command}`,
       `/usr/local/bin/${command}`,
@@ -468,33 +425,30 @@ export class PtyManager {
       `${process.env.HOME ?? ''}/.volta/bin/${command}`
     ];
     for (const c of candidates) if (existsSync(c)) return { path: c, found: true };
-    // Last resort — let node-pty try; will fail with ENOENT if missing.
+    // 最后手段——让 node-pty 试一把；若缺失会以 ENOENT 失败。
     return { path: command, found: false };
   }
 
   /**
-   * WINDOWS ONLY. Decide whether `resolved` is an npm-style shim we can spawn
-   * DIRECTLY (its real interpreter + script, as an argv ARRAY) instead of routing
-   * it through `cmd.exe /d /s /c "<one big string>"`.
+   * 仅 WINDOWS。判断 `resolved` 是不是一个我们可以 DIRECTLY 生成的 npm 风格垫片（其真实
+   * 解释器 + 脚本，以 argv ARRAY 形式），而不是经 `cmd.exe /d /s /c "<one big string>"`
+   * 路由。
    *
-   * The cmd.exe route destroys any multi-line argument (see buildCmdCommandLine),
-   * which is what silently stripped the HIVE PROTOCOL block out of every
-   * npm-installed agent CLI's system prompt on Windows — agents booted fine and
-   * then never messaged each other because they never learned inbox/outbox exist.
+   * cmd.exe 路由会毁掉任何多行参数（见 buildCmdCommandLine），这正是 Windows 上每个
+   * npm 安装的 agent CLI 系统提示词里 HIVE PROTOCOL 块被悄悄剥掉的原因——agent 启动正常，
+   * 却从不互发消息，因为它们从未得知收件箱/发件箱存在。
    *
-   * Returns null for anything not fully understood, and EVERY failure mode here
-   * (not a shim, unreadable, unknown shape, script missing on disk, interpreter
-   * not installed or itself not a real .exe) degrades to exactly today's cmd.exe
-   * behaviour. Never throws.
+   * 对任何未完全理解的东西返回 null，这里的每种失败模式（不是垫片、不可读、未知形状、
+   * 磁盘上缺失脚本、解释器未安装或本身不是真正的 .exe）都恰好退化为今天 cmd.exe 的行为。
+   * 绝不抛出。
    */
   private resolveWindowsShimSpawn(resolved: string): { file: string; script: string | null } | null {
     if (process.platform !== 'win32') return null;
     try {
       const lower = resolved.toLowerCase();
-      // The `.cmd` IS the shim. An extensionless npm shim (`%APPDATA%\npm\claude`)
-      // is a POSIX **sh** script that cmd.exe cannot run at all; npm always writes a
-      // `.cmd` sibling naming the same target, so read that instead — strictly an
-      // improvement over handing sh syntax to cmd.exe.
+      // 这个 `.cmd` 就是垫片。无扩展名的 npm 垫片（`%APPDATA%\npm\claude`）是一个
+      // cmd.exe 根本无法运行的 POSIX **sh** 脚本；npm 总会写一个指向同一目标的 `.cmd`
+      // 兄弟文件，所以改读它——严格优于把 sh 语法交给 cmd.exe。
       const shimPath = lower.endsWith('.cmd') || lower.endsWith('.bat')
         ? resolved
         : (existsSync(`${resolved}.cmd`) ? `${resolved}.cmd` : null);
@@ -504,28 +458,26 @@ export class PtyManager {
 
       const target = parseNpmCmdShim(shimPath, readFileSync(shimPath, 'utf8'));
       if (!target) return null;
-      // The shim can outlive the package it points at (a half-removed global
-      // install). Falling back to cmd.exe then at least reproduces today's error.
+      // 垫片可能比它指向的包活得更久（一个被半删除的全局安装）。此时回退到 cmd.exe 至少
+      // 能复现今天的错误。
       if (!existsSync(target.scriptPath)) return null;
 
-      // Direct-executable shim: the target IS the program. No interpreter to
-      // resolve, and no script argument to prepend — spawning it with an argv
-      // array is exactly what the cmd.exe route was standing in the way of.
+      // 直接执行型垫片：目标本身就是程序。无需解析解释器，也无需前置脚本参数——用 argv
+      // 数组生成它，正是 cmd.exe 路由一直挡着不让做的。
       if (target.interpreter === null) {
         return { file: target.scriptPath, script: null };
       }
 
       const interp = this.resolveCommand(target.interpreter);
       if (!interp.found) return null;
-      // Must be a REAL executable: if `node` itself only resolves to a `.cmd`
-      // (e.g. our own bundled-runtime shim appended to PATH), spawning it directly
-      // would hit the very CreateProcess limitation we are routing around.
+      // 必须是真正的可执行文件：如果 `node` 本身只解析到一个 `.cmd`（例如我们追加到 PATH
+      // 的自带 runtime 垫片），直接生成它会撞上我们正绕开的那个 CreateProcess 限制。
       const il = interp.path.toLowerCase();
       if (!il.endsWith('.exe') && !il.endsWith('.com')) return null;
 
       return { file: interp.path, script: target.scriptPath };
     } catch {
-      return null; // unreadable/racing shim — fall back, never break the spawn
+      return null; // 不可读/竞态的垫片——回退，绝不让生成失败
     }
   }
 
@@ -533,54 +485,46 @@ export class PtyManager {
     if (this.sessions.has(opts.id)) {
       return { ok: false, error: `pty already exists for id ${opts.id}` };
     }
-    // Defense-in-depth: cwd is already tilde-expanded at ingestion (spawnAgentCore),
-    // but any other caller reaching the PTY directly gets the same treatment —
-    // `existsSync('~/dev/foo')` is always false, only a shell expands `~`.
+    // 纵深防御：cwd 在摄入时已做过波浪号展开（spawnAgentCore），但任何其他直接触达 PTY
+    // 的调用方也得到同样的处理——`existsSync('~/dev/foo')` 恒为 false，只有 shell 会展开
+    // `~`。
     opts = { ...opts, cwd: expandTilde(opts.cwd) };
     if (!existsSync(opts.cwd)) {
       return { ok: false, error: `cwd does not exist: ${opts.cwd}` };
     }
     const resolved = this.resolveCommand(opts.command).path;
     try {
-      // Build a user-shell PATH so child can resolve subprocess deps. Cached
-      // for the session (shellEnv.userShellPath, fenced against rc-file noise) —
-      // the interactive-shell launch it replaces cost ~1s of main-thread freeze
-      // on EVERY spawn.
+      // 构建用户 shell 的 PATH，让子进程能解析子进程依赖。为会话缓存（shellEnv.userShellPath，
+      // 用围栏防 rc 文件噪声）——它取代的那次交互式 shell 启动在每次生成时都要花约 1s 的主线程冻结。
       const userPath = withHiveRuntimeFallback(
         process.platform === 'win32' ? (process.env.PATH || '') : userShellPath(),
         opts.env?.HIVE_ROOT
       );
 
-      // On Windows, .cmd/.bat files (and extensionless shims) cannot be executed
-      // directly by CreateProcess — only .exe/.com can. Two ways out, in order of
-      // preference: (1) decode an npm shim to the interpreter + script it wraps and
-      // spawn THAT with an argv array (correct escaping, newlines survive); or
-      // (2) the legacy fallback, route the whole thing through cmd.exe as one
-      // pre-escaped string (loses newlines — see buildCmdCommandLine).
+      // Windows 上 .cmd/.bat 文件（以及无扩展名的垫片）不能被 CreateProcess 直接执行——
+      // 只有 .exe/.com 可以。两条出路，按优先级排列：(1) 把 npm 垫片解码成它包裹的解释器
+      // + 脚本，用 argv 数组生成那个（转义正确、换行得以保留）；或 (2) 传统兜底，把整件事
+      // 经 cmd.exe 作为一条预转义字符串路由（丢失换行——见 buildCmdCommandLine）。
       const isWin = process.platform === 'win32';
       const lower = resolved.toLowerCase();
       const directExe = lower.endsWith('.exe') || lower.endsWith('.com');
       const needsCmd = isWin && !directExe;
-      // Prefer decoding an npm shim to its interpreter over the cmd.exe route (see
-      // resolveWindowsShimSpawn). win32-only and null-on-anything-unexpected, so
-      // macOS/Linux and every undecodable Windows target keep today's behaviour.
-      // Skipped entirely for a shellScript spawn, which never executes `resolved`.
+      // 优先把 npm 垫片解码成它的解释器，而不是走 cmd.exe 路由（见 resolveWindowsShimSpawn）。
+      // 仅 win32，且遇到任何意外都返回 null，因此 macOS/Linux 和每个无法解码的 Windows
+      // 目标都保持今天的行为。对 shellScript 生成完全跳过——它从不执行 `resolved`。
       const shimSpawn = needsCmd && typeof opts.shellScript !== 'string'
         ? this.resolveWindowsShimSpawn(resolved)
         : null;
       let file: string;
       let spawnArgs: string[] | string;
       if (typeof opts.shellScript === 'string') {
-        // Missing-CLI auto-install: run a banner + install command through the
-        // platform shell so it streams to this same Terminal tab. On Windows we
-        // hand cmd.exe a verbatim STRING (`/d /s /c "<script>"`) — node-pty passes
-        // strings through unescaped, and `/s` strips exactly the outer quote pair,
-        // so the `&`-chained script runs as-is (the script carries no embedded `"`).
-        // On unix we use `$SHELL -lc <script>` (login, non-interactive): npm is
-        // already on PATH because spawn() sets env.PATH to the captured interactive
-        // shell PATH (nvm/asdf/brew included), and skipping `-i` avoids dumping the
-        // user's interactive-rc session-restore noise into the install terminal. The
-        // script is one argv element, so no shell-quoting is needed here.
+        // 缺少 CLI 的自动安装：经平台 shell 运行横幅 + 安装命令，让它流式输出到这个同一个
+        // Terminal 标签页。Windows 上我们给 cmd.exe 一条原样 STRING（`/d /s /c "<script>"`）
+        // ——node-pty 不转义地透传字符串，`/s` 精确剥掉外层引号对，因此 `&` 串联的脚本
+        // 原样运行（脚本本身不含内嵌 `"`）。unix 上用 `$SHELL -lc <script>`（登录、非交互）：
+        // npm 已经在 PATH 上，因为 spawn() 把 env.PATH 设为捕获到的交互式 shell PATH
+        // （含 nvm/asdf/brew），而省略 `-i` 可以避免把用户交互式 rc 的会话恢复噪声倾倒进
+        // 安装终端。脚本是一个 argv 元素，因此这里无需 shell 引号转义。
         if (isWin) {
           file = process.env.ComSpec || 'cmd.exe';
           spawnArgs = `/d /s /c "${opts.shellScript}"`;
@@ -589,47 +533,38 @@ export class PtyManager {
           spawnArgs = ['-lc', opts.shellScript];
         }
       } else if (needsCmd && shimSpawn) {
-        // WINDOWS, npm-shim target: spawn the shim's own interpreter with an ARRAY
-        // of args. node-pty then runs its `argsToCommandLine` (MSDN/CRT escaping:
-        // backslash doubling before a quote, whole-arg quoting on whitespace) and
-        // hands the result straight to CreateProcess — no shell parser anywhere in
-        // the chain. That is what lets the hive protocol prompt through intact:
-        // its newlines, parentheses and embedded quotes are just characters inside
-        // one quoted CRT argument, and the ceiling becomes CreateProcess's 32767
-        // instead of cmd.exe's 8191. Routing the same prompt through cmd.exe
-        // truncated it at the first newline, which is why Windows agents never
-        // learned they had an inbox/outbox and could not message each other.
+        // WINDOWS、npm 垫片目标：用 ARRAY 形式的参数生成垫片自己的解释器。node-pty 随后
+        // 运行其 `argsToCommandLine`（MSDN/CRT 转义：引号前反斜杠加倍、遇空白时整参加引号）
+        // 并把结果直接交给 CreateProcess——整个链路中没有任何 shell 解析器。这就是让 hive
+        // 协议提示词完好通过的原因：它的换行、括号和内嵌引号在一个带引号的 CRT 参数里只是
+        // 普通字符，上限也变成 CreateProcess 的 32767 而不是 cmd.exe 的 8191。把同一个
+        // 提示词经 cmd.exe 路由会在第一个换行处截断它，这正是 Windows agent 从未得知自己
+        // 有收件箱/发件箱、无法互相通信的原因。
         file = shimSpawn.file;
-        // `script` is null for a direct-executable shim — there is nothing to
-        // prepend, the args go straight to the binary.
+        // 对直接执行型垫片 `script` 为 null——无需前置任何东西，参数直接给二进制。
         spawnArgs = shimSpawn.script === null
           ? [...(opts.args ?? [])]
           : [shimSpawn.script, ...(opts.args ?? [])];
       } else {
         file = needsCmd ? (process.env.ComSpec || 'cmd.exe') : resolved;
-        // #55: when routing through cmd.exe we must NOT pass `resolved` as a bare,
-        // unquoted array element. A Program-Files path (`C:\Program Files\nodejs\node`)
-        // would split on its space under cmd.exe → "C:\Program is not recognized" and
-        // every Windows agent terminal dies. Build a single, fully-quoted command line
-        // and hand it to node-pty as a STRING (not an array): node-pty's
-        // argsToCommandLine() only re-escapes ARRAY args; a string is passed through
-        // verbatim (isCommandLine === true → `file + " " + args`), so our quoting is
-        // never double-wrapped. We mirror Node's own child_process form,
-        // `cmd.exe /d /s /c "<command>"`, wrapping the WHOLE inner command in one outer
-        // quote pair — cmd's /s flag strips exactly that pair and runs the remainder
-        // (where the resolved path keeps its own quotes) literally. /d skips AutoRun.
+        // #55：经 cmd.exe 路由时，绝不能把 `resolved` 当作裸的、未加引号的数组元素传入。
+        // 一个 Program-Files 路径（`C:\Program Files\nodejs\node`）在 cmd.exe 下会按空格
+        // 拆开 → "C:\Program is not recognized"，然后每个 Windows agent 终端都会死掉。
+        // 构建一条完整加引号的命令行，作为 STRING（而非数组）交给 node-pty：node-pty 的
+        // argsToCommandLine() 只会对 ARRAY 参数重新转义；字符串则原样透传（isCommandLine
+        // === true → `file + " " + args`），因此我们的引号绝不会被二次包裹。我们镜像 Node
+        // 自己的 child_process 形式 `cmd.exe /d /s /c "<command>"`，用一对外层引号包住
+        // 整个内部命令——cmd 的 /s 标志精确剥掉那对引号，并按字面运行剩余部分（其中的
+        // resolved 路径保留自己的引号）。/d 跳过 AutoRun。
         spawnArgs = needsCmd
           ? buildCmdCommandLine(resolved, opts.args ?? [])
           : (opts.args ?? []);
-        // The cmd.exe fallback is LOSSY and was previously SILENT, which is how a
-        // Windows agent could look perfectly healthy while never having received
-        // the hive protocol: cmd.exe cuts a multi-line argument at its first
-        // newline, and the whole protocol block rides on one such argument.
-        // resolveWindowsShimSpawn returns null for any shim shape it does not
-        // fully understand, so this path is reachable on a real machine while
-        // every unit test passes. Say so, loudly, with the two facts needed to
-        // diagnose it: which target refused to decode, and whether a multi-line
-        // argument is actually at risk in THIS spawn.
+        // cmd.exe 兜底是有损的，过去还是静默的——这正是 Windows agent 能看起来完全健康、
+        // 却从未收到 hive 协议的原因：cmd.exe 在第一个换行处切断多行参数，而整个协议块
+        // 就搭载在这样一条参数上。resolveWindowsShimSpawn 对任何它未完全理解的垫片形状
+        // 都返回 null，所以这条路径在真实机器上可达，而所有单元测试都照常通过。要大声、
+        // 明确地说出来，带上诊断所需的两个事实：哪个目标拒绝解码，以及本次生成是否真的有
+        // 多行参数处于风险中。
         if (needsCmd) {
           const multiline = (opts.args ?? []).some((a) => a.includes('\n'));
           console.warn(
@@ -643,23 +578,18 @@ export class PtyManager {
       }
       const proc = pty.spawn(file, spawnArgs, {
         name: 'xterm-256color',
-        cols: opts.cols ?? 100,
+        cols: opts.cols ?? 160,
         rows: opts.rows ?? 30,
         cwd: opts.cwd,
-        // Inherited env minus the parent Claude session's identity markers,
-        // then the app's defaults and locale, then per-agent values — see
-        // ptyEnv.ts for why the strip exists and why it is prefix-based.
+        // 继承的环境减去父 Claude 会话的身份标记，然后是应用的默认值与 locale，再是
+        // 每个 agent 的值——为何要剥离、为何按前缀剥离，见 ptyEnv.ts。
         env: buildPtyEnv(process.env, userPath, opts.env)
       });
-
-      // Capture THIS session object so the proc's callbacks can tell whether the
-      // id still belongs to them. A model change / restart does kill()+spawn()
-      // reusing the SAME id: the old process's kill is asynchronous, so its
-      // onData/onExit can fire AFTER the replacement session is already in the
-      // map. Without the identity guard the dying process would (a) spray its
-      // final bytes into the new agent's fresh TUI frame — scattered/overlapping
-      // text — and (b) on exit delete the replacement session and emit a false
-      // `pty:exit`, killing input to the agent that just started.
+      // 捕获 THIS 会话对象，这样 proc 的回调能判断该 id 是否仍属于它们。模型切换/重启
+      // 会复用同一个 id 做 kill()+spawn()：旧进程的 kill 是异步的，因此它的 onData/onExit
+      // 可能在替换会话已经放进 map 之后触发。没有这个身份守卫，将死进程会 (a) 把它的
+      // 最后字节喷洒进新 agent 刚生成的 TUI 帧——文本散乱/重叠——以及 (b) 在退出时删除
+      // 替换会话并发出假的 `pty:exit`，杀掉刚启动 agent 的输入。
       const session: PtySession = {
         id: opts.id,
         proc,
@@ -672,23 +602,22 @@ export class PtyManager {
       this.sessions.set(opts.id, session);
 
       proc.onData((data) => {
-        // Drop trailing output from a process whose id was already reclaimed by
-        // a respawn (or killed) — it would corrupt the new session's screen.
+        // 丢弃来自已被重新生成（或杀死）回收 id 的进程的尾部输出——它会破坏新会话的屏幕。
         if (this.sessions.get(opts.id) !== session) return;
         session.hasOutput = true;
         session.lastOutputAt = Date.now();
-        // Route to the session's owner window (multi-window owner routing).
+        // 路由到会话的 owner 窗口（多窗口 owner 路由）。
         this.safeSend(`pty:data:${opts.id}`, data, session.owner);
       });
       proc.onExit(({ exitCode, signal }) => {
-        // Stale exit from a process whose id was reclaimed (kill()+respawn) — do
-        // NOT touch the live session or tell the renderer the new pty died.
+        // 来自 id 已被回收（kill()+respawn）进程的过期退出——绝不要碰存活的会话，也不要
+        // 告诉渲染进程新 pty 死了。
         if (this.sessions.get(opts.id) !== session) return;
         this.safeSend(`pty:exit:${opts.id}`, { exitCode, signal }, session.owner);
         this.sessions.delete(opts.id);
-        // Natural exit must run the same lifecycle teardown as an explicit kill.
-        // Guarded so a teardown error can never crash node-pty's exit callback.
-        try { this.exitHandler?.(opts.id, exitCode); } catch { /* never throw out of onExit */ }
+        // 自然退出必须运行与显式 kill 相同的生命周期清理。加上防护，这样清理错误永远不会
+        // 让 node-pty 的退出回调崩溃。
+        try { this.exitHandler?.(opts.id, exitCode); } catch { /* 绝不从 onExit 抛出 */ }
       });
 
       return { ok: true };
@@ -719,9 +648,8 @@ export class PtyManager {
     }
   }
 
-  /** Ask the foreground TUI for a fresh frame without changing its geometry.
-   *  Startup output may predate the renderer subscription, and a same-sized
-   *  first fit otherwise emits no resize. */
+  /** 向前台 TUI 要一个刷新帧但不改变其几何尺寸。启动输出可能早于渲染进程订阅，而同样
+   *  大小的第一次 fit 否则不会触发 resize。 */
   redraw(id: string): { ok: boolean; error?: string } {
     const s = this.sessions.get(id);
     if (!s) return { ok: false, error: `no pty: ${id}` };
@@ -739,7 +667,7 @@ export class PtyManager {
     try {
       const pid = s.proc.pid;
       s.proc.kill();
-      ensureKilled(pid); // verify + sweep the process group so no PID leaks
+      ensureKilled(pid); // 验证并清扫进程组，确保没有 PID 泄漏
       this.sessions.delete(id);
       return { ok: true };
     } catch (e) {
@@ -758,46 +686,42 @@ export class PtyManager {
     }));
   }
 
-  /** Epoch ms of this PTY's most recent output, or undefined if no such PTY. */
+  /** 该 PTY 最近一次输出的 epoch 毫秒数；没有该 PTY 时为 undefined。 */
   lastOutputAt(id: string): number | undefined {
     return this.sessions.get(id)?.lastOutputAt;
   }
 
-  /** Milliseconds since this PTY last produced output (Date.now() - lastOutputAt),
-   *  or undefined if no such PTY. The idle handshake: large value = safe to type. */
+  /** 距该 PTY 上次产生输出已过去的毫秒数（Date.now() - lastOutputAt）；没有该 PTY 时为
+   *  undefined。空闲握手：值越大 = 越安全地键入。 */
   idleFor(id: string): number | undefined {
     const s = this.sessions.get(id);
     return s ? Date.now() - s.lastOutputAt : undefined;
   }
 
-  /** Bulk-kill every PTY for app quit / reset. This is wholesale shutdown, not
-   *  individual agent lifecycle, so it suppresses the natural-exit teardown —
-   *  we don't want to archive every agent or fire a storm of `git worktree
-   *  remove` while the process is tearing down.
+  /** 为应用退出/重置批量杀死每个 PTY。这是整体关闭，不是单个 agent 的生命周期管理，因此
+   *  会抑制自然退出清理——我们不希望在进程拆除期间归档每个 agent 或触发一阵 `git worktree
+   *  remove`。
    *
-   *  On Windows the tree sweep runs SYNCHRONOUSLY here, unlike kill():
-   *  ensureKilled's grace timer is unref'd, and on the quit path the main
-   *  process exits (will-quit caps the analytics flush at ~1.2s) long before
-   *  the 4s grace — so the deferred `taskkill /T /F` never ran and agent trees
-   *  survived the app. conpty's own kill is async and best-effort (and our
-   *  conpty patch degrades a failed console enumeration to killing nothing),
-   *  so the synchronous sweep is the only reliable reaper at quit. POSIX keeps
-   *  the graceful path: closing the pty HUPs the foreground process group, so
-   *  trees die without us SIGKILLing mid-cleanup. */
+   *  Windows 上与 kill() 不同，这里的进程树清扫是 SYNCHRONOUSLY 执行的：ensureKilled 的
+   *  宽限定时器是 unref 的，而在退出路径上主进程会提前退出（will-quit 把分析日志刷新限制
+   *  在约 1.2s），远早于 4s 宽限——所以延迟的 `taskkill /T /F` 从未运行，agent 进程树
+   *  随应用存活下来。conpty 自己的 kill 是异步且尽力而为的（我们的 conpty 补丁会把失败的
+   *  控制台枚举降级为什么都不杀），因此同步清扫是退出时唯一可靠的收割者。POSIX 保留优雅
+   *  路径：关闭 pty 会给前台进程组发 HUP，所以进程树会自然死亡，无需我们在清理中途
+   *  SIGKILL。 */
   killAll() {
     this.exitHandler = null;
     const sweepNow = process.platform === 'win32';
     for (const s of this.sessions.values()) {
       const pid = s.proc.pid;
       if (sweepNow) {
-        // Capture and kill the intact Windows process tree before closing
-        // ConPTY: once the root exits, taskkill may no longer be able to find
-        // descendants by that PID. Keep node-pty cleanup independent so a
-        // failure in either operation cannot prevent the other.
-        try { hardKillTree(pid); } catch { /* noop */ }
-        try { s.proc.kill(); } catch { /* noop */ }
+        // 在关闭 ConPTY 之前捕获并杀死完好的 Windows 进程树：一旦根进程退出，taskkill
+        // 可能就无法再按该 PID 找到后代。让 node-pty 的清理保持独立，这样任一操作的失败
+        // 都不会阻碍另一个。
+        try { hardKillTree(pid); } catch { /* 无操作 */ }
+        try { s.proc.kill(); } catch { /* 无操作 */ }
       } else {
-        try { s.proc.kill(); } catch { /* noop */ }
+        try { s.proc.kill(); } catch { /* 无操作 */ }
         ensureKilled(pid);
       }
     }

--- a/src/main/ptyEnv.ts
+++ b/src/main/ptyEnv.ts
@@ -1,40 +1,35 @@
 /**
- * Environment construction for agent PTYs, as a pure function so the layering
- * is testable off-process (the same trick `buildMissingCliScript` uses for its
- * `platform` parameter).
+ * 为代理 PTY 构建环境变量，作为纯函数实现，使得分层逻辑可以在进程外测试
+ * （与 `buildMissingCliScript` 用其 `platform` 参数所用的技巧相同）。
  *
- * The layering rule, bottom to top:
- *   1. the inherited environment, minus the parent Claude session's identity
- *   2. the app's own defaults (PATH, terminal identity, locale)
- *   3. per-agent values (`opts.env`) — always win, even over the strip below
+ * 分层规则，自下而上：
+ *   1. 继承的环境，减去父级 Claude 会话的身份
+ *   2. 应用自身的默认值（PATH、终端身份、locale）
+ *   3. 按代理设置的值（`opts.env`）——始终优先，甚至高于下面的剥离
  */
 
 /**
- * The app is often launched from INSIDE a Claude Code session (`npm run dev`
- * typed into a claude terminal), so that session's identity markers arrive via
- * `process.env` and would flow into every agent CLI. CLAUDE_CODE_CHILD_SESSION
- * makes the agent believe it is a child session and silently DISABLES
- * transcript saving ("Transcript saving is off — inherited
- * CLAUDE_CODE_CHILD_SESSION marker"), which breaks --resume for every agent of
- * that run: their sessions never reach disk (bit us live 2026-08-16/17 — no
- * worker transcript ever existed). The session id, pid, messaging socket+token,
- * effort, execpath and entrypoint likewise all describe the PARENT session,
- * never a fresh agent.
+ * 应用常常是从 Claude Code 会话内部启动的（在 claude 终端里输入
+ * `npm run dev`），因此该会话的身份标记会经由 `process.env` 传入，
+ * 并流入每个代理 CLI。CLAUDE_CODE_CHILD_SESSION 会让代理以为自己是一个
+ * 子会话，并静默地 DISABLE 掉转录保存（"Transcript saving is off — inherited
+ * CLAUDE_CODE_CHILD_SESSION marker"），从而破坏该次运行每个代理的
+ * --resume：它们的会话永远到不了磁盘（2026-08-16/17 现场翻车——任何
+ * 工作线程转录都不存在）。会话 id、pid、消息 socket+token、
+ * effort、execpath 和 entrypoint 同样都描述的是 PARENT 会话，
+ * 绝不是一个全新的代理。
  *
- * Stripped by PREFIX rather than by name: the CLI grows new markers faster
- * than a hardcoded list keeps up (a five-name list was already seven short of
- * a live session's dump when review caught it). Agents are top-level sessions
- * regardless of how the app was launched, so they inherit NONE of the parent's
- * Claude identity.
+ * 按 PREFIX 而非按名称剥离：CLI 新增标记的速度比硬编码列表跟上的速度还快
+ * （评审发现时，一个五名称的列表面对实时会话的转储已少了七个）。无论应用
+ * 如何启动，代理都是顶级会话，因此它们不继承父级 Claude 的任何身份。
  */
 const CLAUDE_MARKER_RE = /^CLAUDE(CODE|_)/;
 
 /**
- * Configuration, not identity: these share the prefix but are the OPERATOR's
- * own choices — where the CLI keeps its config, how it authenticates, which
- * backend serves it. An operator who exported them wants agents to see them,
- * and stripping them breaks agents in exactly the quiet way the strip above
- * exists to prevent. Everything session-scoped stays out of this list.
+ * 配置而非身份：这些变量共用同一前缀，但属于 OPERATOR 自己的选择——CLI
+ * 把配置放在哪里、如何认证、由哪个后端提供服务。导出它们的操作者希望代理
+ * 能看到这些变量，而剥离它们会以与上面剥离完全相同的静默方式破坏代理。
+ * 所有会话级作用域的内容都排除在此列表之外。
  */
 const CLAUDE_CONFIG_KEEP = new Set([
   'CLAUDE_CONFIG_DIR',
@@ -49,10 +44,9 @@ export function buildPtyEnv(
   agentEnv?: Record<string, string>,
   platform: NodeJS.Platform = process.platform
 ): Record<string, string> {
-  // Layer 1 — inherit, minus the parent session's Claude identity. Only this
-  // layer is stripped: a marker set deliberately via `agentEnv` below survives,
-  // so per-agent environment overrides (and future per-agent env features)
-  // cannot be silently wiped by the strip.
+  // 第 1 层——继承，减去父级会话的 Claude 身份。只有这一层会被剥离：
+  // 下面通过 `agentEnv` 刻意设置的标记得以保留，因此按代理的环境覆盖
+  // （以及未来的按代理环境特性）不会被剥离静默清除。
   const inherited: Record<string, string> = {};
   for (const [k, v] of Object.entries(parentEnv)) {
     if (v === undefined) continue;
@@ -64,19 +58,18 @@ export function buildPtyEnv(
     PATH: userPath,
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',
-    // Help apps that look for a real interactive shell
+    // 帮助那些寻找真实交互式 shell 的应用
     FORCE_COLOR: '1',
-    // A Finder/Dock-launched Electron app inherits NO locale from launchd
-    // (`launchctl getenv LANG` is empty), so without this every child runs in
-    // the C/POSIX locale — where macOS's CoreFoundation default text encoding
-    // is Mac OS Roman (__CF_USER_TEXT_ENCODING=<uid>:0:0). Any locale-sensitive
-    // tool an agent runs then decodes UTF-8 as MacRoman and paints mojibake
-    // into the grid ("—" → "‚Äî"), which copy faithfully reproduces. This
-    // terminal IS UTF-8 (xterm.js + Unicode11), so say so.
+    // 通过 Finder/Dock 启动的 Electron 应用从 launchd 继承不到任何 locale
+    // （`launchctl getenv LANG` 为空），因此没有这里，每个子进程都会在
+    // C/POSIX locale 下运行——此时 macOS 的 CoreFoundation 默认文本编码是
+    // Mac OS Roman（__CF_USER_TEXT_ENCODING=<uid>:0:0）。代理运行的任何
+    // 依赖 locale 的工具随后会把 UTF-8 解码成 MacRoman，并在网格里画出乱码
+    // （"—" → "‚Äî"），复制时也会忠实保留。本终端是 UTF-8
+    // （xterm.js + Unicode11），所以直接声明这一点。
     //
-    // LC_CTYPE only, deliberately: it is the character-encoding category. Using
-    // LC_ALL would also override collation and date formatting for every user
-    // who never exported a locale. A locale the user really did export wins.
+    // 刻意只用 LC_CTYPE：它才是字符编码这一类别。使用 LC_ALL 也会覆盖所有
+    // 从未导出过 locale 用户的排序与日期格式。用户真正导出的 locale 优先。
     ...(platform === 'win32'
       ? {}
       : {
@@ -84,7 +77,7 @@ export function buildPtyEnv(
           LC_CTYPE:
             parentEnv.LC_ALL ?? parentEnv.LC_CTYPE ?? parentEnv.LANG ?? 'en_US.UTF-8'
         }),
-    // Per-agent hive identity (AGENT_ID, HIVE_ROOT, …) when provided.
+    // 按代理的 hive 身份（AGENT_ID、HIVE_ROOT……），当提供时。
     ...(agentEnv ?? {})
   };
 }

--- a/src/main/realtime.ts
+++ b/src/main/realtime.ts
@@ -1,38 +1,37 @@
 /**
- * Realtime Michael — main-process ephemeral-token mint (card rt-1, Phase 1).
+ * Realtime Michael —— 主进程的临时令牌铸造（卡片 rt-1，第一阶段）。
  *
- * The voice orchestrator (OpenAI `gpt-realtime-2`, speech-to-speech over WebRTC)
- * connects from the RENDERER. The renderer must NEVER hold the real OpenAI key, so
- * MAIN owns it: the BYOK key is stored encrypted at rest in `integration-secrets.json`
- * under `apikey:openai` (the same write-only broker the CLI engines use — set via the
- * `providerKey:*` IPC, materialized main-only, never echoed back). On demand MAIN
- * decrypts it ONCE to mint a SHORT-LIVED EPHEMERAL client secret; only that token +
- * a minimal session config cross IPC to the renderer's `RealtimeSession`. The real
- * key is never returned over IPC, never logged.
+ * 语音编排器（OpenAI `gpt-realtime-2`，基于 WebRTC 的语音到语音）从
+ * 渲染进程连接。渲染进程绝不能持有真实的 OpenAI key，所以由 MAIN 持有：
+ * BYOK key 加密静态存储在 `integration-secrets.json` 的 `apikey:openai`
+ * 下（就是 CLI 引擎用的那个只写 broker——通过 `providerKey:*` IPC 设置，
+ * 仅主进程可见，从不回显）。按需时 MAIN 仅解密一次，铸造一个
+ * 短期有效的临时客户端密钥；只有那个 token + 一份最小会话配置跨 IPC
+ * 传给渲染进程的 `RealtimeSession`。真实 key 从不经 IPC 返回、从不记录。
  *
- * Phase 1 is read-only — this module ONLY mints (no action tools; that's rt-5).
+ * 第一阶段只读——本模块只铸造（没有动作工具；那是 rt-5）。
  *
- * Branch feat/realtime-michael. See board.md "🎙 REALTIME MICHAEL".
+ * 分支 feat/realtime-michael。见 board.md “🎙 REALTIME MICHAEL”。
  */
 import { ipcMain } from 'electron';
 import { getSecret, hasSecret } from './integrations';
 
-/** Mirrors `providerKeyRef('openai')` in src/main/index.ts (BACKEND_KEY_ENV maps
- *  openai→OPENAI_API_KEY). Inlined as a local const so this module needs no new
- *  export added to index.ts — keeping the index.ts edit to a single registration
- *  line (rt-1 COORD: Oscar also edits index.ts). */
+/** 镜像 src/main/index.ts 中的 `providerKeyRef('openai')`（BACKEND_KEY_ENV 把
+ *  openai→OPENAI_API_KEY）。内联成局部常量，让本模块无需给 index.ts 增加新
+ *  导出——把 index.ts 的改动保持在单行注册上（rt-1 COORD：Oscar 也改
+ *  index.ts）。 */
 const OPENAI_KEY_REF = 'apikey:openai';
 
-/** GA speech-to-speech model for the voice orchestrator (v0.3.4: bumped to the
- *  July 2026 gpt-realtime-2.1 — 25% p95 latency cut, better interruption handling).
- *  Defined in shared/ and re-exported here: Settings names this model in copy the
- *  user reads, so main and the UI must not be able to disagree about it. */
+/** 语音编排器用的 GA 语音到语音模型（v0.3.4：升到 2026 年 7 月的
+ *  gpt-realtime-2.1——p95 延迟降 25%，打断处理更好）。定义在 shared/
+ *  并在这里再导出：Settings 会在用户能读到的文案里指名这个模型，
+ *  所以主进程和 UI 不能对它有分歧。 */
 export { REALTIME_MODEL } from '../shared/realtimePricing';
 import { REALTIME_MODEL } from '../shared/realtimePricing';
 
-/** GA ephemeral-secret mint endpoint. If an account/tier still answers the legacy
- *  beta shape, we fall back to /v1/realtime/sessions on a 404 and normalize both
- *  response shapes below. (Live verification is pending the user's real key.) */
+/** GA 临时密钥铸造端点。如果某个账户/套餐仍按遗留 beta 形状应答，
+ *  我们就在 404 时回退到 /v1/realtime/sessions，并把下面两种响应形状
+ *  归一化。（真机验证要等用户的真实 key。） */
 const CLIENT_SECRETS_URL = 'https://api.openai.com/v1/realtime/client_secrets';
 const LEGACY_SESSIONS_URL = 'https://api.openai.com/v1/realtime/sessions';
 
@@ -42,15 +41,15 @@ export type MintResult =
   | { ok: true; token: string; expiresAt: number | null; sessionConfig: { model: string } }
   | { ok: false; error: string; code?: string };
 
-/** Whether a BYOK OpenAI key is stored (presence only — no decryption). Gates the
- *  Realtime Michael voice toggle in the renderer, the way `hasGroqKey` gates the
- *  Free Flow mic button. */
+/** 是否已存储 BYOK OpenAI key（只看存在性——不解密）。作为渲染进程中
+ *  Realtime Michael 语音开关的门控，就如同 `hasGroqKey` 门控 Free Flow
+ *  麦克风按钮一样。 */
 export function hasOpenAiKey(): boolean {
   return hasSecret(OPENAI_KEY_REF);
 }
 
-/** Mint a short-lived ephemeral client secret for a realtime WebRTC session. The
- *  real OpenAI key is decrypted MAIN-ONLY here and is NEVER part of the result. */
+/** 为 realtime WebRTC 会话铸造一个短期有效的临时客户端密钥。真实 OpenAI
+ *  key 只在这里于 MAIN 侧解密，而且绝不是结果的一部分。 */
 export async function mintRealtimeToken(model: string = REALTIME_MODEL): Promise<MintResult> {
   const key = getSecret(OPENAI_KEY_REF);
   if (!key) {
@@ -69,7 +68,7 @@ export async function mintRealtimeToken(model: string = REALTIME_MODEL): Promise
       });
       const text = await r.text();
       let json: Record<string, unknown> | undefined;
-      try { json = text ? (JSON.parse(text) as Record<string, unknown>) : undefined; } catch { /* non-JSON body */ }
+      try { json = text ? (JSON.parse(text) as Record<string, unknown>) : undefined; } catch { /* 非 JSON 响应体 */ }
       return { status: r.status, ok: r.ok, json, text };
     } finally {
       clearTimeout(timer);
@@ -77,9 +76,9 @@ export async function mintRealtimeToken(model: string = REALTIME_MODEL): Promise
   };
 
   try {
-    // GA shape first: { session: { type, model } } → { value, expires_at, ... }.
+    // 先试 GA 形状：{ session: { type, model } } → { value, expires_at, ... }。
     let res = await post(CLIENT_SECRETS_URL, { session: { type: 'realtime', model } });
-    // Older accounts: fall back to the legacy sessions endpoint shape.
+    // 老账户：回退到遗留 sessions 端点形状。
     if (res.status === 404) res = await post(LEGACY_SESSIONS_URL, { model });
 
     if (!res.ok) {
@@ -90,7 +89,7 @@ export async function mintRealtimeToken(model: string = REALTIME_MODEL): Promise
       return { ok: false, error: `token mint failed (${res.status}): ${msg}`, code: 'mint_failed' };
     }
 
-    // Normalize across GA ({ value }) and legacy ({ client_secret: { value } }) shapes.
+    // 在 GA ({ value }) 与遗留 ({ client_secret: { value } }) 形状间归一化。
     const clientSecret = res.json?.client_secret as { value?: unknown; expires_at?: unknown } | undefined;
     const token =
       (typeof res.json?.value === 'string' && (res.json.value as string)) ||
@@ -109,14 +108,13 @@ export async function mintRealtimeToken(model: string = REALTIME_MODEL): Promise
   }
 }
 
-/** Register the renderer-facing realtime IPC. A SINGLE call from index.ts (rather
- *  than per-handler `ipcMain.handle` lines there) keeps the index.ts footprint to
- *  one line — rt-1 COORD note (Oscar also edits index.ts). Neither handler ever
- *  returns the real OpenAI key. */
+/** 注册面向渲染进程的 realtime IPC。由 index.ts 调用一次（而不是在那边逐
+ *  handler 写 `ipcMain.handle`）把 index.ts 的占地保持在一行——rt-1 COORD
+ *  说明（Oscar 也改 index.ts）。两个 handler 都绝不返回真实 OpenAI key。 */
 export function registerRealtimeIpc(): void {
-  // Boolean presence only — gates the voice toggle.
+  // 仅布尔存在性——门控语音开关。
   ipcMain.handle('realtime:hasKey', () => hasOpenAiKey());
-  // Mint an ephemeral token; returns { token, sessionConfig } only.
+  // 铸造一个临时令牌；只返回 { token, sessionConfig }。
   ipcMain.handle('realtime:mintToken', async (_evt, payload: unknown) => {
     const p = (payload ?? {}) as { model?: unknown };
     const model = typeof p.model === 'string' && p.model.trim() ? p.model.trim() : REALTIME_MODEL;

--- a/src/main/realtimeActions.ts
+++ b/src/main/realtimeActions.ts
@@ -1,38 +1,36 @@
 /**
- * Realtime Michael — voice ACTION spine (card rt-5, Phase 2).
+ * Realtime Michael —— 语音动作主干（卡片 rt-5，第二阶段）。
  *
- * Phase 1 gave voice-Michael READ tools. Phase 2 gives him WRITE access: he can
- * ping/dispatch agents, edit the task board, steer/pause/halt/kill workers, hire
- * new ones, and edit schedules — entirely by voice. Because the confirm surface is
- * VOICE-ONLY (the human declined on-screen confirm cards), the echo-back spine in
- * this file is the ENTIRE safety surface, so ALL of it lives in MAIN (the trusted
- * side) — the renderer tools are thin callers. Defense in depth: even if the model
- * (or stray audio) tries something, MAIN enforces the tiering, the distinct-token
- * confirm, and the hard allowlist.
+ * 第一阶段给了语音版 Michael 读取工具。第二阶段给他写权限：他可以用纯语音
+ * ping/调度 agent、编辑任务看板、引导/暂停/中止/杀死 worker、雇佣新 worker、
+ * 编辑日程。因为确认面是纯语音的（人类拒绝了屏幕上的确认卡片），本文件中的
+ * 回声主干就是全部的安全面，所以它全部住在 MAIN（受信任的一侧）——渲染进程
+ * 的工具只是薄调用方。纵深防御：即使模型（或杂音音频）尝试越界，MAIN 也会
+ * 强制层级、独立的确认 token 和硬白名单。
  *
- * TIERING (locked by the human 2026-06-25, see board.md Phase-2):
- *   • SOFT writes  — ping, create/assign/update task, dispatch, steer — execute
- *     directly (low blast radius; fully reversible / advisory).
- *   • DESTRUCTIVE / expensive — spawn-hire, kill, pause, halt, edit_schedule —
- *     require a two-step VERBAL echo-back: (1) read back exact verb + target
- *     (+ a $ estimate for spawn/hire — STUBBED here; rt-9 wires the real number),
- *     (2) a DISTINCT confirm token (the verb word or "confirm" — NEVER a bare
- *     "yes", so ambient speech can't authorize a kill), (3) mic-idle at the commit
- *     instant (the renderer mutes the mic during the confirm tool-call — see
- *     session.ts agent_tool_start), (4) the circuit-breaker still gates (actions go
- *     through the same control path it owns).
- *   • HARD ALLOWLIST — kill/pause/halt on the god orchestrator, and any mass /
- *     all-agent op, are VOICE-FORBIDDEN even with a valid confirm — rejected
- *     outright, no pending created.
+ * 分层（2026-06-25 由人类锁定，见 board.md 第二阶段）：
+ *   • 软写入  —— ping、创建/分配/更新任务、调度、引导 —— 直接执行
+ *     （爆炸半径小；完全可逆 / 建议性质）。
+ *   • 破坏性 / 昂贵 —— 雇佣、杀死、暂停、中止、edit_schedule ——
+ *     需要两步口头回声：(1) 原样念回确切的动词 + 目标
+ *     （+ spawn/hire 的 $ 估算——此处为占位；rt-9 接入真实数字），
+ *     (2) 一个独立的确认 token（动词词或 "confirm"——绝不是裸的
+ *     "yes"，以免环境语音授权一次 kill），(3) 提交瞬间麦克风空闲
+ *     （渲染进程在确认工具调用期间静音麦克风——见 session.ts
+ *     agent_tool_start），(4) 熔断器仍然门控（动作走它所拥有的
+ *     同一条控制路径）。
+ *   • 硬白名单 —— 对 god 编排器 kill/pause/halt，以及任何批量 /
+ *     全体 agent 操作，即使有有效确认也禁止语音执行——直接拒绝，
+ *     不创建 pending。
  *
- * Every committed action is attributed to actor `michael-voice` (a log stamp on
- * every verb + `from: michael-voice` on messages). rt-7 deepens this into a live
- * god-PTY cross-notify; rt-5 just needs the attribution present.
+ * 每个已提交的动作都归属 actor `michael-voice`（每个动词上的日志戳 +
+ * 消息上的 `from: michael-voice`）。rt-7 把它深化为实时的 god-PTY
+ * 交叉通知；rt-5 只需要归属在场即可。
  *
- * Thin wrappers ONLY — no new orchestration logic. Each verb maps onto a main fn
- * the god PTY already uses (hive.send / writeTasks / spawnAgentCore /
- * control.pause+steer+halt / pty kill / missions save), injected via deps so this
- * module stays decoupled from index.ts wiring.
+ * 只是薄包装——没有新的编排逻辑。每个动词映射到 god PTY 已在用的
+ * 主函数（hive.send / writeTasks / spawnAgentCore /
+ * control.pause+steer+halt / pty kill / missions save），通过 deps 注入，
+ * 让本模块与 index.ts 接线解耦。
  */
 import { ipcMain } from 'electron';
 import type { HiveMessage, HiveTask, Registry } from './hive';
@@ -43,7 +41,7 @@ import { resolveGodName } from '../shared/godIdentity';
 
 export const VOICE_ACTOR = 'michael-voice';
 
-/** A minimal spawn spec — index.ts adapts it to its AgentSpawnOptions + spawnAgentCore. */
+/** 最小化 spawn 规格——index.ts 把它适配成自己的 AgentSpawnOptions + spawnAgentCore。 */
 export interface RealtimeSpawnSpec {
   id: string;
   cwd: string;
@@ -52,8 +50,8 @@ export interface RealtimeSpawnSpec {
   hive?: { id: string; name: string; provider?: string; role?: string; cwd: string };
 }
 
-/** Existing main fns the voice actions wrap, injected from index.ts so the security
- *  logic here is unit-testable and index.ts stays a thin adapter. */
+/** 语音动作包装的既有主函数，从 index.ts 注入，让这里的安全逻辑可做
+ *  单元测试，index.ts 保持为薄适配器。 */
 export interface RealtimeActionDeps {
   hiveEnabled(): boolean;
   hiveSend(partial: Partial<HiveMessage>, from: string): HiveMessage;
@@ -69,37 +67,35 @@ export interface RealtimeActionDeps {
   spawnAgent(opts: RealtimeSpawnSpec): Promise<{ ok: boolean; error?: string }>;
   listMissions(): ScheduledMission[];
   saveMissions(missions: ScheduledMission[]): void;
-  /** rt-12: register a voice dispatch with the completion watcher so the engine can
-   *  detect it finishing and speak the notice. Optional — wired in index.ts. */
+  /** rt-12：向完成观察器注册一次语音调度，让引擎能检测它结束并说出通知。
+   *  可选——在 index.ts 中接线。 */
   trackDispatch?(d: { correlationId: string; targetAgentId: string; objective?: string; dispatchedAt: number; dispatchMessageId?: string }): void;
-  // ── v0.3.4 full-control extensions ──
+  // ── v0.3.4 全控制扩展 ──
   controlResume(agentId: string): void;
   controlAutoDelivery(agentId: string, paused: boolean): void;
   controlGateTool(agentId: string, tool: string, on: boolean): void;
   setArchived(agentId: string, archived: boolean): { ok: boolean; error?: string };
-  /** clear_context: push text into the agent's renderer message queue, so
-   *  delivery rides EVERY existing gate (idle-only, boot grace, draft/picker
-   *  safety, auto-delivery pause). */
+  /** clear_context：把文本推入 agent 的渲染进程消息队列，于是投递会经过
+   *  每一个既有的门（仅空闲、启动宽限、草稿/选择器安全、自动投递暂停）。 */
   enqueueToAgent(agentId: string, text: string): void;
-  /** update_setting: non-secret config snapshot + patch. The per-key policy
-   *  table in THIS file is the only path from voice to config — never expose a
-   *  raw patch. */
+  /** update_setting：非机密配置快照 + 补丁。本文件中按 key 的策略表是
+   *  从语音到配置的唯一路径——绝不暴露原始补丁。 */
   getConfigValue(key: string): unknown;
   patchConfig(patch: Record<string, unknown>): void;
 }
 
-/** The result every action / confirm / cancel returns to the renderer tool, which
- *  hands `spoken` straight to the model to say. */
+/** 每个 action / confirm / cancel 返回给渲染进程工具的结果，后者把
+ *  `spoken` 直接交给模型去说。 */
 export interface ActionResult {
   ok: boolean;
   spoken: string;
-  /** true when a destructive op is now PENDING a verbal confirm. */
+  /** 当破坏性操作此刻正等待口头确认时为 true。 */
   needsConfirm?: boolean;
 }
 
 type Tier = 'soft' | 'destructive';
 
-/** Per-verb spec: tier + the human-facing word that must appear in a confirm. */
+/** 每个动词的规格：层级 + 确认中必须出现、面向人类的词。 */
 const VERBS: Record<string, { tier: Tier; confirmWord: string; agentTargeted: boolean }> = {
   ping: { tier: 'soft', confirmWord: 'ping', agentTargeted: true },
   create_task: { tier: 'soft', confirmWord: 'create', agentTargeted: false },
@@ -112,7 +108,7 @@ const VERBS: Record<string, { tier: Tier; confirmWord: string; agentTargeted: bo
   pause: { tier: 'destructive', confirmWord: 'pause', agentTargeted: true },
   halt: { tier: 'destructive', confirmWord: 'halt', agentTargeted: true },
   edit_schedule: { tier: 'destructive', confirmWord: 'schedule', agentTargeted: false },
-  // ── v0.3.4 full-control extensions ──
+  // ── v0.3.4 全控制扩展 ──
   resume: { tier: 'soft', confirmWord: 'resume', agentTargeted: true },
   auto_delivery: { tier: 'soft', confirmWord: 'delivery', agentTargeted: true },
   gate_tool: { tier: 'soft', confirmWord: 'gate', agentTargeted: true },
@@ -124,17 +120,16 @@ const VERBS: Record<string, { tier: Tier; confirmWord: string; agentTargeted: bo
   update_setting: { tier: 'destructive', confirmWord: 'setting', agentTargeted: false }
 };
 
-/** v0.3.4 update_setting policy — the ONLY settings voice can touch, each with
- *  a tier and typed validation. Everything not listed (harnessHome, every
- *  secret-bearing key, provider base URLs, integrations, …) is refused
- *  outright: the raw config carries credentials and dangerous keys, and the
- *  unvalidated config:update IPC must never be reachable from speech. */
+/** v0.3.4 update_setting 策略——语音唯一能碰的设置，每项都有层级和类型
+ *  校验。所有未列出的（harnessHome、每个携带机密的 key、provider 基 URL、
+ *  integrations、……）一律拒绝：原始配置带着凭据和危险 key，
+ *  未校验的 config:update IPC 绝不能从语音触达。 */
 const SETTING_POLICY: Record<string, {
   tier: 'soft' | 'confirm';
   type: 'boolean' | 'number' | 'string';
   min?: number; max?: number; values?: string[];
 }> = {
-  // soft: cosmetic / low-blast, instantly reversible
+  // soft：外观型 / 低爆炸半径，可即时撤销
   notifications: { tier: 'soft', type: 'boolean' },
   tvShowOffices: { tier: 'soft', type: 'boolean' },
   officeTheme: { tier: 'soft', type: 'string', values: ['office', 'friends', 'brooklyn99', 'siliconvalley', 'got', 'hogwarts'] },
@@ -143,7 +138,7 @@ const SETTING_POLICY: Record<string, {
   strongKeepalive: { tier: 'soft', type: 'boolean' },
   autoUpdate: { tier: 'soft', type: 'boolean' },
   realtimeIdleDisconnectMs: { tier: 'soft', type: 'number', min: 30_000, max: 3_600_000 },
-  // confirm: behavior-changing — echo old→new + distinct token
+  // confirm：改变行为——回声 old→new + 独立 token
   autoMode: { tier: 'confirm', type: 'boolean' },
   defaultModel: { tier: 'confirm', type: 'string' },
   godProvider: { tier: 'confirm', type: 'string' },
@@ -160,19 +155,17 @@ const SETTING_POLICY: Record<string, {
 const PENDING_TTL_MS = 120_000;
 
 const PROVIDER_COMMAND: Record<string, string> = {
-  claude: 'claude', codex: 'codex', antigravity: 'antigravity', gemini: 'gemini',
-  opencode: 'opencode', crush: 'crush', pi: 'pi', qwen: 'qwen', copilot: 'copilot',
-  cursor: 'cursor-agent'
+  claude: 'claude', codex: 'codex', kimi: 'kimi', qwen: 'qwen'
 };
 
-/** Bare affirmations that must NEVER authorize a destructive op on their own —
- *  ambient speech / a stray "yeah" cannot be allowed to confirm a kill. */
+/** 绝不能独自授权破坏性操作的裸肯定——环境语音 / 一句乱入的 "yeah"
+ *  不能被允许确认一次 kill。 */
 const BARE_AFFIRMATIONS = new Set([
   'yes', 'yeah', 'yep', 'yup', 'ya', 'ok', 'okay', 'k', 'sure', 'go', 'go ahead',
   'do it', 'please', 'fine', 'affirmative', 'uh huh', 'mhm', 'mm hmm', 'right', 'correct'
 ]);
 
-// ─── helpers ────────────────────────────────────────────────────────────────
+// ─── 辅助 ────────────────────────────────────────────────────────────────
 
 const str = (x: unknown): string => (typeof x === 'string' ? x : '');
 const norm = (s: string): string => s.toLowerCase().replace(/[.!?,;:'"]/g, ' ').replace(/\s+/g, ' ').trim();
@@ -181,7 +174,7 @@ const norm = (s: string): string => s.toLowerCase().replace(/[.!?,;:'"]/g, ' ').
 const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 function shortId(): string {
-  // app code (not a Workflow script) — Math.random is fine here.
+  // 应用代码（不是 Workflow 脚本）——这里用 Math.random 没问题。
   return Math.random().toString(36).slice(2, 8);
 }
 
@@ -189,54 +182,54 @@ function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 24) || 'agent';
 }
 
-/** Is the spoken target a mass / all-agent reference? Those are voice-forbidden for
- *  destructive verbs regardless of confirm. */
+/** 说出的目标是批量 / 全体 agent 引用吗？无论有没有确认，破坏性动词都
+ *  禁止语音执行这些。 */
 function isMassTarget(target: string): boolean {
   const t = norm(target);
   if (!t) return false;
   if (/\b(all|every|everyone|everybody)\b/.test(t)) return true;
   if (t === '*' || t === 'agents' || t === 'the team' || t === 'team' || t === 'fleet' || t === 'everything')
     return true;
-  // a comma/and list of multiple targets
+  // 逗号/and 分隔的多目标列表
   if (/,| and /.test(t)) return true;
   return false;
 }
 
 interface ResolvedAgent { id: string; name: string; isGod: boolean }
 
-/** Resolve a spoken target ("jim", "kill oscar", an id) to a single live agent, or
- *  return a spoken disambiguation error. Prefers non-archived matches. */
+/** 把说出的目标（"jim"、"kill oscar"、一个 id）解析成单个存活 agent，
+ *  否则返回口述的消歧错误。优先选未归档的匹配。 */
 function resolveAgent(target: string, reg: Registry): ResolvedAgent | { error: string } {
   const t = norm(target);
-  if (!t) return { error: 'no agent was named' };
+  if (!t) return { error: '未指定任何 agent' };
   const entries = Object.entries(reg.agents ?? {});
   const mk = (id: string, m: { name?: string; isGod?: boolean }): ResolvedAgent => ({
     id, name: m.name || id, isGod: !!m.isGod || id === reg.godId
   });
-  // exact id
+  // 精确 id
   const byId = entries.find(([id]) => id.toLowerCase() === t);
   if (byId) return mk(byId[0], byId[1]);
-  // 'god' / 'michael' alias for the orchestrator
+  // 编排器的 'god' / 'michael' 别名
   if ((t === 'god' || t === 'michael' || t === 'the god') && reg.godId)
     return mk(reg.godId, reg.agents[reg.godId] ?? {});
-  // exact name, prefer live
+  // 精确名称，优先存活的
   const byName = entries.filter(([, m]) => (m.name || '').toLowerCase() === t);
   const liveName = byName.filter(([, m]) => !m.archived);
   const namePick = liveName.length ? liveName : byName;
   if (namePick.length === 1) return mk(namePick[0][0], namePick[0][1]);
   if (namePick.length > 1)
-    return { error: `${namePick.length} agents are named ${target} — say the exact agent id` };
-  // partial contains, live only
+    return { error: `${namePick.length} 个 agent 都叫 ${target}——请说出确切的 agent id` };
+  // 部分包含，仅存活
   const partial = entries.filter(
     ([id, m]) => !m.archived && (id.toLowerCase().includes(t) || (m.name || '').toLowerCase().includes(t))
   );
   if (partial.length === 1) return mk(partial[0][0], partial[0][1]);
-  if (partial.length > 1) return { error: `several agents match "${target}" — be more specific or say an id` };
-  return { error: `I don't see an agent matching "${target}"` };
+  if (partial.length > 1) return { error: `有多个 agent 匹配 "${target}"——请说得更具体或报出 id` };
+  return { error: `没有找到匹配 "${target}" 的 agent` };
 }
 
-/** Distinct-token confirm check. Accept only if the phrase carries the verb word or
- *  the literal "confirm"; a bare affirmation ("yes", "ok") is rejected. */
+/** 独立 token 确认检查。只有当句子带有动词词或字面 "confirm" 时才接受；
+ *  裸肯定（"yes"、"ok"）被拒绝。 */
 function confirmAccepted(phrase: string, confirmWord: string): boolean {
   const p = norm(phrase);
   if (!p) return false;
@@ -246,7 +239,7 @@ function confirmAccepted(phrase: string, confirmWord: string): boolean {
   return false;
 }
 
-// ─── pending (single-slot two-phase confirm) ────────────────────────────────
+// ─── pending（单槽两阶段确认）───────────────────────────────────────────────
 
 interface Pending {
   verb: string;
@@ -262,18 +255,18 @@ function pendingFresh(): Pending | null {
   return pending;
 }
 
-// ─── soft-write executors (run immediately) ─────────────────────────────────
+// ─── 软写入执行器（立即运行）────────────────────────────────────────────────
 
 function attribute(deps: RealtimeActionDeps, verb: string, target: string, extra: Record<string, unknown> = {}): void {
   try {
     deps.hiveLog({ kind: 'voice_action', actor: VOICE_ACTOR, verb, target, ...extra });
   } catch {
-    /* attribution is best-effort — never block the action */
+    /* 归属是尽力而为——绝不阻塞动作 */
   }
-  // rt-7 dual-orchestrator coord: tell the god PTY what voice-Michael just COMMITTED, so
-  // the two autonomous orchestrators stay aware and don't make duplicate/contradictory
-  // moves. attribute() only runs on committed writes (soft execs + post-confirm commits),
-  // so god is never notified for a merely-proposed/uncommitted destructive action.
+  // rt-7 双编排器协调：告诉 god PTY 语音版 Michael 刚刚提交了什么，让
+  // 两个自主编排器保持相互感知，不做重复/矛盾的动作。attribute() 只在已提交
+  // 的写入上运行（软执行 + 确认后的提交），所以 god 绝不会收到仅仅是
+  // 提议/未提交的破坏性动作的通知。
   try {
     const detail =
       typeof extra.objective === 'string' ? `: ${extra.objective}`
@@ -288,13 +281,13 @@ function attribute(deps: RealtimeActionDeps, verb: string, target: string, extra
       {
         to: 'god',
         act: 'inform',
-        subject: `voice action: ${verb} ${target}`,
-        body: `${godName} (voice orchestrator, ${VOICE_ACTOR}) just did: ${verb} on ${target}${detail}. Heads-up so we don't duplicate — the board is the single source of truth.`
+        subject: `语音动作：${verb} ${target}`,
+        body: `${godName}（语音编排器，${VOICE_ACTOR}）刚刚执行了：对 ${target} 执行 ${verb}${detail}。提醒一下以免重复——看板是唯一的事实来源。`
       },
       VOICE_ACTOR
     );
   } catch {
-    /* god cross-notify is best-effort — never block the action */
+    /* god 交叉通知是尽力而为——绝不阻塞动作 */
   }
 }
 
@@ -307,10 +300,10 @@ function execPing(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionR
   const reg = deps.hiveRegistry();
   const r = resolveAgent(str(a.agentId) || str(a.target) || str(a.name), reg);
   if ('error' in r) return { ok: false, spoken: r.error };
-  const message = str(a.message) || str(a.text) || 'Checking in.';
-  deps.hiveSend({ to: r.id, act: 'inform', subject: `Voice ping from ${resolveGodName(reg.agents[reg.godId ?? 'god']?.name)}`, body: message }, VOICE_ACTOR);
+  const message = str(a.message) || str(a.text) || '打个招呼。';
+  deps.hiveSend({ to: r.id, act: 'inform', subject: `来自 ${resolveGodName(reg.agents[reg.godId ?? 'god']?.name)} 的语音消息`, body: message }, VOICE_ACTOR);
   attribute(deps, 'ping', r.id);
-  return { ok: true, spoken: `Pinged ${r.name}.` };
+  return { ok: true, spoken: `已给 ${r.name} 发了消息。` };
 }
 
 function execDispatch(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
@@ -318,21 +311,21 @@ function execDispatch(deps: RealtimeActionDeps, a: Record<string, unknown>): Act
   const r = resolveAgent(str(a.agentId) || str(a.target) || str(a.name), reg);
   if ('error' in r) return { ok: false, spoken: r.error };
   const objective = str(a.objective) || str(a.task) || str(a.message);
-  if (!objective) return { ok: false, spoken: 'What should I dispatch? I need an objective.' };
-  // 4-part contract → the agent's inbox.
+  if (!objective) return { ok: false, spoken: '我要派发什么？需要一个目标说明。' };
+  // 四部分契约 → 投递到 agent 的 inbox。
   const body =
     `OBJECTIVE: ${objective}\n` +
-    `CONTEXT: ${str(a.context) || '(none given)'}\n` +
-    `CONSTRAINTS: ${str(a.constraints) || '(use your judgement; respect the guardrails)'}\n` +
-    `DONE WHEN: ${str(a.doneWhen) || str(a.done) || 'you report the outcome back to god'}`;
+    `背景：${str(a.context) || '（未提供）'}\n` +
+    `约束：${str(a.constraints) || '（自行判断；遵守护栏）'}\n` +
+    `完成标准：${str(a.doneWhen) || str(a.done) || '把结果回报给 god'}`;
   const msg = deps.hiveSend(
-    { to: r.id, act: 'request', subject: `Voice dispatch: ${objective.slice(0, 60)}`, body, requires_reply: true },
+    { to: r.id, act: 'request', subject: `语音派发：${objective.slice(0, 60)}`, body, requires_reply: true },
     VOICE_ACTOR
   );
   attribute(deps, 'dispatch', r.id, { objective: objective.slice(0, 120) });
-  // rt-12: register so the completion watcher can tell us when r.id finishes.
+  // rt-12：注册，让完成观察器能在 r.id 完成时告诉我们。
   deps.trackDispatch?.({ correlationId: msg.id, targetAgentId: r.id, objective, dispatchedAt: Date.now(), dispatchMessageId: msg.id });
-  return { ok: true, spoken: `Dispatched to ${r.name}: ${objective.slice(0, 80)}.` };
+  return { ok: true, spoken: `已派发任务给 ${r.name}：${objective.slice(0, 80)}。` };
 }
 
 function execSteer(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
@@ -340,15 +333,15 @@ function execSteer(deps: RealtimeActionDeps, a: Record<string, unknown>): Action
   const r = resolveAgent(str(a.agentId) || str(a.target) || str(a.name), reg);
   if ('error' in r) return { ok: false, spoken: r.error };
   const text = str(a.text) || str(a.message) || str(a.steer);
-  if (!text) return { ok: false, spoken: 'What guidance should I steer them with?' };
+  if (!text) return { ok: false, spoken: '要用什么指导去引导他们？' };
   deps.controlSteer(r.id, `[${VOICE_ACTOR}] ${text}`);
   attribute(deps, 'steer', r.id, { text: text.slice(0, 120) });
-  return { ok: true, spoken: `Steering ${r.name}: ${text.slice(0, 80)}.` };
+  return { ok: true, spoken: `正在引导 ${r.name}：${text.slice(0, 80)}。` };
 }
 
 function execCreateTask(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
   const title = str(a.title) || str(a.task) || str(a.name);
-  if (!title) return { ok: false, spoken: 'What should the task be titled?' };
+  if (!title) return { ok: false, spoken: '任务该叫什么标题？' };
   const tasks = findTasks(deps);
   const id = `${slug(title)}-${shortId()}`;
   const card: HiveTask = {
@@ -363,27 +356,26 @@ function execCreateTask(deps: RealtimeActionDeps, a: Record<string, unknown>): A
   };
   deps.hiveWriteTasks([...tasks, card]);
   attribute(deps, 'create_task', id, { title: title.slice(0, 120), assignee: card.assignee });
-  return { ok: true, spoken: `Created task "${title}"${card.assignee ? `, assigned to ${card.assignee}` : ''}.` };
+  return { ok: true, spoken: `已创建任务「${title}」${card.assignee ? `，指派给 ${card.assignee}` : ''}。` };
 }
 
-// Match-only normalizer: strips ALL non-alphanumerics (hyphens included) so a
-// spoken "message visibility" matches a stored "message-visibility". Kept
-// separate from `norm` above, which must preserve token shape for the
-// confirm-word echo-back rule.
+// 仅供匹配的归一化器：剥掉所有非字母数字（含连字符），让说出的
+// "message visibility" 匹配存储的 "message-visibility"。与上面的 `norm`
+// 分开，后者必须为确认词回声规则保留 token 形状。
 const normMatch = (s: string): string =>
   (s || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim();
 const toksMatch = (s: string): string[] => normMatch(s).split(' ').filter(Boolean);
-const AMBIGUOUS_MARGIN = 0.08; // top two within this => ask which one, don't guess
+const AMBIGUOUS_MARGIN = 0.08; // 前两名在此范围内 => 问是哪一个，别猜
 
-/** Score how well a spoken/typed ref matches one card. 0..1. Tiered,
- *  order-independent, truncation- and punctuation-tolerant. Mirrors
- *  bin/find-task.cjs scoreTask (validated by its --selftest, 8/8). */
+/** 给一个口头/键入引用与某张卡片的匹配度打分。0..1。分层、与顺序无关、
+ *  容忍截断和标点。镜像 bin/find-task.cjs 的 scoreTask（由它的 --selftest
+ *  验证，8/8）。 */
 function scoreCard(refNorm: string, refToks: string[], c: HiveTask): number {
   if (!refNorm) return 0;
   const titleN = normMatch(c.title);
   const idN = normMatch(c.id);
-  if (idN === refNorm || titleN === refNorm) return 1; // exact (after normalization)
-  if (titleN && (titleN.startsWith(refNorm) || refNorm.startsWith(titleN))) return 0.92; // truncation
+  if (idN === refNorm || titleN === refNorm) return 1; // 精确（归一化后）
+  if (titleN && (titleN.startsWith(refNorm) || refNorm.startsWith(titleN))) return 0.92; // 截断
   if (idN && idN.startsWith(refNorm)) return 0.9;
   const hay = new Set(toksMatch(c.title).concat(toksMatch(c.id)));
   const coverage = refToks.length ? refToks.filter((w) => hay.has(w)).length / refToks.length : 0;
@@ -391,15 +383,15 @@ function scoreCard(refNorm: string, refToks: string[], c: HiveTask): number {
   const prefixCov = refToks.length
     ? refToks.filter((w) => hayArr.some((h) => h.startsWith(w) || w.startsWith(h))).length / refToks.length
     : 0;
-  if (coverage === 1) return 0.85; // every spoken word present (order-independent)
-  if (titleN.includes(refNorm) || idN.includes(refNorm)) return Math.max(0.7, coverage); // contiguous substring
-  if (prefixCov === 1) return 0.78; // every spoken word present as a prefix
-  return Math.max(coverage, prefixCov) * 0.7; // partial overlap
+  if (coverage === 1) return 0.85; // 每个说出的词都在场（与顺序无关）
+  if (titleN.includes(refNorm) || idN.includes(refNorm)) return Math.max(0.7, coverage); // 连续子串
+  if (prefixCov === 1) return 0.78; // 每个说出的词都作为前缀在场
+  return Math.max(coverage, prefixCov) * 0.7; // 部分重叠
 }
 
-/** Find the card a spoken/typed ref refers to. Returns the best scored match,
- *  or `ambiguous` (the close candidates) when the top two are within
- *  AMBIGUOUS_MARGIN — callers ask which rather than mutate the wrong card. */
+/** 找出口头/键入引用所指的卡片。返回得分最高的匹配；当前两名落在
+ *  AMBIGUOUS_MARGIN 之内时返回 `ambiguous`（相近的候选）——调用方会问
+ *  是哪一个，而不是改错卡片。 */
 function findCard(
   deps: RealtimeActionDeps,
   ref: string
@@ -421,60 +413,60 @@ function findCard(
 function execAssignTask(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
   const ref = str(a.taskId) || str(a.task) || str(a.title);
   const assignee = str(a.assignee) || str(a.to) || str(a.agentId);
-  if (!ref || !assignee) return { ok: false, spoken: 'I need both a task and who to assign it to.' };
+  if (!ref || !assignee) return { ok: false, spoken: '我需要一个任务以及把任务指派给谁。' };
   const { tasks, card, ambiguous } = findCard(deps, ref);
   if (ambiguous) {
-    return { ok: false, spoken: `Which one — ${ambiguous.map((c) => `"${c.title}"`).join(', or ')}?` };
+    return { ok: false, spoken: `哪一个——${ambiguous.map((c) => `「${c.title}」`).join('，还是 ')}？` };
   }
-  if (!card) return { ok: false, spoken: `I couldn't find a task matching "${ref}".` };
+  if (!card) return { ok: false, spoken: `找不到匹配 "${ref}" 的任务。` };
   card.assignee = assignee;
   deps.hiveWriteTasks(tasks);
   attribute(deps, 'assign_task', card.id, { assignee });
-  return { ok: true, spoken: `Assigned "${card.title}" to ${assignee}.` };
+  return { ok: true, spoken: `已把「${card.title}」指派给 ${assignee}。` };
 }
 
 function execUpdateTask(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
   const ref = str(a.taskId) || str(a.task) || str(a.title);
-  if (!ref) return { ok: false, spoken: 'Which task should I update?' };
+  if (!ref) return { ok: false, spoken: '要更新哪个任务？' };
   const { tasks, card, ambiguous } = findCard(deps, ref);
   if (ambiguous) {
-    return { ok: false, spoken: `Which one — ${ambiguous.map((c) => `"${c.title}"`).join(', or ')}?` };
+    return { ok: false, spoken: `哪一个——${ambiguous.map((c) => `「${c.title}」`).join('，还是 ')}？` };
   }
-  if (!card) return { ok: false, spoken: `I couldn't find a task matching "${ref}".` };
+  if (!card) return { ok: false, spoken: `找不到匹配 "${ref}" 的任务。` };
   const status = str(a.status);
   const valid = ['todo', 'doing', 'blocked', 'done'];
-  if (status && !valid.includes(status)) return { ok: false, spoken: `"${status}" isn't a valid status.` };
+  if (status && !valid.includes(status)) return { ok: false, spoken: `"${status}" 不是有效状态。` };
   if (status) card.status = status as HiveTask['status'];
   if (str(a.result)) card.result = str(a.result);
   if (str(a.assignee)) card.assignee = str(a.assignee);
   deps.hiveWriteTasks(tasks);
   attribute(deps, 'update_task', card.id, { status: card.status });
-  return { ok: true, spoken: `Updated "${card.title}"${status ? ` to ${status}` : ''}.` };
+  return { ok: true, spoken: `已更新「${card.title}」${status ? `，状态改为 ${status}` : ''}。` };
 }
 
-// ─── v0.3.4 soft executors ──────────────────────────────────────────────────
+// ─── v0.3.4 软执行器 ──────────────────────────────────────────────────
 
 function execResume(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
   const r = resolveAgent(str(a.agentId) || str(a.target) || str(a.name), deps.hiveRegistry());
   if ('error' in r) return { ok: false, spoken: r.error };
   deps.controlResume(r.id);
   attribute(deps, 'resume', r.id);
-  return { ok: true, spoken: `Resumed ${r.name} — tools flow again.` };
+  return { ok: true, spoken: `已恢复 ${r.name}——工具重新流通。` };
 }
 
 function execAutoDelivery(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
   const r = resolveAgent(str(a.agentId) || str(a.target) || str(a.name), deps.hiveRegistry());
   if ('error' in r) return { ok: false, spoken: r.error };
   const raw = norm(str(a.state) || str(a.action) || (a.paused === true ? 'pause' : a.paused === false ? 'resume' : ''));
-  if (!raw) return { ok: false, spoken: 'Should I pause or resume message delivery?' };
+  if (!raw) return { ok: false, spoken: '要暂停还是恢复消息投递？' };
   const paused = /pause|off|hold|stop/.test(raw);
   deps.controlAutoDelivery(r.id, paused);
   attribute(deps, 'auto_delivery', r.id, { action: paused ? 'paused' : 'resumed' });
   return {
     ok: true,
     spoken: paused
-      ? `Paused automatic delivery to ${r.name} — queued messages will wait.`
-      : `Resumed automatic delivery to ${r.name}.`
+      ? `已暂停对 ${r.name} 的自动投递——排队的消息会等着。`
+      : `已恢复对 ${r.name} 的自动投递。`
   };
 }
 
@@ -483,24 +475,24 @@ function execGateTool(deps: RealtimeActionDeps, a: Record<string, unknown>): Act
   if ('error' in r) return { ok: false, spoken: r.error };
   const toolName = str(a.tool) || str(a.toolName);
   if (!toolName || !/^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(toolName)) {
-    return { ok: false, spoken: 'Which tool should I gate? Give me its exact name, like Bash or WebFetch.' };
+    return { ok: false, spoken: '要门控哪个工具？给出精确名称，比如 Bash 或 WebFetch。' };
   }
   const raw = norm(str(a.state) || str(a.action));
-  const on = !/off|allow|ungate|unblock|enable/.test(raw); // default: gate it
+  const on = !/off|allow|ungate|unblock|enable/.test(raw); // 默认：门控它
   deps.controlGateTool(r.id, toolName, on);
   attribute(deps, 'gate_tool', r.id, { action: `${on ? 'gated' : 'ungated'} ${toolName}` });
-  return { ok: true, spoken: `${on ? 'Gated' : 'Un-gated'} the ${toolName} tool for ${r.name}.` };
+  return { ok: true, spoken: `${on ? '已门控' : '已解除门控'} ${r.name} 的 ${toolName} 工具。` };
 }
 
 function execDeleteTask(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
   const ref = str(a.taskId) || str(a.task) || str(a.title);
-  if (!ref) return { ok: false, spoken: 'Which task should I delete?' };
+  if (!ref) return { ok: false, spoken: '要删除哪个任务？' };
   const { tasks, card, ambiguous } = findCard(deps, ref);
-  if (ambiguous) return { ok: false, spoken: `Which one — ${ambiguous.map((c) => `"${c.title}"`).join(', or ')}?` };
-  if (!card) return { ok: false, spoken: `I couldn't find a task matching "${ref}".` };
+  if (ambiguous) return { ok: false, spoken: `哪一个——${ambiguous.map((c) => `「${c.title}」`).join('，还是 ')}？` };
+  if (!card) return { ok: false, spoken: `找不到匹配 "${ref}" 的任务。` };
   deps.hiveWriteTasks(tasks.filter((t) => t.id !== card.id));
   attribute(deps, 'delete_task', card.id, { title: card.title.slice(0, 120) });
-  return { ok: true, spoken: `Deleted the task "${card.title}". Recreate it any time if that was wrong.` };
+  return { ok: true, spoken: `已删除任务「${card.title}」。如果删错了，随时可以重建。` };
 }
 
 function execUnarchive(deps: RealtimeActionDeps, a: Record<string, unknown>): ActionResult {
@@ -509,17 +501,17 @@ function execUnarchive(deps: RealtimeActionDeps, a: Record<string, unknown>): Ac
   const res = deps.setArchived(r.id, false);
   attribute(deps, 'unarchive', r.id);
   return res.ok
-    ? { ok: true, spoken: `Brought ${r.name} back from the archive.` }
-    : { ok: false, spoken: `Couldn't unarchive ${r.name}: ${res.error || 'unknown error'}.` };
+    ? { ok: true, spoken: `已把 ${r.name} 从归档中恢复。` }
+    : { ok: false, spoken: `无法恢复 ${r.name}：${res.error || '未知错误'}。` };
 }
 
-// ─── destructive commit builders (run AFTER confirm) ────────────────────────
+// ─── 破坏性提交构造器（确认后运行）───────────────────────────────────────
 
 function buildKill(deps: RealtimeActionDeps, r: ResolvedAgent): () => Promise<string> {
   return async () => {
     const res = deps.killAgent(r.id);
     attribute(deps, 'kill', r.id);
-    return res.ok ? `Killed ${r.name}.` : `Couldn't kill ${r.name}: ${res.error || 'unknown error'}.`;
+    return res.ok ? `已终止 ${r.name}。` : `无法终止 ${r.name}：${res.error || '未知错误'}。`;
   };
 }
 
@@ -527,7 +519,7 @@ function buildPause(deps: RealtimeActionDeps, r: ResolvedAgent): () => Promise<s
   return async () => {
     deps.controlPause(r.id, true);
     attribute(deps, 'pause', r.id);
-    return `Paused ${r.name}.`;
+    return `已暂停 ${r.name}。`;
   };
 }
 
@@ -535,7 +527,7 @@ function buildHalt(deps: RealtimeActionDeps, r: ResolvedAgent): () => Promise<st
   return async () => {
     deps.controlHalt(r.id);
     attribute(deps, 'halt', r.id);
-    return `Halted ${r.name}.`;
+    return `已中止 ${r.name}。`;
   };
 }
 
@@ -543,27 +535,27 @@ function buildSpawn(deps: RealtimeActionDeps, spec: RealtimeSpawnSpec, label: st
   return async () => {
     const res = await deps.spawnAgent(spec);
     attribute(deps, 'spawn', spec.id, { provider: spec.provider, role: spec.hive?.role });
-    return res.ok ? `Hired ${label}.` : `Couldn't hire ${label}: ${res.error || 'unknown error'}.`;
+    return res.ok ? `已雇佣 ${label}。` : `无法雇佣 ${label}：${res.error || '未知错误'}。`;
   };
 }
 
 function buildClearContext(deps: RealtimeActionDeps, r: ResolvedAgent): () => Promise<string> {
   return async () => {
-    // '/clear' is NOT universal — it was hardcoded here for every provider, which
-    // meant Grok/OpenCode/pi (whose verb is '/new') got a literal "/clear" typed
-    // as chat text, and Crush/Copilot got one with no prompt able to receive it.
-    // Resolve the provider's own verb; null = nothing safe to type, so say so
-    // rather than sending a command that does nothing.
+    // '/clear' 并非通用——过去这里对每个 provider 都硬编码了它，导致
+    // Grok/OpenCode/pi（它们的动词是 '/new'）收到一个被当聊天文本打进去的
+    // 字面 "/clear"，而 Crush/Copilot 收到一个没有提示能接收它的命令。
+    // 解析 provider 自己的动词；null = 没有安全可键入的东西，就直接说出来，
+    // 而不是发一条什么都不做的命令。
     const provider = inferAgentProvider(undefined, deps.hiveRegistry().agents?.[r.id]?.provider);
     const command = clearCommandForProvider(provider);
     if (!command) {
-      return `${r.name} runs on ${provider}, which has no context-clear command I can type. Clear it from their terminal.`;
+      return `${r.name} 运行在 ${provider} 上，而它没有我能键入的清除上下文命令。请在其终端里清除。`;
     }
-    // Queue through the renderer message queue: delivery inherits every existing
-    // safety gate (idle-only, boot grace, draft/picker protection).
+    // 经渲染进程消息队列排队：投递继承每一个既有的安全门
+    // （仅空闲、启动宽限、草稿/选择器保护）。
     deps.enqueueToAgent(r.id, command);
     attribute(deps, 'clear_context', r.id);
-    return `Queued a context clear for ${r.name} — it lands the moment they're idle.`;
+    return `已为 ${r.name} 排队一条清除上下文指令——会在它空闲的那一刻送达。`;
   };
 }
 
@@ -572,8 +564,8 @@ function buildArchive(deps: RealtimeActionDeps, r: ResolvedAgent): () => Promise
     const res = deps.setArchived(r.id, true);
     attribute(deps, 'archive', r.id);
     return res.ok
-      ? `Archived ${r.name} — off the floor, history kept. Say unarchive to bring them back.`
-      : `Couldn't archive ${r.name}: ${res.error || 'unknown error'}.`;
+      ? `已归档 ${r.name}——离开楼层，历史保留。说 unarchive 可恢复。`
+      : `无法归档 ${r.name}：${res.error || '未知错误'}。`;
   };
 }
 
@@ -589,28 +581,28 @@ function buildEditSchedule(
     else next = all.map((m) => (m.id === mission.id ? { ...m, enabled: action === 'enable' } : m));
     deps.saveMissions(next);
     attribute(deps, 'edit_schedule', mission.id, { action });
-    return `${action === 'delete' ? 'Deleted' : action === 'enable' ? 'Enabled' : 'Disabled'} the "${mission.label}" schedule.`;
+    return `${action === 'delete' ? '已删除' : action === 'enable' ? '已启用' : '已停用'}日程「${mission.label}」。`;
   };
 }
 
-// ─── propose: classify, allowlist-gate, run-or-stage ────────────────────────
+// ─── propose：分类、白名单门控、运行或暂存 ────────────────────────
 
 function proposeDestructive(deps: RealtimeActionDeps, verb: string, a: Record<string, unknown>): ActionResult {
   const spec = VERBS[verb];
   const reg = deps.hiveRegistry();
 
-  // Agent-targeted destructive verbs: resolve + hard allowlist (god + mass).
+  // 面向 agent 的破坏性动词：解析 + 硬白名单（god + 批量）。
   if (spec.agentTargeted) {
     const rawTarget = str(a.agentId) || str(a.target) || str(a.name);
     if (isMassTarget(rawTarget))
-      return { ok: false, spoken: `${verb} on all agents at once is voice-forbidden. Do it agent by agent, or use the UI.` };
+      return { ok: false, spoken: `${verb} 一次性对所有 agent 执行是被语音禁止的。请逐个 agent 执行，或改用界面。` };
     const r = resolveAgent(rawTarget, reg);
     if ('error' in r) return { ok: false, spoken: r.error };
-    // God policy per verb: kill/pause/halt/archive on god stay voice-forbidden.
-    // clear_context on god is ALLOWED behind confirm — it's recoverable
-    // (sessions resume) and "clear Michael's context" is a real operator need.
+    // 每个动词的 god 策略：对 god 的 kill/pause/halt/archive 保持禁止语音。
+    // 对 god 的 clear_context 在确认后是允许的——它是可恢复的
+    // （会话可续接），而且“清掉 Michael 的上下文”是真实的运维需求。
     if (r.isGod && verb !== 'clear_context')
-      return { ok: false, spoken: `${verb} on the god orchestrator is voice-forbidden. That has to be done in the UI.` };
+      return { ok: false, spoken: `${verb} 对 god 编排器执行是被语音禁止的。那必须在界面里操作。` };
 
     const commit =
       verb === 'kill' ? buildKill(deps, r)
@@ -619,21 +611,21 @@ function proposeDestructive(deps: RealtimeActionDeps, verb: string, a: Record<st
       : verb === 'clear_context' ? buildClearContext(deps, r)
       : buildArchive(deps, r);
     const breaker = deps.controlSnapshot(r.id);
-    const note = breaker?.halted ? ' (note: already halted)' : breaker?.paused ? ' (note: already paused)' : '';
+    const note = breaker?.halted ? '（注意：已中止）' : breaker?.paused ? '（注意：已暂停）' : '';
     pending = { verb, confirmWord: spec.confirmWord, targetLabel: r.name, createdAt: Date.now(), commit };
     const consequence = verb === 'clear_context'
-      ? `That wipes ${r.name}'s working memory of the current conversation.`
+      ? `这会清除 ${r.name} 对当前会话的工作记忆。`
       : verb === 'archive'
-        ? `That takes ${r.name} off the floor (history kept).`
-        : `That's destructive.`;
+        ? `这会带走 ${r.name}（历史保留）。`
+        : `这是破坏性操作。`;
     return {
       ok: true,
       needsConfirm: true,
-      spoken: `You asked me to ${verb.replace('_', ' ')} ${r.name}${note}. ${consequence} To go ahead, say "confirm" or "${spec.confirmWord}". Say "cancel" to stop.`
+      spoken: `你要求我${verb.replace('_', ' ')} ${r.name}${note}。${consequence} 要继续，请说 "confirm" 或 "${spec.confirmWord}"。说 "cancel" 可取消。`
     };
   }
 
-  // spawn / hire — expensive; stubbed $ estimate (rt-9 wires the real number).
+  // spawn / hire——昂贵；占位 $ 估算（rt-9 接入真实数字）。
   if (verb === 'spawn') {
     const provider = (str(a.provider) || 'claude').toLowerCase();
     const role = str(a.role) || str(a.job);
@@ -641,7 +633,7 @@ function proposeDestructive(deps: RealtimeActionDeps, verb: string, a: Record<st
     const godCwd = reg.godId ? reg.agents[reg.godId]?.cwd : undefined;
     const cwd =
       str(a.cwd) || godCwd || Object.values(reg.agents).find((m) => m.cwd)?.cwd || '';
-    if (!cwd) return { ok: false, spoken: 'I need a working directory to hire into — none is configured.' };
+    if (!cwd) return { ok: false, spoken: '我需要一个工作目录来雇佣——当前未配置。' };
     const command = str(a.command) || PROVIDER_COMMAND[provider] || 'claude';
     const id = `${slug(name)}-${shortId()}`;
     const spec2: RealtimeSpawnSpec = { id, cwd, command, provider, hive: { id, name, provider, role: role || undefined, cwd } };
@@ -649,22 +641,22 @@ function proposeDestructive(deps: RealtimeActionDeps, verb: string, a: Record<st
     return {
       ok: true,
       needsConfirm: true,
-      // Spawn/hire is gated behind a verbal echo-back confirm. No cost is quoted —
-      // the orchestrator persona does not surface money to the user.
-      spoken: `You want to hire a new ${provider} agent${role ? ` as ${role}` : ''}, named ${name}. To hire, say "confirm" or "spawn". Say "cancel" to stop.`
+      // Spawn/hire 由口头回声确认门控。不报价——
+      // 编排器人设不向用户展示金钱。
+      spoken: `你想雇佣一个新的 ${provider} agent${role ? `，担任 ${role}` : ''}，名字叫 ${name}。要雇佣，请说 "confirm" 或 "spawn"。说 "cancel" 可取消。`
     };
   }
 
   // edit_schedule
   if (verb === 'edit_schedule') {
     const missions = deps.listMissions();
-    if (!missions.length) return { ok: false, spoken: 'There are no scheduled missions to edit.' };
+    if (!missions.length) return { ok: false, spoken: '当前没有可编辑的定时任务。' };
     const ref = norm(str(a.missionId) || str(a.schedule) || str(a.label) || str(a.target));
     const m =
       missions.find((x) => x.id.toLowerCase() === ref) ||
       missions.find((x) => (x.label || '').toLowerCase() === ref) ||
       missions.find((x) => (x.label || '').toLowerCase().includes(ref) || x.id.toLowerCase().includes(ref));
-    if (!m) return { ok: false, spoken: ref ? `I couldn't find a schedule matching "${str(a.label) || ref}".` : 'Which schedule should I edit?' };
+    if (!m) return { ok: false, spoken: ref ? `找不到匹配 "${str(a.label) || ref}" 的日程。` : '要编辑哪个日程？' };
     const raw = norm(str(a.action) || str(a.op));
     const action: 'enable' | 'disable' | 'delete' =
       raw.includes('delete') || raw.includes('remove') ? 'delete' : raw.includes('disable') || raw.includes('off') || raw.includes('pause') ? 'disable' : 'enable';
@@ -678,15 +670,15 @@ function proposeDestructive(deps: RealtimeActionDeps, verb: string, a: Record<st
     return {
       ok: true,
       needsConfirm: true,
-      spoken: `You want to ${action} the "${m.label}" schedule. To go ahead, say "confirm" or "schedule". Say "cancel" to stop.`
+      spoken: `你想${action === 'delete' ? '删除' : action === 'enable' ? '启用' : '停用'}日程「${m.label}」。要继续，请说 "confirm" 或 "schedule"。说 "cancel" 可取消。`
     };
   }
 
-  // v0.3.4: create a brand-new schedule (edit_schedule only toggles/deletes).
+  // v0.3.4：创建全新的日程（edit_schedule 只切换/删除）。
   if (verb === 'create_schedule') {
     const label = str(a.label) || str(a.name) || str(a.title);
     const body = str(a.prompt) || str(a.body) || str(a.message);
-    if (!label || !body) return { ok: false, spoken: 'I need a name for the schedule and what it should tell the agent.' };
+    if (!label || !body) return { ok: false, spoken: '我需要日程的名称以及要告诉 agent 的内容。' };
     const minutes = typeof a.intervalMinutes === 'number' && isFinite(a.intervalMinutes)
       ? Math.min(7 * 24 * 60, Math.max(5, Math.round(a.intervalMinutes)))
       : 60;
@@ -706,76 +698,76 @@ function proposeDestructive(deps: RealtimeActionDeps, verb: string, a: Record<st
       commit: async () => {
         deps.saveMissions([...deps.listMissions(), mission]);
         attribute(deps, 'create_schedule', mission.id, { title: label.slice(0, 120) });
-        return `Created the "${label}" schedule — every ${minutes} minutes to ${targetId}.`;
+        return `已创建日程「${label}」——每 ${minutes} 分钟向 ${targetId} 发送。`;
       }
     };
     return {
       ok: true,
       needsConfirm: true,
-      spoken: `You want a new schedule "${label}", every ${minutes} minutes, messaging ${targetId}. To create it, say "confirm" or "schedule". Say "cancel" to stop.`
+      spoken: `你想要一个新日程「${label}」，每 ${minutes} 分钟向 ${targetId} 发送消息。要创建，请说 "confirm" 或 "schedule"。说 "cancel" 可取消。`
     };
   }
 
-  // v0.3.4: settings, through the policy table ONLY.
+  // v0.3.4：设置，只经策略表。
   if (verb === 'update_setting') {
     const key = str(a.key) || str(a.setting) || str(a.name);
     const policy = SETTING_POLICY[key];
-    if (!key) return { ok: false, spoken: 'Which setting should I change?' };
+    if (!key) return { ok: false, spoken: '要更改哪个设置？' };
     if (!policy) {
-      return { ok: false, spoken: `The "${key}" setting can't be changed by voice — use the Settings screen for that one.` };
+      return { ok: false, spoken: `设置 "${key}" 不能通过语音更改——请到设置界面操作。` };
     }
-    // Coerce + validate the value against the key's declared type.
+    // 按 key 声明的类型强制转换 + 校验值。
     let value: unknown = a.value;
     if (policy.type === 'boolean') {
       if (typeof value === 'string') value = /^(true|on|yes|enable|enabled|1)$/i.test(value.trim());
-      if (typeof value !== 'boolean') return { ok: false, spoken: `Should ${key} be on or off?` };
+      if (typeof value !== 'boolean') return { ok: false, spoken: `${key} 应该是开还是关？` };
     } else if (policy.type === 'number') {
       if (typeof value === 'string') value = parseFloat(value);
-      if (typeof value !== 'number' || !isFinite(value)) return { ok: false, spoken: `What number should ${key} be?` };
-      if (policy.min !== undefined && value < policy.min) return { ok: false, spoken: `${key} can't go below ${policy.min}.` };
-      if (policy.max !== undefined && value > policy.max) return { ok: false, spoken: `${key} can't go above ${policy.max}.` };
+      if (typeof value !== 'number' || !isFinite(value)) return { ok: false, spoken: `${key} 应该设为多少？` };
+      if (policy.min !== undefined && value < policy.min) return { ok: false, spoken: `${key} 不能低于 ${policy.min}。` };
+      if (policy.max !== undefined && value > policy.max) return { ok: false, spoken: `${key} 不能超过 ${policy.max}。` };
       value = Math.round(value as number);
     } else {
       if (typeof value !== 'string' || !value.trim() || value.length > 200) {
-        return { ok: false, spoken: `What should ${key} be set to?` };
+        return { ok: false, spoken: `${key} 应该设置成什么？` };
       }
       value = value.trim();
       if (policy.values && !policy.values.includes(value as string)) {
-        return { ok: false, spoken: `${key} must be one of: ${policy.values.join(', ')}.` };
+        return { ok: false, spoken: `${key} 必须是以下之一：${policy.values.join(', ')}。` };
       }
     }
     const oldValue = deps.getConfigValue(key);
     const describe = (v: unknown): string => typeof v === 'boolean' ? (v ? 'on' : 'off') : String(v ?? 'unset');
     if (describe(oldValue) === describe(value)) {
-      return { ok: true, spoken: `${key} is already ${describe(value)} — nothing to change.` };
+      return { ok: true, spoken: `${key} 已经是 ${describe(value)}——无需修改。` };
     }
     const applyNow = (): string => {
       deps.patchConfig({ [key]: value });
       attribute(deps, 'update_setting', key, { action: `${describe(oldValue)} → ${describe(value)}` });
-      return `Done — ${key} is now ${describe(value)} (was ${describe(oldValue)}).`;
+      return `完成——${key} 现为 ${describe(value)}（原为 ${describe(oldValue)}）。`;
     };
     if (policy.tier === 'soft') {
-      // Low-blast keys apply immediately, like other soft verbs.
+      // 低爆炸半径的 key 立即生效，就像其他软动词一样。
       return { ok: true, spoken: applyNow() };
     }
     pending = { verb, confirmWord: 'setting', targetLabel: key, createdAt: Date.now(), commit: async () => applyNow() };
     return {
       ok: true,
       needsConfirm: true,
-      spoken: `${key} is ${describe(oldValue)}; you want it ${describe(value)}. To change it, say "confirm" or "setting". Say "cancel" to stop.`
+      spoken: `${key} 当前为 ${describe(oldValue)}；你想把它设为 ${describe(value)}。要修改，请说 "confirm" 或 "setting"。说 "cancel" 可取消。`
     };
   }
 
-  return { ok: false, spoken: `I don't know how to ${verb}.` };
+  return { ok: false, spoken: `我不知道如何执行 ${verb}。` };
 }
 
-/** Top-level propose/execute for one verb. Soft writes run now; destructive ones
- *  stage a pending and ask for verbal confirm. */
+/** 一个动词的顶层 propose/execute。软写入立即运行；破坏性的暂存一个
+ *  pending 并要求口头确认。 */
 function runAction(deps: RealtimeActionDeps, verb: string, a: Record<string, unknown>): ActionResult {
-  if (!deps.hiveEnabled()) return { ok: false, spoken: 'The hive is not configured, so I can\'t take that action.' };
+  if (!deps.hiveEnabled()) return { ok: false, spoken: 'hive 尚未配置，所以我无法执行该操作。' };
   const spec = VERBS[verb];
-  if (!spec) return { ok: false, spoken: `I don't have an action called "${verb}".` };
-  // Any new proposal supersedes a stale pending.
+  if (!spec) return { ok: false, spoken: `没有名为 "${verb}" 的操作。` };
+  // 任何新提议都取代过期的 pending。
   pending = null;
   if (spec.tier === 'soft') {
     switch (verb) {
@@ -790,17 +782,17 @@ function runAction(deps: RealtimeActionDeps, verb: string, a: Record<string, unk
       case 'gate_tool': return execGateTool(deps, a);
       case 'delete_task': return execDeleteTask(deps, a);
       case 'unarchive': return execUnarchive(deps, a);
-      default: return { ok: false, spoken: `I don't know how to ${verb}.` };
+      default: return { ok: false, spoken: `我不知道如何执行 ${verb}。` };
     }
   }
   return proposeDestructive(deps, verb, a);
 }
 
-// ─── IPC registration ───────────────────────────────────────────────────────
+// ─── IPC 注册 ───────────────────────────────────────────────────────
 
-/** rt-5 live-bug instrumentation: write the REAL error + stack to the console AND
- *  the hive log so the NEXT voice repro is self-diagnosing (the model only ever sees
- *  a friendly 'spoken' string, which hides the true failure). Best-effort. */
+/** rt-5 线上 bug 插桩：把真实的错误 + 堆栈写到控制台和 hive 日志，
+ *  让下一次语音复现能自诊断（模型只看到友好的 'spoken' 字符串，
+ *  它掩盖了真正的失败）。尽力而为。 */
 function logActionFailure(deps: RealtimeActionDeps, channel: string, verb: string, e: unknown): void {
   const err = e instanceof Error ? e : new Error(String(e));
   console.error(`[realtime-action] ${channel} verb=${verb} FAILED:`, err.stack || err.message);
@@ -814,18 +806,18 @@ function logActionFailure(deps: RealtimeActionDeps, channel: string, verb: strin
       stack: (err.stack || '').slice(0, 800)
     });
   } catch {
-    /* never let logging throw into the handler */
+    /* 绝不让日志向 handler 抛异常 */
   }
 }
 
 /**
- * Wire the voice-action IPC. Called once from index.ts with the existing main fns.
- * Channels:
- *   realtime:action          {verb, ...args}  → ActionResult (soft runs now;
- *                                                destructive stages a pending)
- *   realtime:action:confirm  {phrase}         → ActionResult (commits the pending
- *                                                iff the distinct token matches)
- *   realtime:action:cancel   {}               → ActionResult (drops the pending)
+ * 接好语音动作 IPC。从 index.ts 调用一次，带上既有的主函数。
+ * 通道：
+ *   realtime:action          {verb, ...args}  → ActionResult（软动作立即运行；
+ *                                                破坏性动作暂存一个 pending）
+ *   realtime:action:confirm  {phrase}         → ActionResult（仅当独立 token
+ *                                                匹配时提交那个 pending）
+ *   realtime:action:cancel   {}               → ActionResult（丢弃 pending）
  */
 export function registerRealtimeActionIpc(deps: RealtimeActionDeps): void {
   ipcMain.handle('realtime:action', async (_evt, payload: unknown) => {
@@ -833,44 +825,44 @@ export function registerRealtimeActionIpc(deps: RealtimeActionDeps): void {
     const verb = norm(str(p.verb)).replace(/\s+/g, '_');
     try {
       const res = runAction(deps, verb, p);
-      // A non-ok result is an EXPECTED friendly rejection (bad target, hive off, etc.) —
-      // log it quietly so a live repro can still be correlated, but it is not an error.
+      // 非 ok 结果是预期的友好拒绝（目标错误、hive 关闭等）——
+      // 安静地记一条日志，让线上复现仍可关联，但它不是错误。
       if (!res.ok) console.warn(`[realtime-action] verb=${verb} rejected: ${res.spoken}`);
       return res;
     } catch (e) {
       logActionFailure(deps, 'realtime:action', verb, e);
       const msg = e instanceof Error ? e.message : 'unknown error';
-      return { ok: false, spoken: `That action failed: ${msg}.` } satisfies ActionResult;
+      return { ok: false, spoken: `该操作失败：${msg}。` } satisfies ActionResult;
     }
   });
 
   ipcMain.handle('realtime:action:confirm', async (_evt, payload: unknown) => {
     const p = (payload ?? {}) as Record<string, unknown>;
     const cur = pendingFresh();
-    if (!cur) return { ok: false, spoken: 'There\'s nothing waiting to confirm.' } satisfies ActionResult;
+    if (!cur) return { ok: false, spoken: '当前没有待确认的操作。' } satisfies ActionResult;
     const phrase = str(p.phrase) || str(p.confirm) || str(p.text);
     if (!confirmAccepted(phrase, cur.confirmWord)) {
       return {
         ok: false,
-        spoken: `I won't ${cur.verb} ${cur.targetLabel} on that — for safety I need you to say "confirm" or "${cur.confirmWord}", not just yes. Say it clearly, or say cancel.`
+        spoken: `我不会仅凭这句话就对 ${cur.targetLabel} 执行 ${cur.verb}——出于安全，我需要你说 "confirm" 或 "${cur.confirmWord}"，而不是简单的 yes。请清楚地说出来，或说 cancel 取消。`
       } satisfies ActionResult;
     }
     const commit = cur.commit;
     const verb = cur.verb;
-    pending = null; // consume before running so a failure can't be re-confirmed
+    pending = null; // 运行前消费掉，让失败无法被二次确认
     try {
       const spoken = await commit();
       return { ok: true, spoken } satisfies ActionResult;
     } catch (e) {
       logActionFailure(deps, 'realtime:action:confirm', verb, e);
       const msg = e instanceof Error ? e.message : 'unknown error';
-      return { ok: false, spoken: `That action failed: ${msg}.` } satisfies ActionResult;
+      return { ok: false, spoken: `该操作失败：${msg}。` } satisfies ActionResult;
     }
   });
 
   ipcMain.handle('realtime:action:cancel', async () => {
     const had = pendingFresh();
     pending = null;
-    return { ok: true, spoken: had ? `Cancelled the ${had.verb}.` : 'Nothing to cancel.' } satisfies ActionResult;
+    return { ok: true, spoken: had ? `已取消 ${had.verb}。` : '没有要取消的操作。' } satisfies ActionResult;
   });
 }

--- a/src/main/realtimeCompletionWatcher.ts
+++ b/src/main/realtimeCompletionWatcher.ts
@@ -1,46 +1,45 @@
 /**
- * Realtime Michael — completion watcher (card rt-12, Phase 2, "respond when done").
+ * Realtime Michael —— 完成观察器（卡片 rt-12，第二阶段，“完成时回应”）。
  *
- * When voice-Michael DISPATCHES work (fire-and-notify, the default pattern), he does
- * NOT block on it. This module is the main-process engine that watches each dispatched
- * task for completion and EMITS a completion event so the rest of the realtime stack can
- * make Michael speak it unprompted ("Oscar finished — want details?").
+ * 当语音版 Michael 派发工作（fire-and-notify，默认模式）时，他不会阻塞等它。
+ * 本模块就是主进程的引擎：观察每个已派发任务的完成情况，并发出完成事件，
+ * 让 realtime 栈的其余部分能让 Michael 主动说出来（“Oscar 完成了——要细节吗？”）。
  *
- * OWNERSHIP / SEAM (rt-12 split, god-ruled 2026-06-25): this module is OWNED by Jim and
- * is deliberately DISJOINT from Kevin's realtime CORE files. It NEVER imports session.ts
- * / the live RealtimeSession / electron — it only takes injected readers + a clock and
- * EMITS via callbacks. Kevin's side subscribes `onCompletion(...)` and pushes the event
- * down the new main→renderer channel (preload binding + session.ts injection), calls
- * `track(...)` from the dispatch action, flips `setSessionLive(...)` on connect/disconnect,
- * and `drainQueuedCompletions()` at warm-start. Keeping this file electron-free + reader-
- * injected makes it unit-testable and collision-free on the shared checkout.
+ * 归属 / 接缝（rt-12 拆分，2026-06-25 由 god 裁定）：本模块归 Jim 所有，
+ * 刻意与 Kevin 的 realtime CORE 文件不相交。它绝不 import session.ts /
+ * 实时 RealtimeSession / electron——只接受注入的读取器 + 一个时钟，
+ * 并通过回调发出事件。Kevin 一侧订阅 `onCompletion(...)`，
+ * 把事件推下新的 main→renderer 通道（preload 绑定 + session.ts 注入），
+ * 在派发动作里调用 `track(...)`，在连接/断开时翻转 `setSessionLive(...)`，
+ * 并在热启动时 `drainQueuedCompletions()`。让这个文件不依赖 electron、
+ * 读取器注入，使它可做单元测试，也不会在共享 checkout 上冲突。
  *
- * Completion signal (see {@link detectCompletion}) is EITHER:
- *   (a) the dispatched task's card flips to `done` in tasks.json, OR
- *   (b) an inbox done-msg arrives from the assignee (a reply to the dispatch, after it).
+ * 完成信号（见 {@link detectCompletion}）是二者之一：
+ *   (a) 已派发任务的卡片在 tasks.json 中翻到 `done`，或者
+ *   (b) 收件人发来一条 inbox done 消息（对派发消息的回复，且在其之后）。
  *
- * Branch feat/realtime-michael. See board.md "🎙 REALTIME MICHAEL".
+ * 分支 feat/realtime-michael。见 board.md “🎙 REALTIME MICHAEL”。
  */
 
-/** A unit of work voice-Michael dispatched and is now awaiting completion of. */
+/** 语音版 Michael 派发出去、此刻正等待其完成的一个工作单元。 */
 export interface PendingDispatch {
-  /** Stable id for this dispatch (the watcher key). e.g. the dispatch message id. */
+  /** 这次派发的稳定 id（观察器的键）。例如派发消息 id。 */
   correlationId: string;
-  /** What kind of work was dispatched — shapes the spoken summary. */
+  /** 派发了什么类型的工作——决定口头摘要的形态。 */
   kind: 'dispatch' | 'task' | 'spawn';
-  /** The agent the work went to (e.g. "oscar-mqpbr18v"). */
+  /** 工作派给的那个 agent（例如 "oscar-mqpbr18v"）。 */
   targetAgentId: string;
-  /** The task-card id, if a card exists for this dispatch (enables card→done detection). */
+  /** 任务卡片 id——如果这次派发对应一张卡片（启用卡片→done 检测）。 */
   taskId?: string;
-  /** Short objective text, for the spoken summary. */
+  /** 简短的目标文字，供口头摘要使用。 */
   objective?: string;
-  /** Epoch-ms the dispatch happened — only signals AFTER this count (avoids stale replies). */
+  /** 派发发生的 epoch 毫秒——只有此时间之后的信号才算数（避免过期回复）。 */
   dispatchedAt: number;
-  /** The dispatch message id, if known — lets us match an inbox reply via `in_reply_to`. */
+  /** 派发消息的 id（若已知）——让我们能通过 `in_reply_to` 匹配 inbox 回复。 */
   dispatchMessageId?: string;
 }
 
-/** Minimal task-card shape we read from tasks.json (extra fields ignored). */
+/** 我们从 tasks.json 读取的最小任务卡片形状（忽略多余字段）。 */
 export interface TaskCard {
   id: string;
   status?: string;
@@ -49,7 +48,7 @@ export interface TaskCard {
   title?: string;
 }
 
-/** Minimal inbox-message shape we scan for done-signals (extra fields ignored). */
+/** 我们扫描 done 信号的最小 inbox 消息形状（忽略多余字段）。 */
 export interface InboxMessage {
   id: string;
   from?: string;
@@ -61,71 +60,71 @@ export interface InboxMessage {
   created_at?: string;
 }
 
-/** The data the detector reads — injected so this module touches no filesystem itself. */
+/** 检测器读取的数据——注入进来，让本模块不碰任何文件系统。 */
 export interface CompletionContext {
   tasks: TaskCard[];
   inbox: InboxMessage[];
 }
 
-/** Outcome of the pure detection predicate. */
+/** 纯检测谓词的结果。 */
 export interface CompletionResult {
   done: boolean;
-  /** How completion was observed — for logging + de-dupe. */
+  /** 完成是如何被观察到的——供日志与去重用。 */
   via?: 'card-done' | 'inbox-reply';
-  /** Epoch-ms the completion was observed (best-effort). */
+  /** 观察到完成的 epoch 毫秒（尽力而为）。 */
   at?: number;
-  /** Short, speakable summary of what finished. */
+  /** 简短、可念出的“什么完成了”摘要。 */
   summary?: string;
-  /** The matched inbox message id (when via 'inbox-reply') — lets the watcher de-dupe. */
+  /** 匹配到的 inbox 消息 id（当通过 'inbox-reply' 时）——让观察器去重。 */
   messageId?: string;
 }
 
 /**
- * The completion object the watcher emits via `onCompletion` AND returns from
- * `drainQueuedCompletions()` — the SAME shape (rt-12 contract lock with Kevin). Kevin
- * forwards it verbatim over the main→renderer push channel and into warm-start, so every
- * field here reaches Michael. `summary` is the human-speakable line; `completedAt` is
- * epoch-ms. The trailing fields are extra context (safe to ignore on the wire).
+ * 观察器经 `onCompletion` 发出、也从 `drainQueuedCompletions()` 返回的
+ * 完成对象——同一个形状（与 Kevin 的 rt-12 契约锁）。Kevin 原样转发它，
+ * 经 main→renderer 推送通道并进入热启动，所以这里的每个字段都能到达
+ * Michael。`summary` 是给人念的行；`completedAt` 是 epoch 毫秒。
+ * 尾随字段是额外上下文（线上可安全忽略）。
  */
 export interface RealtimeCompletion {
   correlationId: string;
   kind: PendingDispatch['kind'];
   targetAgentId: string;
   taskId?: string;
-  /** Human-speakable line, e.g. "Oscar finished the cost guard." */
+  /** 给人念的行，例如 "Oscar finished the cost guard." */
   summary: string;
-  /** Epoch-ms the completion was observed. */
+  /** 观察到完成的 epoch 毫秒。 */
   completedAt: number;
-  /** Short objective text — extra context for a toast / log. */
+  /** 简短目标文字——供 toast / 日志使用的额外上下文。 */
   objective?: string;
-  /** How completion was detected — extra, for logging / de-dupe. */
+  /** 完成是如何被检测到的——额外信息，供日志 / 去重。 */
   via?: 'card-done' | 'inbox-reply';
-  /** Matched inbox message id when via 'inbox-reply' — extra, for de-dupe. */
+  /** 经 'inbox-reply' 时匹配到的 inbox 消息 id——额外信息，供去重。 */
   messageId?: string;
 }
 
-/** Dependencies injected by the wiring (index.ts), so the watcher stays electron-free. */
+/** 由接线方（index.ts）注入的依赖，让观察器保持无 electron。 */
 export interface CompletionWatcherDeps {
-  /** Current task cards (from tasks.json). Called each poll. */
+  /** 当前任务卡片（来自 tasks.json）。每次轮询调用。 */
   readTasks: () => TaskCard[];
-  /** Current dispatcher-inbox messages (where assignee replies land). Called each poll. */
+  /** 当前调度方 inbox 的消息（收件人回复落在那里）。每次轮询调用。 */
   readInbox: () => InboxMessage[];
-  /** Clock — injectable for tests. Defaults to Date.now. */
+  /** 时钟——供测试注入。默认为 Date.now。 */
   now?: () => number;
-  /** Poll cadence in ms. Default 4000. */
+  /** 轮询节奏（毫秒）。默认 4000。 */
   pollIntervalMs?: number;
-  /** Optional OS-notification hook (e.g. electron Notification) for the session-closed path. */
+  /** 可选的系统通知钩子（例如 electron Notification），用于会话关闭路径。 */
   onNotify?: (event: RealtimeCompletion) => void;
 }
 
 const DEFAULT_POLL_MS = 4000;
 
-/** N2 (rt-10 hardening) — bound memory so a long-lived session can't leak. */
+/** N2（rt-10 加固）——约束内存，让长生命周期会话无法泄漏。 */
 const MAX_PENDING = 200;
 const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_QUEUED = 50;
 
-/** N3 (rt-10 hardening) — prompt-injection lead-ins to neutralize in spoken summaries. */
+/** N3（rt-10 加固）——需要在口头摘要中中和的提示注入前导语。 */
 const INJECTION_PATTERNS: RegExp[] = [
   /\b(?:ignore|disregard|forget|override)\b[^.!?\n]*\b(?:previous|above|prior|instruction|system|prompt)\b[^.!?\n]*/gi,
   /\b(?:system|assistant|developer|user)\s*:/gi,
@@ -134,10 +133,10 @@ const INJECTION_PATTERNS: RegExp[] = [
 ];
 
 /**
- * N3 defense-in-depth: the spoken summary embeds `objective`, which comes from a
- * possibly-crafted task. Strip control chars, neutralize prompt-injection lead-ins, collapse
- * whitespace, and cap length so a malicious objective can't steer what Michael says or does.
- * (Kevin also neutralizes at the session.ts injection seam — this is the watcher-half belt.)
+ * N3 纵深防御：口头摘要内嵌 `objective`，它来自可能被精心构造的任务。
+ * 剥掉控制字符、中和提示注入前导语、折叠空白、限制长度，
+ * 让恶意目标无法左右 Michael 说的话或做的事。
+ * （Kevin 在 session.ts 注入接缝处也会中和——这是观察器这半边的“腰带”。）
  */
 function neutralizeForVoice(text: string): string {
   let out = text.replace(/[\u0000-\u001f\u007f]+/g, ' ');
@@ -149,43 +148,43 @@ function isDoneStatus(status: string | undefined): boolean {
   return (status ?? '').trim().toLowerCase() === 'done';
 }
 
-/** Parse an ISO timestamp to epoch-ms; returns null if absent/unparseable. */
+/** 把 ISO 时间戳解析为 epoch 毫秒；缺失或无法解析时返回 null。 */
 function parseTs(iso: string | undefined): number | null {
   if (!iso) return null;
   const t = Date.parse(iso);
   return Number.isFinite(t) ? t : null;
 }
 
-/** A circuit-breaker / scheduler / system sender never counts as a real completion reply. */
+/** 熔断器 / 调度器 / 系统发送者永远不算真正的完成回复。 */
 function isSystemSender(from: string | undefined): boolean {
   const f = (from ?? '').toLowerCase();
   return f === 'breaker' || f === 'scheduler' || f === 'system' || f === '';
 }
 
 function speakableName(agentId: string): string {
-  // "oscar-mqpbr18v" → "Oscar". Falls back to the raw id if it has no name segment.
+  // "oscar-mqpbr18v" → "Oscar"。若没有名称段则回退到原始 id。
   const head = agentId.split('-')[0] ?? agentId;
   return head ? head.charAt(0).toUpperCase() + head.slice(1) : agentId;
 }
 
 function summarize(pending: PendingDispatch, via: CompletionResult['via']): string {
   const who = speakableName(pending.targetAgentId);
-  // N3: the objective is task-supplied — neutralize it before it reaches the voice model.
+  // N3：目标文字是任务提供的——先中和再让它到达语音模型。
   const obj = pending.objective ? neutralizeForVoice(pending.objective) : '';
-  const what = obj ? ` on "${obj}"` : '';
-  const tail = via === 'card-done' ? ' (card marked done)' : '';
-  return `${who} finished${what}.${tail}`.replace(' .', '.');
+  const what = obj ? `，关于「${obj}」` : '';
+  const tail = via === 'card-done' ? '（卡片已标记完成）' : '';
+  return `${who} 已完成${what}。${tail}`.replace(' 。', '。');
 }
 
 /**
- * PURE completion predicate — given a pending dispatch and a snapshot of tasks + inbox,
- * decide whether the work has completed. No I/O, no realtime imports, fully testable.
+ * 纯完成谓词——给定一个待处理的派发 + tasks/inbox 快照，
+ * 判定工作是否已完成。没有 I/O、没有 realtime 导入，完全可测。
  *
- * Completion = card→done (when a taskId is known) OR an inbox reply from the assignee
- * that post-dates the dispatch (preferring an explicit `in_reply_to` match).
+ * 完成 = 卡片→done（当 taskId 已知时）或收件人发来的、
+ * 晚于派发时间的 inbox 回复（优先显式的 `in_reply_to` 匹配）。
  */
 export function detectCompletion(pending: PendingDispatch, ctx: CompletionContext): CompletionResult {
-  // (a) The dispatched card flipped to done.
+  // (a) 已派发的卡片翻到了 done。
   if (pending.taskId) {
     const card = ctx.tasks.find((t) => t.id === pending.taskId);
     if (card && isDoneStatus(card.status)) {
@@ -193,8 +192,8 @@ export function detectCompletion(pending: PendingDispatch, ctx: CompletionContex
     }
   }
 
-  // (b) The assignee sent a done-msg back. Prefer an explicit in_reply_to; otherwise accept
-  //     a non-system message from the assignee that post-dates the dispatch.
+  // (b) 收件人发回了 done 消息。优先显式的 in_reply_to；否则接受
+  //     一条来自收件人、晚于派发时间的非系统消息。
   let best: { msg: InboxMessage; at: number } | null = null;
   for (const m of ctx.inbox) {
     if (m.from !== pending.targetAgentId) continue;
@@ -205,7 +204,7 @@ export function detectCompletion(pending: PendingDispatch, ctx: CompletionContex
     if (replyMatch || postDates) {
       const effAt = at ?? pending.dispatchedAt;
       if (!best || effAt >= best.at) best = { msg: m, at: effAt };
-      // An explicit reply match is authoritative — take it immediately.
+      // 显式的回复匹配具有权威性——立即采用。
       if (replyMatch) break;
     }
   }
@@ -229,11 +228,11 @@ interface Waiter {
 }
 
 /**
- * The completion watcher. Construct once (in index.ts), `start()` it, `track()` each voice
- * dispatch, and `onCompletion()` to receive events. It polls the injected readers, runs the
- * pure detector, and routes results: emit when a session is live, else queue (+ notify) for
- * warm-start. It owns NO realtime/session/electron state — Kevin's core wires the emit to
- * the main→renderer push channel.
+ * 完成观察器。构造一次（在 index.ts 里），`start()` 它，给每次语音派发
+ * `track()`，并用 `onCompletion()` 接收事件。它轮询注入的读取器、运行
+ * 纯检测器、路由结果：会话存活时发出，否则排队（+ 通知）供热启动。
+ * 它不拥有任何 realtime/session/electron 状态——Kevin 的核心把 emit
+ * 接到 main→renderer 推送通道上。
  */
 export class RealtimeCompletionWatcher {
   private readonly deps: CompletionWatcherDeps;
@@ -243,7 +242,7 @@ export class RealtimeCompletionWatcher {
   private readonly pending = new Map<string, PendingDispatch>();
   private readonly listeners = new Set<CompletionListener>();
   private readonly waiters = new Set<Waiter>();
-  /** Completions detected while no session was live — drained at warm-start. */
+  /** 会话未存活时检测到的完成——在热启动时排空。 */
   private queued: RealtimeCompletion[] = [];
   private sessionLive = false;
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -254,30 +253,30 @@ export class RealtimeCompletionWatcher {
     this.pollMs = deps.pollIntervalMs ?? DEFAULT_POLL_MS;
   }
 
-  /** Begin watching a dispatched unit of work. Idempotent per correlationId. */
+  /** 开始观察一个已派发的工作单元。按 correlationId 幂等。 */
   track(record: PendingDispatch): void {
     this.pending.set(record.correlationId, record);
     this.prunePending();
   }
 
-  /** Stop watching a dispatch (e.g. it was cancelled). */
+  /** 停止观察一次派发（例如它被取消了）。 */
   untrack(correlationId: string): void {
     this.pending.delete(correlationId);
   }
 
-  /** Subscribe to completion events. Returns an unsubscribe fn. */
+  /** 订阅完成事件。返回退订函数。 */
   onCompletion(cb: CompletionListener): () => void {
     this.listeners.add(cb);
     return () => this.listeners.delete(cb);
   }
 
   /**
-   * Await a specific task's completion (the `wait_for(taskId)` tool path). Resolves with the
-   * completion event, or with a timeout sentinel after `timeoutMs`. If the task is already
-   * tracked we use full detection; an untracked taskId still resolves on a card→done signal.
+   * 等待某个特定任务的完成（`wait_for(taskId)` 工具路径）。以完成事件
+   * 兑现，或在 `timeoutMs` 后以超时哨兵兑现。若任务已在跟踪中则用完整
+   * 检测；未跟踪的 taskId 仍会在卡片→done 信号上兑现。
    */
   waitFor(taskId: string, timeoutMs: number): Promise<RealtimeCompletion | { timedOut: true; taskId: string }> {
-    // Already complete? Resolve synchronously off the current snapshot.
+    // 已完成?基于当前快照同步兑现。
     const immediate = this.checkOne(this.pendingForTask(taskId) ?? this.syntheticPending(taskId));
     if (immediate) return Promise.resolve(immediate);
 
@@ -288,29 +287,29 @@ export class RealtimeCompletionWatcher {
         this.waiters.delete(waiter);
         resolve({ timedOut: true, taskId });
       }, Math.max(0, timeoutMs));
-      // Ensure the timeout never keeps the process alive on its own.
+      // 确保超时器不会独自让进程保持存活。
       if (typeof timer === 'object' && timer && 'unref' in timer) (timer as { unref: () => void }).unref();
     });
   }
 
-  /** Tell the watcher whether a realtime session is currently live (emit vs queue). */
+  /** 告诉观察器 realtime 会话当前是否存活（发出 vs 排队）。 */
   setSessionLive(live: boolean): void {
     this.sessionLive = live;
   }
 
-  /** Return + clear completions that queued while no session was live (warm-start use). */
+  /** 返回并清空会话未存活时排队的完成（热启动使用）。 */
   drainQueuedCompletions(): RealtimeCompletion[] {
     const out = this.queued;
     this.queued = [];
     return out;
   }
 
-  /** Number of dispatches still being watched (diagnostics). */
+  /** 仍在被观察的派发数量（诊断）。 */
   get pendingCount(): number {
     return this.pending.size;
   }
 
-  /** Start the poll loop. Safe to call repeatedly. */
+  /** 启动轮询循环。可安全地重复调用。 */
   start(): void {
     if (this.timer) return;
     this.timer = setInterval(() => this.poll(), this.pollMs);
@@ -319,7 +318,7 @@ export class RealtimeCompletionWatcher {
     }
   }
 
-  /** Stop the poll loop. */
+  /** 停止轮询循环。 */
   stop(): void {
     if (this.timer) {
       clearInterval(this.timer);
@@ -327,7 +326,7 @@ export class RealtimeCompletionWatcher {
     }
   }
 
-  /** Run detection across all pending dispatches once. Exposed for tests / manual ticks. */
+  /** 对所有待处理派发运行一次检测。供测试 / 手动滴答暴露。 */
   poll(): void {
     if (this.pending.size === 0 && this.waiters.size === 0) return;
     this.prunePending();
@@ -341,9 +340,9 @@ export class RealtimeCompletionWatcher {
   }
 
   /**
-   * N2: bound the pending map so a long session can't leak. Drop abandoned dispatches
-   * (older than the TTL — we'll never see a completion for them), then, if still over the
-   * cap, evict the oldest by dispatch time.
+   * N2：约束 pending 表，让长会话无法泄漏。丢弃被放弃的派发
+   * （早于 TTL 的——我们永远不会看到它们的完成），然后若仍超上限，
+   * 按派发时间逐出最旧的。
    */
   private prunePending(): void {
     const cutoff = this.now() - PENDING_TTL_MS;
@@ -359,7 +358,7 @@ export class RealtimeCompletionWatcher {
     }
   }
 
-  // --- internals ---
+  // --- 内部 ---
 
   private snapshot(): CompletionContext {
     return { tasks: safeRead(this.deps.readTasks), inbox: safeRead(this.deps.readInbox) };
@@ -381,7 +380,7 @@ export class RealtimeCompletionWatcher {
     };
   }
 
-  /** Resolve any waiters for this task, then emit (live) or queue (closed). */
+  /** 兑现此任务的任何等待者，然后发出（存活）或排队（关闭）。 */
   private route(event: RealtimeCompletion): void {
     for (const w of [...this.waiters]) {
       if (event.taskId && w.taskId === event.taskId) {
@@ -394,17 +393,17 @@ export class RealtimeCompletionWatcher {
         try {
           l(event);
         } catch {
-          /* a listener throwing must not stall the watcher */
+          /* 监听器抛出异常绝不能拖住观察器 */
         }
       }
     } else {
       this.queued.push(event);
-      // N2: cap the closed-session backlog — keep only the most recent MAX_QUEUED.
+      // N2：限制关闭会话的积压——只保留最近的 MAX_QUEUED 个。
       if (this.queued.length > MAX_QUEUED) this.queued = this.queued.slice(-MAX_QUEUED);
       try {
         this.deps.onNotify?.(event);
       } catch {
-        /* notification is best-effort */
+        /* 通知是尽力而为 */
       }
     }
   }
@@ -414,13 +413,13 @@ export class RealtimeCompletionWatcher {
     return undefined;
   }
 
-  /** Minimal pending record for an untracked wait_for(taskId) — card→done only. */
+  /** 未跟踪 wait_for(taskId) 的最小 pending 记录——仅卡片→done。 */
   private syntheticPending(taskId: string): PendingDispatch {
     return { correlationId: `wait:${taskId}`, kind: 'task', targetAgentId: '', taskId, dispatchedAt: 0 };
   }
 }
 
-/** Read a source defensively — a throwing/late reader yields an empty snapshot, never crashes the poll. */
+/** 防御性读取源——抛异常/迟钝的读取器得到空快照，绝不搞崩轮询。 */
 function safeRead<T>(reader: () => T[]): T[] {
   try {
     const v = reader();
@@ -430,18 +429,18 @@ function safeRead<T>(reader: () => T[]): T[] {
   }
 }
 
-// --- shared singleton (rt-12 contract lock with Kevin) ------------------------------------
-// ONE watcher instance across the whole main process: one pending map, one queue. index.ts
-// initializes it with the real hive-backed readers; realtimeActions.ts (and any other core
-// caller) get that SAME instance via getCompletionWatcher(). This avoids a per-call watcher
-// where track() and onCompletion() would land on different objects.
+// --- 共享单例（与 Kevin 的 rt-12 契约锁）------------------------------------
+// 整个主进程只有一个观察器实例：一个 pending 表、一个队列。index.ts
+// 用真实的 hive 支撑读取器初始化它；realtimeActions.ts（以及任何其他核心
+// 调用方）通过 getCompletionWatcher() 拿到同一个实例。这避免了每个调用
+// 各建一个观察器、track() 和 onCompletion() 落在不同对象上的情况。
 
 let _instance: RealtimeCompletionWatcher | null = null;
 
 /**
- * Create (once) and return the shared completion-watcher singleton. Call this from index.ts
- * with readers backed by hive.ts. Calling again returns the existing instance (later `deps`
- * are ignored) so every importer shares one watcher.
+ * 创建（一次）并返回共享的完成观察器单例。从 index.ts 用 hive.ts 支撑的
+ * 读取器调用它。再次调用会返回已有实例（后续 `deps` 被忽略），
+ * 让每个导入方共享同一个观察器。
  */
 export function initCompletionWatcher(deps: CompletionWatcherDeps): RealtimeCompletionWatcher {
   if (!_instance) _instance = new RealtimeCompletionWatcher(deps);
@@ -449,8 +448,8 @@ export function initCompletionWatcher(deps: CompletionWatcherDeps): RealtimeComp
 }
 
 /**
- * Get the shared completion-watcher singleton. Throws if not yet initialized — index.ts must
- * call {@link initCompletionWatcher} first. Use from realtimeActions.ts for track()/waitFor().
+ * 获取共享的完成观察器单例。未初始化则抛出——index.ts 必须先调用
+ * {@link initCompletionWatcher}。供 realtimeActions.ts 的 track()/waitFor() 使用。
  */
 export function getCompletionWatcher(): RealtimeCompletionWatcher {
   if (!_instance) {
@@ -461,7 +460,7 @@ export function getCompletionWatcher(): RealtimeCompletionWatcher {
   return _instance;
 }
 
-/** Test seam: drop the singleton so a fresh instance can be initialized. */
+/** 测试接缝：丢弃单例，让新实例可以被初始化。 */
 export function __resetCompletionWatcherForTest(): void {
   _instance?.stop();
   _instance = null;

--- a/src/main/realtimeCost.ts
+++ b/src/main/realtimeCost.ts
@@ -1,11 +1,10 @@
 /**
- * Realtime Michael — main-process cost helpers (card rt-9, cost-guard).
+ * Realtime Michael —— 主进程成本辅助（卡片 rt-9，成本守卫）。
  *
- * Re-exports the shared realtime audio cost helpers so a main-side caller can price
- * a realtime usage delta without reaching into ../shared directly. These feed the
- * cost cap (the runaway guard), which still fires silently — money is no longer
- * surfaced to the user or spoken by the orchestrator, so the spawn/hire $-estimate
- * that used to live here has been removed (de-monetize). The LIVE session meter +
- * spend cap live in the renderer — see src/renderer/src/realtime/costStore.ts.
+ * 重新导出共享的 realtime 音频成本辅助函数，让主进程侧的调用方无需直接深入
+ * ../shared 即可为 realtime 用量增量计价。这些数据供给成本上限（失控守卫），
+ * 它仍然静默触发——金钱已不再展示给用户或由调度器口头播报，因此原本放在这里
+ * 的 spawn/hire 的 $ 估算已被移除（去货币化）。LIVE 会话计量 + 消费上限位于
+ * 渲染进程——参见 src/renderer/src/realtime/costStore.ts。
  */
 export { computeRealtimeUsd, formatUsd, type RealtimeUsage } from '../shared/realtimePricing';

--- a/src/main/realtimeFloorWatcher.ts
+++ b/src/main/realtimeFloorWatcher.ts
@@ -1,19 +1,18 @@
 /**
- * Realtime Michael — floor delta watcher (v0.3.4).
+ * Realtime Michael —— 面板增量（delta）观察器（v0.3.4）。
  *
- * The voice session's context strategy is "snapshot at connect + APPEND-ONLY
- * deltas" (never session.update on instructions — that busts the prompt cache).
- * This watcher is the delta half: while a voice session is live, it polls the
- * floor's main-side signals and pushes short coalesced update sentences that
- * the renderer injects into the conversation as silent items.
+ * 语音会话的上下文策略是“连接时快照 + 只追加的增量”（绝不 session.update
+ * 指令——那会打爆 prompt 缓存）。这个观察器就是增量那一半：语音会话存活
+ * 期间，它轮询面板在主进程侧的信号，推送短的合并后更新句，由渲染进程把
+ * 它们作为静默项目注入对话。
  *
- * Signals (all owned by main — no renderer trust):
- *   - roster: agents appearing / archiving (hive registry)
- *   - tasks: status transitions on the kanban ledger
- *   - activity: a pty flipping between quiet and streaming (≈ idle ↔ working)
- * Deltas are debounced (≥ MIN_PUSH_GAP_MS between pushes) and coalesced into
- * one parenthetical line, capped in length. When no session is live, nothing
- * is emitted and nothing queues — the next connect takes a fresh snapshot.
+ * 信号（全部归主进程所有——不信任渲染进程）：
+ *   - roster：agent 出现 / 归档（hive 注册表）
+ *   - tasks：看板台账上的状态转换
+ *   - activity：pty 在安静与流式之间翻转（≈ 空闲 ↔ 工作中）
+ * 增量被去抖（两次推送之间 ≥ MIN_PUSH_GAP_MS）并合并成一行带括号的
+ * 文字，长度设上限。没有会话存活时什么都不发、什么都不排队——
+ * 下一次连接会取全新快照。
  */
 
 interface RegistryLike {
@@ -51,7 +50,7 @@ export class RealtimeFloorWatcher {
 
   start(): void {
     if (this.timer) return;
-    this.timer = setInterval(() => { try { this.tick(); } catch { /* never throw from a timer */ } }, POLL_MS);
+    this.timer = setInterval(() => { try { this.tick(); } catch { /* 绝不让定时器抛出异常 */ } }, POLL_MS);
   }
 
   stop(): void {
@@ -61,10 +60,9 @@ export class RealtimeFloorWatcher {
 
   setSessionLive(live: boolean): void {
     this.live = live;
-    // A fresh session starts from a fresh snapshot — old buffered deltas would
-    // duplicate what the snapshot already says.
+    // 新会话从新快照开始——旧的缓冲增量会与快照已有的内容重复。
     this.buffer = [];
-    this.primed = false; // re-prime so the first tick after connect diffs from NOW
+    this.primed = false; // 重新启动，让连接后的第一个滴答从“现在”开始做差
   }
 
   private tick(): void {
@@ -89,20 +87,20 @@ export class RealtimeFloorWatcher {
     }
 
     if (this.primed && this.live) {
-      // roster changes
+      // roster 变化
       for (const [id, cur] of agents) {
         const prev = this.prevAgents.get(id);
         if (!prev) this.buffer.push(`${cur.name} joined the floor`);
         else if (!prev.archived && cur.archived) this.buffer.push(`${cur.name} was archived`);
         else if (prev.archived && !cur.archived) this.buffer.push(`${cur.name} is back from the archive`);
       }
-      // task transitions
+      // 任务状态转换
       for (const [id, cur] of tasks) {
         const prev = this.prevTasks.get(id);
         if (!prev) this.buffer.push(`new task "${cur.title.slice(0, 60)}"`);
         else if (prev.status !== cur.status) this.buffer.push(`task "${cur.title.slice(0, 60)}" moved to ${cur.status}`);
       }
-      // activity flips (quiet ↔ streaming), named via the registry
+      // activity 翻转（quiet ↔ streaming），经注册表取名
       for (const [id, isActive] of active) {
         const prev = this.prevActive.get(id);
         const name = agents.get(id)?.name;

--- a/src/main/reflect.ts
+++ b/src/main/reflect.ts
@@ -1,24 +1,23 @@
 /**
- * MemoryReflector — the missing CONDENSE half of the janitor.
+ * MemoryReflector —— 清理程序缺失的“压缩”那一半。
  *
- * The janitor flags an oversized `agents/<id>/memory.md` ("Needs condensing.")
- * but never shrinks it. This service finishes that job: on an in-process timer it
- * finds memory files that crossed a size/section threshold and rewrites them into
- * a bounded 3-region shape — pinned durable facts (never touched), one rolling
- * recursive summary, and the newest K verbatim sections — using a cheap headless
- * `claude -p` (Haiku) summarization of the evicted tail.
+ * 清理程序会标记一个过大的 `agents/<id>/memory.md`（“需要压缩。”），
+ * 但从不去缩小它。本服务完成这个工作：在一个进程内定时器上，它找出
+ * 越过大小/小节阈值的记忆文件，把它们重写成有界的三段式形状——
+ * 固定的持久事实（绝不触碰）、一份滚动递归摘要、以及最新的 K 个原样
+ * 小节——对被逐出的尾部用一次廉价的无头 `claude -p`（Haiku）做摘要。
  *
- * Why in-process (Electron main), NOT launchd: launchd-spawned shells are blocked
- * by macOS TCC from `~/Documents`; only this process has the folder grant. So the
- * loop lives alongside `memory.start()` — never a cron.
+ * 为什么在进程内（Electron 主进程）而不是 launchd：launchd 拉起的 shell
+ * 会被 macOS TCC 挡住，无法访问 `~/Documents`；只有本进程拥有文件夹
+ * 授权。所以循环与 `memory.start()` 并肩而居——绝不是 cron。
  *
- * Safety is layered so a bad LLM pass can NEVER lose data:
- *   backup-first (lossless cold copy) → verify-don't-trust gate → atomic swap.
- * If any check fails the original file is left byte-for-byte untouched and the
- * only side effect is a `condense-abort` log line. The miner re-indexes the new
- * file automatically on the next tick because its mtime changed (memory.ts).
+ * 安全性分层，让一次糟糕的 LLM 扫描绝不会丢数据：
+ *   先备份（无损冷拷贝）→ 验证而非信任的门 → 原子替换。
+ * 任何检查失败时，原文件一个字节不动地留在原地，唯一副作用是一行
+ * `condense-abort` 日志。因为 mtime 变了，矿工在下一个滴答会自动给
+ * 新文件重新建索引（memory.ts）。
  *
- * Runs in the Electron main process.
+ * 运行在 Electron 主进程。
  */
 import {
   existsSync, statSync, readdirSync, readFileSync, writeFileSync,
@@ -27,20 +26,20 @@ import {
 import { join, dirname } from 'node:path';
 import { runHiddenClaude } from './hiddenClaude';
 
-/** Total memory.md budget — mirrors the janitor's CONTEXT_BUDGET_BYTES (128 KB). */
+/** memory.md 的总预算——镜像清理程序的 CONTEXT_BUDGET_BYTES（128 KB）。 */
 const BUDGET_BYTES = 131_072;
-/** Cheap tail-summarizer (DECIDED by god). The verify gate covers quality. */
+/** 廉价尾部摘要器（由 god 裁定）。验证门负责质量。 */
 const CONDENSE_MODEL = 'claude-haiku-4-5';
-/** Hard cap so a wedged headless run can't stall the reflect loop. */
+/** 硬上限，让卡死的无头运行无法拖住 reflect 循环。 */
 const DEFAULT_TIMEOUT_MS = 180_000;
 
-/** The fixed region headings of the bounded memory shape (the stable contract). */
+/** 有界记忆形状的固定区域标题（稳定契约）。 */
 const PINNED_HEADING = '## 📌 Durable facts (pinned — never condensed)';
 const CONDENSED_HEADING = '## 🗜 Condensed history';
 const RECENT_HEADING = '## Recent';
 
-/** Instruction prefix — kept byte-identical across calls (no dates/ids spliced
- *  in) so Claude Code prompt-caches it; the dynamic content goes in the tail. */
+/** 指令前缀——跨调用保持字节一致（不拼入日期/id），让 Claude Code
+ *  能对它做 prompt 缓存；动态内容放在尾部。 */
 const CONDENSE_SYSTEM = [
   "You are compacting one AI agent's long-term memory file. You will receive:",
   '(A) the current CONDENSED summary, (B) older RECENT sections being evicted,',
@@ -58,36 +57,36 @@ const CONDENSE_SYSTEM = [
 
 export interface ReflectSettings {
   enabled: boolean;
-  /** How often to scan for oversized memory files. */
+  /** 多久扫描一次过大的记忆文件。 */
   intervalMs: number;
-  /** Condense when bytes exceed this percent of BUDGET_BYTES. */
+  /** 当字节数超过 BUDGET_BYTES 的这个百分比时压缩。 */
   byteTriggerPct: number;
-  /** ...OR when `## ` section count exceeds this (AND bytes > minBytes). */
+  /** ...或者当 `## ` 小节数超过此数时（AND 字节 > minBytes）。 */
   sectionTrigger: number;
-  /** Newest K verbatim `## ` sections always kept untouched. */
+  /** 最新的 K 个原样 `## ` 小节总是原封不动地保留。 */
   recentKeep: number;
-  /** Never condense a file smaller than this — both a "don't waste an LLM call"
-   *  guard and the byte floor for the section-count trigger. */
+  /** 绝不压缩小于此值的文件——既是“别浪费一次 LLM 调用”的守卫，
+   *  也是小节数触发器的字节下限。 */
   minBytes: number;
 }
 
-/** A `## ` section: its heading line and the body text beneath it. */
+/** 一个 `## ` 小节：它的标题行及其下方的正文。 */
 interface Section { heading: string; body: string }
 
-/** A parsed memory.md split into the three regions. `pinned`/`condensed` are null
- *  for legacy (un-structured) files — they're created on first condense. */
+/** 解析成三段的 memory.md。`pinned`/`condensed` 对遗留（非结构化）
+ *  文件为 null——它们在首次压缩时创建。 */
 interface Parsed {
-  header: string;            // the `# Memory …` H1 + any preamble before the first `##`
-  pinned: string | null;     // body under the pinned heading (no heading line)
-  condensed: string | null;  // body under the condensed heading
-  recent: Section[];         // every other `## ` section, in file order (oldest→newest)
+  header: string;            // `# Memory …` H1 + 第一个 `##` 之前的任何前言
+  pinned: string | null;     // pinned 标题下的正文（不含标题行）
+  condensed: string | null;  // condensed 标题下的正文
+  recent: Section[];         // 其余每个 `## ` 小节，按文件顺序（旧→新）
 }
 
-/** Outcome of one agent's reflect attempt — surfaced to the manual IPC + tests. */
+/** 一次对某个 agent 的 reflect 尝试的结果——呈现给手动 IPC 和测试。 */
 export interface ReflectResult {
   id: string;
-  condensed: boolean;        // did we actually rewrite the file?
-  reason: string;            // why (skipped/aborted/done), for logging + UI
+  condensed: boolean;        // 我们真的重写了文件吗?
+  reason: string;            // 原因（skipped/aborted/done），供日志和 UI 使用
   oldBytes?: number;
   newBytes?: number;
 }
@@ -95,16 +94,16 @@ export interface ReflectResult {
 export class MemoryReflector {
   private timer: NodeJS.Timeout | null = null;
   private started = false;
-  /** True while a reflectNow() pass is in flight — serializes the loop (a slow
-   *  LLM pass must not overlap the next interval tick), mirroring MemoryManager. */
+  /** 当一次 reflectNow() 正在执行时为 true——串行化循环（慢速 LLM 扫描
+   *  不得与下一个间隔滴答重叠），镜像 MemoryManager。 */
   private reflecting = false;
 
   /**
-   * @param getHome      Lazily resolve harnessHome so reflection follows config.
-   * @param getCommand   The base `claude` command (only its binary name is used).
-   * @param getMemoryEnv Extra env (the shared MemPalace path) merged into the call.
-   * @param getSettings  Reflect tunables (interval + thresholds), read each tick.
-   * @param appendLog    Sink for `condense`/`condense-abort` events (hive log.jsonl).
+   * @param getHome      懒解析 harnessHome，让 reflect 跟随配置。
+   * @param getCommand   基础 `claude` 命令（只用它的二进制名）。
+   * @param getMemoryEnv 合并进调用的额外 env（共享 MemPalace 路径）。
+   * @param getSettings  Reflect 可调项（间隔 + 阈值），每个滴答读取。
+   * @param appendLog    `condense`/`condense-abort` 事件的汇（hive log.jsonl）。
    */
   constructor(
     private getHome: () => string | null,
@@ -114,15 +113,15 @@ export class MemoryReflector {
     private appendLog: (event: Record<string, unknown>) => void
   ) {}
 
-  // — lifecycle (mirrors MemoryManager) —
+  // —— 生命周期（镜像 MemoryManager）——
 
   start(): void {
     if (this.started) return;
     if (!this.getSettings().enabled) return;
     if (!this.getHome()) return;
     this.started = true;
-    // First scan one interval out, not on boot, so launch isn't competing with an
-    // LLM call (and a freshly-restored home isn't condensed before it's mined).
+    // 第一次扫描放在一个间隔之后，而不是启动时，让启动不与
+    // LLM 调用争抢（而且刚恢复的家目录也不会在被挖掘前就被压缩）。
     const ms = Math.max(60_000, this.getSettings().intervalMs);
     this.timer = setInterval(() => { void this.reflectNow(); }, ms);
   }
@@ -132,11 +131,11 @@ export class MemoryReflector {
     this.started = false;
   }
 
-  // — scan —
+  // —— 扫描 ——
 
-  /** Reflect every agent whose memory crossed a threshold (or just `onlyId`),
-   *  one at a time. Serialized via `reflecting` so a slow pass can't overlap the
-   *  next tick. Returns the per-agent outcomes (used by the manual IPC + tests). */
+  /** 逐个 reflect 每个记忆越过阈值（或仅 `onlyId`）的 agent。
+   *  通过 `reflecting` 串行化，让慢扫描无法与下一个滴答重叠。
+   *  返回每个 agent 的结果（供手动 IPC + 测试使用）。 */
   async reflectNow(onlyId?: string): Promise<ReflectResult[]> {
     const home = this.getHome();
     if (!home) return [];
@@ -158,8 +157,8 @@ export class MemoryReflector {
         let text = '';
         try {
           bytes = statSync(mem).size;
-          // A manual single-agent call condenses on demand (skips the trigger);
-          // the autonomous loop honors the threshold.
+          // 手动单 agent 调用按需压缩（跳过触发器）；
+          // 自主循环遵循阈值。
           if (!onlyId && !this.shouldCondense(bytes, mem, settings)) continue;
           text = readFileSync(mem, 'utf8');
         } catch { continue; }
@@ -171,9 +170,9 @@ export class MemoryReflector {
     return results;
   }
 
-  /** The dual trigger (DECIDED): bytes > pct% of budget, OR many-section sprawl
-   *  above the byte floor. The floor doubles as the "never burn an LLM call on a
-   *  tiny file" guard, so it gates BOTH paths. */
+  /** 双重触发器（已裁定）：字节 > 预算的 pct%，或字节下限以上的
+   *  多小节蔓延。字节下限同时充当“绝不为小文件烧 LLM 调用”的守卫，
+   *  因此它同时门控两条路径。 */
   private shouldCondense(bytes: number, mem: string, s: ReflectSettings): boolean {
     if (bytes < s.minBytes) return false;
     if (bytes > (BUDGET_BYTES * s.byteTriggerPct) / 100) return true;
@@ -182,14 +181,14 @@ export class MemoryReflector {
     return sections > s.sectionTrigger;
   }
 
-  // — condense one file —
+  // —— 压缩一个文件 ——
 
   private async condense(
     home: string, id: string, mem: string, text: string, s: ReflectSettings
   ): Promise<ReflectResult> {
     const oldBytes = Buffer.byteLength(text, 'utf8');
     const parsed = parseMemory(text);
-    // Split recent into KEEP (newest K, verbatim) and EVICT (older — summarized).
+    // 把 recent 拆成 KEEP（最新的 K 个，原样）和 EVICT（更旧的——被摘要）。
     const keepCount = Math.max(1, s.recentKeep);
     const keep = parsed.recent.slice(-keepCount);
     const evict = parsed.recent.slice(0, Math.max(0, parsed.recent.length - keepCount));
@@ -197,7 +196,7 @@ export class MemoryReflector {
       return { id, condensed: false, reason: 'nothing-to-evict', oldBytes };
     }
 
-    // 1) BACK UP first — a lossless cold copy makes every later step recoverable.
+    // 1) 先备份——无损冷拷贝让之后每一步都可恢复。
     const stamp = utcStamp();
     const backup = join(home, 'hive', 'backups', stamp, id, 'memory.md');
     try {
@@ -208,7 +207,7 @@ export class MemoryReflector {
       return { id, condensed: false, reason: 'backup-failed', oldBytes };
     }
 
-    // 2) SUMMARIZE the (condensed + evicted) tail via headless Haiku.
+    // 2) 用无头 Haiku 摘要（condensed + evicted）尾部。
     let summary: { condensed: string; hoist: string[] };
     try {
       summary = await this.summarize(home, parsed.condensed, evict, parsed.pinned);
@@ -217,13 +216,13 @@ export class MemoryReflector {
       return { id, condensed: false, reason: 'summarize-failed', oldBytes };
     }
 
-    // 3) REBUILD into the 3-region shape.
+    // 3) 重建为三段式形状。
     const oldPinnedLines = pinnedLines(parsed.pinned);
     const mergedPinned = mergePinned(oldPinnedLines, summary.hoist);
     const rebuilt = rebuild(parsed.header, mergedPinned, summary.condensed, keep);
     const newBytes = Buffer.byteLength(rebuilt, 'utf8');
 
-    // 4) VERIFY-DON'T-TRUST — reject the rewrite unless every check holds.
+    // 4) 验证而非信任——所有检查通过才接受这次重写。
     const verdict = verify({
       rebuilt, newBytes, oldBytes, oldPinnedLines, mergedPinned,
       condensed: summary.condensed, keep
@@ -233,7 +232,7 @@ export class MemoryReflector {
       return { id, condensed: false, reason: verdict.reason, oldBytes, newBytes };
     }
 
-    // 5) ATOMIC SWAP — write a temp sibling, fsync, rename over the original.
+    // 5) 原子替换——写临时同名兄弟文件、fsync、rename 覆盖原文件。
     try {
       atomicWrite(mem, rebuilt);
     } catch (e) {
@@ -246,17 +245,17 @@ export class MemoryReflector {
         kind: 'condense', agentId: id, oldBytes, newBytes,
         evicted: evict.length, kept: keep.length, hoisted: summary.hoist.length, backup
       });
-    } catch { /* logging is best-effort */ }
-    // The miner re-indexes within its next cycle — mtime changed, no extra wiring.
+    } catch { /* 日志是尽力而为 */ }
+    // 矿工在下一个周期内重新建索引——mtime 变了，无需额外接线。
     return { id, condensed: true, reason: 'condensed', oldBytes, newBytes };
   }
 
   private logAbort(id: string, reason: string, detail?: string, extra?: Record<string, unknown>): void {
     try { this.appendLog({ kind: 'condense-abort', agentId: id, reason, ...(detail ? { detail } : {}), ...extra }); }
-    catch { /* best-effort */ }
+    catch { /* 尽力而为 */ }
   }
 
-  // — the headless LLM call (the only non-deterministic step) —
+  // —— 无头 LLM 调用（唯一非确定性的步骤）——
 
   private async summarize(
     home: string, condensed: string | null, evict: Section[], pinned: string | null
@@ -280,7 +279,7 @@ export class MemoryReflector {
       model: CONDENSE_MODEL,
       cwd: home,
       command: this.getCommand(),
-      // Pure text transform — must never touch the repo or shell out.
+      // 纯文本变换——绝不能碰仓库或 shell 出去。
       disallowedTools: ['Edit', 'Write', 'NotebookEdit', 'Bash'],
       env: this.getMemoryEnv(),
       timeoutMs: DEFAULT_TIMEOUT_MS,
@@ -295,23 +294,23 @@ export class MemoryReflector {
   }
 }
 
-// ─── pure helpers (the deterministic, unit-testable half) ────────────────────
+// ─── 纯辅助（确定性、可单测的那一半）────────────────────
 
-/** Count level-2 (`## `) headings — `# ` H1 and `### ` deeper headings excluded. */
+/** 数二级（`## `）标题——排除 `# ` H1 和 `### ` 更深标题。 */
 export function countSections(text: string): number {
   return (text.match(/^##\s/gm) ?? []).length;
 }
 
-/** Split a memory.md into header + the three regions. A legacy flat file (no
- *  pinned/condensed headings) parses with those null and every `## ` section in
- *  `recent`; the structured blocks are created on first condense. */
+/** 把 memory.md 拆成头部 + 三段。遗留扁平文件（无 pinned/condensed
+ *  标题）解析时这两段为 null、每个 `## ` 小节都在 `recent`；
+ *  结构化块在首次压缩时创建。 */
 export function parseMemory(text: string): Parsed {
   const lines = text.split('\n');
   let firstSection = lines.findIndex((l) => /^##\s/.test(l));
   if (firstSection === -1) firstSection = lines.length;
   const header = lines.slice(0, firstSection).join('\n').replace(/\s+$/, '');
 
-  // Carve the remaining lines into `## ` sections (heading + body until next `##`).
+  // 把剩余行切成 `## ` 小节（标题 + 到下一个 `##` 为止的正文）。
   const sections: Section[] = [];
   let cur: Section | null = null;
   for (let i = firstSection; i < lines.length; i++) {
@@ -332,19 +331,19 @@ export function parseMemory(text: string): Parsed {
     const h = s.heading.trim();
     if (h.startsWith('## 📌')) pinned = s.body.replace(/\s+$/, '');
     else if (h.startsWith('## 🗜')) condensed = s.body.replace(/\s+$/, '');
-    else if (h === RECENT_HEADING) { /* divider — its siblings ARE the recent list */ }
+    else if (h === RECENT_HEADING) { /* 分隔线——它的兄弟才是 recent 列表 */ }
     else recent.push(s);
   }
   return { header, pinned, condensed, recent };
 }
 
-/** Non-empty, trimmed lines of the pinned block (the set we must never lose). */
+/** pinned 块中非空、修剪过的行（我们绝不能丢的那组）。 */
 export function pinnedLines(pinned: string | null): string[] {
   if (!pinned) return [];
   return pinned.split('\n').map((l) => l.trim()).filter(Boolean);
 }
 
-/** Append hoisted durable facts to the pinned set, skipping any already present. */
+/** 把提升出来的持久事实追加进 pinned 集合，跳过已存在的。 */
 export function mergePinned(oldLines: string[], hoist: string[]): string[] {
   const have = new Set(oldLines);
   const out = [...oldLines];
@@ -355,7 +354,7 @@ export function mergePinned(oldLines: string[], hoist: string[]): string[] {
   return out;
 }
 
-/** Reassemble the canonical 3-region file. */
+/** 重新组装成规范的 3 段式文件。 */
 export function rebuild(header: string, pinned: string[], condensed: string, keep: Section[]): string {
   const parts: string[] = [];
   if (header.trim()) parts.push(header.trim());
@@ -368,28 +367,28 @@ export function rebuild(header: string, pinned: string[], condensed: string, kee
   return parts.join('\n\n') + '\n';
 }
 
-/** The verify-don't-trust gate. The rewrite is rejected — original kept verbatim
- *  — unless ALL checks pass. The lossless backup makes a rejection a pure no-op. */
+/** 验证而非信任的门。除非所有检查都通过，否则重写被拒绝——
+ *  原文件原样保留。无损备份让一次拒绝成为纯空操作。 */
 export function verify(args: {
   rebuilt: string; newBytes: number; oldBytes: number;
   oldPinnedLines: string[]; mergedPinned: string[];
   condensed: string; keep: Section[];
 }): { ok: true } | { ok: false; reason: string } {
   const { rebuilt, newBytes, oldBytes, oldPinnedLines, mergedPinned, condensed, keep } = args;
-  // 6) Valid summary JSON already enforced upstream (parseSummary). Here: structure.
-  // 1) Parses back into the 3-region structure.
+  // 6) 有效的摘要 JSON 已在更上游强制（parseSummary）。这里是：结构。
+  // 1) 能解析回 3 段式结构。
   const re = parseMemory(rebuilt);
   if (re.pinned === null || re.condensed === null) return { ok: false, reason: 'structure-missing-region' };
-  // 4) Non-empty + sane.
+  // 4) 非空且合理。
   if (newBytes <= 200) return { ok: false, reason: 'too-small' };
   if (!condensed.trim()) return { ok: false, reason: 'empty-condensed' };
-  // 3) Actually smaller (a no-op condense is a failure).
+  // 3) 确实更小（空操作式的压缩是失败）。
   if (!(newBytes < oldBytes * 0.95)) return { ok: false, reason: 'not-smaller' };
-  // 2) Pinned preserved: every old pinned line survives (hoist only adds).
+  // 2) pinned 保留：旧的每行 pinned 都存活（hoist 只增不减）。
   const newPinned = new Set(pinnedLines(re.pinned));
   for (const line of oldPinnedLines) if (!newPinned.has(line)) return { ok: false, reason: 'pinned-line-dropped' };
   for (const line of mergedPinned) if (!newPinned.has(line)) return { ok: false, reason: 'pinned-merge-mismatch' };
-  // 5) Recent integrity: the kept newest sections round-trip byte-for-byte.
+  // 5) recent 完整性：保留的最新小节逐字节往返一致。
   if (re.recent.length !== keep.length) return { ok: false, reason: 'recent-count-mismatch' };
   for (let i = 0; i < keep.length; i++) {
     const a = `${keep[i].heading}\n${keep[i].body}`.replace(/\s+$/, '');
@@ -399,9 +398,9 @@ export function verify(args: {
   return { ok: true };
 }
 
-/** Pull `{condensed, hoist}` out of `claude -p --output-format json` output.
- *  Two layers: the CLI envelope `{result: "<text>"}`, then the model's strict
- *  JSON (tolerating an accidental ```json fence). Returns null on any failure. */
+/** 从 `claude -p --output-format json` 输出中取出 `{condensed, hoist}`。
+ *  两层：CLI 信封 `{result: "<text>"}`，然后是模型的严格 JSON
+ *  （容忍意外的 ```json 围栏）。任何失败返回 null。 */
 export function parseSummary(stdout: string): { condensed: string; hoist: string[] } | null {
   const raw = stdout.trim();
   if (!raw) return null;
@@ -410,7 +409,7 @@ export function parseSummary(stdout: string): { condensed: string; hoist: string
     const env = JSON.parse(raw) as { result?: unknown; text?: unknown };
     if (typeof env.result === 'string') inner = env.result;
     else if (typeof env.text === 'string') inner = env.text;
-  } catch { /* not the CLI envelope — treat stdout itself as the model output */ }
+  } catch { /* 不是 CLI 信封——把 stdout 本身当作模型输出 */ }
   inner = inner.trim().replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim();
   try {
     const obj = JSON.parse(inner) as { condensed?: unknown; hoist?: unknown };
@@ -420,18 +419,18 @@ export function parseSummary(stdout: string): { condensed: string; hoist: string
   } catch { return null; }
 }
 
-/** `20260606T110912Z` — matches the janitor's backup-dir stamp format. */
+/** `20260606T110912Z` —— 与清理程序备份目录的时间戳格式一致。 */
 function utcStamp(): string {
   return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 }
 
-/** Write `text` to `path` atomically: temp sibling → fsync → rename over target. */
+/** 把 `text` 原子地写入 `path`：临时同名兄弟 → fsync → rename 覆盖目标。 */
 function atomicWrite(path: string, text: string): void {
   const tmp = `${path}.tmp-${Math.random().toString(36).slice(2, 10)}`;
   writeFileSync(tmp, text, 'utf8');
   try {
     const fd = openSync(tmp, 'r+');
     try { fsyncSync(fd); } finally { closeSync(fd); }
-  } catch { /* fsync best-effort; rename is the durability guarantee */ }
+  } catch { /* fsync 尽力而为；rename 才是持久性保证 */ }
   renameSync(tmp, path);
 }

--- a/src/main/roster.ts
+++ b/src/main/roster.ts
@@ -1,39 +1,38 @@
 /**
- * The roster on disk — agents, their notes, worktree paths, archived and
- * restorable entries, and parked message queues, stored as one JSON file beside
- * the hive.
+ * 磁盘上的花名册——代理、它们的笔记、工作树路径、已归档和可恢复的条目，
+ * 以及停放的邮件队列，以单个 JSON 文件存储在与 hive 相邻的位置。
  *
- * WHY THIS EXISTS. This is the UI floor (cards, notes, queues, worktrees).
- * Hive identity — id, role, cwd, session — lives in `<harnessHome>/hive/registry.json`
- * and is what agents read. The two must not drift: `description` here is the
- * same durable job string as registry `role`, never live status (pause/idle).
+ * 它为何存在。这是 UI 面板（卡片、笔记、队列、工作树）。
+ * hive 身份——id、role、cwd、session——位于 `<harnessHome>/hive/registry.json`，
+ * 是代理读取的内容。两者绝不能漂移：这里的 `description` 与注册表的
+ * `role` 是同一个持久任务字符串，绝不是实时状态（pause/idle）。
  *
- * All of that used to live only in the renderer's localStorage,
- * and localStorage is partitioned by ORIGIN. A dev run loads the renderer from
- * `http://localhost:5173` and a packaged build loads it from `file://`, so the
- * two never see each other's storage: switching between them showed an empty
- * floor and no notes, even though the hive on disk (sessions, memory, inboxes,
- * tasks) was right there and intact. A file keyed on `harnessHome` is shared by
- * both, because it is addressed by path rather than by page origin.
+ * 所有这些东西过去只存在于渲染进程的 localStorage 中，
+ * 而 localStorage 是按 ORIGIN 分区的。开发运行从
+ * `http://localhost:5173` 加载渲染进程，打包构建则从 `file://` 加载，
+ * 因此两者永远看不到彼此的存储：在它们之间切换会显示一个空面板、
+ * 没有任何笔记，尽管磁盘上的 hive（会话、记忆、收件箱、
+ * 任务）明明就在那里且完好无损。以 `harnessHome` 为键的文件对两者
+ * 是共享的，因为它按路径而非页面来源寻址。
  *
- * localStorage is still written exactly as before. This file is an ADDITION, not
- * a migration away from it — if anything here fails, the renderer falls back to
- * the storage it has always used and nothing is lost.
+ * localStorage 仍然完全按原样写入。这个文件是 ADDITION（新增），而不是
+ * 对它的迁移——如果这里任何东西失败，渲染进程会回退到它一直使用的
+ * 存储，什么都不会丢失。
  *
- * Durability rules, in order of how much they matter:
- *   1. Never lose a roster. Every write first copies the previous file into
- *      `roster-backups/`, which is append-only — nothing in it is ever pruned,
- *      overwritten or deleted.
- *   2. Never write a truncated file. Writes go to a temp file and are renamed
- *      into place, so a crash mid-write leaves the previous file untouched.
- *   3. Never let an empty renderer erase a full roster. See `write`.
+ * 持久化规则，按重要程度排列：
+ *   1. 绝不丢失花名册。每次写入都先把之前的文件复制到
+ *      `roster-backups/`，该目录只增不减——里面的内容从不被清理、
+ *      覆盖或删除。
+ *   2. 绝不写截断的文件。写入先落到临时文件再重命名就位，
+ *      因此写入中途崩溃会保留之前的文件原封不动。
+ *   3. 绝不让空的渲染进程抹掉完整的花名册。参见 `write`。
  */
 import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-/** What the renderer mirrors to disk. The inner agent shape is deliberately
- *  opaque here — the renderer's store owns it, and repeating it would mean
- *  editing this file every time an agent gains a field. Main only counts. */
+/** 渲染进程镜像到磁盘的内容。内部代理形态在这里刻意保持不透明——渲染进程
+ *  的 store 拥有它，重复它意味着每次代理增加字段都要编辑这个文件。
+ *  主进程只计数。 */
 export interface RosterSnapshot {
   version: 1;
   savedAt: string;
@@ -46,7 +45,7 @@ export interface RosterSnapshot {
 
 export interface RosterWriteResult {
   ok: boolean;
-  /** Set when the write was deliberately declined; the file is unchanged. */
+  /** 当写入被刻意拒绝时设置；文件未改动。 */
   skipped?: 'empty-first-write';
   error?: string;
 }
@@ -70,23 +69,19 @@ function entryCount(s: RosterSnapshot): number {
 }
 
 /**
- * Reads and writes one home folder's roster.
+ * 读取和写入一个 home 文件夹的花名册。
  *
- * A class rather than free functions because the empty-guard needs to know
- * whether THIS run has written yet, and a module-level flag would be invisible
- * shared state that no test could reset. One instance per process in `index.ts`;
- * tests make their own. The instance lives in MAIN, so a renderer reload reuses
- * it: the guard's state survives reloads (the 2026-08-16 incident was two
- * refusal-worthy writes in one run, minutes apart) and re-arms only on a fresh
- * app launch.
+ * 用类而非自由函数，是因为空守卫需要知道本次运行是否已写入过，
+ * 而模块级标志将是任何测试都无法重置的不可见共享状态。在 `index.ts` 中
+ * 每个进程一个实例；测试各自创建。实例存活在 MAIN 中，因此渲染进程
+ * 重载会复用它：守卫的状态跨重载存活（2026-08-16 事故是同一运行内
+ * 相隔数分钟的两次本应拒绝的写入）并且只在全新启动应用时才重新武装。
  */
 export class RosterStore {
-  /** Set once this store has written successfully. The empty-guard applies only
-   *  before that: see `write`. */
+  /** 一旦本 store 成功写入即置位。空守卫只在其之前生效：见 `write`。 */
   private wrote = false;
-  /** Disambiguates backups made inside the same millisecond. Two writes in one
-   *  tick used to produce the same filename, and the second silently replaced
-   *  the first — a backup folder that quietly loses backups is worse than none. */
+  /** 区分同一毫秒内产生的备份。同一时刻的两次写入过去会产生同名文件，
+   *  第二次会静默替换第一次——一个会悄悄丢备份的备份文件夹比没有更糟。 */
   private backupSeq = 0;
 
   constructor(private readonly getHome: () => string | null) {}
@@ -95,9 +90,9 @@ export class RosterStore {
     try { return this.getHome(); } catch { return null; }
   }
 
-  /** The stored roster, or null when there isn't one (or it can't be parsed).
-   *  Null means "no opinion" — the renderer then keeps using localStorage, so a
-   *  corrupt file degrades to the old behaviour instead of to an empty floor. */
+  /** 存储的花名册，或不存在时返回 null（或无法解析）。
+   *  null 表示「没有意见」——渲染进程随后继续使用 localStorage，因此
+   *  损坏的文件会降级为旧行为，而不是变成空面板。 */
   read(): RosterSnapshot | null {
     const home = this.home();
     if (!home) return null;
@@ -112,19 +107,17 @@ export class RosterStore {
   }
 
   /**
-   * Write the roster, keeping the previous contents as a backup.
+   * 写入花名册，保留之前的内容作为备份。
    *
-   * THE EMPTY-GUARD. The dangerous sequence is: open the packaged build for the
-   * first time, its localStorage is empty (different origin), the store boots
-   * with zero agents, and the first mirror write flattens a file that holds a
-   * real roster. So an empty write is refused until this run has landed a
-   * NON-empty write — only then has the renderer proven it actually holds a
-   * roster, and a later empty write means the user really removed their agents
-   * (refusing those would make deletion impossible). The guard must survive a
-   * refusal: a renderer reload used to re-send the same empty snapshot, and
-   * because the first refusal disarmed the guard, the second empty write went
-   * through and flattened the file (seen live 2026-08-16 20:40:03). The previous
-   * file is backed up either way, so even a wrong call here is recoverable.
+   * THE EMPTY-GUARD（空守卫）。危险序列是：第一次打开打包构建，其
+   * localStorage 为空（不同来源），store 以零代理启动，第一次镜像写入
+   * 就压平了一个存有真实花名册的文件。因此在本次运行落地一次 NON-empty
+   * （非空）写入之前，空写入会被拒绝——只有到那时渲染进程才证明它确实
+   * 持有一份花名册，而之后的空写入意味着用户真的删除了他们的代理
+   * （拒绝这些会让删除变得不可能）。守卫必须扛住一次拒绝：渲染进程重载
+   * 过去会重新发送同一份空快照，而因为第一次拒绝解除了守卫，第二次空写入
+   * 就通过了并压平了文件（2026-08-16 20:40:03 现场目击）。无论哪种情况，
+   * 之前的文件都会被备份，所以即使这里判断错了也是可恢复的。
    */
   write(snap: unknown): RosterWriteResult {
     const home = this.home();
@@ -136,9 +129,9 @@ export class RosterStore {
       const existing = this.read();
 
       if (!this.wrote && existing && entryCount(existing) > 0 && entryCount(snap) === 0) {
-        // Back it up anyway: what is on disk right now is exactly what we are
-        // protecting, and a copy of it costs nothing. `wrote` stays false: the
-        // guard disarms only when a non-empty write lands, never on a refusal.
+        // 无论如何都备份：磁盘上此刻的内容正是我们要保护的，
+        // 复制它不花什么成本。`wrote` 保持 false：守卫只在非空写入
+        // 落地时解除，绝不在一次拒绝时解除。
         this.backup(home, p, 'declined');
         console.warn('[roster] refused to overwrite a non-empty roster with an empty one');
         return { ok: false, skipped: 'empty-first-write' };
@@ -155,27 +148,26 @@ export class RosterStore {
         queues: snap.queues && typeof snap.queues === 'object' ? snap.queues : {},
         selectedId: typeof snap.selectedId === 'string' ? snap.selectedId : null
       };
-      // Temp + rename: `rename` is atomic within a filesystem, so a crash leaves
-      // either the old file or the new one, never half of either.
+      // 临时文件 + 重命名：`rename` 在同一文件系统内是原子的，因此崩溃
+      // 只会留下旧文件或新文件，绝不会留下两者各一半。
       const tmp = `${p}.tmp`;
       writeFileSync(tmp, JSON.stringify(body, null, 2), 'utf8');
       renameSync(tmp, p);
       this.wrote = true;
       return { ok: true };
     } catch (e) {
-      try { rmSync(`${p}.tmp`, { force: true }); } catch { /* noop */ }
+      try { rmSync(`${p}.tmp`, { force: true }); } catch { /* 无操作 */ }
       return { ok: false, error: e instanceof Error ? e.message : String(e) };
     }
   }
 
   /**
-   * Retire the active roster during a full reset: copied into `roster-backups/`
-   * first, then the live file is removed.
+   * 在完全重置期间退役活动花名册：先复制进 `roster-backups/`，
+   * 然后删除活动文件。
    *
-   * Reset wipes the hive, and the roster must not be left behind as the one
-   * survivor — pointing the home folder back here afterwards would show a floor
-   * full of agents whose sessions, memory and inboxes no longer exist. Archived
-   * rather than deleted, because a roster is never destroyed, only superseded.
+   * 重置会清空 hive，花名册绝不能留下成为唯一幸存者——否则之后把 home
+   * 文件夹指回这里，会显示一屏代理，而它们的会话、记忆和收件箱都已
+   * 不存在。归档而非删除，因为花名册永远不会被销毁，只会被取代。
    */
   archive(): void {
     const home = this.home();
@@ -185,12 +177,11 @@ export class RosterStore {
       if (!existsSync(p)) return;
       this.backup(home, p, 'reset');
       rmSync(p, { force: true });
-    } catch { /* a reset must never fail on this */ }
+    } catch { /* 重置绝不能因此失败 */ }
   }
 
-  /** Copy the current roster into the append-only backup folder. Never prunes:
-   *  these files are the last line of defence, and a few KB per write is a price
-   *  worth paying for that. */
+  /** 把当前花名册复制进只增不减的备份文件夹。从不清理：
+   *  这些文件是最后一道防线，每次写入几 KB 的价格完全值得。 */
   private backup(home: string, p: string, reason: string): void {
     try {
       if (!existsSync(p)) return;
@@ -199,6 +190,6 @@ export class RosterStore {
       const stamp = new Date().toISOString().replace(/[:.]/g, '-');
       this.backupSeq += 1;
       copyFileSync(p, join(dir, `roster-${stamp}-${this.backupSeq}-${reason}.json`));
-    } catch { /* a failed backup must never block the write */ }
+    } catch { /* 失败的备份绝不能阻塞写入 */ }
   }
 }

--- a/src/main/shellEnv.ts
+++ b/src/main/shellEnv.ts
@@ -1,33 +1,29 @@
 import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
-// These helpers mirror the resolution logic in pty.ts. They exist separately so
-// headless child processes can launch `claude` with the same PATH the user's
-// interactive shell sees — Electron on macOS starts without the login-shell PATH,
-// so a bare `claude` would otherwise fail
-// with ENOENT in a packaged build.
+// 这些辅助函数镜像 pty.ts 中的解析逻辑。它们单独存在，是为了让
+// 无头子进程能用用户交互 shell 看到的同一个 PATH 启动 `claude`——
+// macOS 上的 Electron 启动时没有登录 shell 的 PATH，
+// 否则裸的 `claude` 会在打包构建里以 ENOENT 失败。
 
 let cachedPath: string | null = null;
 
-/** script → captured output, memoised for the process lifetime. Every capture
- *  boots a full interactive login shell (rc files and all) — hundreds of ms of
- *  BLOCKING spawnSync on the main process — and shell PATH / binary locations
- *  don't change mid-session. Only successful captures are cached, so a null
- *  (shell failed / fence missing) stays retryable. */
+/** script → 捕获的输出，进程生命周期内记忆化。每次捕获都拉起一个完整的
+ *  交互式登录 shell（含 rc 文件等一切）——在主进程上阻塞 spawnSync
+ *  数百毫秒——而且 shell 的 PATH / 二进制位置在会话中途不会变。
+ *  只有成功的捕获才被缓存，所以 null（shell 失败 / 围栏缺失）保持可重试。 */
 const shellCapture = new Map<string, string>();
 
-/** Run `script` in the user's INTERACTIVE login shell and return only what the
- *  script itself printed.
+/** 在用户的交互式登录 shell 中运行 `script`，只返回脚本自己打印的东西。
  *
- *  An interactive shell is required to pick up nvm/asdf/brew PATH edits, but it
- *  also runs the user's rc files, which are free to print. Some zsh setups emit
- *  `Restored session: <date>` from a session-save plugin BEFORE the script's
- *  own output, which silently poisons every value read back: a plain `.trim()`
- *  on `echo "$PATH"` yields `"Restored session: …\n/opt/homebrew/bin:…"` and
- *  that whole string gets handed to every agent as its PATH. Fencing the output
- *  between two markers makes rc-file chatter (before, after, or both)
- *  impossible to mistake for a result. Returns null when the shell fails or the
- *  fence never appears. */
+ *  需要交互式 shell 才能拾取 nvm/asdf/brew 的 PATH 修改，但它也会运行
+ *  用户的 rc 文件，那些文件可以随意打印。某些 zsh 配置会在脚本自身输出
+ *  之前，从会话保存插件发出 `Restored session: <date>`，静静地毒化读到
+ *  的每个值：对 `echo "$PATH"` 做普通 `.trim()` 会得到
+ *  `"Restored session: …\n/opt/homebrew/bin:…"`，那一整串会被当作 PATH
+ *  发给每个 agent。用两个标记把输出围起来，让 rc 文件的闲聊（之前、
+ *  之后、或前后都有）不可能被误当成结果。shell 失败或围栏从未出现时
+ *  返回 null。 */
 export function captureFromLoginShell(script: string): string | null {
   const cached = shellCapture.get(script);
   if (cached !== undefined) return cached;
@@ -54,50 +50,49 @@ function captureFromLoginShellUncached(script: string): string | null {
   }
 }
 
-/** The user's interactive-shell PATH, queried once and cached for the session. */
+/** 用户的交互式 shell PATH，查询一次并在会话期间缓存。 */
 export function userShellPath(): string {
   if (cachedPath !== null) return cachedPath;
-  // Windows has no interactive login-shell PATH problem — use the process PATH directly.
+  // Windows 没有交互式登录 shell 的 PATH 问题——直接用进程 PATH。
   if (process.platform === 'win32') {
     cachedPath = process.env.PATH || '';
     return cachedPath;
   }
   const shellPath = captureFromLoginShell('printf %s "$PATH"')?.trim();
-  // A PATH is a single colon-joined line. Anything multi-line is rc-file noise
-  // that slipped the fence — fall back rather than hand the agent a corrupt
-  // PATH it would carry into every subprocess it spawns.
+  // PATH 是一条用冒号连接的单一长行。任何多行内容都是溜过围栏的
+  // rc 文件噪音——回退，而不是把一条损坏的 PATH 交给 agent，
+  // 让它带进自己派生的每个子进程。
   cachedPath = shellPath && !shellPath.includes('\n') ? shellPath : process.env.PATH || '';
   return cachedPath;
 }
 
-/** Resolve a bare command (e.g. 'claude') against the user's PATH + common
- *  install locations. Returns the input unchanged if it already looks like a path. */
-/** A plain executable name — the only shape we resolve against the user's PATH.
- *  A resolver may interpolate this token into a shell (`$SHELL -ilc "… which
- *  <it> …"`), so it is constrained to characters that are unambiguously part of
- *  a binary name (`[A-Za-z0-9._+-]`); anything else is not a command name and is
- *  refused rather than resolved. Callers early-return real paths (containing `/`
- *  or `\`) before this, so the only input that reaches a resolver is meant to be
- *  a bare binary name. */
+/** 按用户的 PATH + 常见安装位置解析裸命令（例如 'claude'）。
+ *  若输入看起来已是个路径则原样返回。 */
+/** 普通的可执行文件名——我们按用户 PATH 解析的唯一形状。
+ *  解析器可能把这个 token 插进 shell（`$SHELL -ilc "… which <it> …"`），
+ *  所以它被限制为明确属于二进制名的字符（`[A-Za-z0-9._+-]`）；
+ *  其他任何东西都不是命令名，会被拒绝而不是解析。调用方在此之前
+ *  对真实路径（含 `/` 或 `\`）提前返回，所以到达解析器的唯一输入
+ *  按设计就是裸二进制名。 */
 export function isSafeCommandName(command: string): boolean {
   return /^[A-Za-z0-9._+-]+$/.test(command);
 }
 
 export function resolveCommand(command: string): string {
-  // Already an absolute/relative path (Unix `/` or Windows `\`) — pass through.
+  // 已经是绝对/相对路径（Unix `/` 或 Windows `\`）——直接放行。
   if (command.includes('/') || command.includes('\\')) return command;
-  // Not a plain command name → nothing to resolve. Returned unchanged so the
-  // caller's spawn ENOENTs it, and no shell ever sees it.
+  // 不是普通命令名 → 无需解析。原样返回，让调用方的 spawn 以 ENOENT
+  // 处理，且绝不让任何 shell 看到它。
   if (!isSafeCommandName(command)) return command;
   if (process.platform === 'win32') {
-    // `where` is the Windows equivalent of `which`. No `shell:true`: the command
-    // is already proven metacharacter-free above, and running `where` directly
-    // (libuv resolves it to where.exe via PATHEXT) keeps cmd.exe out of the loop.
+    // `where` 是 Windows 版的 `which`。不用 `shell:true`：上面的检查已经证明
+    // 命令不含元字符，直接运行 `where`（libuv 经 PATHEXT 解析到 where.exe）
+    // 让 cmd.exe 不进入回路。
     try {
       const res = spawnSync('where', [command], { encoding: 'utf8', timeout: 3000 });
       const path = (res.stdout ?? '').trim().split(/\r?\n/)[0];
       if (path && existsSync(path)) return path;
-    } catch { /* fall through */ }
+    } catch { /* 继续往下 */ }
     const appData = process.env.APPDATA ?? '';
     const localAppData = process.env.LOCALAPPDATA ?? '';
     const home = process.env.USERPROFILE ?? process.env.HOME ?? '';

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -1,24 +1,22 @@
 /**
- * SKILLS — what the coding agents on this machine can actually do, plus a
- * browsable catalog of what they could.
+ * SKILLS —— 这台机器上的编码 agent 实际能做什么，外加一份可浏览的
+ * “它们还能做什么”的目录。
  *
- * Two halves, deliberately separate:
+ * 两个半区，刻意分开：
  *
- *  1. LOCAL — skills already installed, discovered by walking the directories
- *     each CLI reads. Claude Code is the well-specified one: a skill is a folder
- *     containing SKILL.md whose YAML frontmatter carries `name` and
- *     `description`. OpenCode and Codex use plugin/config directories instead,
- *     so they are reported as plugins rather than pretending they share a format.
+ *  1. LOCAL —— 已安装的技能，通过遍历每个 CLI 读取的目录发现。
+ *     Claude Code 是规范最明确的一个：技能是一个包含 SKILL.md 的文件夹，
+ *     其 YAML frontmatter 带有 `name` 和 `description`。OpenCode 和 Codex
+ *     改用插件/配置目录，所以它们被报成插件，而不是假装共享同一格式。
  *
- *  2. CATALOG — abubakarsiddik31/claude-skills-collection: 227 skills in 13
- *     categories, as markdown tables with a GitHub source link per row. It has no
- *     JSON index (checked), so entries are parsed from the raw markdown and
- *     cached on disk. Network failure is never fatal: a stale cache, then an
- *     empty list, then the UI says so.
+ *  2. CATALOG —— abubakarsiddik31/claude-skills-collection：13 个类别、
+ *     227 个技能，以 markdown 表格呈现，每行带一个 GitHub 源链接。
+ *     它没有 JSON 索引（已确认），所以条目从原始 markdown 解析出来并
+ *     缓存在磁盘。网络失败绝非致命：先是过期缓存，然后是空列表，
+ *     然后 UI 会如实说明。
  *
- * Nothing here installs anything. Discovery and browsing only — installing a
- * third-party skill means running someone else's instructions inside an agent
- * that has the user's tools, and that decision stays with the user.
+ * 这里什么都不安装。只做发现和浏览——安装第三方技能意味着在一个拥有
+ * 用户工具的 agent 里运行别人的指令，那个决定始终留给用户。
  */
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join, basename, dirname, resolve, sep } from 'node:path';
@@ -29,9 +27,9 @@ export interface LocalSkill {
   id: string;
   name: string;
   description: string;
-  /** Which CLI reads this directory. */
-  provider: 'claude' | 'opencode' | 'codex';
-  /** 'user' = global for the whole machine, 'project' = one repo, 'bundled' = ships with the app. */
+  /** 哪个 CLI 读取这个目录。 */
+  provider: 'claude' | 'codex';
+  /** 'user' = 整台机器的全局，'project' = 某个仓库，'bundled' = 随应用附带。 */
   scope: 'user' | 'project' | 'bundled';
   path: string;
 }
@@ -41,16 +39,16 @@ export interface CatalogSkill {
   description: string;
   url: string;
   category: string;
-  /** The publisher, taken from the source URL's GitHub owner — anthropics,
-   *  stripe, supabase. The names in this list are bare (`docx`, `pdf`), so the
-   *  URL is the only place the publisher appears. */
+  /** 发布者，取自来源 URL 的 GitHub 属主——anthropics、stripe、
+   *  supabase。这个列表里的名字都是裸名（`docx`、`pdf`），
+   *  所以发布者只出现在 URL 里。 */
   owner: string;
 }
 
-/** Strip a leading YAML frontmatter block and pull the two fields we render.
- *  Deliberately not a YAML parser: `name` and `description` are all the UI shows,
- *  and description is routinely a multi-line `|` block, which a naive
- *  key:value split would truncate at the first line. */
+/** 剥掉开头的 YAML frontmatter 块，取出我们渲染的两个字段。
+ *  刻意不做成 YAML 解析器：UI 只显示 `name` 和 `description`，
+ *  而且 description 通常是一个多行 `|` 块，朴素的 key:value 切分
+ *  会在第一行截断它。 */
 export function parseSkillFrontmatter(md: string): { name?: string; description?: string } {
   const m = /^---\r?\n([\s\S]*?)\r?\n---/.exec(md);
   if (!m) return {};
@@ -58,10 +56,10 @@ export function parseSkillFrontmatter(md: string): { name?: string; description?
   const out: { name?: string; description?: string } = {};
   const nameM = /^name:\s*(.+)$/m.exec(body);
   if (nameM) out.name = nameM[1].trim().replace(/^["']|["']$/g, '');
-  // Block scalar (`description: |`) → take the indented lines that follow.
-  // Consecutive INDENTED lines after `description: |`. The earlier lookahead
-  // form ended at `\r?\n?$`, which under /m matches the end of the FIRST line —
-  // so every multi-line description silently arrived truncated to one line.
+  // 块标量（`description: |`）→ 取其后缩进的行。
+  // `description: |` 之后连续缩进的行。更早的前瞻形式
+  // 以 `\r?\n?$` 结尾，在 /m 下匹配的是第一行的末尾 ——
+  // 因此每个多行 description 都静默被截断成了一行。
   const blockM = /^description:\s*[|>]-?[ \t]*\r?\n((?:[ \t]+.*(?:\r?\n|$))+)/m.exec(body);
   if (blockM) {
     out.description = blockM[1].split(/\r?\n/).map((l) => l.trim()).filter(Boolean).join(' ').trim();
@@ -72,7 +70,7 @@ export function parseSkillFrontmatter(md: string): { name?: string; description?
   return out;
 }
 
-/** Every folder under `dir` holding a SKILL.md, read into a LocalSkill. */
+/** 读取 `dir` 下每个含 SKILL.md 的文件夹，组装为 LocalSkill。 */
 function scanSkillDir(
   dir: string,
   provider: LocalSkill['provider'],
@@ -101,9 +99,9 @@ function scanSkillDir(
   return out;
 }
 
-/** Plugin directories for the CLIs that do not use Claude's SKILL.md format.
- *  Reported as entries so the tab tells the truth about what a provider has,
- *  instead of implying only Claude Code is extensible. */
+/** 不支持 Claude SKILL.md 格式的 CLI 的插件目录。
+ *  作为条目报告，使标签页如实反映某个提供者可用的东西，
+ *  而非暗示只有 Claude Code 可扩展。 */
 function scanPluginDir(dir: string, provider: LocalSkill['provider'], scope: LocalSkill['scope']): LocalSkill[] {
   const out: LocalSkill[] = [];
   try {
@@ -123,23 +121,20 @@ function scanPluginDir(dir: string, provider: LocalSkill['provider'], scope: Loc
   return out;
 }
 
-/**
- * Everything installed, deduped by (provider, name) with the most specific scope
- * winning — a project skill shadows the user's, which shadows the bundled copy,
- * which is the same precedence the CLIs themselves apply.
- */
+/** 所有已安装的技能，按 (provider, name) 去重，作用域最具体的胜出 ——
+ *  项目级技能覆盖用户级，用户级覆盖内置副本，
+ *  优先级与 CLI 自身应用的一致。 */
 export function listLocalSkills(opts: { cwds: string[]; bundledDir: string | null }): LocalSkill[] {
   const home = homedir();
   const found: LocalSkill[] = [
     ...(opts.bundledDir ? scanSkillDir(opts.bundledDir, 'claude', 'bundled') : []),
     ...scanSkillDir(join(home, '.claude', 'skills'), 'claude', 'user'),
-    ...scanPluginDir(join(home, '.config', 'opencode', 'plugin'), 'opencode', 'user'),
     ...scanPluginDir(join(home, '.codex', 'plugins'), 'codex', 'user')
   ];
   for (const cwd of opts.cwds) {
     if (!cwd) continue;
     found.push(...scanSkillDir(join(cwd, '.claude', 'skills'), 'claude', 'project'));
-    found.push(...scanPluginDir(join(cwd, '.opencode', 'plugin'), 'opencode', 'project'));
+
   }
   const rank = { project: 3, user: 2, bundled: 1 } as const;
   const best = new Map<string, LocalSkill>();
@@ -153,23 +148,22 @@ export function listLocalSkills(opts: { cwds: string[]; bundledDir: string | nul
 
 const CATALOG_URL =
   'https://raw.githubusercontent.com/abubakarsiddik31/claude-skills-collection/main/README.md';
-/** A curated list changes on a human timescale; a day-old copy is fine and keeps
- *  the tab instant on every open after the first. */
+/** 精选列表按人类时间尺度更新，隔天的副本就够用，
+ *  且让标签页在首次打开后的每次开启都即时加载。 */
 const CATALOG_TTL_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Parse the catalog README into entries.
+ * 解析 catalog README 为条目列表。
  *
- * The list is markdown TABLES under `## <emoji> Category` headings:
+ * 列表是 `## <emoji> Category` 标题下的 markdown 表格：
  *
  *   | Name | Description | Link |
  *   |------|-------------|------|
- *   | **docx** | Create and edit Word documents | [Source](https://github.com/…/tree/main/skills/docx) |
+ *   | **docx** | 创建和编辑 Word 文档 | [Source](https://github.com/…/tree/main/skills/docx) |
  *
- * Rows that are not skill rows — the header row, the `|---|` rule, the overview
- * table that counts skills per category — are skipped by requiring three cells
- * AND a resolvable https link. Anything else is dropped rather than guessed at:
- * a catalog missing a row is honest, one full of parsed headers is not.
+ * 非技能行的行——表头行、`|---|` 分隔行、统计每类技能数量的概览表——
+ * 通过要求三列单元格 AND 一个可解析的 https 链接来跳过。其余一律丢弃而非猜测：
+ * 缺少行的目录是诚实的，充满已解析表头的目录则不然。
  */
 export function parseCatalogMarkdown(md: string): CatalogSkill[] {
   const out: CatalogSkill[] = [];
@@ -182,8 +176,8 @@ export function parseCatalogMarkdown(md: string): CatalogSkill[] {
       category = h[1]
         .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
         .replace(/[*_`]/g, '')
-        // Leading pictographs only — a blanket non-alphanumeric strip would eat
-        // the dot off a name like ".NET".
+        // 仅开头的图形符号 —— 无差别剥离非字母数字会吃掉
+        // 只剥开头的图形符号，避免吃掉 ".NET" 这类名字里的点。
         .replace(/^[\p{Extended_Pictographic}\uFE0F\s]+/u, '')
         .trim() || category;
       continue;
@@ -214,9 +208,8 @@ export function parseCatalogMarkdown(md: string): CatalogSkill[] {
 
 
 /**
- * The catalog, from cache when fresh and from the network otherwise. A failed
- * refresh falls back to whatever is cached — an offline user still gets to
- * browse, flagged as stale, instead of an empty tab and no explanation.
+ * 目录缓存：新鲜时来自缓存，否则从网络获取。刷新失败时回退到已有缓存 ——
+ * 离线用户仍可浏览，只是标记为过时，而不是空标签页且无解释。
  */
 export async function loadCatalog(
   cachePath: string,
@@ -233,7 +226,7 @@ export async function loadCatalog(
   try {
     const md = await getText(CATALOG_URL);
     const skills = parseCatalogMarkdown(md);
-    // An empty parse means the README's shape changed under us. Keep the cache.
+    // 空解析意味着 README 的格式已变更。保留缓存。
     if (skills.length === 0 && cached) {
       return { skills: cached.skills, fetchedAt: cached.fetchedAt, stale: true, error: 'catalog format changed' };
     }
@@ -252,27 +245,24 @@ export async function loadCatalog(
 
 /* ── Install / uninstall ──────────────────────────────────────────────────────
  *
- * A skill is INSTRUCTIONS THAT RUN INSIDE AN AGENT holding the user's tools and
- * keys, so this half of the file is written as if the source is hostile, because
- * from the app's point of view it is: it is arbitrary content from a public list
- * that anyone can PR into.
+ * 技能是「在持有用户工具和密钥的 agent 内部运行的指令」，所以本文件的这一半
+ * 以源端具有敌意的方式来编写 —— 从应用的角度看确实如此：
+ * 它是来自任何人可发起 PR 的公开列表的任意内容。
  *
- * Every limit below exists to bound a specific abuse:
- *   - the destination name is sanitised, so `../../.claude/settings.json` cannot
- *     be a "skill name";
- *   - each downloaded path is re-checked to be inside the destination AFTER
- *     resolution, so a crafted API response cannot escape it;
- *   - file count, total bytes and depth are capped, so a repo cannot fill a disk;
- *   - only regular files are written — a `symlink` or `submodule` entry from the
- *     contents API is skipped, never followed.
+ * 以下所有限制都是为特定滥用场景设界：
+ *   - 目标名称经过sanitize，因此 `../../.claude/settings.json` 不能伪装成
+ *     "技能名"；
+ *   - 每个下载路径在解析后重新检查是否在目标目录内部，
+ *     因此伪造的 API 响应无法逃逸；
+ *   - 文件数、总字节数和深度均有限制，因此仓库无法撑满磁盘；
+ *   - 仅写入常规文件 —— 来自 contents API 的 `symlink` 或 `submodule`
+ *     条目被跳过，绝不跟随。
  *
- * Uninstall is the more dangerous verb and is treated as such: it deletes a
- * directory, so it refuses anything that is not INSIDE a known skills root and
- * does not itself contain a SKILL.md. A bundled skill can never be removed — it
- * ships inside the app and would reappear on the next spawn anyway.
+ * 卸载是更危险的动词，因此按更严格的方式处理：它删除一个目录，
+ * 所以它拒绝任何不在已知技能根目录内部且自身不含 SKILL.md 的内容。
+ * 内置技能永远无法被移除 —— 它随应用一起发布，下次启动仍会重新出现。
  */
-
-/** GitHub's per-directory listing. Only the fields we actually consume. */
+/** GitHub 按目录列出的条目。只保留我们实际消费的字段。 */
 interface GhEntry { name: string; path: string; type: string; size?: number; download_url?: string | null }
 
 const MAX_FILES = 60;
@@ -280,13 +270,12 @@ const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
 const MAX_DEPTH = 5;
 
 /**
- * A GitHub source URL → the pieces the contents API needs.
  *
- * Two shapes, because the catalog uses both: a folder inside a repo
- * (`owner/repo/tree/<ref>/<path>`, 145 entries) and a whole repo whose root IS
- * the skill (`owner/repo`, 81 entries). For the latter `ref` is empty and the
- * caller omits it, which makes the API use the repo's default branch — there is
- * no reliable way to guess between `main` and `master` and no need to.
+ * 两种形状，因为目录同时使用两种：仓库内的文件夹
+ * （`owner/repo/tree/<ref>/<path>`，145 个条目）和根目录就是技能本身的整个仓库
+ * （`owner/repo`，81 个条目）。后者 `ref` 为空，调用方省略它，
+ * 使 API 使用仓库的默认分支 —— 在 `main` 和 `master` 之间没有可靠方法猜测，
+ * 也不需要。
  */
 export function parseGitHubSourceUrl(url: string): { owner: string; repo: string; ref: string; path: string } | null {
   const clean = url.trim().replace(/[#?].*$/, '').replace(/\/+$/, '');
@@ -299,15 +288,14 @@ export function parseGitHubSourceUrl(url: string): { owner: string; repo: string
   const root = /^https:\/\/github\.com\/([^/]+)\/([^/]+)$/.exec(clean);
   if (root) {
     const [, owner, repo] = root;
-    // Reserved paths that are not repositories.
+    // 非仓库的保留路径。
     if (['orgs', 'topics', 'collections', 'sponsors', 'features'].includes(owner.toLowerCase())) return null;
     return { owner, repo: repo.replace(/\.git$/i, ''), ref: '', path: '' };
   }
   return null;
 }
 
-/** A folder name we are willing to create. Anything with a separator, a dot-dot,
- *  or a leading dot is rejected outright rather than massaged into safety. */
+/** 我们愿意创建的文件夹名。任何含分隔符、双点或前导点的名字一律拒绝，绝不柔化处理。 */
 export function safeSkillDirName(raw: string): string | null {
   const base = raw.trim().split('/').pop() ?? '';
   if (!base || base === '.' || base === '..') return null;
@@ -320,9 +308,9 @@ function getJson<T>(url: string): Promise<T> {
   return getText(url).then((t) => JSON.parse(t) as T);
 }
 
-/** officialskills.sh pages are a rendering of a GitHub folder and link back to
- *  it. Resolving that link is one request and turns 578 otherwise un-installable
- *  catalog rows into installable ones. */
+/** officialskills.sh 页面是 GitHub 文件夹的渲染，并链接回该仓库。
+ *  解析该链接只需一次请求，就能将 578 个原本不可安装的
+ *  目录行转换为可安装的。 */
 async function resolveSourceUrl(url: string): Promise<string | null> {
   if (parseGitHubSourceUrl(url)) return url;
   if (!/^https:\/\/(www\.)?officialskills\.sh\//i.test(url)) return null;
@@ -334,10 +322,10 @@ async function resolveSourceUrl(url: string): Promise<string | null> {
 }
 
 /**
- * Download one skill folder into the user's Claude skills directory.
+ * 将单个技能文件夹下载到用户的 Claude 技能目录。
  *
- * Returns a structured refusal rather than throwing, so the UI can say WHY —
- * "not installable" and "install failed" are different answers for the user.
+ * 返回结构化的拒绝而非抛出异常，这样 UI 可以说明原因 ——
+ * "不可安装"和"安装失败"对用户是两种不同的答案。
  */
 export async function installSkill(
   entryUrl: string,
@@ -357,8 +345,8 @@ export async function installSkill(
   const dest = join(root, dirName);
   if (existsSync(dest)) return { ok: false, error: `Already installed at ${dest}` };
 
-  // An empty ref means "the repo's default branch" — omit the parameter entirely
-  // rather than guessing main vs master.
+  // 空 ref 表示"仓库的默认分支" —— 完全省略参数
+  // 而非猜测 main 还是 master。
   const api = (p: string) =>
     `https://api.github.com/repos/${gh.owner}/${gh.repo}/contents/${p ? encodeURI(p) : ''}`
     + (gh.ref ? `?ref=${encodeURIComponent(gh.ref)}` : '');
@@ -381,7 +369,7 @@ export async function installSkill(
         if (err) return err;
         continue;
       }
-      // Only regular files. A symlink/submodule entry is skipped, never followed.
+      // 仅常规文件。symlink/submodule 条目被跳过，绝不跟随。
       if (it.type !== 'file' || !it.download_url) continue;
       const size = it.size ?? 0;
       total += size;
@@ -396,13 +384,13 @@ export async function installSkill(
   if (walkErr) return { ok: false, error: walkErr };
   if (files.length === 0) return { ok: false, error: 'No files found at that source.' };
 
-  // Write only after the whole tree resolved, so a mid-download failure cannot
-  // leave a half-installed skill that an agent would then load.
+  // 只在整棵树都解析后才写入，以防中途下载失败
+  // 留下一个 agent 可能加载的半成品技能。
   const written: string[] = [];
   try {
     for (const f of files) {
       const target = resolve(dest, f.path);
-      // Post-resolution containment: the only check that survives a crafted path.
+      // 解析后的安全边界检查：唯一能抵御伪造路径的检查。
       if (target !== dest && !target.startsWith(dest + sep)) {
         throw new Error(`refusing to write outside the skill folder: ${f.path}`);
       }
@@ -419,9 +407,8 @@ export async function installSkill(
 }
 
 /**
- * Remove an installed skill. Refuses anything it cannot prove is a skill folder
- * inside a skills root — the failure mode of getting this wrong is deleting a
- * directory of the user's work.
+ * 移除已安装的技能。拒绝任何无法证明是技能根目录下的技能文件夹的内容 ——
+ * 出错时的失败模式是删除用户的作品目录。
  */
 export function uninstallSkill(
   skillPath: string,
@@ -433,11 +420,9 @@ export function uninstallSkill(
 
   const roots = [
     join(homedir(), '.claude', 'skills'),
-    join(homedir(), '.config', 'opencode', 'plugin'),
     join(homedir(), '.codex', 'plugins'),
     ...opts.cwds.filter(Boolean).flatMap((c) => [
-      join(c, '.claude', 'skills'),
-      join(c, '.opencode', 'plugin')
+      join(c, '.claude', 'skills')
     ])
   ].map((r) => resolve(r));
 
@@ -446,7 +431,7 @@ export function uninstallSkill(
   if (target === root) return { ok: false, error: 'refusing to delete the skills directory itself' };
   if (!existsSync(target)) return { ok: false, error: 'Already gone.' };
 
-  // A directory must look like a skill; a plugin entry must be a plain file.
+  // 目录必须看起来像个技能；插件条目必须是普通文件。
   try {
     const st = statSync(target);
     if (st.isDirectory()) {

--- a/src/main/slack.ts
+++ b/src/main/slack.ts
@@ -1,31 +1,30 @@
 /**
- * SlackWebhookServer — receive Slack messages and hand them to the harness.
+ * SlackWebhookServer —— 接收 Slack 消息并交给 harness。
  *
- * A bare `node:http` server (no @slack/bolt) that implements just enough of the
- * Slack Events API to let the user pipe a channel's messages into Michael's
- * message queue:
- *   - verifies EVERY request with Slack's signing-secret HMAC over the RAW body
- *     plus a 5-minute replay-timestamp guard (403 on any failure),
- *   - answers the one-time `url_verification` challenge handshake,
- *   - on a plain `message` event, strips a leading bot mention and emits the
- *     text via `onMessage`.
+ * 一个裸的 `node:http` 服务器（无 @slack/bolt），只实现 Slack Events API
+ * 中恰好够用的部分，让用户能把频道消息灌进 Michael 的消息队列：
+ *   - 用 Slack 的签名密钥 HMAC 对原始请求体验证每一个请求，
+ *     外加 5 分钟的重放时间戳守卫（任何失败返回 403），
+ *   - 应答一次性的 `url_verification` 挑战握手，
+ *   - 在普通 `message` 事件上，剥掉开头的机器人 @提及，
+ *     并经 `onMessage` 发出文本。
  *
- * It also opens a `tunnelmole` tunnel so the local port is reachable from Slack's
- * servers; the tunnel URL is what the user pastes into their Slack app's Event
- * Subscriptions → Request URL. The tunnel is best-effort: the local handler is
- * the security boundary and stays up even if the tunnel can't be established.
+ * 它还开一条 `tunnelmole` 隧道，让本地端口能被 Slack 的服务器触达；
+ * 隧道 URL 就是用户粘进 Slack 应用 Event Subscriptions → Request URL
+ * 的东西。隧道是尽力而为：本地 handler 是安全边界，
+ * 即使隧道建不起来它也保持在线。
  *
- * Runs in the Electron main process. Deliberately free of any `electron`
- * import so it can be unit-/smoke-tested as a plain Node module.
+ * 运行在 Electron 主进程。刻意不导入任何 `electron`，
+ * 以便作为普通 Node 模块做单元/冒烟测试。
  */
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { createHmac, timingSafeEqual } from 'node:crypto';
-// NOTE: `tunnelmole` is an ESM-only package. The Electron main process is bundled
-// as CommonJS, so a static `import` gets externalized into `require('tunnelmole')`
-// and throws ERR_REQUIRE_ESM at load. It is imported dynamically inside
-// `openTunnel()` instead — Rollup preserves dynamic import() in CJS output, which
-// can load ESM. Do not hoist this back to a top-level import.
+// 注意：`tunnelmole` 是仅 ESM 的包。Electron 主进程被打包成 CommonJS，
+// 静态 `import` 会被外部化成 `require('tunnelmole')` 并在加载时抛出
+// ERR_REQUIRE_ESM。它在 `openTunnel()` 内部做动态导入——Rollup 会保留
+// CJS 输出中的动态 import()，而动态 import 可以加载 ESM。
+// 别把它提升回顶层 import。
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const {
@@ -56,8 +55,8 @@ interface _ISeenEvents {
   readonly size: number;
 }
 
-/** Raw Slack file metadata as received in the `files[]` array of a file_share event.
- *  Populated by slack-trigger.cjs; consumed and stripped by index.ts after download. */
+/** file_share 事件的 `files[]` 数组中收到的原始 Slack 文件元数据。
+ *  由 slack-trigger.cjs 填充；下载后由 index.ts 消费并剥掉。 */
 export interface SlackEventFile {
   id?: string;
   url_private: string;
@@ -65,48 +64,45 @@ export interface SlackEventFile {
   mimetype?: string;
   size?: number;
 }
-// Internal alias used within this module.
+// 本模块内部使用的别名。
 type _SlackEventFile = SlackEventFile;
 
 export interface SlackWebhookServerOptions {
-  /** Local TCP port the HTTP server binds to (and the tunnel forwards to). */
+  /** HTTP 服务器绑定的本地 TCP 端口（隧道也转发到它）。 */
   port: number;
-  /** Slack app signing secret (Basic Information → Signing Secret). Required. */
+  /** Slack 应用的签名密钥（Basic Information → Signing Secret）。必填。 */
   signingSecret: string;
-  /** Optional channel id filter — when set, events from other channels are dropped. */
+  /** 可选的频道 id 过滤——设置后，来自其他频道的事件被丢弃。 */
   channelId?: string;
-  /** Called once per accepted, de-mentioned message — with the Slack thread
-   *  coordinates needed to reply back in the originating thread. May be async
-   *  (e.g. to download file attachments before forwarding via IPC). */
+  /** 每个被接受、已去 @提及的消息调用一次——带着在原线程中回复所需的
+ *  Slack 线程坐标。可以是异步的（例如在经 IPC 转发前下载文件附件）。 */
   onMessage: (m: SlackInboundMessage) => void | Promise<void>;
 }
 
-/** A verified, de-mentioned inbound Slack message plus the coordinates needed to
- *  reply in-thread. `thread_ts` is the original message's thread (or its own ts
- *  when it isn't itself a reply), so office replies nest under the request.
+/** 一条已验证、已去 @提及的入站 Slack 消息，外加在线程内回复所需的坐标。
+ *  `thread_ts` 是原消息的线程（若它本身不是回复，就是它自己的 ts），
+ *  这样办公室回复会嵌套在请求之下。
  *
- *  `files` carries LOCAL file paths (post-download by index.ts); it is absent for
- *  text-only messages. `_rawFiles` is an INTERNAL transport field that index.ts
- *  reads to download attachments, then strips before forwarding via IPC — renderers
- *  never see it. */
+ *  `files` 携带本地文件路径（index.ts 下载之后）；纯文本消息没有它。
+ *  `_rawFiles` 是内部传输字段：index.ts 读取它以下载附件，
+ *  然后在经 IPC 转发前剥掉它——渲染进程永远看不到。 */
 export interface SlackInboundMessage {
   text: string;
   channel: string;
   ts: string;
   thread_ts: string;
-  /** LOCAL paths of downloaded attachments (undefined for text-only messages). */
+  /** 已下载附件的本地路径（纯文本消息为 undefined）。 */
   files?: { path: string; name: string; mimetype: string }[];
-  /** INTERNAL: raw Slack file metadata; consumed + stripped by index.ts onMessage. */
+  /** 内部：原始 Slack 文件元数据；由 index.ts onMessage 消费并剥掉。 */
   _rawFiles?: SlackEventFile[];
 }
 
-/** Reject request bodies larger than this — Slack event payloads are tiny; the
- *  cap stops an unauthenticated peer from forcing unbounded memory use before
- *  we've even checked the signature. */
+/** 拒绝大于此值的请求体——Slack 事件载荷很小；该上限阻止未认证的
+ *  对等方在我们检查签名之前就强迫我们用掉无界内存。 */
 const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
-/** Slack's recommended replay window: reject timestamps more than 5 min off. */
+/** Slack 建议的重放窗口：拒绝偏差超过 5 分钟的时间戳。 */
 const REPLAY_WINDOW_SECONDS = 60 * 5;
-/** Cap how long we wait for the public tunnel before giving up (server stays up). */
+/** 放弃前等待公共隧道的时长上限（服务器保持在线）。 */
 const TUNNEL_START_TIMEOUT_MS = 10_000;
 
 export class SlackWebhookServer {
@@ -116,16 +112,16 @@ export class SlackWebhookServer {
   private readonly signingSecret: string;
   private readonly channelId?: string;
   private readonly onMessage: (m: SlackInboundMessage) => void | Promise<void>;
-  /** Bot's own Slack user id — learned from `authorizations[].user_id` on the
-   *  first event_callback. Used to detect <@BOTID> text mentions. */
+  /** Bot 自己的 Slack 用户 id——从第一个 event_callback 的
+   *  `authorizations[].user_id` 学到。用于检测 <@BOTID> 文本提及。 */
   private botUserId: string | null = null;
-  /** Thread roots where the bot was @-mentioned; subsequent replies in these
-   *  threads also trigger onMessage. Bounded FIFO to prevent unbounded growth. */
+  /** bot 被 @提及过的线程根；这些线程里之后的回复也触发 onMessage。
+   *  有界 FIFO，防止无界增长。 */
   private readonly activatedThreads: _IActivatedThreads = new _ActivatedThreads();
-  /** Idempotency cache of recently-forwarded message identities (channel:ts).
-   *  Stops a single message from firing onMessage — and thus the ack reply —
-   *  twice when the app subscribes to both `app_mention` and `message.*` (Slack
-   *  sends both for one @-mention), and absorbs Slack's retry of un-acked events. */
+  /** 最近转发过的消息身份（channel:ts）的幂等缓存。
+   *  当应用同时订阅 `app_mention` 和 `message.*` 时（一次 @提及 Slack 会
+   *  各发一份），阻止同一条消息触发两次 onMessage——以及因此的两次 ack
+   *  回复——并吸收 Slack 对未确认事件的重试。 */
   private readonly seenEvents: _ISeenEvents = new _SeenEvents();
 
   constructor(opts: SlackWebhookServerOptions) {
@@ -136,11 +132,10 @@ export class SlackWebhookServer {
   }
 
   /**
-   * Bind the local HTTP server, then open a public tunnel to it. The HTTP
-   * handler (the security boundary) is live the instant `listen` resolves; the
-   * tunnel is opened afterwards and is non-fatal — if it can't be established
-   * (offline, loca.lt down, timed out) the server keeps running and we report
-   * the tunnel error without a URL.
+   * 绑定本地 HTTP 服务器，然后为它打开公共隧道。`listen` 一兑现，
+   * HTTP handler（安全边界）就立即在线；隧道随后打开且非致命——
+   * 若建不起来（离线、loca.lt 宕机、超时），服务器继续运行，
+   * 我们不带 URL 地报告隧道错误。
    */
   async start(): Promise<{ ok: boolean; url?: string; error?: string }> {
     if (this.server) return { ok: false, error: 'already running' };
@@ -155,19 +150,19 @@ export class SlackWebhookServer {
       const url = await this.openTunnel();
       if (!url) throw new Error('tunnelmole returned empty URL');
       this.tunnelUrl = url;
-      // tunnelmole runs in the background; there is no close handle to wire here.
+      // tunnelmole 在后台运行；这里没有可接线的关闭句柄。
       return { ok: true, url };
     } catch (e) {
-      // Surface the tunnel failure rather than silently returning ok:true with no url.
+      // 把隧道失败呈现出来，而不是静默返回没有 url 的 ok:true。
       return { ok: false, error: `tunnel unavailable: ${errMsg(e)}` };
     }
   }
 
-  /** Close the HTTP server. Idempotent and best-effort.
-   *  Note: tunnelmole has no documented close handle; teardown is best-effort. */
+  /** 关闭 HTTP 服务器。幂等且尽力而为。
+   *  注意：tunnelmole 没有文档化的关闭句柄；拆除是尽力而为。 */
   stop(): void {
     this.tunnelUrl = null;
-    try { this.server?.close(); } catch { /* noop */ }
+    try { this.server?.close(); } catch { /* 空操作 */ }
     this.server = null;
   }
 
@@ -185,8 +180,8 @@ export class SlackWebhookServer {
   }
 
   private async openTunnel(): Promise<string> {
-    // TODO: optional persistent domain — pass `domain` here when config carries one.
-    // Dynamic import keeps the ESM-only `tunnelmole` out of the CJS require graph.
+    // TODO：可选持久域名——配置携带时在这里传 `domain`。
+    // 动态导入让仅 ESM 的 `tunnelmole` 不进入 CJS require 图。
     const { tunnelmole } = await import('tunnelmole');
     return new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error('timed out')), TUNNEL_START_TIMEOUT_MS);
@@ -196,8 +191,8 @@ export class SlackWebhookServer {
     });
   }
 
-  /** Buffer the raw body (needed verbatim for the HMAC) under a size cap, then
-   *  verify + dispatch. Only POST is accepted. */
+  /** 在大小上限内缓冲原始请求体（HMAC 需要原样字节），然后验证 +
+   *  分发。只接受 POST。 */
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
     if (req.method !== 'POST') { res.writeHead(405); res.end(); return; }
     const chunks: Buffer[] = [];
@@ -220,30 +215,30 @@ export class SlackWebhookServer {
     });
     req.on('error', () => {
       if (aborted) return;
-      try { res.writeHead(400); res.end(); } catch { /* socket already gone */ }
+      try { res.writeHead(400); res.end(); } catch { /* socket 已经没了 */ }
     });
   }
 
   private handleBody(req: IncomingMessage, res: ServerResponse, rawBody: string): void {
-    // 1) Authenticate over the RAW body BEFORE parsing. Any failure → 403.
+    // 1) 在解析之前对原始请求体验证。任何失败 → 403。
     if (!this.verify(req, rawBody)) { res.writeHead(403); res.end(); return; }
 
     let payload: SlackPayload;
     try { payload = JSON.parse(rawBody) as SlackPayload; }
     catch { res.writeHead(400); res.end(); return; }
 
-    // 2) URL verification handshake — echo the challenge back.
+    // 2) URL 验证握手——把 challenge 原样回显。
     if (payload.type === 'url_verification' && typeof payload.challenge === 'string') {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ challenge: payload.challenge }));
       return;
     }
 
-    // 3) Real events: only @-mentions or replies in activated threads — not every
-    //    plain channel message. Cache the bot user id from authorizations so we
-    //    can detect text mentions (<@BOTID>) without an extra API scope.
+    // 3) 真实事件：只有 @提及或已激活线程里的回复——不是每条普通频道消息。
+    //    从 authorizations 缓存 bot 用户 id，这样无需额外 API scope
+    //    就能检测文本提及（<@BOTID>）。
     if (payload.type === 'event_callback' && payload.event) {
-      // Learn the bot's own user id on first sighting (present on every event_callback).
+      // 第一次见到时学习 bot 自己的用户 id（每个 event_callback 都带）。
       const authUserId = payload.authorizations?.[0]?.user_id;
       if (authUserId && !this.botUserId) this.botUserId = authUserId;
 
@@ -256,39 +251,38 @@ export class SlackWebhookServer {
         const channel = typeof ev.channel === 'string' ? ev.channel : '';
         const ts = typeof ev.ts === 'string' ? ev.ts : '';
         const thread_ts = (typeof ev.thread_ts === 'string' && ev.thread_ts) || ts;
-        // Fire when text is non-empty OR files are attached (file_share may have no caption).
+        // 当文本非空或附了文件时触发（file_share 可能没有标题）。
         if ((text || rawFiles.length > 0) && channel && ts) {
-          // Dedup: only ONE onMessage (and thus one ack) per logical message. When
-          // the app subscribes to both `app_mention` and `message.*`, a single
-          // @-mention arrives as TWO event_callbacks that share channel:ts; this
-          // also absorbs Slack's retry of an un-acked event. Gated AFTER the
-          // mention/thread filter, so non-triggering messages are unaffected.
+          // 去重：每条逻辑消息只有一个 onMessage（因此只有一个 ack）。当
+          // 应用同时订阅 `app_mention` 和 `message.*` 时，一次 @提及会以两个
+          // 共享 channel:ts 的 event_callback 到达；这也吸收 Slack 对未确认事件
+          // 的重试。门控放在提及/线程过滤之后，因此不触发的消息不受影响。
           const dupKey = _dedupKey(ev);
           const isDuplicate = dupKey ? this.seenEvents.seen(dupKey) : false;
           if (!isDuplicate) {
             const msg: SlackInboundMessage = { text, channel, ts, thread_ts };
             if (rawFiles.length > 0) msg._rawFiles = rawFiles;
-            try { void this.onMessage(msg); } catch { /* delivery is best-effort */ }
+            try { void this.onMessage(msg); } catch { /* 投递是尽力而为 */ }
           }
         }
       }
     }
 
-    // Always 200 so Slack treats the event as delivered and doesn't retry.
+    // 总是返回 200，让 Slack 认为事件已投递、不再重试。
     res.writeHead(200); res.end();
   }
 
   /**
-   * Verify a request is genuinely from Slack: HMAC-SHA256 of `v0:<ts>:<rawBody>`
-   * with the signing secret must equal the `X-Slack-Signature` header (compared
-   * in constant time), AND the timestamp must be within the replay window.
+   * 验证请求真的来自 Slack：以签名密钥对 `v0:<ts>:<rawBody>` 做
+   * HMAC-SHA256，结果必须等于 `X-Slack-Signature` 头（常量时间比较），
+   * 并且时间戳必须在重放窗口内。
    */
   private verify(req: IncomingMessage, rawBody: string): boolean {
     const sig = req.headers['x-slack-signature'];
     const ts = req.headers['x-slack-request-timestamp'];
     if (typeof sig !== 'string' || typeof ts !== 'string') return false;
 
-    // Replay guard: reject stale or non-numeric timestamps (> 5 min skew).
+    // 重放守卫：拒绝过期或非数字的时间戳（偏差 > 5 分钟）。
     const tsNum = Number(ts);
     if (!Number.isFinite(tsNum)) return false;
     if (Math.abs(Date.now() / 1000 - tsNum) > REPLAY_WINDOW_SECONDS) return false;
@@ -298,33 +292,33 @@ export class SlackWebhookServer {
       .digest('hex');
     const provided = Buffer.from(sig);
     const computed = Buffer.from(expected);
-    // timingSafeEqual throws on length mismatch — guard, and a differing length
-    // is itself a mismatch, so bail before the constant-time compare.
+    // timingSafeEqual 在长度不匹配时抛异常——先守卫；长度不同本身就是
+    // 不匹配，所以在常量时间比较之前就退出。
     if (provided.length !== computed.length) return false;
     return timingSafeEqual(provided, computed);
   }
 }
 
-/** Minimal shape of the Slack Events API payloads we handle. */
+/** 我们处理的 Slack Events API 载荷的最小形状。 */
 interface SlackPayload {
   type?: string;
   challenge?: string;
-  /** Present on event_callback — contains the bot's own user_id so we can
-   *  detect <@BOTID> text mentions without any extra API scope. */
+  /** 出现在 event_callback 上——含 bot 自己的 user_id，因此无需任何额外
+   *  API scope 就能检测 <@BOTID> 文本提及。 */
   authorizations?: { user_id?: string }[];
   event?: {
-    /** 'message' for regular channel messages; 'app_mention' for @-mentions. */
+    /** 普通频道消息是 'message'；@提及是 'app_mention'。 */
     type?: string;
-    /** 'file_share' for file uploads; 'message_changed' / 'channel_join' etc. dropped. */
+    /** 文件上传是 'file_share'；'message_changed' / 'channel_join' 等被丢弃。 */
     subtype?: string;
     bot_id?: string;
     channel?: string;
     text?: string;
-    /** Message timestamp — Slack's per-message id, used as the reply thread root. */
+    /** 消息时间戳——Slack 的每条消息 id，用作回复线程根。 */
     ts?: string;
-    /** Set when the message is itself a reply; the thread to post back into. */
+    /** 当消息本身是回复时设置；要回帖进的线程。 */
     thread_ts?: string;
-    /** Present on file_share events — the uploaded files' metadata. */
+    /** 出现在 file_share 事件上——上传文件的元数据。 */
     files?: {
       id?: string;
       url_private?: string;
@@ -335,7 +329,7 @@ interface SlackPayload {
   };
 }
 
-/** Strip a single leading `<@BOTID>` app-mention so "@bot do X" enqueues "do X". */
+/** 剥掉单个开头的 `<@BOTID>` 应用提及，让 "@bot do X" 入队 "do X"。 */
 function stripLeadingMention(text: string): string {
   return text.replace(/^\s*<@[A-Z0-9]+>\s*/i, '').trim();
 }
@@ -345,10 +339,10 @@ function errMsg(e: unknown): string {
 }
 
 /**
- * Post a reply into a Slack thread via `chat.postMessage` — a raw `node:https`
- * POST (no `@slack/*` dep), matching the repo's zero-SDK approach. The bot token
- * is passed in by the caller: it lives in main's config and never leaves the
- * main process, and is NEVER logged. Resolves Slack's `{ ok, error? }`.
+ * 经 `chat.postMessage` 把回复发进 Slack 线程——裸 `node:https` POST
+ * （无 `@slack/*` 依赖），与仓库零 SDK 的做法一致。bot token 由调用方
+ * 传入：它住在主进程的配置里，绝不离开主进程，也绝不记录。
+ * 兑现 Slack 的 `{ ok, error? }`。
  */
 export function postSlackReply(opts: {
   botToken: string;
@@ -358,12 +352,11 @@ export function postSlackReply(opts: {
 }): Promise<{ ok: boolean; error?: string }> {
   return new Promise((resolve) => {
     if (!opts.botToken) { resolve({ ok: false, error: 'missing bot token' }); return; }
-    // CLAUSE-1 guard (fix-slack-integration): refuse any send that lacks an
-    // EXPLICIT channel + thread target. A blank/whitespace thread_ts would post
-    // to the channel root — an implicit destination the caller never named — so
-    // every app/voice-initiated send must pass the thread it was explicitly given.
-    // The Slack-origin done-reply poller and the loopback /reply endpoint always
-    // pass concrete values, so this never fires for them (no behaviour change).
+    // CLAUSE-1 守卫（fix-slack-integration）：拒绝任何缺少显式频道 + 线程
+    // 目标的发送。空白/纯空格的 thread_ts 会发到频道根部——一个调用方从未
+    // 指名过的隐含目的地——所以每次应用/语音发起的发送都必须带着它被
+    // 显式给予的线程。来自 Slack 的完成回复轮询器和 loopback /reply 端点
+    // 总是传具体值，因此这条路永远不会为它们触发（行为无变化）。
     if (!opts.channel?.trim() || !opts.thread_ts?.trim()) {
       resolve({ ok: false, error: 'missing explicit channel or thread_ts' }); return;
     }
@@ -393,26 +386,25 @@ export function postSlackReply(opts: {
   });
 }
 
-/** Per-session shared secret + lazy bot-token accessor for the reply endpoint. */
+/** 回复端点的每次会话共享密钥 + 懒加载 bot-token 访问器。 */
 export interface SlackReplyServerOptions {
-  /** Secret the helper must echo in the `x-md-reply-token` header. */
+  /** 辅助脚本必须在 `x-md-reply-token` 头中回显的密钥。 */
   token: string;
-  /** Latest bot token, read lazily so a config change is picked up at reply time. */
+  /** 最新的 bot token，懒读取以便回复时能拾取配置变更。 */
   getBotToken: () => string | undefined;
-  /** Fired with a thread_ts after an agent's DIRECT reply posts successfully through
-   *  this loopback. Lets main record that the thread was already answered so the
-   *  done-summary poller can skip it (the poller is a fallback, not a duplicator). */
+  /** agent 的直接回复经此 loopback 成功发出后，带着 thread_ts 触发。
+   *  让主进程记录该线程已被答复，使完成摘要轮询器可以跳过它
+   *  （轮询器是兜底，不是重复器）。 */
   onReplied?: (thread_ts: string) => void;
 }
 
 /**
- * Loopback-only HTTP endpoint that lets a bundled helper script post a Slack
- * reply WITHOUT ever seeing the bot token. It binds to `127.0.0.1` exclusively
- * and is NEVER placed behind the public tunnel (only the webhook port is
- * forwarded). Every request must carry the per-session `x-md-reply-token`
- * header; non-loopback peers are refused even though the bind already excludes
- * them (defense in depth). Main writes `{ port, token }` to
- * `<userData>/slack-reply.json` so the helper can find this socket.
+ * 仅 loopback 的 HTTP 端点，让捆绑的辅助脚本可以发布 Slack 回复，
+ * 却从头到尾看不到 bot token。它只绑定 `127.0.0.1`，绝不放在公共隧道
+ * 后面（只有 webhook 端口被转发）。每个请求必须携带按会话的
+ * `x-md-reply-token` 头；即使绑定已经排除了非 loopback 对等方，
+ * 它们仍会被拒绝（纵深防御）。主进程把 `{ port, token }` 写进
+ * `<userData>/slack-reply.json`，让辅助脚本能找到这个 socket。
  */
 export class SlackReplyServer {
   private server: Server | null = null;
@@ -426,7 +418,7 @@ export class SlackReplyServer {
     this.onReplied = opts.onReplied;
   }
 
-  /** Bind a loopback port (0 ⇒ OS-assigned). Resolves the actual bound port. */
+  /** 绑定一个 loopback 端口（0 ⇒ 由操作系统分配）。兑现实际绑定的端口。 */
   start(preferredPort = 0): Promise<{ ok: boolean; port?: number; error?: string }> {
     return new Promise((resolve) => {
       if (this.server) { resolve({ ok: false, error: 'already running' }); return; }
@@ -440,19 +432,19 @@ export class SlackReplyServer {
       };
       server.once('error', onError);
       server.once('listening', onListening);
-      // '127.0.0.1' ONLY — the public tunnel forwards the webhook port, never this.
+      // 仅 '127.0.0.1'——公共隧道转发 webhook 端口，绝不转发这个。
       server.listen(preferredPort, '127.0.0.1');
     });
   }
 
-  /** Close the endpoint. Idempotent and best-effort. */
+  /** 关闭端点。幂等且尽力而为。 */
   stop(): void {
-    try { this.server?.close(); } catch { /* noop */ }
+    try { this.server?.close(); } catch { /* 空操作 */ }
     this.server = null;
   }
 
   private handle(req: IncomingMessage, res: ServerResponse): void {
-    // Defense in depth: even bound loopback-only, refuse any non-loopback peer.
+    // 纵深防御：即使只绑定 loopback，也拒绝任何非 loopback 对等方。
     if (!isLoopback(req.socket.remoteAddress ?? '')) { res.writeHead(403); res.end(); return; }
     if (req.method !== 'POST' || (req.url ?? '').split('?')[0] !== '/reply') {
       res.writeHead(404); res.end(); return;
@@ -481,17 +473,17 @@ export class SlackReplyServer {
       const thread_ts = parsed.thread_ts;
       postSlackReply({ botToken, channel: parsed.channel, thread_ts, text: parsed.text })
         .then((r) => {
-          // A successful DIRECT reply means the agent already answered this thread —
-          // tell main so the done-summary poller treats it as a fallback and skips it.
-          if (r.ok) { try { this.onReplied?.(thread_ts); } catch { /* never break the reply */ } }
+          // 一次成功的直接回复意味着 agent 已经答复了这个线程——
+          // 告诉主进程，让完成摘要轮询器把它当作兜底并跳过。
+          if (r.ok) { try { this.onReplied?.(thread_ts); } catch { /* 绝不破坏回复 */ } }
           res.writeHead(r.ok ? 200 : 502, { 'content-type': 'application/json' }); res.end(JSON.stringify(r));
         })
         .catch((e) => { res.writeHead(500); res.end(JSON.stringify({ ok: false, error: errMsg(e) })); });
     });
-    req.on('error', () => { if (!aborted) { try { res.writeHead(400); res.end(); } catch { /* socket gone */ } } });
+    req.on('error', () => { if (!aborted) { try { res.writeHead(400); res.end(); } catch { /* socket 没了 */ } } });
   }
 
-  /** Constant-time match of the request's reply token against the session token. */
+  /** 请求的回复 token 与会话 token 的常量时间匹配。 */
   private checkToken(provided: string | string[] | undefined): boolean {
     if (typeof provided !== 'string') return false;
     const a = Buffer.from(provided);
@@ -501,7 +493,7 @@ export class SlackReplyServer {
   }
 }
 
-/** True for IPv4 loopback (127.0.0.0/8) and IPv6 ::1 (incl. v4-mapped form). */
+/** IPv4 loopback（127.0.0.0/8）和 IPv6 ::1（含 v4 映射形式）时为 true。 */
 function isLoopback(addr: string): boolean {
   const a = addr.replace(/^::ffff:/, '');
   return a === '::1' || a.startsWith('127.');

--- a/src/main/telemetry.ts
+++ b/src/main/telemetry.ts
@@ -1,60 +1,57 @@
 /**
- * TelemetryCollector — the live, first-party observability tap for the hive.
+ * TelemetryCollector —— 面向 hive 的实时、第一方可观测性数据入口。
  *
- * Every spawned `claude` is launched with `CLAUDE_CODE_ENABLE_TELEMETRY=1` and
- * `OTEL_EXPORTER_OTLP_ENDPOINT` pointed here (see hive.ts `ensureAgent`). Claude
- * Code then PUSHES OpenTelemetry over plain OTLP/HTTP JSON to this embedded
- * collector — no protobuf, no external process, loopback only. We decode it into
- * two products:
+ * 每个派生的 `claude` 都以 `CLAUDE_CODE_ENABLE_TELEMETRY=1` 启动，并把
+ * `OTEL_EXPORTER_OTLP_ENDPOINT` 指向这里（见 hive.ts `ensureAgent`）。Claude
+ * Code 随后通过纯 OTLP/HTTP JSON 把 OpenTelemetry 数据 PUSH 到这个内嵌的
+ * 收集器——无 protobuf、无外部进程、仅限回环。我们把它解码为两类产物：
  *
- *   1. The usage PROVIDER (the locked cross-lane seam) — `getAgentUsage(agentId)`
- *      (pull, primary) + `onAgentUsage(cb)` (push). Returns `AgentUsageSample`,
- *      a PII-free cumulative cost/token snapshot. Lane A's circuit breaker (#6)
- *      consumes this; the swap between the OTel backend and the transcript
- *      fallback is hidden here so the breaker never changes.
- *   2. An EPHEMERAL ring buffer of rich tool spans (`tool_result` durations +
- *      success) per agent, for the per-agent span waterfall (#7B.2).
+ *   1. 用量 PROVIDER（锁定的跨 lane 接缝）—— `getAgentUsage(agentId)`
+ *      （拉取，主）+ `onAgentUsage(cb)`（推送）。返回 `AgentUsageSample`，
+ *      一个无 PII 的累计成本/令牌快照。Lane A 的熔断器（#6）消费它；
+ *      OTel 后端与转录回退之间的切换在此处隐藏，熔断器永远不会受影响。
+ *   2. 每个 agent 的丰富工具跨度（`tool_result` 耗时 + 成功与否）的
+ *      EPHEMERAL 环形缓冲区，用于按 agent 展示的跨度瀑布（#7B.2）。
  *
- * 🔒 PII: raw OTel records carry `user.email`, `user.account_id/uuid`,
- * `organization.id` and a hashed `user.id`. We read ONLY an allowlist of keys
- * ({agent.id, session.id, model, token type, cost, tool fields}) and never
- * persist a raw record — so everything this module emits is PII-free BY
- * CONSTRUCTION. Downstream durable stores (Lane A's cost-ledger, Lane B's
- * SQLite) inherit that guarantee and must never persist a raw record either.
+ * 🔒 PII：原始 OTel 记录携带 `user.email`、`user.account_id/uuid`、
+ * `organization.id` 以及哈希后的 `user.id`。我们只读取一个允许列表中的键
+ * （{agent.id, session.id, model, token type, cost, tool fields}），绝不
+ * 持久化原始记录——因此本模块产出的任何内容在结构上就是无 PII 的。
+ * 下游的持久化存储（Lane A 的成本账本、Lane B 的 SQLite）继承这一保证，
+ * 也绝不能持久化任何原始记录。
  *
- * Transport posture mirrors `slack.ts`: the local handler bound to 127.0.0.1 is
- * the security boundary. Runs in the Electron main process; deliberately free of
- * any `electron` import so it can be smoke-tested as a plain Node module.
+ * 传输姿态与 `slack.ts` 一致：绑定到 127.0.0.1 的本地处理器就是安全边界。
+ * 运行于 Electron 主进程；刻意不引入任何 `electron` 导入，以便可以当作
+ * 普通 Node 模块进行冒烟测试。
  */
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { readAgentUsage } from './transcript';
 import { normalizeModel } from './pricing';
 
-// ─── The locked cross-lane contract (do not change without re-agreeing) ───────
+// ─── 锁定的跨 lane 契约（未经重新协商不得修改） ─────────────────────────────
 
-/** A cumulative cost/token snapshot for one agent. The shared row consumed by
- *  Lane A's breaker (#6) and persisted by Lane A's cost-ledger / Lane B's SQLite
- *  (#4). PII-free by construction (see file header). `usd` is Claude's own
- *  per-model cost on the live path, the fallback estimate on the transcript
- *  path — never recomputed downstream. */
+/** 某个 agent 的累计成本/令牌快照。这是 Lane A 熔断器（#6）消费、并由
+ *  Lane A 成本账本 / Lane B SQLite（#4）持久化的共享行。按结构保证无 PII
+ *  （见文件头）。`usd` 在实况路径上是 Claude 自己的按模型成本，在转录路径
+ *  上是回退估算——下游绝不重算。 */
 export interface AgentUsageSample {
   agentId: string;
-  /** Dedup/accounting key — present on every OTel record; fixes the cwd
-   *  double-count. Empty string on the transcript fallback when unknown. */
+  /** 去重/记账键——每条 OTel 记录都带；修复 cwd 重复计数。转录回退时
+   *  若未知则为空字符串。 */
   sessionId: string;
   ts: number;
   input: number;
   output: number;
   cacheRead: number;
   cacheCreation: number;
-  /** Normalized model id (`claude-opus-4-8`, no `[1m]` suffix). */
+  /** 规范化后的模型 id（`claude-opus-4-8`，不带 `[1m]` 后缀）。 */
   model: string;
   usd: number;
 }
 
-/** Breaker state, emitted by Lane A's policy on `control:breakerState` and
- *  consumed by this lane's avatar adapter (#5C) + cost meter. Defined here as
- *  the shared type so both lanes import one shape. */
+/** 熔断器状态，由 Lane A 的策略在 `control:breakerState` 上发出，并由本 lane
+ *  的 avatar 适配器（#5C）+ 成本计量器消费。在此定义为共享类型，使两个 lane
+ *  都导入同一形状。 */
 export interface BreakerState {
   agentId: string;
   level: 'healthy' | 'steering' | 'constrained' | 'stopped';
@@ -62,10 +59,10 @@ export interface BreakerState {
   ts: number;
 }
 
-// ─── Internal, lane-owned shapes ──────────────────────────────────────────────
+// ─── 内部、lane 自有的形状 ────────────────────────────────────────────────────
 
-/** A single tool invocation, for the per-agent span waterfall. Ephemeral — kept
- *  only in the in-memory ring buffer, never persisted. */
+/** 单次工具调用，用于按 agent 的跨度瀑布。瞬时数据——仅保存在内存环形缓冲
+ *  区中，绝不持久化。 */
 export interface ToolSpan {
   agentId: string;
   sessionId: string;
@@ -77,20 +74,20 @@ export interface ToolSpan {
   error?: string;
 }
 
-/** The normalized event pushed to the renderer over `telemetry:event`. */
+/** 通过 `telemetry:event` 推送给渲染进程的规范化事件。 */
 export type TelemetryEvent =
   | { kind: 'usage'; sample: AgentUsageSample }
   | { kind: 'tool_result'; span: ToolSpan }
   | { kind: 'api_error'; agentId: string; sessionId: string; ts: number; error: string };
 
-/** Cold-start backfill returned by `snapshot()`. */
+/** 由 `snapshot()` 返回的冷启动回填。 */
 export interface TelemetrySnapshot {
   usage: AgentUsageSample[];
   spans: Record<string, ToolSpan[]>;
 }
 
-/** Per-session running accumulation (token.usage / cost.usage are DELTA +
- *  monotonic, so we sum each export rather than treating it as a total). */
+/** 按会话的持续累计（token.usage / cost.usage 是 DELTA + 单调递增的，因此
+ *  我们累加每次导出，而不是把它当作总量）。 */
 interface SessionAccum {
   agentId: string;
   model: string;
@@ -102,26 +99,25 @@ interface SessionAccum {
   usd: number;
 }
 
-const MAX_BODY_BYTES = 8 * 1024 * 1024; // OTLP batches are small; cap unauth peers.
-const SPAN_RING_CAP = 200; // rich spans retained per agent for the waterfall.
+const MAX_BODY_BYTES = 8 * 1024 * 1024; // OTLP 批次很小；限制未认证对等方。
+const SPAN_RING_CAP = 200; // 每个 agent 在瀑布中保留的丰富跨度数。
 
 export interface TelemetryCollectorOptions {
-  /** Loopback host to bind. Defaults to 127.0.0.1 (the trust boundary). */
+  /** 要绑定的回环主机。默认 127.0.0.1（信任边界）。 */
   host?: string;
-  /** TCP port. Defaults to 0 → OS-assigned ephemeral port (avoids clashing with
-   *  a user's own collector on 4318); the chosen port is read back from the
-   *  bound socket and exposed via `endpoint()`. */
+  /** TCP 端口。默认 0 → 由 OS 分配临时端口（避免与用户自己在 4318 上的
+   *  收集器冲突）；选定的端口会从已绑定的 socket 读回，并通过
+   *  `endpoint()` 暴露。 */
   port?: number;
-  /** Sink for renderer-facing events (set to `webContents.send`). No-op in tests. */
+  /** 面向渲染进程的事件的接收端（设为 `webContents.send`）。测试中为 no-op。 */
   emit?: (channel: string, payload: unknown) => void;
-  /** Resolve an agent's cwd (from the hive registry) for the transcript fallback. */
+  /** 解析某个 agent 的 cwd（来自 hive 注册表），用于转录回退。 */
   resolveCwd?: (agentId: string) => string | null;
-  /** Resolve an agent's CURRENT Claude Code session id (from the hive registry)
-   *  for the transcript fallback (D11). Without this, the fallback can only
-   *  fall back further to summing every `.jsonl` ever written in the agent's
-   *  cwd — correct for a lone agent in its own directory, but a shared/reused
-   *  cwd (the common case for hive workers) pulls in every other agent's and
-   *  every past session's history too. */
+  /** 解析某个 agent 当前的 Claude Code 会话 id（来自 hive 注册表），用于
+   *  转录回退（D11）。没有它，回退只能进一步退化为对该 agent cwd 中写下的
+   *  每个 `.jsonl` 求和——对独居其目录的单个 agent 是正确的，但对共享/复用
+   *  的 cwd（hive worker 的常见情况）会把其他所有 agent 及所有历史会话
+   *  一并纳入。 */
   resolveSessionId?: (agentId: string) => string | undefined;
 }
 
@@ -134,16 +130,16 @@ export class TelemetryCollector {
   private readonly resolveCwd?: (agentId: string) => string | null;
   private readonly resolveSessionId?: (agentId: string) => string | undefined;
 
-  /** sessionId → running accumulation. */
+  /** sessionId → 持续累计。 */
   private readonly sessions = new Map<string, SessionAccum>();
-  /** agentId → its sessionIds (lets getAgentUsage aggregate across --resume). */
+  /** agentId → 其 sessionIds（让 getAgentUsage 能跨 `--resume` 聚合）。 */
   private readonly agentSessions = new Map<string, Set<string>>();
-  /** agentId → ring buffer of recent tool spans. */
+  /** agentId → 最近工具跨度的环形缓冲区。 */
   private readonly spans = new Map<string, ToolSpan[]>();
-  /** Push subscribers (Lane A breaker + dashboard). */
+  /** 推送订阅者（Lane A 熔断器 + 仪表盘）。 */
   private readonly usageSubs = new Set<(s: AgentUsageSample) => void>();
-  /** api_error subscribers — feeds Lane A's breaker error-storm trip (#6), which
-   *  has no input source of its own (hook payloads don't expose api errors). */
+  /** api_error 订阅者——为 Lane A 熔断器的错误风暴熔断（#6）供数，而它本身
+   *  没有输入来源（hook 载荷不暴露 api 错误）。 */
   private readonly apiErrorSubs = new Set<(agentId: string) => void>();
 
   constructor(opts: TelemetryCollectorOptions = {}) {
@@ -154,8 +150,8 @@ export class TelemetryCollector {
     this.resolveSessionId = opts.resolveSessionId;
   }
 
-  /** Bind the loopback OTLP listener. The handler is live the instant this
-   *  resolves; `endpoint()` then returns the URL to inject into agent env. */
+  /** 绑定回环 OTLP 监听器。本方法 resolve 的瞬间处理器即已生效；
+   *  `endpoint()` 随后返回要注入 agent 环境的 URL。 */
   async start(): Promise<{ ok: boolean; endpoint?: string; error?: string }> {
     if (this.server) return { ok: true, endpoint: this.endpoint() ?? undefined };
     try {
@@ -167,55 +163,53 @@ export class TelemetryCollector {
     }
   }
 
-  /** Close the listener. Idempotent and best-effort. Accumulated state is kept
-   *  (it's ephemeral anyway) so a restart doesn't lose live agents' totals. */
+  /** 关闭监听器。幂等且尽力而为。累计状态会保留（反正也是瞬时的），
+   *  这样重启不会丢失在线 agent 的总量。 */
   stop(): void {
     try { this.server?.close(); } catch { /* noop */ }
     this.server = null;
     this.boundPort = null;
   }
 
-  /** The bound loopback URL agents export to, or null until started. */
+  /** agent 导出到的已绑定回环 URL，未启动时为 null。 */
   endpoint(): string | null {
     return this.boundPort ? `http://${this.host}:${this.boundPort}` : null;
   }
 
-  // ─── The locked provider seam ──────────────────────────────────────────────
+  // ─── 锁定的 provider 接缝 ──────────────────────────────────────────────────
 
-  /** Pull (contract primary). OTel-live aggregate preferred; transcript fallback
-   *  when an agent has no live telemetry yet (e.g. spawned before the feature, or
-   *  telemetry off). Returns null only when neither source has anything. */
+  /** 拉取（契约主路径）。优先使用 OTel 实时聚合；当 agent 尚无实时遥测
+   *  （例如在功能上线前派生，或遥测关闭）时使用转录回退。仅在两个来源都
+   *  没有数据时才返回 null。 */
   getAgentUsage(agentId: string): AgentUsageSample | null {
     const live = this.aggregateLive(agentId);
     if (live) return live;
     return this.transcriptFallback(agentId);
   }
 
-  /** Push (additive, OTel-only). Fires the agent's fresh aggregate whenever new
-   *  telemetry lands. Returns an unsubscribe fn. */
+  /** 推送（附加式，仅 OTel）。每当新遥测落地时触发该 agent 的最新聚合。
+   *  返回一个退订函数。 */
   onAgentUsage(cb: (s: AgentUsageSample) => void): () => void {
     this.usageSubs.add(cb);
     return () => this.usageSubs.delete(cb);
   }
 
-  /** In-process api_error feed for Lane A's breaker (#6). At integration:
-   *  `telemetry.onApiError((agentId) => breaker.recordError(agentId))`. Returns
-   *  an unsubscribe fn. */
+  /** 供 Lane A 熔断器（#6）使用的进程内 api_error 馈送。集成时：
+   *  `telemetry.onApiError((agentId) => breaker.recordError(agentId))`。
+   *  返回一个退订函数。 */
   onApiError(cb: (agentId: string) => void): () => void {
     this.apiErrorSubs.add(cb);
     return () => this.apiErrorSubs.delete(cb);
   }
 
-  /** Drop an agent's live usage so a respawn starts with a fresh counter.
-   *  Clears the in-memory accumulation only — the on-disk cost ledger and the
-   *  transcript fallback are untouched, so lifetime spending still reports. The
-   *  span ring goes too: it is keyed by agent id, so a replacement would
-   *  otherwise inherit the dead agent's tool waterfall.
+  /** 丢弃某 agent 的实时用量，以便重启后从全新计数开始。只清内存中的累计
+   *  ——磁盘上的成本账本和转录回退都不受影响，因此终身支出仍会如实上报。
+   *  跨度环形缓冲区也随之清空：它以 agent id 为键，否则替换者会继承已死
+   *  agent 的工具瀑布。
    *
-   *  Known edge: metrics are delivered asynchronously, so a batch already in
-   *  flight when the PTY dies can land after this call and recreate the dead
-   *  session's entries. The window is milliseconds and the next teardown
-   *  clears it, so it is left unguarded rather than carrying a tombstone. */
+   *  已知边界：指标是异步投递的，因此 PTY 死亡时已在途中的批次可能在本
+   *  调用之后落地并重建已死会话的条目。窗口只有几毫秒，且下一次拆除会将其
+   *  清除，所以此处不做墓碑标记而是留之不管。 */
   forgetAgent(agentId: string): void {
     const sessionIds = this.agentSessions.get(agentId);
     if (sessionIds) {
@@ -225,12 +219,12 @@ export class TelemetryCollector {
     this.spans.delete(agentId);
   }
 
-  /** Recent tool spans for the per-agent waterfall (#7B.2), oldest→newest. */
+  /** 用于按 agent 瀑布（#7B.2）的最近工具跨度，按时间由旧到新排列。 */
   getSpans(agentId: string): ToolSpan[] {
     return this.spans.get(agentId)?.slice() ?? [];
   }
 
-  /** Everything the renderer needs on cold start (it missed the live pushes). */
+  /** 渲染进程冷启动时需要的一切（它错过了实时推送）。 */
   snapshot(): TelemetrySnapshot {
     const usage: AgentUsageSample[] = [];
     for (const agentId of this.agentSessions.keys()) {
@@ -242,7 +236,7 @@ export class TelemetryCollector {
     return { usage, spans };
   }
 
-  // ─── HTTP plumbing (mirrors slack.ts) ──────────────────────────────────────
+  // ─── HTTP 管道（仿照 slack.ts） ────────────────────────────────────────────
 
   private listen(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -282,23 +276,23 @@ export class TelemetryCollector {
         const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
         if (url.includes('/v1/metrics')) this.ingestMetrics(body);
         else if (url.includes('/v1/logs')) this.ingestLogs(body);
-      } catch { /* malformed batch — drop it, never throw into the socket */ }
-      // OTLP success response is an empty JSON ExportServiceResponse.
+      } catch { /* 畸形批次——丢弃，绝不把异常抛进 socket */ }
+      // OTLP 成功响应是一个空的 JSON ExportServiceResponse。
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end('{}');
     });
     req.on('error', () => {
       if (aborted) return;
-      try { res.writeHead(400); res.end(); } catch { /* socket gone */ }
+      try { res.writeHead(400); res.end(); } catch { /* socket 已消失 */ }
     });
   }
 
-  // ─── OTLP decode → normalize → accumulate ──────────────────────────────────
+  // ─── OTLP 解码 → 规范化 → 累计 ────────────────────────────────────────────
 
   private ingestMetrics(body: unknown): void {
     const root = body as { resourceMetrics?: ResourceMetrics[] };
     if (!Array.isArray(root?.resourceMetrics)) return;
-    const touched = new Set<string>(); // agentIds with new data this batch
+    const touched = new Set<string>(); // 本批次中带有新数据的 agentId
     for (const rm of root.resourceMetrics) {
       const resAttrs = flattenAttrs(rm.resource?.attributes);
       for (const sm of rm.scopeMetrics ?? []) {
@@ -358,13 +352,13 @@ export class TelemetryCollector {
             this.pushSpan(span);
             this.emit?.('telemetry:event', { kind: 'tool_result', span } satisfies TelemetryEvent);
           } else if (name === 'tool_decision') {
-            // Attach the accept/reject decision to the most recent span, and emit.
+            // 把 accept/reject 决定挂到最近的跨度上，并发出事件。
             const decision = str(attrs['decision']) === 'reject' ? 'reject' : 'accept';
             const ring = this.spans.get(agentId);
             if (ring?.length) ring[ring.length - 1].decision = decision;
           } else if (name === 'api_error' || (name && name.includes('error'))) {
             const error = str(attrs['error']) || str(attrs['message']) || name;
-            for (const cb of this.apiErrorSubs) { try { cb(agentId); } catch { /* subscriber threw */ } }
+            for (const cb of this.apiErrorSubs) { try { cb(agentId); } catch { /* 订阅者抛错 */ } }
             this.emit?.('telemetry:event', { kind: 'api_error', agentId, sessionId, ts: Date.now(), error } satisfies TelemetryEvent);
           }
         }
@@ -372,7 +366,7 @@ export class TelemetryCollector {
     }
   }
 
-  // ─── Accumulation helpers ──────────────────────────────────────────────────
+  // ─── 累计辅助函数 ─────────────────────────────────────────────────────────
 
   private session(agentId: string, sessionId: string): SessionAccum {
     let accum = this.sessions.get(sessionId);
@@ -393,8 +387,8 @@ export class TelemetryCollector {
     if (ring.length > SPAN_RING_CAP) ring.splice(0, ring.length - SPAN_RING_CAP);
   }
 
-  /** Sum an agent's live sessions into one cumulative sample (sessionId/model =
-   *  the most recently active session). Null if the agent has no live data. */
+  /** 把一个 agent 的实时会话汇总为一个累计样本（sessionId/model 取最近
+   *  活跃的会话）。该 agent 没有实时数据时返回 null。 */
   private aggregateLive(agentId: string): AgentUsageSample | null {
     const set = this.agentSessions.get(agentId);
     if (!set || set.size === 0) return null;
@@ -414,21 +408,19 @@ export class TelemetryCollector {
     return out;
   }
 
-  /** D11: a cwd is routinely SHARED — every hive worker spawned against the same
-   *  repo (isolation is best-effort and several call sites deliberately skip it)
-   *  lands in the same `~/.claude/projects/<key>/` directory as every other
-   *  agent that ever ran there, this app-run or a past one. Without a session
-   *  filter, `readAgentUsage` sums ALL of it — confirmed live: a probe worker
-   *  with zero LLM calls was reaped citing 143,369,766 tokens, which was in fact
-   *  the shared project directory's entire history across other agents'
-   *  sessions, not its own. So this fallback now filters to the agent's OWN
-   *  current session id and, when that id isn't known yet (nothing has hooked
-   *  in for this agent this run — the true zero-usage case for a just-spawned
-   *  agent), reports "no data" rather than someone else's history. `sessionId`
-   *  stays '' on the returned sample regardless — deliberately, so it keeps
-   *  reading as "no live session" to the #56 cost-ledger dedup gate in
-   *  index.ts (`if (sample?.sessionId) appendCostLedger(...)`); the resolved id
-   *  is used only to filter the read, never surfaced as if it were live OTel. */
+  /** D11：cwd 经常是 SHARED 的——每个针对同一 repo 派生的 hive worker
+   *  （隔离是尽力而为，且多个调用点刻意跳过它）都会落入与其他所有曾在那里
+   *  运行过的 agent（无论是本次运行还是过去运行）相同的
+   *  `~/.claude/projects/<key>/` 目录。如果没有会话过滤，
+   *  `readAgentUsage` 会把这一切全部累加——已实况确认：一个零 LLM 调用的
+   *  探针 worker 被收割时引用了 143,369,766 个令牌，那其实是共享项目目录
+   *  里其他 agent 各会话的整个历史，而非它自己的。因此该回退现在只过滤到
+   *  agent 自己的当前会话 id，而当该 id 尚不可知时（本次运行还没有任何东西
+   *  为该 agent 挂接——这正是刚派生 agent 真正的零用量情形），上报
+   *  “无数据”而不是别人的历史。返回样本上的 `sessionId` 一律保持 ''——
+   *  刻意如此，以便对 index.ts 中的 #56 成本账本去重闸门
+   *  （`if (sample?.sessionId) appendCostLedger(...)`）始终读作“无在线会话”；
+   *  解析出的 id 只用于过滤读取，绝不当作实时 OTel 外露。 */
   private transcriptFallback(agentId: string): AgentUsageSample | null {
     const cwd = this.resolveCwd?.(agentId);
     if (!cwd) return null;
@@ -452,12 +444,12 @@ export class TelemetryCollector {
   private publishUsage(agentId: string): void {
     const sample = this.aggregateLive(agentId);
     if (!sample) return;
-    for (const cb of this.usageSubs) { try { cb(sample); } catch { /* subscriber threw */ } }
+    for (const cb of this.usageSubs) { try { cb(sample); } catch { /* 订阅者抛错 */ } }
     this.emit?.('telemetry:event', { kind: 'usage', sample } satisfies TelemetryEvent);
   }
 }
 
-// ─── OTLP/JSON attribute decoding ─────────────────────────────────────────────
+// ─── OTLP/JSON 属性解码 ──────────────────────────────────────────────────────
 
 interface OtelKV { key?: string; value?: OtelAnyValue }
 interface OtelAnyValue {
@@ -472,15 +464,15 @@ interface ResourceMetrics { resource?: { attributes?: OtelKV[] }; scopeMetrics?:
 interface OtelLogRecord { attributes?: OtelKV[]; body?: { stringValue?: string } }
 interface ResourceLogs { resource?: { attributes?: OtelKV[] }; scopeLogs?: { logRecords?: OtelLogRecord[] }[] }
 
-/** Allowlist of attribute keys we ever read — anything else (notably the PII:
- *  user.email, user.account_id/uuid, organization.id, user.id) is ignored, so
- *  nothing this module emits can carry identity. */
+/** 我们会读取的属性键允许列表——其余一切（尤其 PII：user.email、
+ *  user.account_id/uuid、organization.id、user.id）都会被忽略，因此本模块
+ *  产出的任何内容都无法携带身份信息。 */
 const ATTR_ALLOWLIST = new Set([
   'agent.id', 'agent.name', 'session.id', 'model', 'type',
   'tool_name', 'success', 'duration_ms', 'decision', 'event.name', 'error', 'message'
 ]);
 
-/** Flatten an OTLP KeyValue[] to a plain object, keeping only allowlisted keys. */
+/** 把 OTLP KeyValue[] 展平为普通对象，只保留允许列表中的键。 */
 function flattenAttrs(attrs: OtelKV[] | undefined): Record<string, string | number | boolean> {
   const out: Record<string, string | number | boolean> = {};
   if (!Array.isArray(attrs)) return out;
@@ -496,7 +488,7 @@ function flattenAttrs(attrs: OtelKV[] | undefined): Record<string, string | numb
   return out;
 }
 
-/** A metric data point's numeric value (int counters arrive as strings in JSON). */
+/** 指标数据点的数值（整数计数器在 JSON 中会以字符串到达）。 */
 function pointValue(dp: OtelDataPoint): number {
   if (dp.asInt !== undefined) return Number(dp.asInt) || 0;
   if (typeof dp.asDouble === 'number') return dp.asDouble;

--- a/src/main/transcript.ts
+++ b/src/main/transcript.ts
@@ -3,73 +3,70 @@ import os from 'node:os';
 import path from 'node:path';
 import { estimateCostUsd, normalizeModel } from './pricing';
 
-/** Claude Code's project key: the absolute cwd with EVERY non-alphanumeric
- *  character turned into a dash — the leading slash and any dots included.
+/** Claude Code 的项目键：绝对 cwd 中 EVERY 非字母数字
+ *  字符全部转成短横线——前导斜杠和任何点都包括在内。
  *  /Users/me/app → -Users-me-app, /Users/me/MDv0.3.0 → -Users-me-MDv0-3-0,
  *  C:\Users\me\app → C--Users-me-app.
  *
- *  One rule for every platform. The Windows branch always used it; POSIX had its
- *  own narrower spelling, and that divergence is what broke — see projectDir. */
+ *  每个平台只有一条规则。Windows 分支一直用它；POSIX 有自己的
+ *  更窄拼写，正是这种分歧坏了事——见 projectDir。 */
 function projectKey(cwd: string): string {
   return cwd.replace(/[^a-zA-Z0-9]/g, '-');
 }
 
-/** The pre-2026 POSIX key: leading slash DROPPED, only slashes dashed, so dots
- *  survived (/Users/me/MDv0.3.0 → Users-me-MDv0.3.0). Kept solely so transcripts
- *  written before the change stay readable. */
+/** 2026 之前的 POSIX 键：去掉前导斜杠，只把斜杠变成短横线，因此点
+ *  得以保留（/Users/me/MDv0.3.0 → Users-me-MDv0.3.0）。仅保留以使
+ *  变更之前写入的转录仍可读。 */
 function legacyProjectKey(cwd: string): string {
   return process.platform === 'win32'
     ? projectKey(cwd)
     : cwd.replace(/^\//, '').replaceAll('/', '-');
 }
 
-/** Resolve the Claude Code transcript directory for a given working directory:
- *  ~/.claude/projects keyed by cwd.
+/** 解析给定工作目录对应的 Claude Code 转录目录：
+ *  ~/.claude/projects 以 cwd 为键。
  *
- *  We used to emit the legacy key unconditionally on POSIX, which silently
- *  stopped matching once Claude Code moved to dashing every non-alphanumeric.
- *  Nothing errored — every caller reads an absent directory as "no transcripts
- *  yet" — so the miss cost months of dead memory condensation (a long run of
- *  `condense-abort`s with zero successes) and a usage reconciler quietly reading
- *  nothing at all.
+ *  我们过去在 POSIX 上无条件地输出旧键，一旦 Claude Code 改为把所有
+ *  非字母数字字符加短横线，这个键就静默地不再匹配了。什么都不会报错——
+ *  每个调用方都把缺失目录读作「还没有转录」——因此这次错失耗掉了数月
+ *  无效的记忆冷凝（一长串 `condense-abort`，零成功）以及一个用量对账器
+ *  一直在安静地读空。
  *
- *  Prefer the CURRENT spelling; fall back to the legacy one only when it exists
- *  and the current one does not, so pre-change installs stay readable. That order
- *  is not cosmetic: this harness itself created legacy-named directories by
- *  copying transcripts into them, so a fallback-first resolver would keep reading
- *  our own stale copies forever. When neither exists we return the CURRENT
- *  spelling, because callers that go on to create the directory must create the
- *  one Claude Code will actually read. */
+ *  优先使用 CURRENT（当前）拼写；仅当旧拼写存在而当前拼写不存在时
+ *  才回退到旧拼写，这样变更前的安装仍可读。这个顺序不是装饰：本 harness
+ *  自己就曾把转录复制进旧命名目录，因此一个「先回退」的解析器会永远
+ *  继续读我们自己过时的副本。当两者都不存在时返回 CURRENT 拼写，
+ *  因为继续创建目录的调用方必须创建 Claude Code 真正会读的那一个。 */
 export function projectDir(cwd: string): string {
   const root = path.join(os.homedir(), '.claude/projects');
   const current = path.join(root, projectKey(cwd));
   if (existsSync(current)) return current;
-  // For cwd '/' the legacy key is the empty string, and path.join(root, '')
-  // collapses to the projects ROOT — which always exists, so the fallback would
-  // hand back a directory holding every project rather than one, and callers
-  // would read/seed `~/.claude/projects/<session>.jsonl`. An empty key is not a
-  // project name; treat it as no legacy candidate at all.
+  // 对 cwd '/' 而言，旧键是空字符串，而 path.join(root, '')
+  // 会折叠成 projects 的 ROOT——它总是存在，因此回退会交出一个装有
+  // 所有项目的目录而非某一个，调用方会读/种下
+  // `~/.claude/projects/<session>.jsonl`。空键不是项目名；
+  // 把它当作根本没有旧候选。
   const legacyKey = legacyProjectKey(cwd);
   if (!legacyKey) return current;
   const legacy = path.join(root, legacyKey);
   return existsSync(legacy) ? legacy : current;
 }
 
-/** Ensure session `<sessionId>.jsonl` exists in `cwd`'s Claude project dir so a
- *  `claude --resume <sessionId>` spawn in that cwd can find it. Claude keys
- *  transcripts by cwd, so a session started elsewhere is invisible until its
- *  `.jsonl` is seeded across.
+/** 确保会话 `<sessionId>.jsonl` 存在于 `cwd` 的 Claude 项目目录中，
+ *  这样该 cwd 下 `claude --resume <sessionId>` 生成才能找到它。Claude
+ *  按 cwd 键控转录，因此一个别处启动的会话在它的 `.jsonl` 跨目录种下
+ *  之前是不可见的。
  *
- *  - Already present in the target project dir → no-op, returns true.
- *  - Found under a DIFFERENT project dir (resumed from another cwd — the Add
- *    Agent "resume session" flow, #2) → copied across, returns true.
- *  - Not found anywhere → returns false, so the caller can fall back to a fresh
- *    session instead of launching a broken `--resume`.
+ *  - 已存在于目标项目目录 → 无操作，返回 true。
+ *  - 在 DIFFERENT（不同）项目目录下找到（从另一个 cwd 恢复——Add
+ *    Agent 的「恢复会话」流程，#2）→ 复制过来，返回 true。
+ *  - 任何地方都找不到 → 返回 false，这样调用方可回退到全新会话，
+ *    而不是启动一个坏掉的 `--resume`。
  *
- *  Best-effort: any fs error yields false rather than throwing into the spawn. */
-/** A Claude session id is a UUID. Renderer-supplied ids flow into `path.join`, so
- *  reject anything outside this charset before using one as a path component (a
- *  crafted id like `../../x` would otherwise traverse out of the project dirs). */
+ *  尽力而为：任何 fs 错误都返回 false，而不是把异常抛进生成流程。 */
+/** Claude 会话 id 是一个 UUID。渲染进程提供的 id 会流入 `path.join`，
+ *  因此在把 id 用作路径组件之前，要拒绝该字符集之外的任何内容
+ *  （精心构造的 `../../x` 之类 id 否则会穿越出项目目录）。 */
 const VALID_SESSION_ID = /^[A-Za-z0-9_-]+$/;
 
 export function seedSessionTranscript(cwd: string, sessionId: string): boolean {
@@ -93,13 +90,13 @@ export function seedSessionTranscript(cwd: string, sessionId: string): boolean {
   }
 }
 
-/** Resolve a session id to the ORIGINAL working directory it ran in, for the Add
- *  Agent "resume session" auto-fill. The cwd is read from a transcript RECORD
- *  (every line carries a `cwd` field) — deliberately NOT by un-dashing the
- *  project-dir name, which is lossy when the path itself contains dashes. Searches
- *  every `~/.claude/projects/<dir>/<sessionId>.jsonl`; if more than one matches
- *  (shouldn't — session ids are unique UUIDs) the most-recently-modified wins.
- *  Returns the cwd string, or null if not found / unreadable / no cwd record. */
+/** 把会话 id 解析回它运行的 ORIGINAL（原始）工作目录，用于 Add
+ *  Agent 的「恢复会话」自动填充。cwd 从转录 RECORD（每条记录都携带
+ *  `cwd` 字段）中读取——刻意 NOT 通过去短横线还原项目目录名，
+ *  后者在路径本身含短横线时会有损。搜索每个
+ *  `~/.claude/projects/<dir>/<sessionId>.jsonl`；若有多个匹配
+ *  （不应出现——会话 id 是唯一 UUID）则最近修改者胜出。
+ *  返回 cwd 字符串；找不到/不可读/无 cwd 记录时返回 null。 */
 export function resolveSessionCwd(sessionId: string): string | null {
   try {
     if (!sessionId || !VALID_SESSION_ID.test(sessionId)) return null;
@@ -111,7 +108,7 @@ export function resolveSessionCwd(sessionId: string): string | null {
       try {
         const st = statSync(candidate);
         if (!best || st.mtimeMs > best.mtime) best = { file: candidate, mtime: st.mtimeMs };
-      } catch { /* not present in this project dir */ }
+      } catch { /* 该项目目录中不存在 */ }
     }
     if (!best) return null;
     const text = readFileSync(best.file, 'utf8');
@@ -121,7 +118,7 @@ export function resolveSessionCwd(sessionId: string): string | null {
       try {
         const rec = JSON.parse(trimmed) as { cwd?: unknown };
         if (typeof rec.cwd === 'string' && rec.cwd) return rec.cwd;
-      } catch { /* skip a malformed line */ }
+      } catch { /* 跳过畸形行 */ }
     }
     return null;
   } catch {
@@ -135,8 +132,8 @@ export interface AgentUsage {
   cacheReadTokens: number;
   cacheWriteTokens: number;
   estimatedCostUsd: number;
-  /** The most-recently-seen model id (normalized, e.g. `claude-opus-4-8`), or
-   *  undefined if no priced record was found. Lets the UI label the row. */
+  /** 最近一次看到的模型 id（已规范化，如 `claude-opus-4-8`），或
+   *  没有找到已计价的记录时为 undefined。让 UI 给该行贴标签。 */
   model?: string;
 }
 
@@ -145,33 +142,32 @@ function zero(): AgentUsage {
 }
 
 export interface ReadUsageOptions {
-  /** When set, only transcripts whose records carry this `sessionId` are summed.
-   *  This is how the co-located-agents double-count (bug #2) is avoided: two
-   *  agents sharing a cwd each filter to their own session instead of summing
-   *  every `.jsonl` under the shared project dir. When unset, all are summed
-   *  (the legacy behavior, used when the agent's session id isn't yet known). */
+  /** 设置后，只对记录携带此 `sessionId` 的转录求和。
+   *  这正是避免同驻代理重复计数（bug #2）的方式：两个共享 cwd 的代理
+   *  各自过滤到自己的会话，而不是对共享项目目录下每个 `.jsonl` 求和。
+   *  未设置时全部求和（旧行为，用于代理的会话 id 尚不可知的情况）。 */
   sessionId?: string;
 }
 
-/** Per-file incremental parse state for the usage cache. Transcripts are
- *  append-only JSONL, so a parsed byte range's totals never change — repeat
- *  reads only stat the file and parse the appended tail. Keyed by
- *  dir|file|sessionFilter since the filter changes what a range sums to. */
+/** 用量缓存的按文件增量解析状态。转录是只增的 JSONL，
+ *  因此已解析字节区间的总计绝不会变——重复读取只会 stat 文件并解析
+ *  追加的尾部。以 dir|file|sessionFilter 为键，因为过滤器会改变
+ *  一个区间求和的结果。 */
 interface FileUsageEntry {
   size: number;
   mtimeMs: number;
-  /** Bytes parsed so far — always ends on a newline boundary, so a torn
-   *  trailing line is simply re-read once the writer completes it. */
+  /** 目前已解析的字节数——总是停在新行边界上，因此被截断的
+   *  尾部行只会在写入方写完它之后才被重新读取。 */
   offset: number;
   totals: AgentUsage;
 }
 
 const usageCache = new Map<string, FileUsageEntry>();
-/** Soft bound; when crossed, the oldest-inserted half is dropped (entries
- *  rebuild on demand). Real fleets have tens of transcripts, not thousands. */
+/** 软上限；越过时丢弃最早插入的一半（条目按需重建）。
+ *  真实群组只有几十份转录，不是几千份。 */
 const USAGE_CACHE_MAX = 2048;
 
-/** Parse complete JSONL lines into `acc` (the shared per-record logic). */
+/** 把完整的 JSONL 行解析进 `acc`（共享的逐记录逻辑）。 */
 function parseUsageLines(text: string, sessionId: string | undefined, acc: AgentUsage): void {
   for (const line of text.split('\n')) {
     const trimmed = line.trim();
@@ -187,7 +183,7 @@ function parseUsageLines(text: string, sessionId: string | undefined, acc: Agent
       continue;
     }
     if (rec.type !== 'assistant') continue;
-    // Session filter: skip records that aren't this agent's session.
+    // 会话过滤：跳过不属于该代理会话的记录。
     if (sessionId && rec.sessionId !== sessionId) continue;
     const u = rec.message?.usage;
     if (!u) continue;
@@ -201,8 +197,8 @@ function parseUsageLines(text: string, sessionId: string | undefined, acc: Agent
     acc.outputTokens += rOut;
     acc.cacheWriteTokens += rCacheWrite;
     acc.cacheReadTokens += rCacheRead;
-    // Price THIS record by its own model, then accumulate — so a mixed-model
-    // agent (rare) is still costed correctly rather than at one flat rate.
+    // 按该记录自己的模型计价，然后累加——这样混合模型的代理（罕见）
+    // 仍能被正确计费，而不是按一个统一费率估算。
     acc.estimatedCostUsd += estimateCostUsd(model, {
       inputTokens: rIn,
       outputTokens: rOut,
@@ -212,9 +208,9 @@ function parseUsageLines(text: string, sessionId: string | undefined, acc: Agent
   }
 }
 
-/** Cached totals for one transcript file, refreshed incrementally: unchanged
- *  size+mtime → cache hit (no read at all); grown → parse only the appended
- *  tail; shrunk (rewritten) → full re-parse. Null when the file vanished. */
+/** 单个转录文件的缓存总计，增量刷新：size+mtime 未变 → 缓存命中
+ *  （完全不读）；变大 → 只解析追加的尾部；变小（被重写）→ 完整重解析。
+ *  文件消失时返回 Null。 */
 function readFileUsage(dir: string, file: string, sessionId: string | undefined): FileUsageEntry | null {
   const key = `${dir}|${file}|${sessionId ?? '*'}`;
   const full = path.join(dir, file);
@@ -234,9 +230,8 @@ function readFileUsage(dir: string, file: string, sessionId: string | undefined)
         const buf = Buffer.alloc(len);
         const read = readSync(fd, buf, 0, len, entry.offset);
         const text = buf.subarray(0, read).toString('utf8');
-        // Consume only up to the last complete line; a torn trailing line
-        // stays unparsed (offset holds at the newline) until the writer
-        // finishes it — it is then counted exactly once.
+        // 只消费到最后一个完整行为止；被截断的尾部行保持未解析
+        // （offset 停在新行处），直到写入方把它写完——它随后恰好被计数一次。
         const lastNl = text.lastIndexOf('\n');
         if (lastNl !== -1) {
           const complete = text.slice(0, lastNl + 1);
@@ -246,7 +241,7 @@ function readFileUsage(dir: string, file: string, sessionId: string | undefined)
       }
     } finally { closeSync(fd); }
   } catch {
-    // Unreadable right now — keep what we have; totals refresh on the next call.
+    // 此刻不可读——保留已解析的部分；总计在下一次调用时刷新。
   }
   usageCache.set(key, entry);
   if (usageCache.size > USAGE_CACHE_MAX) {
@@ -256,17 +251,16 @@ function readFileUsage(dir: string, file: string, sessionId: string | undefined)
   return entry;
 }
 
-/** Sum real token usage across Claude Code transcripts for `cwd`, pricing each
- *  assistant record by ITS OWN model (fixes cost bug #1 — no more Sonnet for
- *  everyone) via the fallback price table. Optionally filtered to one session
- *  (fixes bug #2). Resilient by design: any unreadable file or malformed line is
- *  skipped, and any unexpected failure yields a zeroed result rather than
- *  throwing into the IPC handler. This is the OFFLINE reconciler / fallback —
- *  the live source is the OTel collector (`telemetry.ts`).
+/** 对 `cwd` 的 Claude Code 转录做真实 token 用量求和，按每个 assistant
+ *  记录 ITS OWN（它自己的）模型计价（修复成本 bug #1——不再人人都是
+ *  Sonnet）经由回退价格表。可选地过滤到单个会话（修复 bug #2）。
+ *  设计上就健壮：任何不可读文件或畸形行都会被跳过，任何意外失败都返回
+ *  归零结果，而不是把异常抛进 IPC 处理器。这是 OFFLINE（离线）对账 /
+ *  回退——实时来源是 OTel 采集器（`telemetry.ts`）。
  *
- *  Called from the ~30s breaker/cost beat for every agent without live OTel, so
- *  it must stay cheap on multi-MB transcript dirs: per-file incremental caching
- *  above means a steady-state call is a readdir + one stat per file. */
+ *  在每个没有实时 OTel 的代理上由 ~30s 熔断/成本节拍调用，因此它必须在
+ *  多 MB 的转录目录上保持廉价：上面的按文件增量缓存意味着稳态调用只是
+ *  一次 readdir 加每个文件一次 stat。 */
 export function readAgentUsage(cwd: string, opts: ReadUsageOptions = {}): AgentUsage {
   const usage = zero();
   try {
@@ -295,12 +289,11 @@ function num(v: unknown): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : 0;
 }
 
-/** Current context size (tokens) of a live session: the token accounting of the
- *  LAST assistant message in its transcript — input + cache read/write is what
- *  the model just consumed as context, plus its output which joins the context
- *  for the next turn. Tail-reads the file (transcripts grow to many MB), so a
- *  poll stays cheap. Returns null when the transcript is missing/unreadable or
- *  holds no assistant message yet. */
+/** 活动会话的当前上下文大小（token 数）：其转录中 LAST（最后一条）
+ *  assistant 消息的 token 记账——输入 + 缓存读/写正是模型刚作为上下文
+ *  消耗的量，再加上它的输出，后者会加入下一轮的上下文。尾部读取文件
+ *  （转录会长到数 MB），因此轮询保持廉价。当转录缺失/不可读或
+ *  还没有 assistant 消息时返回 null。 */
 const CONTEXT_TAIL_BYTES = 256 * 1024;
 
 export function readContextTokens(transcriptPath: string): number | null {
@@ -314,8 +307,8 @@ export function readContextTokens(transcriptPath: string): number | null {
       const buf = Buffer.alloc(len);
       readSync(fd, buf, 0, len, size - len);
       const lines = buf.toString('utf8').split('\n');
-      // Scan from the end; the very first chunk line may be cut mid-record and
-      // simply fails to parse, which is fine.
+      // 从末尾向前扫；最开头的块行可能被从记录中间切断，
+      // 解析失败即可，这没关系。
       for (let i = lines.length - 1; i >= 0; i--) {
         const trimmed = lines[i].trim();
         if (!trimmed) continue;

--- a/src/main/triggerHistory.ts
+++ b/src/main/triggerHistory.ts
@@ -1,22 +1,20 @@
 /**
- * The trigger ledger on disk — every inbound message a webhook or a peer's clone
- * node pushed at us, and every reply we sent back.
+ * 磁盘上的触发台账——webhook 或对等节点的克隆节点推给我们的每一条入站
+ * 消息，以及我们发回的每一条回复。
  *
- * It lives in its OWN file rather than in config.json for two reasons: it is
- * append-heavy (config.json is rewritten wholesale on every `writeConfig`, so a
- * growing array in it would make every unrelated settings write more expensive),
- * and it is disposable — losing history must never be able to cost the user their
- * settings. Structurally it follows config.ts: sync fs, mkdirSync-on-write, and a
- * try/catch around every disk touch that degrades to an empty ledger. Nothing here
- * throws at its caller, because the caller is always on a request path where
- * failing to RECORD an event must not fail the event itself.
+ * 它住在自己的文件里而不是 config.json，原因有二：它高度追加
+ * （config.json 每次 `writeConfig` 都会整块重写，里面的数组越长，
+ * 每次无关的设置写入就越贵）；而且它是可丢弃的——丢历史绝不能
+ * 连累用户的设置。结构上跟随 config.ts：同步 fs、写时 mkdirSync、
+ * 以及围绕每次磁盘触碰的 try/catch，失败时降级为空台账。
+ * 这里不会向调用方抛异常，因为调用方总在请求路径上，
+ * “记录事件”的失败绝不能拖垮事件本身。
  *
- * SECURITY — NEVER write a secret, API key or token into an entry. The ledger is
- * plaintext JSON in userData and is surfaced verbatim in the UI, so a webhook
- * secret or an org apiKey landing here would be a durable leak of a live
- * credential. Entries are therefore built FIELD BY FIELD below rather than by
- * spreading the caller's object: a caller that hands us a whole `WebhookTrigger`
- * (which carries `secret`) still gets only the ledger fields persisted.
+ * 安全——绝不要把机密、API key 或 token 写进条目。台账是 userData 里的
+ * 明文 JSON，并在 UI 中原样呈现，所以 webhook 密钥或 org apiKey 落到这里
+ * 就是对活凭据的持久泄漏。因此下面的条目是逐字段构建的，
+ * 而不是展开调用方的对象：即使调用方递给我们一个完整的
+ * `WebhookTrigger`（携带着 `secret`），也只有台账字段被持久化。
  */
 import { app } from 'electron';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -28,14 +26,14 @@ import {
   type TriggerHistoryEntry
 } from '../shared/triggers';
 
-/** What a caller must supply; `id` and `at` are stamped for them unless the
- *  caller has its own (a replayed/reconstructed entry keeps its identity). */
+/** 调用方必须提供的内容；`id` 和 `at` 会替它们盖章，除非调用方
+ *  自带（重放/重建的条目保留其身份）。 */
 export type TriggerHistoryInput =
   Omit<TriggerHistoryEntry, 'id' | 'at'> & { id?: string; at?: number };
 
-/** Only these may be changed after the fact. The ledger is append-only in spirit:
- *  an entry's source, direction and body are the record of what happened and are
- *  not rewritable — the mutable part is the operator's verdict on it. */
+/** 事后只有这些可以被修改。台账精神上是只追加的：条目的来源、方向
+ *  和正文是对已发生之事的记录，不可重写——可变的部分是操作员对它的
+ *  裁决。 */
 export type TriggerHistoryPatch = Partial<
   Pick<TriggerHistoryEntry, 'decision' | 'taskId' | 'correlationId' | 'title'>
 >;
@@ -44,10 +42,9 @@ function historyPath(): string {
   return join(app.getPath('userData'), 'trigger-history.json');
 }
 
-/** Newest first ON DISK as well as in memory. `listTriggerHistory` is the hot
- *  path (the UI re-reads it on every render of the Triggers tab) and the cap is
- *  enforced on every append, so keeping the file in display order makes both a
- *  slice instead of a sort. */
+/** 磁盘上和内存里都是最新在前。`listTriggerHistory` 是热路径（UI 每次
+ *  渲染 Triggers 标签页都会重读），上限在每次追加时强制，所以让文件
+ *  保持显示顺序，使两者都是切片而不是排序。 */
 function readAll(): TriggerHistoryEntry[] {
   const p = historyPath();
   if (!existsSync(p)) return [];
@@ -65,11 +62,11 @@ function writeAll(entries: TriggerHistoryEntry[]): void {
     const p = historyPath();
     mkdirSync(dirname(p), { recursive: true });
     writeFileSync(p, JSON.stringify(entries, null, 2), 'utf8');
-  } catch { /* best-effort; a ledger write must never fail the event it records */ }
+  } catch { /* 尽力而为；台账写入绝不能拖垮它所记录的事件 */ }
 }
 
-/** Structural guard for one persisted row. A hand-edited or partially-written
- *  file drops the bad rows rather than the whole ledger. */
+/** 对单条持久化行的结构守卫。手改过或写了一半的文件只丢弃坏行，
+ *  而不是整本台账。 */
 function isEntry(v: unknown): v is TriggerHistoryEntry {
   if (!v || typeof v !== 'object') return false;
   const e = v as Partial<TriggerHistoryEntry>;
@@ -85,14 +82,14 @@ function normaliseKind(kind: unknown): InboundKind {
 }
 
 /**
- * Record one event and return the row as persisted (the caller usually needs the
- * generated `id` so it can flip a `pending` decision later).
+ * 记录一个事件并返回持久化后的行（调用方通常需要生成的 `id`，
+ * 以便稍后翻转某个 `pending` 裁决）。
  *
- * The returned entry is what went to disk, so callers never have to guess how
- * their input was normalised.
+ * 返回的条目就是落盘的条目，所以调用方永远不用猜
+ * 自己的输入是如何被归一化的。
  */
 export function appendTriggerHistory(input: TriggerHistoryInput): TriggerHistoryEntry {
-  // Explicit field list — see the SECURITY note at the top of this file.
+  // 显式字段列表——见本文件顶部的安全说明。
   const entry: TriggerHistoryEntry = {
     id: input.id ?? randomBytes(8).toString('hex'),
     source: input.source,
@@ -112,17 +109,16 @@ export function appendTriggerHistory(input: TriggerHistoryInput): TriggerHistory
   return entry;
 }
 
-/** The whole ledger, newest first. */
+/** 整本台账，最新在前。 */
 export function listTriggerHistory(): TriggerHistoryEntry[] {
   return readAll();
 }
 
 /**
- * Amend one entry's verdict — the `pending` → `approved`/`rejected` transition
- * when the operator answers a strict-mode message, plus the `taskId` of whatever
- * the approval spawned. Returns null when the id is gone, which is a normal
- * outcome: the entry may have aged past TRIGGER_HISTORY_LIMIT while the operator
- * was deciding, and that is not an error worth throwing over.
+ * 修改一个条目的裁决——操作员答复严格模式消息时的
+ * `pending` → `approved`/`rejected` 转换，外加批准所派生的东西的 `taskId`。
+ * id 已消失时返回 null，这是正常结果：条目可能在操作员决策期间
+ * 已经老过 TRIGGER_HISTORY_LIMIT，那不值得为一个错误抛异常。
  */
 export function updateTriggerHistory(
   id: string,
@@ -141,12 +137,12 @@ export function updateTriggerHistory(
   return next;
 }
 
-/** Wipe the ledger, or just one source's half of it (clearing webhook noise
- *  should not throw away the org conversation, and vice versa). Removing the file
- *  outright on a full clear keeps a stale-but-unreadable file from lingering. */
+/** 清空台账，或只清某个来源的那一半（清 webhook 噪音不应丢掉
+ *  org 对话，反之亦然）。全清时直接删文件，
+ *  避免一个过期却不可读的文件留存。 */
 export function clearTriggerHistory(source?: 'webhook' | 'org'): void {
   if (!source) {
-    try { rmSync(historyPath(), { force: true }); } catch { /* best-effort */ }
+    try { rmSync(historyPath(), { force: true }); } catch { /* 尽力而为 */ }
     return;
   }
   writeAll(readAll().filter((e) => e.source !== source));

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -8,77 +8,69 @@ import { DEFAULT_DROP_HTML } from '../shared/releaseDrop';
 import { reduceStatus, clampPercent, isNewer, installerUrl, shouldShowReleaseDrop, type UpdateStatus } from '../shared/updateState';
 
 /**
- * Auto-update from GitHub releases.
+ * 从 GitHub releases 自动更新。
  *
- * Primary path: electron-updater against the `publish` block in
- * electron-builder.yml — the release workflow uploads latest*.yml + zip +
- * blockmaps, macOS builds are Developer ID signed + notarized + stapled, so
- * Squirrel.Mac (zip), NSIS, and AppImage all update natively. Downloads happen
- * in the background; installation is ALWAYS user-initiated ("restart to update"
- * → `update:restartAndInstall`). The app never restarts on its own.
+ * 主路径：electron-updater 对接 electron-builder.yml 中的 `publish` 块——
+ * 发布工作流会上传 latest*.yml + zip + blockmaps，macOS 构建经过 Developer ID
+ * 签名 + 公证 + 钉章，因此 Squirrel.Mac (zip)、NSIS 和 AppImage 都能原生更新。
+ * 下载在后台进行；安装始终由用户发起（"restart to update" →
+ * `update:restartAndInstall`）。应用绝不会自行重启。
  *
- * Fallback path (win-portable exe, or a genuine updater error): a plain
- * `releases/latest` poll — semver-compare against the running version and show a
- * notify-only state linking the release page.
+ * 回退路径（win-portable exe，或真正的更新器错误）：纯 `releases/latest`
+ * 轮询——与运行版本做 semver 比较，并展示一个仅通知、链接到发布页的状态。
  *
- * Everything is gated on the `autoUpdate` HarnessConfig flag (default ON,
- * Settings → General) and on `app.isPackaged` — dev runs never poll.
+ * 一切都受 `autoUpdate` HarnessConfig 开关（默认开，Settings → General）和
+ * `app.isPackaged` 限制——开发环境从不轮询。
  *
- * ─── v0.3.7: why native updating never actually ran ──────────────────────────
- * electron-updater is CommonJS and exposes `autoUpdater` through a lazy
- * `Object.defineProperty` getter. Node's cjs-module-lexer cannot see through
- * that, so the ESM namespace produced by `await import('electron-updater')` has
- * NO `autoUpdater` named export — only `.default.autoUpdater`. The old code did
- * `const { autoUpdater } = await import('electron-updater')`, got `undefined`,
- * and threw `TypeError: Cannot set properties of undefined (setting
- * 'autoDownload')` on the very first line of setup. That threw into a catch that
- * silently latched notify-only mode, so from v0.3.4 through v0.3.6 EVERY
- * packaged build only ever offered "open the releases page". It never showed up
- * in dev because the whole block is behind `app.isPackaged`.
+ * ─── v0.3.7：为什么原生更新从未真正运行过 ──────────────────────────────────
+ * electron-updater 是 CommonJS，并通过惰性 `Object.defineProperty` getter 暴露
+ * `autoUpdater`。Node 的 cjs-module-lexer 无法看穿它，因此
+ * `await import('electron-updater')` 产生的 ESM 命名空间里没有 `autoUpdater`
+ * 命名导出——只有 `.default.autoUpdater`。旧代码写的是
+ * `const { autoUpdater } = await import('electron-updater')`，得到 `undefined`，
+ * 并在 setup 第一行就抛出 `TypeError: Cannot set properties of undefined
+ * (setting 'autoDownload')`。该异常落入一个 catch，静默锁定了仅通知模式，
+ * 因此从 v0.3.4 到 v0.3.6 每个打包构建都只提供 "open the releases page"。
+ * 在开发环境从不显示，因为整个块在 `app.isPackaged` 之后。
  *
- * Two rules came out of that and both are load-bearing here:
- *   1. resolve the module through `loadAutoUpdater()` below, which handles the
- *      namespace/default interop and throws a NAMED error if the export is gone;
- *   2. never swallow an updater error — every failure is surfaced to the
- *      renderer AND appended to `updater.log` in userData, and the notify-only
- *      downgrade is per-check, not a permanent latch.
+ * 由此得出两条规则，且都承载关键负载：
+ *   1. 通过下面的 `loadAutoUpdater()` 解析模块，它处理
+ *      命名空间/default 互操作，若导出缺失则抛出带名字的错误；
+ *   2. 绝不吞掉更新器错误——每次失败都上报给渲染进程，并追加到 userData 的
+ *      `updater.log`，且仅通知降级是按次检查的，不是永久锁定。
  */
 
 const REPO = 'chaitanyagiri/munder-difflin';
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
-const FALLBACK_CACHE_MS = 60 * 60 * 1000;     // 1h between releases/latest polls
+const FALLBACK_CACHE_MS = 60 * 60 * 1000;     // 两次 releases/latest 轮询间隔 1h
 
 export type { UpdateStatus };
 
 let sendTo: (() => WebContents | null) | null = null;
 let started = false;
 let lastFallbackCheck = 0;
-/** Remembered so a status survives a renderer reload and can be re-served. */
+/** 记住状态，以便渲染进程重载后状态仍在并可重新提供。 */
 let lastStatus: UpdateStatus | null = null;
 /**
- * Resolved when a restart-to-install is CALLED OFF.
+ * 在重启即安装被 CALLED OFF（取消）时 resolve。
  *
- * `quitAndInstall()` does not report an outcome. It asks the app to quit, and
- * the app may refuse: with agents running, the quit warning goes up and the user
- * can cancel it. The handler used to return `{ ok: true }` the instant it made
- * that request, so the renderer was told the restart succeeded while the app was
- * still sitting there. Every surface that had disabled its button waiting for a
- * process that was never going to die then had nothing to wait for, and the
- * button stayed "restarting…" with no way back.
+ * `quitAndInstall()` 不报告结果。它请求应用退出，而应用可能拒绝：有 agent
+ * 在运行时，退出警告会弹出，用户可以取消它。旧处理器在发出该请求的瞬间就
+ * 返回 `{ ok: true }`，于是渲染进程被告知重启成功，而应用仍停留在原地。
+ * 每个为等待一个永远不会死的进程而禁用按钮的界面随后便失去了可等待的对象，
+ * 按钮卡在 "restarting…" 无法返回。
  *
- * So the handler now waits on this instead. Exactly one of two things happens:
- * the app really quits and this never settles (the process is gone, nothing is
- * left to tell), or the user cancels and `abortPendingRestart()` settles it and
- * the handler reports the truth.
+ * 因此处理器现在改为等待这个。只会发生两件事之一：应用真的退出，此承诺
+ * 永不 settle（进程已消失，没有东西可告知），或用户取消后
+ * `abortPendingRestart()` 使其 settle，处理器如实上报。
  */
 let pendingRestart: ((outcome: { ok: boolean; error?: string }) => void) | null = null;
 
 /**
- * The user backed out of the quit that a restart-to-install asked for.
+ * 用户从重启即安装所要求的退出中反悔退出。
  *
- * Called from the cancel path of the quit warning, which is the only place that
- * knows a requested quit was refused. Safe to call when no restart is pending —
- * an ordinary quit the user cancels is not our business.
+ * 由退出警告的取消路径调用，那是唯一知道某次请求的退出被拒绝的地方。
+ * 在没有待处理的重启时调用是安全的——用户取消一次普通退出与我们无关。
  */
 export function abortPendingRestart(): void {
   if (!pendingRestart) return;
@@ -89,14 +81,12 @@ export function abortPendingRestart(): void {
 }
 
 /**
- * A restart-to-install that the native updater REFUSED (Squirrel emits "The
- * command is disabled and cannot be executed" rather than throwing) reports
- * through the autoUpdater error event, not the handler's try/catch. Without
- * this, the handler's `await` would hang forever, the button would spin, the
- * user would click again, and the repeated quitAndInstall is exactly what keeps
- * Squirrel wedged. Settling here reports the failure back so the UI shows it and
- * stops the user re-clicking. Safe when nothing is pending (an ordinary check
- * error is not our business).
+ * 原生更新器 REFUSED（Squirrel 发出 "The command is disabled and cannot be
+ * executed" 而不是抛错）的重启即安装，通过 autoUpdater 错误事件上报，而不是
+ * 通过处理器的 try/catch。没有它，处理器的 `await` 会永远挂起，按钮一直
+ * 转圈，用户再次点击，而反复的 quitAndInstall 正是让 Squirrel 卡死的元凶。
+ * 在这里 settle 会把失败反馈回去，让 UI 展示它并阻止用户反复点击。
+ * 没有待处理项时调用是安全的（普通检查错误与我们无关）。
  */
 function failPendingRestart(error: string): void {
   if (!pendingRestart) return;
@@ -105,8 +95,8 @@ function failPendingRestart(error: string): void {
   resolve({ ok: false, error });
 }
 
-/** Append-only breadcrumb trail in userData. The whole point of this file's
- *  existence is that the last failure left no trace anywhere. */
+/** userData 中只追加的面包屑轨迹。本文件存在的全部意义就在于上一次失败
+ *  没有在别处留下任何痕迹。 */
 function logLine(msg: string): void {
   const line = `[${new Date().toISOString()}] ${msg}\n`;
   console.log('[updater]', msg);
@@ -114,17 +104,17 @@ function logLine(msg: string): void {
     const dir = app.getPath('userData');
     mkdirSync(dir, { recursive: true });
     appendFileSync(join(dir, 'updater.log'), line);
-  } catch { /* logging must never take the app down */ }
+  } catch { /* 日志绝不能拖垮应用 */ }
 }
 
 function emit(status: UpdateStatus): void {
   lastStatus = reduceStatus(lastStatus, status);
-  try { sendTo?.()?.send('update:status', lastStatus); } catch { /* window tore down */ }
+  try { sendTo?.()?.send('update:status', lastStatus); } catch { /* 窗口已拆除 */ }
 }
 
 function autoUpdateEnabled(): boolean {
   try {
-    return readConfig().autoUpdate !== false; // default ON
+    return readConfig().autoUpdate !== false; // 默认开
   } catch {
     return true;
   }
@@ -135,12 +125,12 @@ type AutoUpdater = import('electron-updater').AppUpdater;
 let autoUpdaterPromise: Promise<AutoUpdater> | null = null;
 
 /**
- * Resolve electron-updater's `autoUpdater` across the CJS/ESM interop seam.
+ * 在 CJS/ESM 互操作接缝上解析 electron-updater 的 `autoUpdater`。
  *
- * See the header note: the named export is invisible to the ESM lexer, so the
- * namespace object only carries it on `.default`. Both shapes are checked so
- * this keeps working if a future electron-updater ships real named exports, and
- * a missing export throws something we can actually read in a log.
+ * 见文件头注释：命名导出对 ESM 词法分析器不可见，因此命名空间对象只在
+ * `.default` 上携带它。两种形状都会检查，这样若未来某版 electron-updater
+ * 提供真正的命名导出也能继续工作；缺失导出时会抛出我们能在日志里读懂的
+ * 错误。
  */
 async function loadAutoUpdater(): Promise<AutoUpdater> {
   autoUpdaterPromise ??= (async () => {
@@ -155,7 +145,7 @@ async function loadAutoUpdater(): Promise<AutoUpdater> {
   try {
     return await autoUpdaterPromise;
   } catch (e) {
-    autoUpdaterPromise = null; // let a later attempt retry rather than latch
+    autoUpdaterPromise = null; // 让稍后的尝试能重试，而不是锁定
     throw e;
   }
 }
@@ -165,12 +155,11 @@ function errText(e: unknown): string {
   return m.length > 300 ? `${m.slice(0, 300)}…` : m;
 }
 
-/** The one asset in a release that installs on THIS machine, by the names
- *  electron-builder.yml produces: mac-{arch}.dmg, win-x64-setup.exe,
- *  linux-x86_64.AppImage. Null when the release has no matching asset, and the
- *  caller falls back to the releases page. Download URLs live under
- *  github.com/REPO/releases/download/, so the openRelease prefix guard already
- *  admits them. */
+/** 发布中可在 THIS 机器上安装的那一个资源，按 electron-builder.yml 生成的
+ *  名称匹配：mac-{arch}.dmg、win-x64-setup.exe、linux-x86_64.AppImage。
+ *  发布中没有匹配资源时返回 null，调用方回退到发布页。下载 URL 位于
+ *  github.com/REPO/releases/download/ 之下，因此 openRelease 前缀守卫已经
+ *  放行它们。 */
 export function pickDownloadAsset(
   assets: ReadonlyArray<{ name?: string; browser_download_url?: string }> | undefined,
   platform: NodeJS.Platform = process.platform,
@@ -186,7 +175,7 @@ export function pickDownloadAsset(
   return hit?.browser_download_url ?? null;
 }
 
-/** Body of the release tagged v{version}, or undefined. Never throws. */
+/** 标签为 v{version} 的发布正文，或 undefined。绝不抛错。 */
 function fetchReleaseBody(version: string, done: (notes: string | undefined) => void): void {
   try {
     const req = httpsRequest(
@@ -215,7 +204,7 @@ function fetchReleaseBody(version: string, done: (notes: string | undefined) => 
   } catch { done(undefined); }
 }
 
-/** Notify-only check against releases/latest (no download). Never throws. */
+/** 针对 releases/latest 的仅通知检查（不下载）。绝不抛错。 */
 function fallbackCheck(reason: string | undefined, force = false): void {
   const now = Date.now();
   if (!force && now - lastFallbackCheck < FALLBACK_CACHE_MS) return;
@@ -244,36 +233,34 @@ function fallbackCheck(reason: string | undefined, force = false): void {
                 url: rel.html_url ?? `https://github.com/${REPO}/releases/latest`,
                 reason,
                 downloadUrl: pickDownloadAsset(rel.assets) ?? undefined,
-                // Already in the response we just parsed — carrying it costs
-                // nothing and lets the notify-only toast show "What's new" too.
-                // NOT a new request: see TELEMETRY.md, this app never adds one.
+                // 已经在刚解析的响应里了——带着它零成本，还能让仅通知的
+                // toast 也显示 "What's new"。不是新请求：见 TELEMETRY.md，
+                // 本应用从不额外发请求。
                 notes: typeof rel.body === 'string' ? rel.body : undefined
               });
             }
-          } catch { /* malformed body — try again next interval */ }
+          } catch { /* 畸形正文——下个周期再试 */ }
         });
       }
     );
     req.on('timeout', () => req.destroy());
-    req.on('error', () => { /* offline — try again next interval */ });
+    req.on('error', () => { /* 离线——下个周期再试 */ });
     req.end();
-  } catch { /* never let the fallback take the app down */ }
+  } catch { /* 绝不让回退拖垮应用 */ }
 }
 
-/** electron-updater's checkForUpdates has no timeout of its own. If the feed
- *  request opens but never responds (a stalled connection, a captive portal, a
- *  half-open socket after the machine sleeps), the promise never settles, so
- *  runCheck never leaves 'checking', the badge spins forever, and nothing is
- *  logged. And electron-updater caches its in-flight check promise, so once one
- *  check hangs, every later check returns that same hung promise. A hard cap is
- *  what guarantees the check always reaches a terminal state, and it is why a
- *  wedged updater shows a definite error on every tick instead of a permanent
- *  spinner. Generous, because the feed payload (a few-hundred-byte YAML) is
- *  tiny, so anything past this is hung, not merely slow. */
+/** electron-updater 的 checkForUpdates 没有自己的超时。如果 feed 请求打开
+ *  但从不响应（连接卡死、强制门户、机器睡眠后半开 socket），promise 永不
+ *  settle，于是 runCheck 永远停在 'checking'，徽章一直转圈，且什么都不记录。
+ *  而且 electron-updater 会缓存进行中的检查 promise，因此一旦一次检查挂起，
+ *  之后每次检查都返回同一个挂起 promise。硬性上限才能保证检查总是到达终止
+ *  状态，这也是为什么卡死的更新器每个周期都显示明确错误而不是永久转圈。
+ *  设得宽松，因为 feed 载荷（几百字节的 YAML）很小，超过它只能是挂了，而
+ *  不是单纯的慢。 */
 const CHECK_TIMEOUT_MS = 30_000;
 
-/** Reject after `ms` if `p` has not settled; clears the timer either way so a
- *  slow-but-successful check leaves no dangling handle. */
+/** 若 `ms` 内 `p` 尚未 settle 则 reject；无论哪种情况都清定时器，这样
+ *  慢但成功的检查不会留下悬挂的句柄。 */
 function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s`)), ms);
@@ -285,16 +272,15 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 }
 
 /**
- * One check. Native first; on failure, report the real error AND degrade to the
- * notify-only poll for THIS check only — the next tick tries native again, so a
- * single blip no longer costs the session its ability to self-update.
+ * 一次检查。先走原生；失败时上报真实错误，并仅对本次检查降级为仅通知轮询
+ * ——下一个周期再试原生，因此一次小故障不再让本次会话失去自我更新能力。
  */
 async function runCheck(): Promise<{ ok: boolean; error?: string }> {
   emit({ state: 'checking' });
   try {
-    // Hard-capped so a stalled feed request cannot leave the badge on 'checking'
-    // forever (see withTimeout above); a timeout falls through to the catch,
-    // which logs it, shows an error state, and runs the notify-only fallback.
+    // 硬性设限，使卡死的 feed 请求无法把徽章永久停在 'checking'
+    // （见上面的 withTimeout）；超时会落入 catch，后者记录它、显示错误
+    // 状态，并运行仅通知回退。
     const result = await withTimeout(
       loadAutoUpdater().then((autoUpdater) => autoUpdater.checkForUpdates()),
       CHECK_TIMEOUT_MS,
@@ -303,8 +289,8 @@ async function runCheck(): Promise<{ ok: boolean; error?: string }> {
     if (!result || !isNewer(result.updateInfo.version, app.getVersion())) {
       emit({ state: 'not-available' });
     }
-    // `update-available` / `download-progress` / `update-downloaded` handlers
-    // (wired in initAutoUpdater) carry it from here.
+    // `update-available` / `download-progress` / `update-downloaded` 处理器
+    // （在 initAutoUpdater 中接线）从这里接续。
     return { ok: true };
   } catch (e) {
     const message = errText(e);
@@ -315,7 +301,7 @@ async function runCheck(): Promise<{ ok: boolean; error?: string }> {
   }
 }
 
-/** Explicitly start (or restart) the download. Safe to call twice. */
+/** 显式启动（或重启）下载。可安全调用两次。 */
 async function runDownload(): Promise<{ ok: boolean; error?: string }> {
   try {
     const autoUpdater = await loadAutoUpdater();
@@ -331,18 +317,17 @@ async function runDownload(): Promise<{ ok: boolean; error?: string }> {
 }
 
 /**
- * Start the updater. Call once from app.whenReady with an accessor for the
- * primary window's webContents. Safe to call in dev (registers IPC, no polling).
+ * 启动更新器。在 app.whenReady 中调用一次，并传入主窗口 webContents 的
+ * 访问器。开发环境可安全调用（注册 IPC，不轮询）。
  */
-/** DEV ONLY — a realistic release body for `update:simulate`.
+/** 仅开发环境——为 `update:simulate` 提供一份贴近真实的发布正文。
  *
- *  Structurally a copy of the REAL v0.4.4 release body, not of CHANGELOG.md, and
- *  the difference is load-bearing: summarizeReleaseNotes digests the first section
- *  that yields list items, so it must skip a title, a marketing paragraph, a rule
- *  and a `> [!IMPORTANT]` block before reaching the bullets. Fed the CHANGELOG
- *  shape instead (bold lead paragraph, then `### Fixed`) it returns ONE bullet —
- *  the lead paragraph, clipped mid-sentence. Verified against the published
- *  v0.4.4-rc.1 body: this shape yields the same 3 bullets the real toast shows. */
+ *  结构上是真实 v0.4.4 发布正文的副本，而不是 CHANGELOG.md 的；这个区别
+ *  承载关键负载：summarizeReleaseNotes 会消化第一个产出列表项的段落，因此
+ *  它必须先跳过标题、营销段落、分隔线和 `> [!IMPORTANT]` 块，才能到达列表
+ *  项。若换成 CHANGELOG 的形态（加粗引导段，然后是 `### Fixed`）只会返回
+ *  一个列表项——引导段，被从句子中间截断。已对照已发布的 v0.4.4-rc.1 正文
+ *  验证：这种形态会产生与真实 toast 相同的 3 个列表项。 */
 const SIMULATED_NOTES = `# Munder Difflin v9.9.9
 
 **A local hive of Claude Code, Antigravity, Codex, Grok & Copilot agents that run themselves** —
@@ -366,23 +351,21 @@ its first newline.
 export function initAutoUpdater(getWebContents: () => WebContents | null): void {
   sendTo = getWebContents;
 
-  // IPC surface is registered unconditionally so the renderer can always call it.
+  // IPC 接口无条件注册，渲染进程始终可以调用。
   ipcMain.handle('update:restartAndInstall', async () => {
-    // Re-entry guard: a restart is already in flight. Firing quitAndInstall a
-    // second time hits a native command Squirrel has already disabled and it
-    // throws "The command is disabled and cannot be executed", the recurring
-    // wedge behind the six-clicks-to-install reports. Refuse the duplicate and
-    // let the caller wait on the one already running instead of starting another.
+    // 重入守卫：已有一次重启在途。第二次触发 quitAndInstall 会命中 Squirrel
+    // 已经禁用的原生命令并抛出 "The command is disabled and cannot be
+    // executed"——这正是六次点击才能安装的报告背后反复出现的卡死。拒绝重复
+    // 调用，让调用方等待已在进行的那一次，而不是另起一个。
     if (pendingRestart) return { ok: false, error: 'a restart is already in progress' };
     try {
       const autoUpdater = await loadAutoUpdater();
       logLine('quitAndInstall requested by the user');
       const cancelled = new Promise<{ ok: boolean; error?: string }>((resolve) => { pendingRestart = resolve; });
       autoUpdater.quitAndInstall();
-      // Settles ONLY if the quit was called off (abortPendingRestart) or the
-      // native updater reported it failed (failPendingRestart, from the error
-      // event). If the app is really going, the process exits here and the
-      // renderer's promise dies with the window.
+      // 仅当退出被取消（abortPendingRestart）或原生更新器报告失败
+      // （failPendingRestart，来自错误事件）时才 settle。若应用真的要退出，
+      // 进程在这里结束，渲染进程的 promise 随窗口一起消亡。
       return await cancelled;
     } catch (e) {
       pendingRestart = null;
@@ -400,27 +383,25 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
     if (!app.isPackaged) return { ok: false, error: 'dev build — updates are only downloaded in packaged apps' };
     return runDownload();
   });
-  /** Re-serve the last known status to a freshly loaded window. */
+  /** 向刚加载的窗口重新提供最后已知状态。 */
   ipcMain.handle('update:current', () => lastStatus ?? { state: 'idle' });
   /**
-   * DEV ONLY — push a synthetic status so the update toast can be seen without a
-   * real release. The toast renders for exactly two states ('downloaded' and
-   * 'available-manual'), and a dev build can reach NEITHER: the whole polling
-   * block below is behind `app.isPackaged`, and checkNow/download refuse above.
-   * So the one UI that only ever appears at release time was the one UI nobody
-   * could look at while building it.
+   * 仅开发环境——推送一条合成的状态，让更新 toast 无需真实发布即可查看。
+   * toast 只为两个状态渲染（'downloaded' 与 'available-manual'），而开发构建
+   * 两个都到不了：下面的整个轮询块都在 `app.isPackaged` 之后，且 checkNow/
+   * download 在上面拒绝了。于是唯一只在发布时出现的 UI，成了构建它时谁都
+   * 看不到的那一个。
    *
-   * Hard-gated on `!app.isPackaged` — in a shipped build this handler answers
-   * `{ok:false}` and can never fabricate an update for a real user.
+   * 硬性受 `!app.isPackaged` 限制——在发布构建里此处理器回答 `{ok:false}`，
+   * 绝不可能为真实用户伪造更新。
    */
   ipcMain.handle('update:simulate', (_evt, opts: unknown) => {
     if (app.isPackaged) return { ok: false, error: 'simulate is dev-only' };
     const o = (opts ?? {}) as { state?: string; version?: string; notes?: string; drop?: boolean };
     const version = typeof o.version === 'string' && o.version ? o.version : '9.9.9';
-    // `drop: true` previews the centered release page built from the default
-    // template; without it you get the corner digest toast. Both paths ship, so
-    // both need to be previewable — defaulting to one would leave the other
-    // only ever seen by users.
+    // `drop: true` 预览由默认模板构建的居中发布页；不带它则得到角落里的摘要
+    // toast。两条路径都会发布，因此都需要可预览——只默认其一会让另一个永远
+    // 只有用户才看得到。
     const notes = typeof o.notes === 'string'
       ? o.notes
       : o.drop === true
@@ -432,11 +413,11 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
     logLine(`SIMULATED ${o.state === 'downloaded' ? 'downloaded' : 'available-manual'} ${version} (dev only)`);
     return { ok: true };
   });
-  // DEV ONLY — `MD_DROP_PREVIEW=<path to a release body .md>` (see
-  // `npm run dev:drop`) feeds that file through the simulate path on boot, so a
-  // drop under authoring opens centred the moment the window is up, with no
-  // DevTools paste. The renderer pulls `update:current` on mount, so emitting
-  // before the window exists is fine. Same hard gate as `update:simulate`.
+  // 仅开发环境——`MD_DROP_PREVIEW=<某份发布正文 .md 的路径>`（见
+  // `npm run dev:drop`）会在启动时把该文件喂进 simulate 路径，因此创作中的
+  // drop 会在窗口一出现时就居中打开，无需 DevTools 粘贴。渲染进程在挂载时
+  // 拉取 `update:current`，所以在窗口存在之前发出也完全没问题。与
+  // `update:simulate` 同一道硬性闸门。
   const previewPath = process.env.MD_DROP_PREVIEW;
   if (!app.isPackaged && previewPath) {
     try {
@@ -449,20 +430,19 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
       logLine(`MD_DROP_PREVIEW unreadable: ${errText(e)}`);
     }
   }
-  // First launch after the version moved: show THIS release's page. The stamp
-  // is the updater's own (analytics keeps a separate one that only exists when
-  // telemetry initialised). Skipped when a preview is being forced, and the
-  // fetch failing just means no page, never a broken boot.
+  // 版本变化后的首次启动：展示 THIS 版本的发布页。印记是更新器自己的
+  // （analytics 另有一个独立的，只在遥测初始化后才存在）。在有预览被强制
+  // 注入时跳过，且取数失败最多只是没有页面，绝不会破坏启动。
   if (!previewPath) {
     try {
       const stampFile = join(app.getPath('userData'), 'last-run-version');
       let previous: string | null = null;
-      try { previous = readFileSync(stampFile, 'utf8').trim() || null; } catch { /* first run */ }
+      try { previous = readFileSync(stampFile, 'utf8').trim() || null; } catch { /* 首次运行 */ }
       const current = app.getVersion();
-      // The stamp write stays UNCONDITIONAL on a version change (it already ran
-      // even when `previous` was null), which is what arms every install that
-      // boots this version even once. Its own try/catch so an unwritable
-      // userData cannot skip the decision below by throwing to the outer catch.
+      // 印记写入在版本变化时保持无条件（即使 `previous` 为 null 时也已
+      // 运行），这正是让每个安装只要启动过本版本就被武装的机制。自带
+      // try/catch，这样不可写的 userData 也不会通过抛给外层 catch 而跳过
+      // 下面的决策。
       let stamped = false;
       if (previous !== current) {
         try {
@@ -473,10 +453,9 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
           logLine(`last-run-version stamp failed: ${errText(e)}`);
         }
       }
-      // Gated on the stamp having LANDED, not merely been attempted: if the
-      // stamp cannot be written, `previous` stays null on every future launch,
-      // so firing here would reopen the drop on every single boot forever.
-      // Showing it zero times on an unwritable userData is the lesser failure.
+      // 以印记真的落地为准，而不只是尝试过：若印记写不进去，`previous` 在
+      // 之后的每次启动都保持 null，那么在这里触发会在每次启动都重新打开
+      // drop，永远如此。在不可写的 userData 上显示零次才是较小的失败。
       if (stamped && shouldShowReleaseDrop(previous, current)) {
         logLine(`first run of ${current} (previous ${previous ?? 'none'}); fetching its release page`);
         fetchReleaseBody(current, (notes) => {
@@ -490,14 +469,13 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
   }
   ipcMain.handle('update:openRelease', (_evt, url: unknown) => {
     const href = typeof url === 'string' ? url : `https://github.com/${REPO}/releases/latest`;
-    // Only ever open the project's releases page — this is not a generic opener.
+    // 只打开项目的 releases 页面——这不是通用 opener。
     if (!href.startsWith(`https://github.com/${REPO}/`)) return { ok: false };
-    // An asset URL means the badge's download click, not the notes link. It is
-    // the only positive trace the manual path leaves, and it has to be written
-    // by the build being REPLACED, so the version that reads it is the next one
-    // — analytics.ts (update_applied.via) picks it up from 0.4.6, and until then
-    // this line is here purely so there is something to pick up. Nothing else
-    // depends on it and openExternal has already been decided above.
+    // 资源 URL 意味着徽章的下载点击，而不是说明链接。它是手动路径留下的唯一
+    // 正面痕迹，而且必须由被 REPLACED 的构建来写，因此读到它的版本是下一个
+    // ——analytics.ts（update_applied.via）从 0.4.6 开始拾取它，在那之前这行
+    // 纯粹是为了有东西可拾取。没有别的东西依赖它，且 openExternal 在上面
+    // 已经决定了。
     const asset = /\/releases\/download\/v([0-9][^/]*)\//.exec(href);
     if (asset) logLine(`manual download opened: ${asset[1]}`);
     void shell.openExternal(href);
@@ -512,7 +490,7 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
     try {
       const autoUpdater = await loadAutoUpdater();
       autoUpdater.autoDownload = true;
-      autoUpdater.autoInstallOnAppQuit = false; // install ONLY on explicit restart
+      autoUpdater.autoInstallOnAppQuit = false; // 仅在明确重启时安装
       autoUpdater.on('update-available', (info) => {
         logLine(`update available: ${info.version}`);
         emit({ state: 'available', version: info.version, notes: typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined });
@@ -529,26 +507,26 @@ export function initAutoUpdater(getWebContents: () => WebContents | null): void 
         const message = errText(err);
         logLine(`native updater error: ${message}`);
         emit({ state: 'error', message });
-        // A restart-to-install that failed reports here, not as a throw. Settle
-        // the pending restart (no-op if none) so the handler stops awaiting and
-        // the UI shows the error instead of spinning, and so the user does not
-        // click again, which is the repeated quitAndInstall that wedges Squirrel.
+        // 失败的「重启即安装」从这里上报，而不是作为异常抛出。settle 待处理的
+        // 重启（没有则为 no-op），让处理器停止等待、UI 显示错误而不是转圈，
+        // 也让用户不再重复点击——那正是反复 quitAndInstall 卡死 Squirrel 的
+        // 原因。
         failPendingRestart(message);
-        // Notify-only for THIS failure; the next tick still tries native.
+        // 仅对本次失败做仅通知；下一个周期仍会尝试原生。
         fallbackCheck(message);
       });
       logLine(`native updater ready (current v${app.getVersion()})`);
     } catch (e) {
-      // Reaching here means the module itself is unusable — the exact class of
-      // bug that hid from v0.3.4 to v0.3.6. Say so loudly, in the log and the UI.
+      // 走到这里意味着模块本身不可用——正是从 v0.3.4 到 v0.3.6 一直藏匿的
+      // 那类 bug。在日志和 UI 里大声说出来。
       const message = errText(e);
       logLine(`electron-updater unavailable; notify-only mode: ${message}`);
       emit({ state: 'error', message });
     }
 
     const tick = (): void => { if (autoUpdateEnabled()) void runCheck(); };
-    // First check shortly after boot (don't compete with spawn/startup I/O),
-    // then every CHECK_INTERVAL_MS.
+    // 启动后不久先检查一次（不与派生/启动 I/O 争抢），之后每隔
+    // CHECK_INTERVAL_MS 检查一次。
     setTimeout(tick, 30_000);
     setInterval(tick, CHECK_INTERVAL_MS);
   })();

--- a/src/main/usage.ts
+++ b/src/main/usage.ts
@@ -1,84 +1,78 @@
 /**
- * Usage telemetry seam (Lane A #6.6 — Seam 1, the LOCKED contract with Oscar/#7).
+ * 用量遥测接缝（Lane A #6.6 — Seam 1，与 Oscar/#7 的锁定契约）。
  *
- * The circuit breaker (breaker.ts) and the durable cost ledger (hive.ts
- * appendCostLedger) consume usage ONLY through the `UsageProvider` interface —
- * they never read transcripts, never compute tokens, and never recompute `usd`.
- * That keeps a single source of truth for cost and lets the backend swap with
- * zero changes to the consumers:
+ * 熔断器（breaker.ts）与持久成本账本（hive.ts appendCostLedger）只通过
+ * `UsageProvider` 接口消费用量——它们从不读转录、从不计算 token、也从不
+ * 重算 `usd`。这样成本只有唯一的事实来源，后端更换时消费者零改动：
  *
- *   - PRIMARY (pull): `getAgentUsage(agentId)` — both backends implement it
- *     identically, so consumer code is swap-stable.
- *   - ADDITIVE (push): `onAgentUsage(cb)` — OTel-backend only, a later
- *     zero-rewrite latency upgrade. The stub does not implement it.
+ *   - 主路径（拉取）：`getAgentUsage(agentId)` —— 两个后端实现完全一致，
+ *     所以消费者代码可无缝切换。
+ *   - 附加路径（推送）：`onAgentUsage(cb)` —— 仅 OTel 后端，是后续
+ *     零重写的低延迟升级；桩实现不提供它。
  *
- * Two invariants every consumer must honor (Oscar's 7A.1 spike findings):
- *   (i)  Samples are CUMULATIVE snapshots (monotonic running totals). Velocity is
- *        the DIFF of consecutive pulls (Δusd/Δt, Δoutput/Δt) — never treat a
- *        single sample as an increment.
- *   (ii) `model` arrives normalized (base id, any `[1m]` suffix stripped).
+ * 每个消费者都必须遵守两条不变量（Oscar 的 7A.1 尖峰结论）：
+ *   (i)  样本是累积快照（单调递增的运行总量）。速度是相邻两次拉取的差值
+ *        （Δusd/Δt、Δoutput/Δt）——绝不要把单个样本当作增量。
+ *   (ii) `model` 到达时已规范化（基础 id，任何 `[1m]` 后缀已去除）。
  *
- * `StubUsageProvider` is a thin INTERIM backend so Lane A isn't blocked on Lane C:
- * it wraps the existing transcript reader (readAgentUsage) — the same interim
- * "transcript-poll" backend Oscar owns and will evolve, then replace with the
- * native-OTel collector. At integration we drop in Oscar's module; breaker.ts and
- * the ledger are untouched. The stub's `usd` is the transcript fallback estimate
- * (and inherits the known Sonnet-hardcoded pricing limitation, which Oscar fixes
- * in exactly one place — his provider); it is NOT recomputed downstream.
+ * `StubUsageProvider` 是一个轻量的临时后端，让 Lane A 不被 Lane C 阻塞：
+ * 它包装现有转录读取器（readAgentUsage）——这正是 Oscar 拥有并会演进、
+ * 之后替换为原生 OTel 采集器的同一个临时“转录轮询”后端。集成时我们直接
+ * 换上 Oscar 的模块；breaker.ts 和账本都不动。桩的 `usd` 是转录回退估算值
+ * （并继承了已知的 Sonnet 硬编码定价限制，Oscar 会在恰好一个地方——他的
+ * provider 里修复）；下游绝不重算。
  */
 import { readAgentUsage } from './transcript';
 
-/** One cumulative usage snapshot for an agent. The identical row that Oscar
- *  emits, Jim (this lane) persists to cost-ledger.jsonl, and Kevin (#4) stores
- *  in the cost_ledger SQLite table — one shape across all three lanes.
+/** 一个代理的累积用量快照。与 Oscar 输出的行完全一致；Jim（本车道）将其
+ *  持久化到 cost-ledger.jsonl，Kevin（#4）存入 cost_ledger SQLite 表——
+ *  三条车道共用同一形态。
  *
- *  🔒 PII-free by construction: the provider's normalize step allowlists only
- *  these fields and strips every identity attribute (user.email, account/uuid,
- *  organization.id, hashed user.id) BEFORE emitting. Persist ONLY this sample;
- *  never a raw OTel record. */
+ *  🔒 构造上无 PII：provider 的规范化步骤只放行这些字段，并在发出前剔除
+ *  所有身份属性（user.email、account/uuid、organization.id、hashed user.id）。
+ *  只持久化本样本；绝不保存原始 OTel 记录。 */
 export interface AgentUsageSample {
   agentId: string;
-  /** Doubles as the #6.6a --resume key AND the cost accounting/dedup key. */
+  /** 兼作 #6.6a --resume 键 AND 成本核算/去重键。 */
   sessionId: string | null;
   ts: number;
   input: number;
   output: number;
   cacheRead: number;
   cacheCreation: number;
-  /** Normalized base model id (no `[1m]` suffix), or null if unknown. */
+  /** 规范化的基础模型 id（无 `[1m]` 后缀），未知时为 null。 */
   model: string | null;
-  /** Claude-precomputed cost (live path) / transcript-fallback estimate (interim).
-   *  Never recomputed by a consumer. */
+  /** Claude 预先算好的成本（实时路径）/ 转录回退估算（临时路径）。
+   *  消费者绝不重算。 */
   usd: number;
 }
 
-/** The seam both backends implement. */
+/** 两个后端都实现的接缝。 */
 export interface UsageProvider {
-  /** PRIMARY pull. Returns a cumulative snapshot, or null when unknown. */
+  /** 主路径拉取。返回累积快照，未知时返回 null。 */
   getAgentUsage(agentId: string): AgentUsageSample | null;
-  /** ADDITIVE push (OTel backend only). Optional; the stub omits it. */
+  /** 附加路径推送（仅 OTel 后端）。可选；桩实现省略它。 */
   onAgentUsage?(cb: (sample: AgentUsageSample) => void): () => void;
 }
 
-/** What the stub needs to turn an agentId into a transcript read + sample fields.
- *  Wired (in index.ts) to the hive registry: cwd for the transcript dir,
- *  sessionId for the resume/dedup key, model for the (best-effort) tier. */
+/** 桩把 agentId 变成一次转录读取 + 样本字段所需的一切。
+ *  在 index.ts 中接到 hive 注册表：cwd 用于转录目录、
+ *  sessionId 用于恢复/去重键、model 用于（尽力而为的）档位。 */
 export interface UsageResolver {
   (agentId: string): { cwd: string; sessionId?: string | null; model?: string | null } | null;
 }
 
-/** Strip the `[1m]` (or `[…]`) context-window suffix so the model id matches the
- *  normalized form Oscar's OTel ingest emits. */
+/** 去除 `[1m]`（或 `[…]`）上下文窗口后缀，让模型 id 与
+ *  Oscar 的 OTel 摄取所输出的规范化形式一致。 */
 function normalizeModel(model: string | null | undefined): string | null {
   if (!model) return null;
   return model.replace(/\[[^\]]*\]$/, '').trim() || null;
 }
 
 /**
- * Interim transcript-backed provider. Reads cumulative token totals from an
- * agent's Claude Code transcripts (readAgentUsage) and shapes them into an
- * AgentUsageSample. Stands in for Oscar's provider until Lane C lands; the
- * consumers (breaker, ledger) call it through UsageProvider and never change.
+ * 临时转录后端。从代理的 Claude Code 转录（readAgentUsage）读取累积 token
+ * 总量，整理成 AgentUsageSample。在 Lane C 落地前暂代 Oscar 的 provider；
+ * 消费者（breaker、ledger）通过 UsageProvider 调用它，从不改变。
  */
 export class StubUsageProvider implements UsageProvider {
   constructor(private resolve: UsageResolver) {}
@@ -86,7 +80,7 @@ export class StubUsageProvider implements UsageProvider {
   getAgentUsage(agentId: string): AgentUsageSample | null {
     const info = this.resolve(agentId);
     if (!info) return null;
-    const u = readAgentUsage(info.cwd); // cumulative running totals across transcripts
+    const u = readAgentUsage(info.cwd); // 各转录之间的累积运行总量
     return {
       agentId,
       sessionId: info.sessionId ?? null,
@@ -96,7 +90,7 @@ export class StubUsageProvider implements UsageProvider {
       cacheRead: u.cacheReadTokens,
       cacheCreation: u.cacheWriteTokens,
       model: normalizeModel(info.model),
-      usd: u.estimatedCostUsd // interim fallback estimate; Oscar's provider supplies Claude-precomputed usd
+      usd: u.estimatedCostUsd // 临时回退估算；Oscar 的 provider 提供 Claude 预先算好的 usd
     };
   }
 }

--- a/src/main/webhook.ts
+++ b/src/main/webhook.ts
@@ -1,98 +1,92 @@
 /**
- * WebhookServer — a generic, secret-gated inbound HTTP API that turns external
- * POSTs into hive work and lets each caller poll that work's status by a token.
+ * WebhookServer —— 一个通用的、受密钥门控的入站 HTTP API，把外部 POST 变成
+ * hive 工作，并让每个调用方凭令牌轮询该工作的状态。
  *
- * MANY endpoints, ONE server, ONE tunnel. Endpoints are told apart by the id in
- * the request path, so adding a webhook costs no extra port and no extra tunnel:
- *   - POST /<webhookId>  + `x-md-webhook-secret: <that endpoint's secret>`
- *       + JSON body matching THAT endpoint's user-editable schema
- *       → 200 `{ ok, token, taskId }`  when the endpoint's TriggerMode lets the
- *         message through (routed to god, kanban card created), or
- *       → 202 `{ ok, pending: true, token, status: 'awaiting-approval' }` when the
- *         mode holds it for the operator. Either way the caller gets its token.
- *   - GET  /<webhookId>  + `x-md-webhook-token: <token>` (or `?token=`)
- *       → returns ONLY that token's task status: `{ ok, status, title, result? }`.
- *   - POST / (bare) is an alias for the endpoint with id `legacy`, so a caller
- *     holding the pre-multi-endpoint URL keeps working across the upgrade.
+ * 多端点，单服务器，单隧道。端点靠请求路径中的 id 区分，因此新增 webhook
+ * 不占额外端口、不占额外隧道：
+ *   - POST /<webhookId>  + `x-md-webhook-secret: <该端点的密钥>`
+ *       + 匹配该端点用户可编辑 schema 的 JSON body
+ *       → 当端点的 TriggerMode 放行消息时返回 200 `{ ok, token, taskId }`
+ *         （路由给 god、创建看板卡片），或
+ *       → 当模式为操作员保留消息时返回 202
+ *         `{ ok, pending: true, token, status: 'awaiting-approval' }`。
+ *         无论哪种情况调用方都能拿到自己的 token。
+ *   - GET  /<webhookId>  + `x-md-webhook-token: <token>`（或 `?token=`）
+ *       → 只返回该 token 对应的任务状态：`{ ok, status, title, result? }`。
+ *   - POST /（裸路径）是 id 为 `legacy` 的端点的别名，因此持有升级前 URL 的
+ *     调用方在升级后仍能继续工作。
  *
- * SECURITY — this is a PUBLIC surface (tunnel-forwarded), unlike the loopback
- * /reply endpoint, so the gate is strict. Every property of the single-endpoint
- * version is preserved, plus the ones multi-tenancy adds:
- *   - constant-time secret comparison (`timingSafeEqual`, length-guarded), against
- *     THAT endpoint's secret only — revoking one endpoint cannot affect another,
- *   - an UNKNOWN endpoint id is answered exactly like a WRONG secret: the compare
- *     still runs (against an unguessable per-process decoy) and the reply is the
- *     same 401 body, so the surface can't be walked to discover which ids exist,
- *   - GET does its token lookup whether or not the id is known, for the same
- *     reason: identical work, identical 404 — no enumeration signal,
- *   - secrets are held only in this class, and NEVER logged, echoed, or forwarded
- *     into the routed message / card / response (the handler is handed `{id,name}`,
- *     not the endpoint record),
- *   - the capability token is unguessable (minted by the caller-side handler,
- *     192-bit) and a GET reveals only the single task it maps to — no listing,
- *   - a request body cap + fixed-window rate limits (GLOBAL *and* per-endpoint, so
- *     one noisy caller can't starve the others) bound abuse before parsing/crypto.
+ * 安全——这是一个 PUBLIC 表面（经隧道转发），不同于回环的 /reply 端点，
+ * 因此闸门严格。单端点版本的每个性质都保留，外加多租户新增的：
+ *   - 常量时间密钥比较（`timingSafeEqual`，长度守卫），只针对该端点的密钥
+ *     ——吊销一个端点不会影响另一个，
+ *   - 未知端点 id 的应答与错误密钥完全一致：比较仍然执行（针对不可猜测的
+ *     每进程诱饵），回复是同样的 401 body，因此该表面无法被遍历以发现哪些
+ *     id 存在，
+ *   - GET 无论 id 是否已知都会做 token 查询，理由相同：相同的工作、相同的
+ *     404——不泄露可枚举信号，
+ *   - 密钥只保存在本类中，绝不记录、回显或转发进路由消息 / 卡片 / 响应
+ *     （处理器拿到的是 `{id,name}`，而不是端点记录），
+ *   - 能力 token 不可猜测（由调用方侧处理器铸造，192 位），且 GET 只揭示它
+ *     映射到的单个任务——无列表，
+ *   - 请求体上限 + 固定窗口限流（GLOBAL *且* 按端点，因此一个吵闹的调用方
+ *     无法饿死其他调用方）在解析/加密之前就限制滥用。
  *
- * Runs in the Electron main process. Deliberately free of any `electron` import so
- * it can be unit-/smoke-tested as a plain Node module. The actual card creation +
- * god routing + token→status lookup are injected as callbacks (they need hive
- * access, which lives in the main entrypoint); this class owns only transport,
- * the secret gate, schema validation, rate limiting, and the tunnel.
+ * 运行于 Electron 主进程。刻意不引入任何 `electron` 导入，以便可以作为普通
+ * Node 模块进行单元/冒烟测试。实际的卡片创建 + god 路由 + token→状态查找
+ * 以回调形式注入（它们需要 hive 访问，那存在于主入口）；本类只负责传输、
+ * 密钥门、schema 校验、限流和隧道。
  */
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { validateAgainstSchema, type InboundKind } from '../shared/triggers';
-// NOTE: `tunnelmole` is an ESM-only package. The Electron main process is bundled
-// as CommonJS, so a static `import` gets externalized into `require('tunnelmole')`
-// and throws ERR_REQUIRE_ESM at load. It is imported dynamically inside
-// `openTunnel()` instead — Rollup preserves dynamic import() in CJS output, which
-// can load ESM. Do not hoist this back to a top-level import.
+// 注意：`tunnelmole` 是仅 ESM 的包。Electron 主进程以 CommonJS 打包，因此
+// 静态 `import` 会被外部化为 `require('tunnelmole')`，在加载时抛出
+// ERR_REQUIRE_ESM。它改为在 `openTunnel()` 内部动态导入——Rollup 在 CJS
+// 输出中保留动态 import()，这样可以加载 ESM。别把它重新提升为顶层导入。
 
-/** One servable endpoint — the structural subset of `WebhookTrigger` this class
- *  needs. A whole `WebhookTrigger` is assignable, so callers pass config rows
- *  straight in without a mapping step. */
+/** 一个可服务的端点——本类需要的 `WebhookTrigger` 结构子集。整个
+ *  `WebhookTrigger` 可赋值给它，因此调用方无需映射步骤即可直接传入配置行。 */
 export interface WebhookEndpoint {
   id: string;
   name: string;
-  /** Shared secret the caller echoes in `x-md-webhook-secret`. Never leaves this class. */
+  /** 调用方在 `x-md-webhook-secret` 中回显的共享密钥。绝不离开本类。 */
   secret: string;
-  /** User-editable JSON Schema (serialised) inbound bodies are checked against. */
+  /** 用户可编辑的 JSON Schema（序列化后），入站 body 会据此校验。 */
   schema: string;
 }
 
-/** What the dispatch handler is told about the endpoint a message arrived on.
- *  DELIBERATELY excludes `secret`: the handler writes cards, hive messages and
- *  history rows, and none of them may ever be able to carry a live credential. */
+/** 分派处理器被告知的、消息到达端点时的信息。DELIBERATELY 排除 `secret`：
+ *  处理器会写卡片、hive 消息和历史行，其中任何一项都绝不能携带实时凭证。 */
 export interface WebhookEndpointRef {
   id: string;
   name: string;
 }
 
-/** The validated body of an accepted POST — just the work to do plus the sender's
- *  own framing of it. The secret has already been verified and is intentionally
- *  NOT part of this shape, so it can never be forwarded onward. */
+/** 已接受 POST 的校验后 body——只是要做的工作加上发送者自己的框定。密钥
+ *  已经过验证，并有意识地不属于此形状，因此它永远不会被转发出去。 */
 export interface WebhookInbound {
   message: string;
   title?: string;
-  /** Declared by the caller when they bothered to; the handler classifies when not. */
+  /** 调用方愿意声明时声明之；否则由处理器分类。 */
   kind?: InboundKind;
-  /** Who is sending, for the trigger history. Falls back to the endpoint name. */
+  /** 谁在发送，用于触发历史。缺省回退到端点名。 */
   from?: string;
 }
 
-/** What the handler did with an accepted message. `pending` is the whole point of
- *  the split: the caller is told, honestly, whether work actually started. */
+/** 处理器对已接受消息所做的处理。`pending` 是整个拆分的关键：如实地告诉
+ *  调用方工作是否真的开始了。 */
 export interface WebhookDispatch {
-  /** Capability token to hand back — the ONLY echo, and only ever returned once. */
+  /** 要交回的能力令牌——唯一的回显，且只返回一次。 */
   token: string;
-  /** Kanban card id; absent while a message waits for the operator (no card yet). */
+  /** 看板卡片 id；消息等待操作员时缺失（还没有卡片）。 */
   taskId?: string;
-  /** true = held for operator approval (→ 202), false = routed to god (→ 200). */
+  /** true = 为操作员审批保留（→ 202），false = 已路由给 god（→ 200）。 */
   pending: boolean;
 }
 
-/** What a GET exposes for a token — mirrors the kanban's public columns only,
- *  plus the synthetic statuses a held message reports before it becomes work. */
+/** GET 为一个令牌揭示的内容——只镜像看板的公开列，外加消息成为工作之前
+ *  报告的合成状态。 */
 export interface WebhookTaskStatus {
   status: string;
   title: string;
@@ -100,44 +94,43 @@ export interface WebhookTaskStatus {
 }
 
 export interface WebhookServerOptions {
-  /** Local TCP port the HTTP server binds to (and the tunnel forwards to). */
+  /** HTTP 服务器绑定的本地 TCP 端口（隧道也转发到它）。 */
   port: number;
-  /** The endpoints to serve. May be swapped later with `setEndpoints`. */
+  /** 要服务的端点。之后可用 `setEndpoints` 替换。 */
   endpoints: WebhookEndpoint[];
   /**
-   * Turn a verified POST into hive work (or into a held message awaiting the
-   * operator). Return null to signal a server-side failure (→ 500). The token it
-   * returns is the ONLY thing echoed to the caller; no secret ever reaches here.
+   * 把已验证的 POST 变成 hive 工作（或变成等待操作员的消息）。返回 null 表示
+   * 服务端失败（→ 500）。它返回的令牌是回显给调用方的唯一内容；密钥绝不
+   * 到达这里。
    */
   onMessage: (msg: WebhookInbound, endpoint: WebhookEndpointRef) => WebhookDispatch | null;
   /**
-   * Resolve a capability token to its task's public status, or null when the
-   * token maps to nothing (→ 404). MUST be scoped to the one token — it must
-   * never reveal or enumerate any other task.
+   * 把一个能力令牌解析为其任务的公开状态，令牌映射不到任何东西时返回 null
+   * （→ 404）。MUST 限定于那一个令牌——绝不能揭示或枚举其他任何任务。
    */
   lookupStatus: (token: string) => WebhookTaskStatus | null;
 }
 
-/** Reject bodies larger than this before buffering — callers send tiny JSON; the
- *  cap stops an unauthenticated peer forcing unbounded memory use pre-auth. */
+/** 在缓冲之前拒绝大于此的请求体——调用方发送的是很小的 JSON；该上限阻止
+ *  未认证对等方在认证前强迫无限内存占用。 */
 const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
-/** Cap how long we wait for the public tunnel before giving up (server stays up). */
+/** 在放弃公共隧道前等待的最长时间（服务器保持运行）。 */
 const TUNNEL_START_TIMEOUT_MS = 10_000;
-/** Basic abuse guard: at most this many requests per fixed window, globally. */
+/** 基础滥用防护：固定窗口内全局最多这么多请求。 */
 const RATE_LIMIT = 120;
-/** …and this many per endpoint, so one noisy caller burns its own budget first
- *  instead of everyone's. Strictly below the global cap, or it would never bind. */
+/** ……且每个端点这么多，因此一个吵闹的调用方先烧光自己的预算，而不是大家
+ *  的。严格低于全局上限，否则它永远不会生效。 */
 const PER_ENDPOINT_RATE_LIMIT = 60;
 const RATE_WINDOW_MS = 60_000;
 
-/** Bare `POST /` keeps serving the endpoint the pre-multi-endpoint migration
- *  parked under this id, so a caller already pointed at the old URL is unaffected. */
+/** 裸 `POST /` 继续服务升级前迁移停靠在该 id 下的端点，因此已经指向旧 URL
+ *  的调用方不受影响。 */
 export const LEGACY_ENDPOINT_ID = 'legacy';
 
-/** Rate-limit bucket shared by EVERY unknown id. One bucket, not one per id:
- *  per-id buckets for ids we don't serve would let a prober both grow our memory
- *  unboundedly and — worse — observe that unknown ids never hit the per-endpoint
- *  limit while real ones do. Sharing one bucket makes the two indistinguishable. */
+/** 由每个未知 id 共享的限流桶。一个桶，而不是每 id 一个：如果我们不为
+ *  未服务的 id 建每 id 桶，探测者既能让我们的内存无限增长，更糟的是——
+ *  还能观察到未知 id 从不触发每端点上限，而真实 id 会。共享一个桶让两者
+ *  无法区分。 */
 const UNKNOWN_BUCKET = ':unknown';
 
 export class WebhookServer {
@@ -147,12 +140,11 @@ export class WebhookServer {
   private endpoints = new Map<string, WebhookEndpoint>();
   private readonly onMessage: (msg: WebhookInbound, endpoint: WebhookEndpointRef) => WebhookDispatch | null;
   private readonly lookupStatus: (token: string) => WebhookTaskStatus | null;
-  /** Compared against when the requested id doesn't exist, purely so the failure
-   *  path does the same work as a wrong-secret failure. Random per process and
-   *  never exported, so it cannot be matched even by accident. */
+  /** 请求的 id 不存在时与之比较，纯粹为了让失败路径与错误密钥失败做同样的
+   *  工作。每进程随机且绝不导出，因此连意外都无法匹配上。 */
   private readonly decoySecret = randomBytes(32).toString('hex');
-  // Fixed-window rate limiters keyed by bucket ('' = global, else the endpoint id).
-  // The remote IP is the tunnel's, so per-IP would be meaningless behind tunnelmole.
+  // 以桶为键的固定窗口限流器（'' = 全局，否则为端点 id）。
+  // 远程 IP 是隧道的，因此经过 tunnelmole 后按 IP 限流没有意义。
   private windows = new Map<string, { start: number; count: number }>();
 
   constructor(opts: WebhookServerOptions) {
@@ -163,11 +155,9 @@ export class WebhookServer {
   }
 
   /**
-   * Swap the served endpoint list WITHOUT restarting the server or the tunnel —
-   * the operator adds, edits and revokes webhooks from the UI, and a restart would
-   * mint a fresh (ephemeral) tunnel URL, silently breaking every caller of every
-   * OTHER endpoint. The map is rebuilt wholesale so a removed id stops resolving
-   * on the very next request.
+   * 不重启服务器或隧道就替换所服务的端点列表——操作员从 UI 添加、编辑和吊销
+   * webhook，而重启会铸造一个全新的（临时）隧道 URL，静默破坏其他所有端点的
+   * 每个调用方。映射整体重建，因此被移除的 id 会在下一个请求就不再解析。
    */
   setEndpoints(list: WebhookEndpoint[]): void {
     const next = new Map<string, WebhookEndpoint>();
@@ -176,36 +166,35 @@ export class WebhookServer {
       next.set(e.id, e);
     }
     this.endpoints = next;
-    // Drop rate-limit state for ids we no longer serve; keep the global and
-    // unknown buckets so a swap can't be used to reset an in-flight flood.
+    // 丢弃不再服务的 id 的限流状态；保留全局和未知桶，这样一次替换不能
+    // 被用来重置一场正在进行的洪泛。
     for (const key of [...this.windows.keys()]) {
       if (key === '' || key === UNKNOWN_BUCKET) continue;
       if (!next.has(key)) this.windows.delete(key);
     }
   }
 
-  /** Ids currently served, for the settings surface that shows per-endpoint URLs. */
+  /** 当前服务的 id，供显示每端点 URL 的设置界面使用。 */
   endpointIds(): string[] {
     return [...this.endpoints.keys()];
   }
 
-  /** The public tunnel URL, or null when no tunnel is up. */
+  /** 公共隧道 URL，无隧道时为 null。 */
   publicUrl(): string | null {
     return this.tunnelUrl;
   }
 
-  /** Is the local HTTP server bound? `start()` reports ok:false for a tunnel
-   *  failure too, and in THAT case the security boundary is still live — the
-   *  caller must keep the instance (or the listener leaks, unstoppable). */
+  /** 本地 HTTP 服务器是否已绑定？`start()` 在隧道失败时也会报告 ok:false，
+   *  而在那种情况下安全边界仍然存活——调用方必须保留该实例（否则监听器
+   *  泄漏，且无法停止）。 */
   listening(): boolean {
     return this.server != null;
   }
 
   /**
-   * Bind the local HTTP server, then open a public tunnel to it. The HTTP handler
-   * (the security boundary) is live the instant `listen` resolves; the tunnel is
-   * opened afterwards and is non-fatal — if it can't be established the server
-   * keeps running and we report the tunnel error without a URL.
+   * 绑定本地 HTTP 服务器，然后向它打开公共隧道。HTTP 处理器（安全边界）在
+   * `listen` resolve 的瞬间即已生效；隧道随后打开且不会致命——若无法建立，
+   * 服务器继续运行，我们在没有 URL 的情况下报告隧道错误。
    */
   async start(): Promise<{ ok: boolean; url?: string; error?: string }> {
     if (this.server) return { ok: false, error: 'already running' };
@@ -220,16 +209,16 @@ export class WebhookServer {
       const url = await this.openTunnel();
       if (!url) throw new Error('tunnelmole returned empty URL');
       this.tunnelUrl = url;
-      // tunnelmole runs in the background; there is no close handle to wire here.
+      // tunnelmole 在后台运行；这里没有可接线的关闭句柄。
       return { ok: true, url };
     } catch (e) {
-      // Surface the tunnel failure rather than silently returning ok:true with no url.
+      // 把隧道失败暴露出来，而不是静默返回不带 url 的 ok:true。
       return { ok: false, error: `tunnel unavailable: ${errMsg(e)}` };
     }
   }
 
-  /** Close the HTTP server. Idempotent and best-effort.
-   *  Note: tunnelmole has no documented close handle; teardown is best-effort. */
+  /** 关闭 HTTP 服务器。幂等且尽力而为。
+   *  注意：tunnelmole 没有文档化的关闭句柄；拆除是尽力而为。 */
   stop(): void {
     this.tunnelUrl = null;
     try { this.server?.close(); } catch { /* noop */ }
@@ -250,8 +239,8 @@ export class WebhookServer {
   }
 
   private async openTunnel(): Promise<string> {
-    // TODO: optional persistent domain — pass `domain` here when config carries one.
-    // Dynamic import keeps the ESM-only `tunnelmole` out of the CJS require graph.
+    // TODO: 可选持久域名——当配置携带 domain 时在这里传入。
+    // 动态导入让仅 ESM 的 `tunnelmole` 远离 CJS require 图。
     const { tunnelmole } = await import('tunnelmole');
     return new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error('timed out')), TUNNEL_START_TIMEOUT_MS);
@@ -261,7 +250,7 @@ export class WebhookServer {
     });
   }
 
-  /** Fixed-window limiter — bounds total work before any parse/crypto runs. */
+  /** 固定窗口限流器——在任何解析/加密运行前就限制总工作量。 */
   private allowRequest(bucket: string, limit: number): boolean {
     const now = Date.now();
     const w = this.windows.get(bucket);
@@ -274,11 +263,11 @@ export class WebhookServer {
   }
 
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
-    // Rate limit first — cheapest possible rejection, ahead of any work.
+    // 先限流——在任何工作之前做最便宜的拒绝。
     if (!this.allowRequest('', RATE_LIMIT)) { json(res, 429, { ok: false, error: 'rate limited' }); return; }
     const id = readEndpointId(req);
     const endpoint = id !== null ? this.endpoints.get(id) ?? null : null;
-    // Per-endpoint budget, with every unknown id sharing one bucket (see UNKNOWN_BUCKET).
+    // 每端点预算，所有未知 id 共享一个桶（见 UNKNOWN_BUCKET）。
     if (!this.allowRequest(endpoint ? endpoint.id : UNKNOWN_BUCKET, PER_ENDPOINT_RATE_LIMIT)) {
       json(res, 429, { ok: false, error: 'rate limited' }); return;
     }
@@ -289,12 +278,11 @@ export class WebhookServer {
   }
 
   /**
-   * GET — return the status of the token's task (token only; never a listing).
+   * GET —— 返回令牌对应任务的状态（只按令牌；绝无列表）。
    *
-   * The lookup runs even when the id is unknown, and the answer is then the same
-   * 404 the unknown-token case gives. Skipping the lookup would make "no such
-   * webhook" measurably cheaper than "no such token", which is exactly the signal
-   * an id-enumeration probe is looking for.
+   * 即使 id 未知也会执行查找，此时答案与未知令牌情形给出的 404 相同。
+   * 跳过查找会让"无此 webhook"比"无此令牌"明显更廉价——这正是 id 枚举
+   * 探测想要找的信号。
    */
   private handleStatus(req: IncomingMessage, res: ServerResponse, endpoint: WebhookEndpoint | null): void {
     const token = readToken(req);
@@ -302,17 +290,17 @@ export class WebhookServer {
     let status: WebhookTaskStatus | null = null;
     try { status = this.lookupStatus(token); }
     catch { json(res, 500, { ok: false, error: 'lookup failed' }); return; }
-    // 404 for an unknown token — identical to a malformed one and to an unknown
-    // endpoint id, so a probe can't distinguish any of the three (no enumeration).
+    // 未知令牌返回 404 ——与畸形令牌和未知端点 id 完全相同，因此探测者无法
+    // 区分三者中的任何一个（不可枚举）。
     if (!status || !endpoint) { json(res, 404, { ok: false, error: 'not found' }); return; }
     json(res, 200, { ok: true, status: status.status, title: status.title, result: status.result ?? null });
   }
 
-  /** POST — verify this endpoint's secret, then buffer + validate + dispatch. */
+  /** POST —— 先验证该端点的密钥，再缓冲 + 校验 + 分派。 */
   private handleCreate(req: IncomingMessage, res: ServerResponse, endpoint: WebhookEndpoint | null): void {
-    // Authenticate BEFORE reading the body so an unauthenticated peer can't even
-    // make us buffer (within the size cap). 401 on any failure — no detail leaked,
-    // and an unknown id lands here too so it is answered identically.
+    // 在读 body 之前先认证，让未认证对等方甚至连缓冲（在大小上限内）都
+    // 做不到。任何失败都返回 401——不泄露任何细节；未知 id 也会走到这里，
+    // 得到完全一致的应答。
     if (!this.verifySecret(req, endpoint) || !endpoint) { json(res, 401, { ok: false, error: 'unauthorized' }); return; }
 
     const chunks: Buffer[] = [];
@@ -330,16 +318,16 @@ export class WebhookServer {
       try { parsed = JSON.parse(Buffer.concat(chunks).toString('utf8')); }
       catch { json(res, 400, { ok: false, error: 'bad json' }); return; }
 
-      // The endpoint's own schema decides what a valid body is. Echoing the
-      // validator's message is safe: it describes the CALLER's payload and can
-      // never contain our secret (the schema is the operator's own document).
+      // 端点自己的 schema 决定什么 body 是有效的。回显校验器的消息是安全的：
+      // 它描述的是 CALLER 的载荷，绝不可能包含我们的密钥（schema 是操作员
+      // 自己的文档）。
       const check = validateAgainstSchema(parsed, parseSchema(endpoint.schema));
       if (!check.ok) { json(res, 400, { ok: false, error: check.error }); return; }
 
       const body = (parsed ?? {}) as Record<string, unknown>;
-      // `message` is required regardless of what the user's schema says — it is
-      // the one field the router cannot work without, so a schema edited to drop
-      // it fails here rather than producing an empty card.
+      // 无论用户的 schema 怎么说，`message` 都是必需的——它是路由器缺了
+      // 就无法工作的那个字段，因此把 schema 编辑到去掉它也会在这里失败，
+      // 而不是产出一张空卡片。
       const message = typeof body.message === 'string' ? body.message.trim() : '';
       if (!message) { json(res, 400, { ok: false, error: 'message required' }); return; }
       const inbound: WebhookInbound = { message };
@@ -353,9 +341,8 @@ export class WebhookServer {
       try { out = this.onMessage(inbound, { id: endpoint.id, name: endpoint.name }); }
       catch { json(res, 500, { ok: false, error: 'could not create task' }); return; }
       if (!out) { json(res, 500, { ok: false, error: 'could not create task' }); return; }
-      // 202, not 200: the message was accepted but no work has started. The caller
-      // still gets its token so it can poll the hold, and the GET reports the hold
-      // honestly rather than pretending a task is queued.
+      // 202 而非 200：消息已被接受但工作尚未开始。调用方仍然拿到自己的令牌
+      // 以便轮询保留状态，GET 也如实报告保留，而不是假装任务已排队。
       if (out.pending) {
         json(res, 202, {
           ok: true,
@@ -368,17 +355,15 @@ export class WebhookServer {
       }
       json(res, 200, { ok: true, token: out.token, taskId: out.taskId });
     });
-    req.on('error', () => { if (!aborted) { try { res.writeHead(400); res.end(); } catch { /* socket gone */ } } });
+    req.on('error', () => { if (!aborted) { try { res.writeHead(400); res.end(); } catch { /* socket 已消失 */ } } });
   }
 
   /**
-   * Constant-time check that `x-md-webhook-secret` equals THIS endpoint's secret.
-   * A length mismatch is itself a failure and short-circuits before the compare
-   * (timingSafeEqual throws on unequal lengths).
+   * 常量时间检查 `x-md-webhook-secret` 是否等于该端点的密钥。长度不匹配本身
+   * 就是失败，并在比较前短路（timingSafeEqual 遇到长度不等会抛错）。
    *
-   * A null endpoint (unknown id) still runs the comparison, against a decoy no
-   * caller can hold, and then fails unconditionally — so "no such webhook" costs
-   * the same as "wrong secret" and answers with the same 401.
+   * null 端点（未知 id）仍会运行比较——针对任何调用方都无法持有的诱饵——
+   * 然后无条件失败：因此"无此 webhook"与"密钥错误"代价相同，应答也同为 401。
    */
   private verifySecret(req: IncomingMessage, endpoint: WebhookEndpoint | null): boolean {
     const provided = req.headers['x-md-webhook-secret'];
@@ -392,9 +377,8 @@ export class WebhookServer {
 }
 
 /**
- * The endpoint id from the request path: `/foo` → `foo`, bare `/` → `legacy`.
- * A deeper path (`/a/b`) resolves to null = "no such endpoint", which is then
- * answered exactly like a wrong secret / unknown token.
+ * 从请求路径取端点 id：`/foo` → `foo`，裸 `/` → `legacy`。更深路径
+ * （`/a/b`）解析为 null = "无此端点"，应答与错误密钥 / 未知令牌完全一致。
  */
 function readEndpointId(req: IncomingMessage): string | null {
   let pathname: string;
@@ -406,16 +390,15 @@ function readEndpointId(req: IncomingMessage): string | null {
   try { return decodeURIComponent(segments[0]); } catch { return segments[0]; }
 }
 
-/** Parse the endpoint's stored schema. An unparseable one yields `undefined`,
- *  which `validateAgainstSchema` treats as "accept" — a mistyped schema must not
- *  lock a caller out of an endpoint they hold a valid secret for. */
+/** 解析端点存储的 schema。无法解析的返回 `undefined`，`validateAgainstSchema`
+ *  将其视为"接受"——打错的 schema 绝不能把持有有效密钥的调用方锁在端点外。 */
 function parseSchema(schema: string): unknown {
   if (typeof schema !== 'string' || !schema.trim()) return undefined;
   try { return JSON.parse(schema); } catch { return undefined; }
 }
 
-/** Pull the capability token from the `x-md-webhook-token` header, falling back
- *  to a `?token=` query param. Header is preferred (kept out of URL/access logs). */
+/** 从 `x-md-webhook-token` 请求头取能力令牌，缺省回退到 `?token=` 查询参数。
+ *  优先使用请求头（不进入 URL/访问日志）。 */
 function readToken(req: IncomingMessage): string {
   const h = req.headers['x-md-webhook-token'];
   if (typeof h === 'string' && h.trim()) return h.trim();
@@ -423,7 +406,7 @@ function readToken(req: IncomingMessage): string {
     const url = new URL(req.url ?? '', 'http://localhost');
     const q = url.searchParams.get('token');
     if (q && q.trim()) return q.trim();
-  } catch { /* malformed url → no token */ }
+  } catch { /* 畸形 url → 无令牌 */ }
   return '';
 }
 
@@ -431,7 +414,7 @@ function json(res: ServerResponse, status: number, body: unknown): void {
   try {
     res.writeHead(status, { 'content-type': 'application/json' });
     res.end(JSON.stringify(body));
-  } catch { /* socket already gone */ }
+  } catch { /* socket 已消失 */ }
 }
 
 function errMsg(e: unknown): string {

--- a/src/main/workerLaunch.ts
+++ b/src/main/workerLaunch.ts
@@ -1,61 +1,59 @@
 /**
- * How a god-hired worker's spawn request becomes an executable + argv, as a
- * pure function: this exact translation silently killed real workers for days
- * while reporting success, which is what earned it a unit test.
+ * god 雇佣的工作线程的生成请求如何变成一个可执行文件 + argv，以
+ * 纯函数的方式实现：这个精确的转换曾静默地让真实工作线程挂了数天，
+ * 却仍然上报成功，正因如此它才赢得了一个单元测试。
  */
 import { autoModeFlagForProvider, hasAutoModeStance, inferAgentProvider } from '../shared/agentProvider';
 import { tokenizeCommand } from '../shared/commandLine';
 
 export interface WorkerLaunch {
-  /** The executable name alone — what the PTY layer resolves and spawns. */
+  /** 仅可执行文件名——PTY 层解析并生成的东西。 */
   bin: string;
-  /** Everything else, in argv form, model flag included when applicable. */
+  /** 其余一切，以 argv 形式表示，适用时包含模型标志。 */
   args: string[];
-  /** The full effective command line, for display and floor cards. */
+  /** 完整有效的命令行，用于展示和面板卡片。 */
   command: string;
 }
 
 export function buildWorkerLaunch(opts: {
-  /** `command` from the spawn request — god authors a full command LINE. */
+  /** 来自生成请求的 `command` —— god 编写的是完整的命令行。 */
   requestCommand?: unknown;
   requestProvider?: unknown;
-  /** Separate `model` field from the request, if any. */
+  /** 请求中独立的 `model` 字段，如果有的话。 */
   requestModel?: unknown;
   defaultCommand?: string;
-  /** The app's auto (skip-permissions) setting. */
+  /** 应用的 auto（跳过权限）设置。 */
   autoMode: boolean;
 }): WorkerLaunch {
   let command =
     typeof opts.requestCommand === 'string' && opts.requestCommand.trim()
       ? opts.requestCommand.trim()
       : (opts.defaultCommand ?? 'claude');
-  // Inherit the app's auto (skip-permissions) mode when the request takes no
-  // stance of its own: a headless worker has no human to click through tool
-  // prompts, so without the flag it stalls at the first ask until the idle
-  // reaper kills it. The flag is the PROVIDER'S — a codex worker needs
-  // `-a never -s workspace-write`, and claude's --permission-mode
-  // would mean nothing to it (an earlier hardcoded-claude version left every
-  // non-claude worker stalling; review caught it). An explicit stance in the
-  // request still wins: the flag's leading token already present as a TOKEN
-  // (not substring — copilot's flag starts with `-s`) means the request chose.
+  // 当请求没有自带立场时，继承应用的 auto（跳过权限）模式：无头工作线程
+  // 没有人去点击工具提示，所以没有该标志它会在第一次询问时就卡住，直到
+  // 空闲回收器把它杀掉。该标志属于 PROVIDER——codex 工作线程需要
+  // `-a never -s danger-full-access`，而 claude 的 --permission-mode
+  // 对它毫无意义（早期硬编码 claude 的版本让每个非 claude 工作线程
+  // 卡死；评审发现了这一点）。请求中明确的立场仍然优先：标志的前导 token
+  // 已作为 TOKEN 存在（而非子串——copilot 的标志以 `-s` 开头）
+  // 即表示请求已做出选择。
   const provider = inferAgentProvider(command, opts.requestProvider);
   const autoFlag = opts.autoMode ? autoModeFlagForProvider(provider) : '';
   if (autoFlag && !hasAutoModeStance(tokenizeCommand(command), provider)) {
     command += ` ${autoFlag}`;
   }
-  // god authors `command` as a full command LINE ("claude --model … --permission-mode …"),
-  // but the PTY layer takes ONE executable name (resolveCommand) plus argv — the
-  // unsplit line made node-pty exec a binary literally named like the whole
-  // string → ENOENT → the worker died within ~1s of spawning while its request
-  // archived as .done (this killed both flag-carrying Ryan spawns on 2026-08-16;
-  // only the bare-`claude` one lived). Split with the SAME tokenizer the
-  // renderer's spawn flows use, and hand the flags over as argv.
+  // god 把 `command` 编写为完整的命令行（"claude --model … --permission-mode …"），
+  // 但 PTY 层只接受一个可执行文件名（resolveCommand）加 argv——未拆分的
+  // 命令行会让 node-pty 去执行一个字面意义上就叫整串命令的二进制文件
+  // → ENOENT → 工作线程在生成后约 1 秒内死亡，而它的请求却归档为
+  // .done（2026-08-16 两个带标志的 Ryan 生成都因此被杀；
+  // 只有裸 `claude` 的那个活了下来）。用渲染进程生成流程所用的同一个
+  // 分词器来拆分，并把标志作为 argv 传下去。
   const tokens = tokenizeCommand(command);
   const bin = tokens[0] || command;
   const flags = tokens.slice(1);
-  // A separate `model` field only applies when the command line didn't pick a
-  // model itself (spawnAgentCore likewise skips its default-model injection
-  // when argv already carries --model).
+  // 独立的 `model` 字段只在命令行本身没有选定模型时才会生效
+  // （spawnAgentCore 在 argv 已携带 --model 时同样会跳过默认模型注入）。
   const model =
     typeof opts.requestModel === 'string' && opts.requestModel.trim() ? opts.requestModel.trim() : '';
   const args = [...flags, ...(model && !flags.includes('--model') ? ['--model', model] : [])];

--- a/src/main/workerWake.ts
+++ b/src/main/workerWake.ts
@@ -1,51 +1,50 @@
 /**
- * WorkerWakeWatchdog — main-process inbox-wake watchdog for worker agents (#151).
+ * WorkerWakeWatchdog —— 主进程针对工作线程代理的收件箱唤醒看门狗（#151）。
  *
- * The renderer's idle inbox-wake nudge (useHive.ts effect #3) is the ONLY wake
- * path for a worker that has gone quiet at its prompt: it polls on a setInterval
- * in the renderer, so a throttled/occluded window (Chromium suspends background
- * setInterval timers) can miss the moment mail lands and the worker then sits on
- * an undrained inbox forever — the orchestrator ("god") never has this problem
- * because the main process re-engages it on its own heartbeat cadence.
+ * 渲染进程的空闲收件箱唤醒提示（useHive.ts 的 effect #3）是唯一能让
+ * 在提示符处安静下来的工作线程重新醒来的路径：它在渲染进程里用
+ * setInterval 轮询，因此被节流/遮挡的窗口（Chromium 会挂起后台的
+ * setInterval 定时器）可能错过邮件落地的时刻，然后工作线程就会永远
+ * 坐在一个未被消费的收件箱前——编排者（"god"）从不会有这个问题，
+ * 因为主进程会按自己的心跳节奏重新驱动它。
  *
- * This watchdog is the worker-side counterpart: on a cadence it finds live
- * workers that are genuinely idle, have undrained inbox mail, are not paused /
- * not awaiting a human decision, and have not been nudged recently — then types
- * the same guarded nudge the renderer would have, directly into the PTY.
+ * 这个看门狗是工作线程侧的对应物：按节奏找出真正空闲、有未消费的收件箱
+ * 邮件、未暂停/未等待人类决策、且最近未被提示过的工作线程——然后把
+ * 渲染进程本会打出的那个同样带防护的提示，直接敲进 PTY。
  *
- * Safety mirrors the renderer's guarded queue-drain (useHive.ts dispatch):
- *  - only a GENUINELY idle worker is nudged (no PTY output for IDLE_MS — the
- *    same quiescence the renderer's idle fallback uses), never a mid-turn one,
- *  - never inside the boot sequence (BOOT_GRACE_MS from spawn, mirroring the
- *    renderer's bootGraceUntil),
- *  - delivery paused / agent paused / halted → no nudge (ControlRegistry),
- *  - a recent permission/HITL notification re-arms a block (HITL_REARM_MS) so a
- *    prompt the human is deciding on is never typed into,
- *  - a per-worker cooldown (NUDGE_COOLDOWN_MS) so the watchdog and the renderer
- *    nudge don't stack on top of each other.
+ * 安全性与渲染进程带防护的队列排空（useHive.ts dispatch）保持一致：
+ *  - 只有 GENUINELY 空闲的工作线程才会被提示（IDLE_MS 内没有 PTY 输出——
+ *    与渲染进程空闲回退所用的同一静默标准），绝不打扰回合中途的线程，
+ *  - 绝不在启动序列内提示（生成后的 BOOT_GRACE_MS，对应渲染进程的
+ *    bootGraceUntil），
+ *  - 投递暂停 / 代理暂停 / 已停机 → 不提示（ControlRegistry），
+ *  - 最近的权限/HITL 通知会重新武装一次封锁（HITL_REARM_MS），确保
+ *    人类正在决策的提示不会被敲进去，
+ *  - 每个工作线程有冷却时间（NUDGE_COOLDOWN_MS），避免看门狗与渲染进程
+ *    的提示叠加在一起。
  *
- * Deliberately the renderer's own nudge text, and the same type pattern the
- * renderer's submitToPty uses (text first, Enter as a separate keystroke).
+ * 刻意复用渲染进程自己的提示文本，以及渲染进程 submitToPty 所用的同一
+ * 打字模式（先文本，Enter 作为单独的按键）。
  *
- * No electron import — unit-testable (mirrors ControlRegistry).
+ * 不 import electron —— 可单元测试（与 ControlRegistry 一致）。
  */
 
-/** The exact nudge the renderer's inbox-wake loop would have typed. */
+/** 渲染进程收件箱唤醒循环本会敲出的那一条确切提示。 */
 export const WORKER_WAKE_NUDGE =
   'You have new hive inbox message(s) — read your inbox, act on them now, and move handled ones to inbox/.done/. Act autonomously; only message god if you genuinely need a decision.';
 
-/** No PTY output for this long = genuinely idle (renderer QUIESCE_IDLE_MS). */
+/** 这么久没有 PTY 输出 = 真正空闲（渲染进程的 QUIESCE_IDLE_MS）。 */
 export const WORKER_WAKE_IDLE_MS = 12_000;
-/** Never nudge inside the boot sequence (renderer BOOT_GRACE_MS). */
+/** 绝不在启动序列内提示（渲染进程的 BOOT_GRACE_MS）。 */
 export const WORKER_WAKE_BOOT_GRACE_MS = 35_000;
-/** Minimum gap between two watchdog nudges of the same worker. */
+/** 同一工作线程两次看门狗提示之间的最小间隔。 */
 export const WORKER_WAKE_COOLDOWN_MS = 60_000;
-/** A permission/HITL notification blocks nudges for this long after it fires. */
+/** 权限/HITL 通知触发后，会在这么长时间内封锁提示。 */
 export const WORKER_WAKE_HITL_REARM_MS = 5 * 60_000;
 
-/** A hook event message that means "the agent needs the human" — permission /
- *  approve / confirm prompts (mirrors the renderer's needsHuman detection in
- *  useHive.ts). Anything matching the idle-waiting shape is NOT a HITL hold. */
+/** 表示「代理需要人类」的钩子事件消息——权限 / 批准 / 确认提示
+ *  （对应渲染进程 useHive.ts 中的 needsHuman 检测）。任何符合
+ *  空闲等待形态的消息都不是 HITL 挂起。 */
 export type HookClass = 'needsHuman' | 'idle' | null;
 
 export function classifyHook(event: string | undefined, message: string | undefined): HookClass {
@@ -65,59 +64,58 @@ export function classifyHook(event: string | undefined, message: string | undefi
   return null;
 }
 
-/** One worker's live facts, gathered by the caller each beat. */
+/** 某个工作线程的实时事实，由调用方每个周期收集。 */
 export interface WorkerWakeFacts {
-  /** Worker agent id (god is never a candidate). */
+  /** 工作线程代理 id（god 永远不会成为候选）。 */
   agentId: string;
-  /** True when this agent is the orchestrator — god is never nudged. */
+  /** 该代理是否为编排者——god 永远不会被提示。 */
   isGod?: boolean;
-  /** Live PTY id, or undefined when the agent has no terminal. */
+  /** 实时 PTY id；代理没有终端时为 undefined。 */
   ptyId?: string;
-  /** Timestamp of the PTY's last output (0 = never output). */
+  /** PTY 最后一次输出的时间戳（0 = 从未输出）。 */
   lastOutputAt: number;
-  /** Count of undrained inbox messages (0 → nothing to wake for). */
+  /** 未消费的收件箱消息数（0 → 没有需要唤醒的理由）。 */
   inboxCount: number;
-  /** ControlRegistry snapshot flags. */
+  /** ControlRegistry 快照标志。 */
   autoDeliveryPaused: boolean;
   paused: boolean;
   halted: boolean;
 }
 
 export class WorkerWakeWatchdog {
-  /** ptyId → spawn timestamp (boot grace). */
+  /** ptyId → 生成时间戳（启动宽限）。 */
   private spawnedAt = new Map<string, number>();
-  /** agentId → last nudge timestamp (cooldown). */
+  /** agentId → 上次提示时间戳（冷却）。 */
   private lastNudgeAt = new Map<string, number>();
-  /** agentId → timestamp of the last needsHuman hook notification. */
+  /** agentId → 最近一次 needsHuman 钩子通知的时间戳。 */
   private lastHumanNeedsAt = new Map<string, number>();
 
-  /** Record a PTY spawn so its boot sequence is left alone. */
+  /** 记录一次 PTY 生成，以便它的启动序列不被打扰。 */
   noteSpawn(ptyId: string, at = Date.now()): void {
     this.spawnedAt.set(ptyId, at);
   }
 
-  /** Feed hook events (from HookServer) so a HITL prompt blocks nudges. */
+  /** 投喂钩子事件（来自 HookServer），使 HITL 提示得以封锁提示。 */
   noteHook(agentId: string | undefined, event: string | undefined, message: string | undefined, at = Date.now()): void {
     if (!agentId) return;
     if (classifyHook(event, message) === 'needsHuman') this.lastHumanNeedsAt.set(agentId, at);
   }
 
-  /** Forget per-agent state (e.g. the agent's PTY was closed). */
+  /** 遗忘按代理的状态（例如该代理的 PTY 已关闭）。 */
   forget(agentId: string, ptyId?: string): void {
     this.lastNudgeAt.delete(agentId);
     this.lastHumanNeedsAt.delete(agentId);
     if (ptyId) this.spawnedAt.delete(ptyId);
   }
 
-  /** The worker ids that should be nudged right now, in stable registry order.
-   *  Pure decision — the caller types the nudge. */
+  /** 现在应当被提示的工作线程 id，按稳定的注册表顺序。纯决策——由调用方敲入提示。 */
   decide(facts: readonly WorkerWakeFacts[], now = Date.now()): string[] {
     const out: string[] = [];
     for (const f of facts) {
       if (f.isGod || f.inboxCount <= 0 || !f.ptyId) continue;
       if (f.autoDeliveryPaused || f.paused || f.halted) continue;
-      if (f.lastOutputAt <= 0) continue; // never produced output → still booting
-      if (now - f.lastOutputAt < WORKER_WAKE_IDLE_MS) continue; // mid-turn
+      if (f.lastOutputAt <= 0) continue; // 从未产生输出 → 仍在启动中
+      if (now - f.lastOutputAt < WORKER_WAKE_IDLE_MS) continue; // 回合中途
       const spawned = this.spawnedAt.get(f.ptyId) ?? 0;
       if (spawned > 0 && now - spawned < WORKER_WAKE_BOOT_GRACE_MS) continue;
       const lastHuman = this.lastHumanNeedsAt.get(f.agentId) ?? 0;
@@ -130,7 +128,7 @@ export class WorkerWakeWatchdog {
     return out;
   }
 
-  /** Last time this worker was nudged (0 = never) — useful for diagnostics. */
+  /** 该工作线程上次被提示的时间（0 = 从未）——用于诊断。 */
   lastNudge(agentId: string): number {
     return this.lastNudgeAt.get(agentId) ?? 0;
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,18 +21,17 @@ export type {
   ContextRule, ContextTriggerConfig, OrgTriggerConfig, TriggerHistoryEntry, WebhookTrigger
 } from '../shared/triggers';
 
-/** Renderer-visible integration record: the secretRef handle is redacted to a
- *  presence boolean. Matches main `integrations.listRecordsRedacted()` — the
- *  write-only secret contract (spec §2): a secret value is NEVER returned over IPC. */
+/** 渲染进程可见的集成记录：secretRef 句柄被脱敏为
+ *  存在性布尔值。与主进程 `integrations.listRecordsRedacted()` 一致——
+ *  只写密钥契约（规范 §2）：密钥值绝不通过 IPC 返回。 */
 export type IntegrationRecordView = Omit<IntegrationRecord, 'secretRef'> & { hasSecret: boolean };
 
-// Injected at build time from package.json (see electron.vite.config.ts).
+// 构建时从 package.json 注入（见 electron.vite.config.ts）。
 declare const __APP_VERSION__: string;
 
-/** The renderer's roster as mirrored to `<harnessHome>/roster.json`. The agent
- *  entries stay `unknown` here for the same reason main leaves them opaque: the
- *  store owns that shape, and repeating it in the bridge would mean editing two
- *  files every time an agent gains a field. */
+/** 渲染进程的花名册，与 `<harnessHome>/roster.json` 保持同步。agent
+ *  条目在此保持 `unknown`，与主进程让它们保持不透明同理：存储层拥有该形状，
+ *  若在桥接层重复定义，则每次为 agent 新增字段都要改两个文件。 */
 export interface RosterSnapshot {
   version: 1;
   savedAt: string;
@@ -46,13 +45,13 @@ export interface RosterSnapshot {
 export interface HiveAgentMeta {
   id: string;
   name: string;
-  /** Which CLI this agent runs on (claude/codex/grok/antigravity/custom); defaults claude. */
+  /** 该 agent 运行在哪个 CLI 上（claude/codex/grok/antigravity/custom）；默认为 claude。 */
   provider?: AgentProvider;
   role?: string;
   capabilities?: string[];
   cwd: string;
   isGod?: boolean;
-  /** Michael's prep assistant — send-only; enriches prompts and forwards them. */
+  /** Michael 的预处理助手——只发送；增强提示词后转发。 */
   isAssistant?: boolean;
 }
 
@@ -71,10 +70,9 @@ export interface HiveMessage {
   created_at: string;
 }
 
-/** A hive message reshaped for the voice read-layer (`hive:messages`). `subject`
- *  and `body` are REDACTED in the main process before crossing this boundary —
- *  the renderer never receives a raw body or a secret. Mirror of `VoiceMessage`
- *  in src/main/hive.ts. */
+/** 为语音读取层（`hive:messages`）重塑后的 hive 消息。`subject` 与 `body`
+ *  在跨越此边界前已由主进程脱敏——渲染进程永远不会收到原始正文或密钥。
+ *  与 src/main/hive.ts 中的 `VoiceMessage` 保持一致。 */
 export interface VoiceMessage {
   id: string;
   conversation: string;
@@ -92,8 +90,8 @@ export interface VoiceMessage {
 
 export interface HiveRegistry {
   godId: string | null;
-  /** `archived` agents have had their terminal closed — retained + flagged, not
-   *  deleted; only live-PTY agents are 'active'. */
+  /** `archived` agent 的终端已关闭——保留并打标记，而不是删除；
+   *  只有实时 PTY 的 agent 才是 'active'。 */
   agents: Record<string, HiveAgentMeta & {
     status: string;
     lastSeen: number;
@@ -102,30 +100,30 @@ export interface HiveRegistry {
   }>;
 }
 
-/** One row of the consolidated voice read-layer directory (`hive:agentDirectory`):
- *  everything the office-floor sidebar + telemetry know for an agent, joined into
- *  one PII-free record. Includes archived agents. */
+/** 合并后的语音读取层目录（`hive:agentDirectory`）中的一行：办公室楼层侧边栏
+ *  与遥测所知的关于某 agent 的全部信息，汇集成一条不含 PII 的记录。
+ *  包含已归档的 agent。 */
 export interface AgentDirectoryEntry {
   id: string;
   name: string;
   role: string;
   provider: string;
-  /** Live model id (normalized), if any usage has been recorded — else null. */
+  /** 实时模型 id（已规范化，若记录过任何用量）；否则为 null。 */
   model: string | null;
   status: string;
   cwd: string | null;
-  /** Whether `cwd` is an absolute, existing directory (spawn-usable). */
+  /** `cwd` 是否为绝对路径且真实存在的目录（可用于启动）。 */
   cwdValid: boolean | null;
   archived: boolean;
   isGod: boolean;
   isAssistant: boolean;
   sessionId: string | null;
-  /** Whether the agent has recorded non-trivial memory beyond the seed header. */
+  /** 该 agent 是否已记录超出种子头部之外的非平凡记忆。 */
   hasMemory: boolean;
   inboxBacklog: number;
   breaker: string;
   tokens: number;
-  /** Aggregate spend; carried for completeness — the voice layer speaks tokens. */
+  /** 累计花费；仅为完整性而携带——语音层以 token 为口径。 */
   usd: number;
   lastTool: string | null;
   lastActiveSecAgo: number | null;
@@ -139,7 +137,7 @@ export interface AgentDirectory {
   agents: AgentDirectoryEntry[];
 }
 
-/** One question→answer exchange with the human, recorded ON the task card. */
+/** 与人类的一次问答往来，记录在任务卡片上。 */
 export interface HumanQA {
   q: string;
   a?: string;
@@ -148,7 +146,7 @@ export interface HumanQA {
   dismissedAt?: string;
 }
 
-/** A card on the task kanban, persisted to hive/tasks.json. */
+/** 任务看板上的一张卡片，持久化到 hive/tasks.json。 */
 export interface HiveTask {
   id: string;
   title: string;
@@ -158,22 +156,21 @@ export interface HiveTask {
   dependsOn: string[];
   priority: number;
   createdAt: string;
-  /** First-class human feedback: god appends {q}, the harness UI fills {a};
-   *  the full history stays on the card. */
+  /** 第一类人类反馈：god 追加 {q}，harness UI 填写 {a}；
+   *  完整历史保留在卡片上。 */
   humanQA?: HumanQA[];
-  /** Outcome summary used for the Slack done-notification. */
+  /** 用于 Slack 完成通知的结果摘要。 */
   result?: string;
-  /** Origin thread for a Slack-sourced task (drives the done-summary reply). */
+  /** Slack 来源任务的原始线程（驱动完成摘要的回复）。 */
   slack?: { channel: string; thread_ts: string };
-  /** SHA-256 of the capability token for a generic-webhook-sourced task (drives
-   *  the GET status lookup; the raw token is never persisted). */
+  /** 通用 Webhook 来源任务的能力令牌的 SHA-256（驱动 GET 状态查询；
+   *  原始令牌从不持久化）。 */
   webhook?: { tokenHash: string };
 }
 
-/** A message the router just delivered, with its resolved recipient ids. Drives
- *  the envelope-handoff animation on the office floor. `needsHuman` is set when
- *  the sender aimed at "human" (now routed to the god proxy) — cosmetic tint
- *  only; there is no approval queue. */
+/** 路由器刚刚投递的一条消息，带已解析的收件人 id。驱动办公室楼层的信封交接
+ *  动画。当发送方以 "human" 为目标（现已路由到 god 代理）时设置 `needsHuman`
+ *  ——仅作外观着色；不存在审批队列。 */
 export interface HiveRouteEvent {
   id: string;
   from: string;
@@ -184,8 +181,8 @@ export interface HiveRouteEvent {
   needsHuman: boolean;
 }
 
-/** A direct hive message addressed to a provider that cannot drain hive inbox.
- *  The renderer turns this into a queued terminal work order for that agent. */
+/** 发送给无法清空 hive 收件箱的 provider 的直接 hive 消息。
+ *  渲染进程将其转换为该 agent 的排队终端工单。 */
 export interface HiveTerminalHandoffEvent {
   id: string;
   from: string;
@@ -201,31 +198,31 @@ export interface SpawnPtyOptions {
   id: string;
   cwd: string;
   command: string;
-  /** Which CLI to spawn; usually inferred from `command` in the main process. */
+  /** 要启动哪个 CLI；通常在主进程中从 `command` 推断。 */
   provider?: AgentProvider;
   args?: string[];
   cols?: number;
   rows?: number;
-  /** When present, the agent is provisioned in the hive at spawn. */
+  /** 存在时，agent 在启动时于 hive 中预置。 */
   hive?: HiveAgentMeta;
-  /** When true (and cwd is a git repo), spawn the agent in its own git worktree. */
+  /** 为 true（且 cwd 是 git 仓库）时，在 agent 自己的 git worktree 中启动。 */
   isolate?: boolean;
-  /** When true, continue the agent's prior CLI session if one was recorded
-   *  (provider-aware: Claude/Grok `--resume`, Antigravity `--conversation`). For
-   *  Claude the main process looks up the session id from the hive registry and
-   *  seeds its transcript into the cwd's project dir (#1 — restore on restart). */
+  /** 为 true 且记录过会话时，继续该 agent 之前的 CLI 会话
+   *  （按 provider 区分：Claude/Grok `--resume`，Antigravity `--conversation`）。
+   *  对于 Claude，主进程从 hive 注册表查找会话 id，并将其转录种子写入
+   *  cwd 的项目目录（#1 — 重启时恢复）。 */
   resume?: boolean;
-  /** Fail before spawning when a requested resume cannot be attached. */
+  /** 请求的恢复会话无法挂接时，在启动前失败。 */
   requireResume?: boolean;
-  /** Explicit Claude session id to resume (#2 — Add Agent "resume session"). The
-   *  main process seeds that session's `.jsonl` into the target cwd's project dir
-   *  (copying it from wherever it lives) and launches `claude --resume <id>`. */
+  /** 要恢复的显式 Claude 会话 id（#2 — 添加 Agent「恢复会话」）。主进程
+   *  将该会话的 `.jsonl` 种子写入目标 cwd 的项目目录（从任意所在位置复制）
+   *  并启动 `claude --resume <id>`。 */
   resumeSessionId?: string;
 }
 
 export interface PtyExit { exitCode: number; signal?: number | undefined }
 
-/** A recurring auto-dispatched mission fired on an interval by the scheduler. */
+/** 由调度器按时间间隔触发的循环自动派发任务。 */
 export interface ScheduledMission {
   id: string;
   label: string;
@@ -235,13 +232,13 @@ export interface ScheduledMission {
   enabled: boolean;
   autoCompact?: boolean;
   lastFiredAt?: number;
-  /** Mission flavor; 'heartbeat' (Lane A #1) is a context-aware adaptive beat. */
+  /** 任务风格；'heartbeat'（泳道 A #1）是一种感知上下文的自适应心跳。 */
   kind?: 'dispatch' | 'heartbeat' | 'compact';
-  /** Heartbeat only: floor-quiet threshold in ms. */
+  /** 仅限心跳：楼层静默阈值（毫秒）。 */
   quietThresholdMs?: number;
 }
 
-/** Circuit-breaker thresholds (Lane A #6.6b). Mirrors src/main/config.ts. */
+/** 熔断器阈值（泳道 A #6.6b）。与 src/main/config.ts 保持一致。 */
 export interface KnowledgeGraphConfig {
   enabled?: boolean;
   rootPath?: string;
@@ -257,22 +254,22 @@ export interface CircuitBreakerConfig {
 
 export interface HarnessConfig {
   onboardingComplete: boolean;
-  /** Onboarding audience ('technical' | 'non-technical'); drives onboarding copy.
-   *  Mirrors src/main/config.ts. */
+  /** 引导受众（'technical' | 'non-technical'）；决定引导文案。
+   *  与 src/main/config.ts 保持一致。 */
   audience?: 'technical' | 'non-technical';
   harnessHome: string | null;
-  /** Recently-opened hive home folders (most-recent first). Mirrors src/main/config.ts. */
+  /** 最近打开的 hive home 文件夹（最新在前）。与 src/main/config.ts 保持一致。 */
   recentHives?: string[];
   registeredRepos: string[];
   autoMode: boolean;
   defaultCommand: string;
   defaultModel?: string;
-  /** Which provider+model powers the GOD orchestrator ("Michael"). Default
-   *  'claude' / 'claude-opus-4-8'. Mirrors src/main/config.ts. */
+  /** 为 GOD 编排器（"Michael"）提供能力的 provider+model。默认
+   *  'claude' / 'claude-opus-4-8'。与 src/main/config.ts 保持一致。 */
   godProvider?: AgentProvider;
   godModel?: string;
-  /** Per-server consent for the default MCP bundle, keyed by catalog id. Mirrors
-   *  src/main/config.ts. */
+  /** 默认 MCP 集合的按服务器同意配置，以目录 id 为键。与
+   *  src/main/config.ts 保持一致。 */
   mcpDefaults?: { [id: string]: { enabled: boolean } };
   semanticMemory: boolean;
   embeddingModel: 'minilm' | 'embeddinggemma';
@@ -280,13 +277,13 @@ export interface HarnessConfig {
   opsStandupSeeded?: boolean;
   heartbeatSeeded?: boolean;
   notifications?: boolean;
-  /** Opt-in strong keep-alive (prevent-display-sleep). Mirrors main + renderer
-   *  HarnessConfig so updateConfig({ strongKeepalive }) is typed across the bridge. */
+  /** 选择加入的强保活（防止显示器休眠）。与主进程 + 渲染进程
+   *  的 HarnessConfig 保持一致，使 updateConfig({ strongKeepalive }) 在桥上带类型。 */
   strongKeepalive?: boolean;
-  /** Auto-update from GitHub releases (default ON; Settings → General). */
+  /** 从 GitHub releases 自动更新（默认开启；设置 → 常规）。 */
   autoUpdate?: boolean;
-  /** Anonymous product analytics (default ON, opt-out; see TELEMETRY.md).
-   *  Mirrors main + renderer HarnessConfig. */
+  /** 匿名产品分析（默认开启，可选择退出；见 TELEMETRY.md）。
+   *  与主进程 + 渲染进程的 HarnessConfig 保持一致。 */
   telemetryEnabled?: boolean;
   slackEnabled?: boolean;
   slackSigningSecret?: string;
@@ -297,17 +294,17 @@ export interface HarnessConfig {
   webhookEnabled?: boolean;
   webhookSecret?: string;
   webhookPort?: number;
-  /** Free Flow voice dictation — master flag (default off), user Groq key, model.
-   *  Entry point B (hold-Option-to-talk) is handled in the renderer, no hotkey. */
+  /** Free Flow 语音听写——总开关（默认关闭）、用户 Groq 密钥、模型。
+   *  入口点 B（按住 Option 说话）由渲染进程处理，无快捷键。 */
   freeflowEnabled?: boolean;
   groqApiKey?: string;
   freeflowModel?: string;
-  /** Realtime Michael voice loop — true ONLY while a session holds the mic
-   *  (renderer session sets it at start()/stop()); the main mic permission gate
-   *  reads it. Default off. */
+  /** Realtime Michael 语音循环——仅当会话持有麦克风时为 true
+   *  （渲染进程会话在 start()/stop() 时设置它）；主进程的麦克风权限闸
+   *  读取该值。默认关闭。 */
   realtimeVoiceEnabled?: boolean;
-  /** Realtime voice idle auto-disconnect (ms); default 180000 (3 min), 0 = never.
-   *  Tuned in Settings → Realtime Michael; the cost cap stays the runaway guard. */
+  /** 实时语音空闲自动断开（毫秒）；默认 180000（3 分钟），0 = 从不。
+   *  在设置 → Realtime Michael 中调节；成本上限始终是失控保护。 */
   realtimeIdleDisconnectMs?: number;
   costCapUsd?: number;
   costCapTokens?: number;
@@ -315,19 +312,19 @@ export interface HarnessConfig {
   autoDeliveryPausedAgents?: string[];
   maxTurns?: number;
   circuitBreaker?: CircuitBreakerConfig;
-  /** Enterprise Knowledge Graph (multimodal context for agents). Default OFF. */
+  /** 企业知识图谱（面向 agent 的多模态上下文）。默认关闭。 */
   knowledgeGraph?: KnowledgeGraphConfig;
-  /** Terminal theme, mirrored into each agent's per-session Claude settings. */
+  /** 终端主题，镜像到每个 agent 的会话级 Claude 设置。 */
   terminalTheme?: 'light' | 'dark';
-  /** TV-show office themes feature flag (Settings picker + switch flow). Default OFF. */
+  /** 电视剧办公室主题功能开关（设置选择器 + 切换流程）。默认关闭。 */
   tvShowOffices?: boolean;
-  /** Active office map/cast theme (honored only when tvShowOffices is on). */
+  /** 当前的办公室地图/演员主题（仅在 tvShowOffices 开启时生效）。 */
   officeTheme?: 'office' | 'friends' | 'brooklyn99' | 'siliconvalley' | 'got' | 'hogwarts';
-  /** Per-CLI-provider local/self-hosted base URL (Ollama/LM Studio/vLLM, …) for the
-   *  OpenCode/Crush/pi/qwen engines; applied at spawn. API KEYS are NOT stored here —
-   *  they live write-only in the secret broker. */
+  /** 每个 CLI provider 的本地/自托管 base URL（Ollama/LM Studio/vLLM, …），
+   *  用于 OpenCode/Crush/pi/qwen 引擎；启动时应用。API 密钥不存储在这里——
+   *  它们以只写方式存放在密钥代理中。 */
   providerBaseUrls?: Partial<Record<AgentProvider, string>>;
-  /** Per-CLI-provider default model slug, used to pre-fill the model picker. */
+  /** 每个 CLI provider 的默认模型 slug，用于预填模型选择器。 */
   providerDefaultModels?: Partial<Record<AgentProvider, string>>;
 }
 
@@ -341,7 +338,7 @@ export interface MemoryStatus {
   bin: string | null;
 }
 
-/** Enterprise Knowledge Graph — corpus status, one document, and a search hit. */
+/** 企业知识图谱——语料状态、单篇文档与一条搜索结果。 */
 export interface KnowledgeStatus {
   enabled: boolean;
   root: string;
@@ -397,7 +394,7 @@ export interface GitCommit {
 }
 export interface GitStatusEntry { path: string; index: string; worktree: string }
 export interface GitStatus { staged: GitStatusEntry[]; unstaged: GitStatusEntry[]; untracked: string[] }
-/** A single file's two sides for a working-tree-vs-HEAD diff (see main git.getDiff). */
+/** 单个文件在「工作区 vs HEAD」diff 中的两侧内容（见主进程 git.getDiff）。 */
 export interface GitDiff {
   ok: true;
   path: string;
@@ -409,7 +406,7 @@ export interface GitDiff {
   isBinary: boolean;
 }
 
-/** v0.3.4 git visualization — mirrors src/main/git.ts GitCommit / GitCommitFile. */
+/** v0.3.4 git 可视化——与 src/main/git.ts 的 GitCommit / GitCommitFile 保持一致。 */
 export interface GitCommitRow {
   sha: string;
   shortSha: string;
@@ -425,21 +422,21 @@ export interface GitFileChange {
   oldPath?: string;
 }
 
-/** Real token usage + estimated USD cost summed from an agent's Claude Code
- *  transcripts under ~/.claude/projects. Reconciler/fallback path — now priced
- *  PER MODEL (not Sonnet-for-everyone). The live path uses AgentUsageSample. */
+/** 从 ~/.claude/projects 下某 agent 的 Claude Code 转录中汇总的真实 token
+ *  用量 + 预估 USD 成本。对账/回退路径——现在按模型单独计价
+ *  （不再是全民 Sonnet）。实时路径使用 AgentUsageSample。 */
 export interface AgentUsage {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
   estimatedCostUsd: number;
-  /** Most-recently-seen model id (normalized), if any priced record was found. */
+  /** 最近见到的模型 id（已规范化，若找到任何计价记录）。 */
   model?: string;
 }
 
-/** Live cumulative cost/token snapshot from the OTel collector (the locked
- *  cross-lane seam). PII-free by construction. Mirrors telemetry.ts. */
+/** 来自 OTel 采集器的实时累计成本/token 快照（固定的跨泳道接缝）。
+ *  结构上不含 PII。与 telemetry.ts 保持一致。 */
 export interface AgentUsageSample {
   agentId: string;
   sessionId: string;
@@ -452,7 +449,7 @@ export interface AgentUsageSample {
   usd: number;
 }
 
-/** One tool invocation for the per-agent span waterfall (#7B.2). Ephemeral. */
+/** 单个工具调用，用于按 agent 划分的 span 瀑布图（#7B.2）。临时数据。 */
 export interface ToolSpan {
   agentId: string;
   sessionId: string;
@@ -464,10 +461,9 @@ export interface ToolSpan {
   error?: string;
 }
 
-/** Power-resume signal (mirrors the emitter in src/main). Fired after the Mac
- *  wakes from sleep / unlocks: `dead` lists PTY ids that were live before sleep
- *  but emitted nothing after resume (wedged terminals); `total` is how many were
- *  checked. The renderer auto-respawns exactly the `dead` ids. */
+/** 电源恢复信号（与 src/main 中的发射器保持一致）。Mac 从睡眠/解锁中
+ *  唤醒后触发：`dead` 列出睡眠前存活但在恢复后没有任何输出的 PTY id
+ *  （卡死的终端）；`total` 是被检查的数量。渲染进程只自动重生这些 `dead` id。 */
 export interface PowerResumeEvent {
   reason: string;
   awayMs: number | null;
@@ -475,15 +471,15 @@ export interface PowerResumeEvent {
   total: number;
 }
 
-/** Closing-time progress event (mirrors src/main/closingTime.ts). */
+/** 打烊（收尾）进度事件（与 src/main/closingTime.ts 保持一致）。 */
 export interface ClosingTimeEvent {
   phase: 'started' | 'progress' | 'complete' | 'timeout' | 'cancelled';
-  /** Workers that have ACKed so far / total workers being waited on. */
+  /** 目前已完成 ACK 的 worker 数 / 正在等待的 worker 总数。 */
   acked: number;
   total: number;
 }
 
-/** Per-agent operator-control state (#7C.1–7C.3). */
+/** 每 agent 的操作员控制状态（#7C.1–7C.3）。 */
 export interface AgentControlSnapshot {
   paused: boolean;
   halted: boolean;
@@ -492,7 +488,7 @@ export interface AgentControlSnapshot {
   pendingSteers: number;
 }
 
-/** Circuit-breaker state (Lane A #6 → this lane's avatars/meter). */
+/** 熔断器状态（泳道 A #6 → 本泳道的头像/仪表）。 */
 export interface BreakerState {
   agentId: string;
   level: 'healthy' | 'steering' | 'constrained' | 'stopped';
@@ -500,19 +496,19 @@ export interface BreakerState {
   ts: number;
 }
 
-/** Live telemetry push payload (channel `telemetry:event`). */
+/** 实时遥测推送负载（通道 `telemetry:event`）。 */
 export type TelemetryEvent =
   | { kind: 'usage'; sample: AgentUsageSample }
   | { kind: 'tool_result'; span: ToolSpan }
   | { kind: 'api_error'; agentId: string; sessionId: string; ts: number; error: string };
 
-/** Cold-start backfill from the collector. */
+/** 来自采集器的冷启动回填。 */
 export interface TelemetrySnapshot {
   usage: AgentUsageSample[];
   spans: Record<string, ToolSpan[]>;
 }
 
-/** One captured user prompt from the SQLite command_history table. */
+/** 从 SQLite 的 command_history 表捕获的一条用户提示。 */
 export interface CommandHistoryEntry {
   id: number;
   agentId: string;
@@ -521,7 +517,7 @@ export interface CommandHistoryEntry {
   ts: number;
 }
 
-/** A GitHub issue, normalized for the renderer (labels/assignees flattened to names). */
+/** 一个 GitHub issue，已为渲染进程规范化（标签/指派者摊平为名称）。 */
 export interface GHIssue {
   number: number;
   title: string;
@@ -531,7 +527,7 @@ export interface GHIssue {
   assignees: string[];
 }
 
-/** A CI (GitHub Actions) workflow run, normalized for the renderer. */
+/** 一次 CI（GitHub Actions）工作流运行，已为渲染进程规范化。 */
 export interface CIRun {
   name: string;
   status: string;
@@ -539,7 +535,7 @@ export interface CIRun {
   url: string;
 }
 
-/** One live god-triggered ephemeral worker, as shown in the Workers tab. */
+/** 一个由 god 触发存活的临时 worker，如 Workers 标签页所示。 */
 export interface WorkerSnapshot {
   workerId: string;
   reqId: string;
@@ -547,14 +543,14 @@ export interface WorkerSnapshot {
   baseBranch: string;
   spawnedAt: number;
   ageMs: number;
-  idleMs: number | null;        // null = PTY already gone
+  idleMs: number | null;        // null = PTY 已消失
   tokensUsed: number;
-  tokenCap: number | null;      // effective cap; null = unlimited (the default)
+  tokenCap: number | null;      // 生效上限；null = 不限（默认）
   hasSlack: boolean;
   releasing: boolean;
   status: 'releasing' | 'working';
 }
-/** A worker worktree preserved at teardown, awaiting integration + GC. */
+/** 在拆卸时保留的 worker worktree，等待集成 + GC。 */
 export interface PreservedWorktreeSnapshot {
   workerId: string;
   wtPath: string;
@@ -565,18 +561,17 @@ export interface PreservedWorktreeSnapshot {
 const api = {
   version: __APP_VERSION__,
 
-  // ─── Analytics ───────────────────────────────────────────────────────────
-  /** Count ONE human-sent message (TELEMETRY.md → `message_sent`). Carries a
-   *  surface name and nothing else — no text, no length, no agent id — and main
-   *  accepts only 'terminal' and 'composer' here (steer and hive are counted in
-   *  main, at their own handlers). Never awaited by callers and never allowed to
-   *  throw: a telemetry hiccup must not break sending a message. */
+  // ─── 分析 ───────────────────────────────────────────────────────────
+  /** 计数一条人类发送的消息（TELEMETRY.md → `message_sent`）。只携带
+   *  界面名称，别无其他——无文本、无长度、无 agent id——主进程在此只接受
+   *  'terminal' 和 'composer'（steer 和 hive 在主进程各自的处理器中计数）。
+   *  调用方从不等待它，也绝不允许它抛出异常：遥测小故障不得破坏发送消息。 */
   trackMessageSent: (surface: 'terminal' | 'composer'): Promise<void> =>
     ipcRenderer.invoke('analytics:messageSent', surface).then(() => undefined, () => undefined),
 
   // ─── PTY ─────────────────────────────────────────────────────────────────
-  /** `cwd` in the result is the TILDE-EXPANDED absolute path main actually spawned
-   *  into — the renderer stores that, not the raw `~/…` the user typed. */
+  /** 结果里的 `cwd` 是主进程实际启动时所在的、已展开波浪号的绝对路径——
+   *  渲染进程保存它，而不是用户输入的原始 `~/…`。 */
   spawnPty: (opts: SpawnPtyOptions): Promise<{ ok: boolean; error?: string; cwd?: string; worktreePath?: string; resumeNotFound?: boolean; resumed?: boolean; seedPrompt?: string }> =>
     ipcRenderer.invoke('pty:spawn', opts),
   writePty: (id: string, data: string): Promise<{ ok: boolean; error?: string }> =>
@@ -596,8 +591,8 @@ const api = {
     hasOutput: boolean;
   }>> =>
     ipcRenderer.invoke('pty:list'),
-  /** Resolve a Claude session id to the cwd it originally ran in (Add Agent
-   *  resume auto-fill), or null if the id is invalid/unknown. */
+  /** 将 Claude 会话 id 解析为其最初运行的 cwd（添加 Agent 的
+   *  恢复自动填充），若 id 无效/未知则为 null。 */
   resolveSessionCwd: (sessionId: string): Promise<string | null> =>
     ipcRenderer.invoke('session:resolveCwd', sessionId),
   onPtyData: (id: string, cb: (data: string) => void): (() => void) => {
@@ -612,9 +607,9 @@ const api = {
     ipcRenderer.on(channel, listener);
     return () => ipcRenderer.removeListener(channel, listener);
   },
-  /** Fires when an agent is auto restart-and-continued into this SAME pty after a
-   *  first-time engine-CLI install. The terminal should re-arm in place (clear the
-   *  "process exited" line + re-enable input) so the relaunched CLI paints clean. */
+  /** 首次安装引擎 CLI 后，agent 被自动重启并恢复到同一个 pty 时触发。
+   *  终端应在原地重新武装（清除「进程已退出」行 + 重新启用输入），
+   *  使重启后的 CLI 干净呈现。 */
   onPtyRelaunch: (id: string, cb: () => void): (() => void) => {
     const channel = `pty:relaunch:${id}`;
     const listener = () => cb();
@@ -622,7 +617,7 @@ const api = {
     return () => ipcRenderer.removeListener(channel, listener);
   },
 
-  // ─── Dialog ──────────────────────────────────────────────────────────────
+  // ─── 对话框 ──────────────────────────────────────────────────────────────
   chooseFolder: (): Promise<{ ok: true; path: string } | { ok: false; error: string }> =>
     ipcRenderer.invoke('dialog:chooseFolder'),
 
@@ -630,83 +625,79 @@ const api = {
   openTerminalAt: (cwd: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('terminal:openAtFolder', cwd),
 
-  // ─── Clipboard ─────────────────────────────────────────────────────────────
+  // ─── 剪贴板 ─────────────────────────────────────────────────────────────
   copyToClipboard: (text: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('app:copyToClipboard', text),
-  /** Read the system clipboard as plain text ('' when empty/unreadable). */
+  /** 以纯文本读取系统剪贴板（为空/不可读时为 ''）。 */
   readClipboard: (): Promise<string> =>
     ipcRenderer.invoke('app:readClipboard'),
-  /** Clipboard text, read SYNCHRONOUSLY. Only for the terminal's paste shortcut,
-   *  where an async read loses a race against dictation tools that restore the
-   *  previous clipboard right after sending the paste key.
+  /** 剪贴板文本，同步读取。仅用于终端的粘贴快捷键——
+   *  在那里，异步读取会输给听写工具的竞态：它们在发送粘贴键
+   *  之后立即恢复此前的剪贴板。
    *
-   *  TRADEOFF, stated plainly because sendSync blocks the renderer until main
-   *  answers: this app has a history of main-thread stalls (iCloud-evicted files
-   *  wedging a spawnSync git call), and during such a stall this call freezes the
-   *  paste keystroke rather than merely delaying it. Accepted because a clipboard
-   *  read is a memory lookup with no I/O, and because the async alternative is
-   *  measurably WRONG — it pastes the user's previous clipboard. Do not reach for
-   *  sendSync elsewhere on this reasoning; it is justified by the race, not by
-   *  convenience. */
+   *  权衡，明说如下：sendSync 会阻塞渲染进程直到主进程应答——
+   *  本应用有主线程卡顿的历史（iCloud 驱逐的文件卡住 spawnSync git 调用），
+   *  而在这种卡顿期间，本调用会冻结粘贴按键而非仅仅延迟。之所以接受，
+   *  是因为剪贴板读取是不涉及 I/O 的内存查找，而且异步替代方案
+   *  实测是错误的——它会粘贴用户此前的剪贴板。不要以这套理由
+   *  在别处使用 sendSync；它由竞态而非便利性所正当化。 */
   readClipboardSync: (): string => {
     try { return ipcRenderer.sendSync('app:readClipboardSync') ?? ''; } catch { return ''; }
   },
 
-  // ─── Config ──────────────────────────────────────────────────────────────
+  // ─── 配置 ──────────────────────────────────────────────────────────────
   getConfig: (): Promise<HarnessConfig> =>
     ipcRenderer.invoke('config:get'),
   updateConfig: (patch: Partial<HarnessConfig>): Promise<HarnessConfig> =>
     ipcRenderer.invoke('config:update', patch),
-  /** Set or clear one per-agent token ceiling against main's latest config. */
+  /** 针对主进程最新配置，设置或清除单个 agent 的 token 上限。 */
   setAgentTokenCap: (agentId: string, tokenCap?: number): Promise<HarnessConfig> =>
     ipcRenderer.invoke('config:setAgentTokenCap', agentId, tokenCap),
   ensureHarnessHome: (path: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('config:ensureHome', path),
-  /** Change the harness home folder. 'move' copies the existing hive + palace
-   *  into the new folder (old kept as a safety net); 'fresh' just re-points and
-   *  bootstraps an empty home. On success the app relaunches (never resolves);
-   *  on failure (e.g. copy error) returns { ok: false, error }. */
+  /** 更改 harness home 文件夹。'move' 将现有 hive + palace 复制到新文件夹
+   *  （旧目录保留作安全网）；'fresh' 只是重新指向并引导一个空 home。
+   *  成功时应用会重启（promise 永不 resolve）；失败时
+   *  （如复制错误）返回 { ok: false, error }。 */
   changeHome: (newHome: string, mode: 'move' | 'fresh'): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('config:changeHome', { newHome, mode }),
 
-  // ─── Filesystem (sandboxed to cwd) ───────────────────────────────────────
+  // ─── 文件系统（限定于 cwd） ───────────────────────────────────────
   listDir: (root: string, rel: string): Promise<
     { ok: true; entries: DirEntry[]; path: string } | { ok: false; error: string }
   > => ipcRenderer.invoke('fs:listDir', root, rel),
   readFile: (root: string, rel: string): Promise<
     { ok: true; content: string; path: string; size: number } | { ok: false; error: string }
   > => ipcRenderer.invoke('fs:readFile', root, rel),
-  /** Raw bytes for files `readFile` refuses (images). The renderer has no way to
-   *  load them off disk — the CSP allows no `file:` source and no file protocol
-   *  is registered — so images travel as bytes and become a `blob:` URL in the
-   *  renderer, which `img-src` already permits. Root-confined and size-capped in
-   *  the main process; `mime` is derived from the extension. */
+  /** `readFile` 拒绝读取的文件（如图片）的原始字节。渲染进程无法从磁盘
+   *  加载它们——CSP 不允许 `file:` 源，也没有注册 file 协议——因此图片以
+   *  字节形式传输，并在渲染进程中变成 `blob:` URL，`img-src` 已允许这种形式。
+   *  主进程将其限制在根目录内并设置大小上限；`mime` 由扩展名推导。 */
   readBinary: (root: string, rel: string): Promise<
-    // `Uint8Array<ArrayBuffer>`, not the bare alias: structured clone always
-    // hands the renderer a view over a plain ArrayBuffer, and saying so is what
-    // lets the value go straight into `new Blob([...])` — the default
-    // `ArrayBufferLike` admits SharedArrayBuffer, which BlobPart rejects.
+    // `Uint8Array<ArrayBuffer>`，而不是裸别名：结构化克隆总是
+    // 把「普通 ArrayBuffer 上的视图」交给渲染进程，在类型上这样写明，
+    // 值才能直接进入 `new Blob([...])`——默认的
+    // `ArrayBufferLike` 允许 SharedArrayBuffer，而 BlobPart 会拒绝它。
     { ok: true; bytes: Uint8Array<ArrayBuffer>; mime: string; path: string; size: number }
     | { ok: false; error: string }
   > => ipcRenderer.invoke('fs:readBinary', root, rel),
   writeFile: (root: string, rel: string, content: string): Promise<
     { ok: true; path: string } | { ok: false; error: string }
   > => ipcRenderer.invoke('fs:writeFile', root, rel, content),
-  /** v0.3.4: existence check for an absolute path (expands ~) — backs the
-   *  terminal ⌘-click markdown flow. Metadata only, never contents. */
+  /** v0.3.4：绝对路径的存在性检查（展开 ~）——支撑终端的 ⌘-点击
+   *  markdown 流程。仅元数据，绝不涉及内容。 */
   statAbs: (p: string): Promise<{ exists: boolean; isFile: boolean; path: string }> =>
     ipcRenderer.invoke('fs:statAbs', p),
-  /** Show a path in the OS file browser (Finder / Explorer / the Linux default).
-   *  Backs ⌘-click on a terminal path we have no viewer for. Reveals only — main
-   *  never launches a file's default application, because the path came from
-   *  agent output. */
+  /** 在系统文件浏览器（Finder / Explorer / Linux 默认）中显示路径。
+   *  支撑对终端路径的 ⌘-点击——我们对它没有可用的查看器。仅做揭示——主进程
+   *  从不启动文件的默认应用，因为该路径来自 agent 的输出。 */
   revealPath: (p: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('fs:revealPath', p),
 
   // ─── Git ─────────────────────────────────────────────────────────────────
   gitIsRepo: (cwd: string): Promise<boolean> => ipcRenderer.invoke('git:isRepo', cwd),
-  /** Absolute path of the MAIN working tree `cwd` belongs to — a linked worktree
-   *  resolves to the original repo, not to itself. null when not a git repo. */
+  /** `cwd` 所属主工作树（MAIN working tree）的绝对路径——链接的 worktree
+   *  解析为原始仓库，而不是自身。非 git 仓库时为 null。 */
   gitMainRepo: (cwd: string): Promise<string | null> => ipcRenderer.invoke('git:mainRepo', cwd),
   gitBranch: (cwd: string) =>
     ipcRenderer.invoke('git:branch', cwd) as Promise<{ current: string | null; detached: boolean } | { error: string }>,
@@ -718,12 +709,12 @@ const api = {
     ipcRenderer.invoke('git:branches', cwd) as Promise<{ local: string[]; remote: string[]; current: string | null } | { error: string }>,
   gitAheadBehind: (cwd: string) =>
     ipcRenderer.invoke('git:aheadBehind', cwd) as Promise<{ ahead: number; behind: number; upstream: string | null } | { error: string }>,
-  /** Diff one repo-root-relative file: its HEAD content vs its working-tree content.
-   *  Path-validated main-side against `cwd`; the renderer only ever gets the two
-   *  text sides. Backs the IDE's git-diff (Monaco DiffEditor) view. */
+  /** 对单个相对仓库根目录的文件做 diff：其 HEAD 内容 vs 工作区内容。
+   *  路径在主进程侧针对 `cwd` 校验；渲染进程只会拿到两侧文本。
+   *  支撑 IDE 的 git-diff（Monaco DiffEditor）视图。 */
   gitDiff: (cwd: string, relPath: string) =>
     ipcRenderer.invoke('git:diff', cwd, relPath) as Promise<GitDiff | { ok: false; error: string }>,
-  // ── v0.3.4: history / compare / checkout (git visualization) ──
+  // ── v0.3.4：历史 / 对比 / 检出（git 可视化） ──
   gitLogGraph: (cwd: string, n: number, skip?: number) =>
     ipcRenderer.invoke('git:logGraph', cwd, n, skip ?? 0) as Promise<GitCommitRow[] | { error: string }>,
   gitCommitFiles: (cwd: string, sha: string) =>
@@ -745,16 +736,16 @@ const api = {
       { ok: true; detached: boolean } | { ok: false; error: string }
     >,
 
-  // ─── Hive (multi-agent coordination) ─────────────────────────────────────
+  // ─── Hive（多 agent 协调） ─────────────────────────────────────
   hiveRegistry: (): Promise<HiveRegistry> => ipcRenderer.invoke('hive:registry'),
-  /** Persist a hire/job role to hive registry.json + identity.md (no respawn). */
+  /** 将招聘/岗位角色持久化到 hive 的 registry.json + identity.md（不重启）。 */
   hivePatchAgentRole: (id: string, role: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('hive:patchAgentRole', id, role),
-  /** Rename an agent's display name. Its id, hive directory, and PTY are unchanged. */
+  /** 重命名 agent 的显示名称。其 id、hive 目录和 PTY 保持不变。 */
   hiveRenameAgent: (id: string, name: string): Promise<{ ok: boolean; name?: string; error?: string }> =>
     ipcRenderer.invoke('hive:renameAgent', id, name),
-  /** Put an agent on hold (the human has them 1:1) or take it off. Held agents
-   *  keep running; Michael is told to stop routing work to them. */
+  /** 让 agent 挂起（人类与它 1:1 对接）或解除挂起。挂起的 agent
+   *  继续运行；Michael 被告知停止向它们分派工作。 */
   hiveSetAgentHold: (id: string, hold: boolean): Promise<{ ok: boolean; onHold?: boolean; error?: string }> =>
     ipcRenderer.invoke('hive:setAgentHold', id, hold),
   hiveBoard: (): Promise<string> => ipcRenderer.invoke('hive:board'),
@@ -762,47 +753,47 @@ const api = {
   hiveLog: (n?: number): Promise<unknown[]> => ipcRenderer.invoke('hive:log', n ?? 200),
   hiveMemory: (id: string): Promise<string> => ipcRenderer.invoke('hive:memory', id),
   hiveInbox: (id: string): Promise<HiveMessage[]> => ipcRenderer.invoke('hive:inbox', id),
-  /** Voice read-layer: recent message CONTENT (inbox/outbox bodies), REDACTED in
-   *  main. Pass { id } for one message, { agentId } to scope to one mailbox, or
-   *  {} for the whole floor. Backs Realtime Michael's get_messages. The renderer
-   *  never sees a raw body or a secret — stripping happens main-side. */
+  /** 语音读取层：最近的消息内容（收件箱/发件箱正文），已在主进程中
+   *  脱敏。传 { id } 获取单条消息，{ agentId } 限定到某个邮箱，或
+   *  传 {} 获取整个楼层。支撑 Realtime Michael 的 get_messages。渲染进程
+   *  永远不会看到原始正文或密钥——剥离在主进程侧完成。 */
   hiveMessages: (opts?: { agentId?: string; id?: string; limit?: number; includeArchived?: boolean }): Promise<VoiceMessage[]> =>
     ipcRenderer.invoke('hive:messages', opts ?? {}),
-  /** Consolidated per-agent directory (registry + telemetry + context), incl.
-   *  archived agents. Backs Realtime Michael's get_agent_detail / list_agents. */
+  /** 合并后的按 agent 目录（注册表 + 遥测 + 上下文），包含
+   *  已归档的 agent。支撑 Realtime Michael 的 get_agent_detail / list_agents。 */
   hiveAgentDirectory: (): Promise<AgentDirectory> => ipcRenderer.invoke('hive:agentDirectory'),
 
-  // ─── Ephemeral workers (P4 — Slack-triggered isolated workers) ───────────
-  /** Live ephemeral workers + worktrees preserved awaiting integration/GC. */
+  // ─── 临时 worker（P4 — Slack 触发的隔离 worker） ───────────
+  /** 存活的临时 worker + 等待集成/GC 而保留的 worktree。 */
   listWorkers: (): Promise<{ live: WorkerSnapshot[]; preserved: PreservedWorktreeSnapshot[]; maxWorkers: number }> =>
     ipcRenderer.invoke('workers:list'),
-  /** Manually stop a live ephemeral worker (safety-gated teardown; work preserved). */
+  /** 手动停止存活的临时 worker（带安全闸的拆卸；工作成果保留）。 */
   stopWorker: (workerId: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('workers:stop', workerId),
 
-  // ─── Semantic memory (MemPalace CLI) ─────────────────────────────────────
+  // ─── 语义记忆（MemPalace CLI） ─────────────────────────────────────
   memoryStatus: (): Promise<MemoryStatus> => ipcRenderer.invoke('hive:memoryStatus'),
-  /** Which external tools (uv, mempalace, git, each agent engine) are actually
-   *  present on this machine, with a platform-resolved install command each. */
+  /** 本机实际存在哪些外部工具（uv、mempalace、git、各 agent 引擎），
+   *  并为每个工具给出按平台解析的安装命令。 */
   toolsStatus: (): Promise<ToolStatus[]> => ipcRenderer.invoke('tools:status'),
-  /** Settings hero payload — plan + sponsor, fetched from the repo and cached. */
+  /** 设置页 hero 负载——方案 + 赞助商，从仓库获取并缓存。 */
   heroPayload: (force?: boolean): Promise<{ hero: HeroPayload; fetchedAt: number; stale: boolean }> =>
     ipcRenderer.invoke('hero:payload', force),
-  /** Skills already installed for the coding agents on this machine. */
+  /** 已为本机上的编码 agent 安装的技能。 */
   skillsLocal: (cwd?: string): Promise<LocalSkill[]> => ipcRenderer.invoke('skills:local', cwd),
-  /** The browsable skills catalog (cached; `force` re-fetches). */
+  /** 可浏览的技能目录（已缓存；`force` 重新拉取）。 */
   skillsCatalog: (force?: boolean): Promise<{
     skills: CatalogSkill[]; fetchedAt: number; stale: boolean; error?: string;
   }> => ipcRenderer.invoke('skills:catalog', force),
-  /** Install a catalog skill into ~/.claude/skills. `unsupported` distinguishes
-   *  "there is no downloadable source" from "the download failed". */
+  /** 将目录技能安装到 ~/.claude/skills。`unsupported` 用于区分
+   *  「没有可下载的来源」与「下载失败」。 */
   skillsInstall: (url: string, name: string): Promise<
     { ok: true; path: string } | { ok: false; error: string; unsupported?: boolean }
   > => ipcRenderer.invoke('skills:install', url, name),
-  /** Delete an installed skill. Main refuses any path outside a skills root. */
+  /** 删除已安装的技能。主进程拒绝技能根目录之外的任何路径。 */
   skillsUninstall: (path: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('skills:uninstall', path),
-  /** Show a skill's folder in the OS file manager. */
+  /** 在系统文件管理器中显示技能的文件夹。 */
   skillsReveal: (path: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('skills:reveal', path),
   searchMemory: (query: string, wing?: string): Promise<{ ok: boolean; output: string; error?: string }> =>
@@ -810,13 +801,13 @@ const api = {
   memoryWakeUp: (wing?: string): Promise<{ ok: boolean; output: string; error?: string }> =>
     ipcRenderer.invoke('hive:memoryWakeUp', wing),
   mineNow: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('hive:mineNow'),
-  /** Condense agent memory.md files (the janitor's missing half). With an id,
-   *  condense that agent on demand; without, run a full threshold scan. Returns
-   *  the per-agent outcomes ({ id, condensed, reason, oldBytes?, newBytes? }). */
+  /** 压缩 agent 的 memory.md 文件（管理员缺失的另一半）。传入 id 时，
+   *  按需压缩该 agent；不传时执行完整阈值扫描。返回
+   *  每个 agent 的结果（{ id, condensed, reason, oldBytes?, newBytes? }）。 */
   reflectNow: (id?: string): Promise<Array<{ id: string; condensed: boolean; reason: string; oldBytes?: number; newBytes?: number }>> =>
     ipcRenderer.invoke('memory:reflectNow', id),
 
-  // ─── Enterprise Knowledge Graph (multimodal context for agents) ───────────
+  // ─── 企业知识图谱（面向 agent 的多模态上下文） ───────────
   kgStatus: (): Promise<KnowledgeStatus> => ipcRenderer.invoke('kg:status'),
   kgList: (): Promise<KnowledgeDoc[]> => ipcRenderer.invoke('kg:list'),
   kgSearch: (query: string, limit?: number): Promise<KnowledgeHit[]> =>
@@ -824,32 +815,32 @@ const api = {
   kgGet: (id: string): Promise<{ meta: KnowledgeDoc; text: string } | null> =>
     ipcRenderer.invoke('kg:get', id),
   kgRemove: (id: string): Promise<{ ok: boolean }> => ipcRenderer.invoke('kg:remove', id),
-  /** Open an OS file picker and ingest the chosen artifacts in one round-trip. */
+  /** 打开系统文件选择器，并在一次往返中摄取所选工件。 */
   kgAddFiles: (): Promise<KnowledgeIngestResult> => ipcRenderer.invoke('kg:addFiles'),
-  /** Ingest explicit file paths (e.g. drag-and-drop). */
+  /** 摄取显式的文件路径（如拖放）。 */
   kgIngestFiles: (paths: string[], tags?: string[]): Promise<KnowledgeIngestResult> =>
     ipcRenderer.invoke('kg:ingestFiles', { paths, tags }),
 
-  // ─── Composer attachments (images + files, sent to agents by PATH) ─────────
-  /** Open an OS picker for images/files; returns chosen absolute paths + names. */
+  // ─── Composer 附件（图片 + 文件，按路径发给 agent） ─────────
+  /** 打开系统图片/文件选择器；返回所选绝对路径 + 名称。 */
   attachFiles: (): Promise<
     { ok: true; files: { path: string; name: string }[] } | { ok: false; error: string }
   > => ipcRenderer.invoke('dialog:attachFiles'),
-  /** Resolve a dropped File's absolute path (Electron 32 removed File.path). */
+  /** 解析被拖放 File 的绝对路径（Electron 32 移除了 File.path）。 */
   pathForFile: (file: File): string => webUtils.getPathForFile(file),
-  /** Write the current clipboard image to a temp PNG and return its path (paste-to-attach). */
+  /** 将当前剪贴板图片写入临时 PNG 并返回其路径（粘贴即附件）。 */
   saveClipboardImage: (): Promise<
     { ok: true; file: { path: string; name: string } } | { ok: false; error: string }
   > => ipcRenderer.invoke('clipboard:saveImage'),
 
-  // ─── Command history (SQLite — every prompt submitted to an agent) ─────────
-  /** Record one submitted prompt. Fire-and-forget from the prompt-detection hook. */
+  // ─── 命令历史（SQLite — 提交给 agent 的每条提示词） ─────────
+  /** 记录一条已提交的提示。由提示检测钩子触发，发后即忘。 */
   historyAdd: (entry: { agentId: string; cwd?: string; text: string }): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('history:add', entry),
-  /** Most-recent-first history, optionally scoped to one agent. */
+  /** 最近优先的历史记录，可选择限定到某个 agent。 */
   historyList: (agentId?: string, limit?: number): Promise<CommandHistoryEntry[]> =>
     ipcRenderer.invoke('history:list', agentId, limit),
-  /** Substring search over prompt text, most-recent-first. */
+  /** 对提示文本做子串搜索，最近优先。 */
   historySearch: (query: string, limit?: number): Promise<CommandHistoryEntry[]> =>
     ipcRenderer.invoke('history:search', query, limit),
   hiveSend: (msg: Partial<HiveMessage>, from?: string): Promise<{ ok: boolean; error?: string; message?: HiveMessage }> =>
@@ -862,8 +853,8 @@ const api = {
     ipcRenderer.on('hive:hookEvent', listener);
     return () => ipcRenderer.removeListener('hive:hookEvent', listener);
   },
-  /** Push-based context accounting from the status line: live tokens + the
-   *  session's EXACT context-window size. Same pattern as onHiveHookEvent. */
+  /** 来自状态行的推送式上下文计量：实时 token 数 + 该会话
+   *  精确的上下文窗口大小。与 onHiveHookEvent 相同的模式。 */
   onHiveContextUpdate: (
     cb: (e: { agentId: string; tokens: number; limit: number }) => void
   ): (() => void) => {
@@ -876,16 +867,16 @@ const api = {
     ipcRenderer.on('hive:message', listener);
     return () => ipcRenderer.removeListener('hive:message', listener);
   },
-  /** Register a listener for hive tasks routed to non-Claude agents (e.g.
-   *  Codex). Main emits this instead of bouncing; the renderer enqueues the
-   *  raw text so the drain effect types it into the agent's REPL when idle. */
+  /** 为路由到非 Claude agent（如 Codex）的 hive 任务注册监听器。
+   *  主进程发出此事件而非退回；渲染进程将原始文本入队，
+   *  使 drain 效果在 agent 空闲时将其键入其 REPL。 */
   onHiveEnqueue: (cb: (e: { targetId: string; text: string }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: { targetId: string; text: string }) => cb(payload);
     ipcRenderer.on('hive:enqueueToAgent', listener);
     return () => ipcRenderer.removeListener('hive:enqueueToAgent', listener);
   },
-  /** A MAIN-initiated agent spawn (e.g. a voice hire via rt-5) — the renderer adds
-   *  the floor card from this descriptor since it didn't initiate the hire itself. */
+  /** 主进程发起的 agent 启动（如通过 rt-5 的语音招聘）——渲染进程
+   *  根据此描述符添加楼层卡片，因为它没有自行发起招聘。 */
   onHiveAgentSpawned: (
     cb: (rec: {
       id: string; name: string; provider?: string; cwd: string;
@@ -897,42 +888,42 @@ const api = {
     ipcRenderer.on('hive:agentSpawned', listener);
     return () => ipcRenderer.removeListener('hive:agentSpawned', listener);
   },
-  /** A MAIN-initiated agent kill/archive (e.g. a voice kill via rt-5) — the renderer
-   *  archives the floor card since it didn't initiate the kill itself. */
+  /** 主进程发起的 agent 终止/归档（如通过 rt-5 的语音终止）——渲染进程
+   *  归档楼层卡片，因为它没有自行发起终止。 */
   onHiveAgentArchived: (cb: (e: { id: string }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: { id: string }) => cb(payload);
     ipcRenderer.on('hive:agentArchived', listener);
     return () => ipcRenderer.removeListener('hive:agentArchived', listener);
   },
-  /** Register a listener for terminal work-order handoffs (#53) — hive mail to a
-   *  hookless provider that can't drain an inbox; the renderer types it into the
-   *  agent's REPL as a work order. */
+  /** 注册终端工单交接（#53）的监听器——发给无法清空收件箱的
+   *  无钩子 provider 的 hive 邮件；渲染进程将其作为工单键入
+   *  该 agent 的 REPL。 */
   onHiveTerminalHandoff: (cb: (e: HiveTerminalHandoffEvent) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: HiveTerminalHandoffEvent) => cb(payload);
     ipcRenderer.on('hive:terminalHandoff', listener);
     return () => ipcRenderer.removeListener('hive:terminalHandoff', listener);
   },
 
-  // ─── Shareable hires (deep link / file import) ────────────────────────────
-  /** Fired when a validated hire manifest arrives via the munderdifflin://
-   *  deep link. The renderer opens the Add-Agent modal pre-filled — import
-   *  never spawns anything by itself. */
+  // ─── 可分享的招聘（深链接 / 文件导入） ────────────────────────────
+  /** 经 munderdifflin:// 深链接到达已验证的招聘清单时触发。
+   *  渲染进程打开预填好的「添加 Agent」模态框——导入
+   *  本身从不启动任何东西。 */
   onHireImport: (cb: (manifest: HireManifest) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, manifest: HireManifest) => cb(manifest);
     ipcRenderer.on('hire:import', listener);
     return () => ipcRenderer.removeListener('hire:import', listener);
   },
-  /** Fired when a deep-linked manifest failed validation/fetch. */
+  /** 深链接清单校验/获取失败时触发。 */
   onHireError: (cb: (info: { error: string }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, info: { error: string }) => cb(info);
     ipcRenderer.on('hire:error', listener);
     return () => ipcRenderer.removeListener('hire:error', listener);
   },
-  /** Signal readiness and pull any queued deep-linked manifests (cold-start
-   *  links, links that arrived during load). Resolves the queued list. */
+  /** 发出就绪信号并拉取任何排队的深链接清单（冷启动链接、
+   *  加载期间到达的链接）。resolve 为排队的列表。 */
   drainPendingHires: (): Promise<HireManifest[]> =>
     ipcRenderer.invoke('hire:drainPending'),
-  /** Open a multi-file picker and validate every selected hire manifest. */
+  /** 打开多文件选择器并校验每个选中的招聘清单。 */
   importHireFiles: (): Promise<{
     ok: boolean;
     manifests: HireManifest[];
@@ -941,15 +932,15 @@ const api = {
   }> =>
     ipcRenderer.invoke('hire:openFile'),
 
-  // ─── Config changes ──────────────────────────────────────────────────────
-  /** Fired whenever a setting is saved, with the full updated config. */
+  // ─── 配置变更 ──────────────────────────────────────────────────────
+  /** 每当设置被保存时触发，携带完整更新后的配置。 */
   onConfigChanged: (cb: (config: HarnessConfig) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, config: HarnessConfig) => cb(config);
     ipcRenderer.on('config:changed', listener);
     return () => ipcRenderer.removeListener('config:changed', listener);
   },
 
-  // ─── Quit confirmation ───────────────────────────────────────────────────
+  // ─── 退出确认 ───────────────────────────────────────────────────
   onCloseRequested: (cb: (info: { ptyCount: number }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, info: { ptyCount: number }) => cb(info);
     ipcRenderer.on('app:closeRequested', listener);
@@ -958,318 +949,318 @@ const api = {
   confirmClose: (): Promise<void> => ipcRenderer.invoke('app:confirmClose'),
   cancelClose: (): Promise<void> => ipcRenderer.invoke('app:cancelClose'),
 
-  // ─── Power / wake (auto-revive wedged PTYs after sleep/lock) ────────────────
-  /** Subscribe to the main-process power-resume signal; returns an unsubscribe
-   *  fn. The main process catches up after a sleep/unlock and reports the PTY
-   *  ids that wedged across it in `dead` — the renderer respawns ONLY those
-   *  (empty `dead[]` = no-op). Same main→renderer push pattern as onClosingTime. */
+  // ─── 电源 / 唤醒（睡眠/锁屏后自动复活卡死的 PTY） ────────────────
+  /** 订阅主进程的电源恢复信号；返回一个取消订阅函数。
+   *  主进程在睡眠/解锁后补发，并在 `dead` 中报告跨越其间的
+   *  卡死 PTY id——渲染进程只重生这些（空的 `dead[]` = 空操作）。
+   *  与 onClosingTime 相同的主进程→渲染进程推送模式。 */
   onPowerResume: (cb: (e: PowerResumeEvent) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: PowerResumeEvent) => cb(payload);
     ipcRenderer.on('power:resume', listener);
     return () => ipcRenderer.removeListener('power:resume', listener);
   },
 
-  // ─── Multi-window floors ───────────────────────────────────────────────────
-  /** Open a new floor (independent office window). No-op when the multiWindow
-   *  flag is off. Resolves { ok } indicating whether a window opened. */
+  // ─── 多窗口楼层 ───────────────────────────────────────────────────
+  /** 打开新楼层（独立的办公室窗口）。multiWindow 标志关闭时为空操作。
+   *  resolve 出 { ok }，指示窗口是否打开。 */
   newFloor: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('window:newFloor'),
 
-  // ─── Closing time (graceful shutdown via the hive) ─────────────────────────
-  /** Start the closing-time protocol: the god broadcasts shutdown, every worker
-   *  saves its memory and ACKs, the god concludes — then the app quits itself.
-   *  Resolves with ok:false (+ error) when no god agent is running. */
+  // ─── 打烊时间（经 hive 优雅关闭） ─────────────────────────
+  /** 启动打烊协议：god 广播关闭，每个 worker 保存记忆并 ACK，
+   *  god 总结收尾——然后应用自行退出。
+   *  没有 god agent 运行时 resolve 出 ok:false（+ error）。 */
   startClosingTime: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('app:startClosingTime'),
-  /** Abort an in-progress closing time and tell the floor to resume work. */
+  /** 中止进行中的打烊，并告知楼层恢复工作。 */
   cancelClosingTime: (): Promise<void> => ipcRenderer.invoke('app:cancelClosingTime'),
-  /** Progress events for the quit dialog: started → progress (ACK counts) →
-   *  complete (the app tears down moments later) | timeout | cancelled. */
+  /** 退出对话框的进度事件：started → progress（ACK 计数）→
+   *  complete（片刻后应用拆除）| timeout | cancelled。 */
   onClosingTime: (cb: (ev: ClosingTimeEvent) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, ev: ClosingTimeEvent) => cb(ev);
     ipcRenderer.on('app:closingTime', listener);
     return () => ipcRenderer.removeListener('app:closingTime', listener);
   },
 
-  // ─── Reset ─────────────────────────────────────────────────────────────────
-  /** Wipe all hive data + the memory palace, reset config, and relaunch the app
-   *  into onboarding. The process exits, so this promise never resolves. */
+  // ─── 重置 ─────────────────────────────────────────────────────────────────
+  /** 清空所有 hive 数据 + 记忆宫殿，重置配置，并重新启动应用进入引导。
+   *  进程会退出，因此该 promise 永不 resolve。 */
   resetAll: (): Promise<void> => ipcRenderer.invoke('app:resetAll'),
 
-  // ─── Token telemetry (real usage + est. cost from CC transcripts) ──────────
-  /** Sum input/output/cache tokens + estimated USD cost for an agent from its
-   *  Claude Code transcripts (reconciler/fallback). Returns null for an invalid cwd. */
+  // ─── Token 遥测（来自 CC 转录的真实用量 + 预估成本） ──────────
+  /** 从某个 agent 的 Claude Code 转录中汇总输入/输出/缓存 token +
+   *  预估 USD 成本（对账/回退）。cwd 无效时返回 null。 */
   agentUsage: (cwd: string): Promise<AgentUsage | null> =>
     ipcRenderer.invoke('hive:agentUsage', cwd),
-  /** Current context size (tokens) of an agent's live session, read from the
-   *  last assistant message of its transcript. Null until the agent's hooks
-   *  have fired at least once (the transcript path is learned from them). */
+  /** agent 实时会话的当前上下文大小（token 数），从其中
+   *  转录的最后一条 assistant 消息读取。在 agent 的钩子至少触发一次之前
+   *  为 null（转录路径是从钩子学到的）。 */
   agentContext: (agentId: string): Promise<number | null> =>
     ipcRenderer.invoke('hive:agentContext', agentId),
 
-  // ─── Live telemetry (OTel collector — the usage-provider seam + spans) ──────
-  /** Live cumulative usage for an agent (OTel-preferred, transcript fallback). */
+  // ─── 实时遥测（OTel 采集器 — 用量提供者接缝 + spans） ──────
+  /** agent 的实时累计用量（优先 OTel，回退转录）。 */
   telemetryUsage: (agentId: string): Promise<AgentUsageSample | null> =>
     ipcRenderer.invoke('telemetry:usage', agentId),
-  /** Recent tool spans for an agent's waterfall (#7B.2). */
+  /** 某个 agent 瀑布图（#7B.2）的近期的工具 spans。 */
   telemetrySpans: (agentId: string): Promise<ToolSpan[]> =>
     ipcRenderer.invoke('telemetry:spans', agentId),
-  /** Cold-start backfill of all agents' usage + recent spans. */
+  /** 所有 agent 用量 + 近期 spans 的冷启动回填。 */
   telemetrySnapshot: (): Promise<TelemetrySnapshot> =>
     ipcRenderer.invoke('telemetry:snapshot'),
-  /** Subscribe to live telemetry pushes; returns an unsubscribe fn. */
+  /** 订阅实时遥测推送；返回取消订阅函数。 */
   onTelemetryEvent: (cb: (e: TelemetryEvent) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: TelemetryEvent) => cb(payload);
     ipcRenderer.on('telemetry:event', listener);
     return () => ipcRenderer.removeListener('telemetry:event', listener);
   },
 
-  // ─── Circuit breaker (Lane A #6 state → avatars/meter) ──────────────────────
-  /** Subscribe to breaker-state changes; returns an unsubscribe fn. */
+  // ─── 熔断器（泳道 A #6 状态 → 头像/仪表） ──────────────────────
+  /** 订阅熔断器状态变更；返回取消订阅函数。 */
   onBreakerState: (cb: (s: BreakerState) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: BreakerState) => cb(payload);
     ipcRenderer.on('control:breakerState', listener);
     return () => ipcRenderer.removeListener('control:breakerState', listener);
   },
-  /** Push a breaker state to the renderer (Lane A's policy / interim glue calls this). */
+  /** 向渲染进程推送熔断器状态（泳道 A 的策略/临时胶水调用它）。 */
   setBreakerState: (state: BreakerState): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('control:setBreakerState', state),
 
-  // ─── Operator control over agents (#7C.1–7C.3) ──────────────────────────────
-  /** Pause/unpause an agent — paused → its tool calls are denied at PreToolUse. */
+  // ─── 对 agent 的操作员控制（#7C.1–7C.3） ──────────────────────────────
+  /** 暂停/取消暂停 agent——暂停后 → 其工具调用在 PreToolUse 被拒绝。 */
   controlPause: (agentId: string, on: boolean): Promise<AgentControlSnapshot | null> =>
     ipcRenderer.invoke('control:pause', agentId, on),
-  /** Pause/resume automatic inbox and queued-message delivery for one agent. */
+  /** 暂停/恢复某个 agent 的自动收件箱与排队消息投递。 */
   controlAutoDelivery: (agentId: string, paused: boolean): Promise<AgentControlSnapshot | null> =>
     ipcRenderer.invoke('control:autoDelivery', agentId, paused),
-  /** Clear pause + halt so the agent can run again. */
+  /** 清除暂停 + 中止，使 agent 可以再次运行。 */
   controlResume: (agentId: string): Promise<AgentControlSnapshot | null> =>
     ipcRenderer.invoke('control:resume', agentId),
-  /** Gate/ungate a specific tool for an agent (denied at PreToolUse). */
+  /** 为某个 agent 开启/关闭特定工具的门（在 PreToolUse 拒绝）。 */
   controlGateTool: (agentId: string, tool: string, on: boolean): Promise<AgentControlSnapshot | null> =>
     ipcRenderer.invoke('control:gateTool', agentId, tool, on),
-  /** Queue a steer note — injected as context on the agent's next hook (#7C.2). */
+  /** 排队一条引导备注——在 agent 的下一次钩子（#7C.2）中作为上下文注入。 */
   controlSteer: (agentId: string, text: string): Promise<AgentControlSnapshot | null> =>
     ipcRenderer.invoke('control:steer', agentId, text),
-  /** Request a graceful stop at the next hook boundary (#7C.3). */
+  /** 请求在下一个钩子边界（#7C.3）优雅停止。 */
   controlHalt: (agentId: string): Promise<AgentControlSnapshot | null> =>
     ipcRenderer.invoke('control:halt', agentId),
-  /** Read an agent's current control snapshot. */
+  /** 读取 agent 当前的控制快照。 */
   controlSnapshot: (agentId: string): Promise<AgentControlSnapshot | null> =>
     ipcRenderer.invoke('control:snapshot', agentId),
-  /** Subscribe to gate/deny events (a tool was blocked); returns unsubscribe fn. */
+  /** 订阅门控/拒绝事件（工具被拦截）；返回取消订阅函数。 */
   onApprovalRequest: (cb: (e: { agentId: string; tool?: string; reason?: string }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: { agentId: string; tool?: string; reason?: string }) => cb(payload);
     ipcRenderer.on('control:approvalRequest', listener);
     return () => ipcRenderer.removeListener('control:approvalRequest', listener);
   },
 
-  // ─── Task kanban (hive/tasks.json) ───────────────────────────────────────
-  /** Atomically append one card against the latest main-process ledger. */
+  // ─── 任务看板（hive/tasks.json） ───────────────────────────────────────
+  /** 针对主进程最新账本原子地追加一张卡片。 */
   hiveAddTask: (task: HiveTask): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('hive:addTask', task),
-  /** Atomically patch one named card without replacing unrelated cards/fields. */
+  /** 原子地修补某张指定卡片，而不替换无关的卡片/字段。 */
   hivePatchTask: (
     id: string,
     patch: Partial<Omit<HiveTask, 'id'>>
   ): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('hive:patchTask', id, patch),
-  /** Atomically remove one named card from the latest main-process ledger. */
+  /** 从主进程最新账本中原子地移除某张指定卡片。 */
   hiveDeleteTask: (id: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('hive:deleteTask', id),
 
-  // ─── Scheduled missions (recurring auto-dispatch) ──────────────────────────
+  // ─── 定时任务（周期性自动派发） ──────────────────────────
   listMissions: (): Promise<ScheduledMission[]> => ipcRenderer.invoke('missions:list'),
   saveMissions: (missions: ScheduledMission[]): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('missions:save', missions),
-  /** Fires when the scheduler stamps a mission's lastFiredAt (a beat/dispatch),
-   *  so the SCHEDULES panel can refresh "last fired" without a reload. */
+  /** 调度器为某个任务的 lastFiredAt 盖时间戳（一次心跳/派发）时触发，
+   *  使「计划」面板无需重载即可刷新「上次触发」。 */
   onMissionsUpdated: (cb: () => void): (() => void) => {
     const listener = (): void => cb();
     ipcRenderer.on('missions:updated', listener);
     return () => ipcRenderer.removeListener('missions:updated', listener);
   },
-  /** Fires when an autoCompact mission ticks — the renderer queues a /compact
-   *  per agent (deduped) and delivers it when each agent is idle. */
+  /** autoCompact 任务滴答时触发——渲染进程为每个 agent 排队一次 /compact
+   *  （去重），并在各 agent 空闲时投递。 */
   onAutoCompact: (cb: () => void): (() => void) => {
     const listener = (): void => cb();
     ipcRenderer.on('mission:autoCompact', listener);
     return () => ipcRenderer.removeListener('mission:autoCompact', listener);
   },
 
-  // ─── Full-text search across hive files (board, tasks, memory) ─────────────
+  // ─── 跨 hive 文件全文搜索（看板、任务、记忆） ─────────────
   textSearch: (q: string): Promise<{ ok: boolean; results: Array<{ source: string; excerpt: string }> }> =>
     ipcRenderer.invoke('hive:textSearch', q),
 
-  // ─── GitHub issue ingestion (gh CLI) ───────────────────────────────────────
-  /** List up to 30 open issues in the repo at `cwd` via the `gh` CLI. Returns
-   *  `{ ok: false, error }` if `gh` is missing/unauthenticated or `cwd` isn't a repo. */
+  // ─── GitHub issue 摄取（gh CLI） ───────────────────────────────────────
+  /** 通过 `gh` CLI 列出 `cwd` 处仓库中最多 30 个打开的 issue。若 `gh`
+   *  缺失/未认证或 `cwd` 不是仓库，返回 `{ ok: false, error }`。 */
   githubIssues: (cwd: string): Promise<{ ok: boolean; issues?: GHIssue[]; error?: string }> =>
     ipcRenderer.invoke('github:issues', cwd),
 
-  // ─── GitHub CI status watcher (gh CLI) ─────────────────────────────────────
-  /** List up to 5 recent CI (GitHub Actions) runs in the repo at `cwd` via the
-   *  `gh` CLI. Returns `{ ok: false, error }` if `gh` is missing/unauthenticated,
-   *  `cwd` isn't a repo, or the repo has no Actions. */
+  // ─── GitHub CI 状态监视（gh CLI） ─────────────────────────────────────
+  /** 通过 `gh` CLI 列出 `cwd` 处仓库中最多 5 次最近的 CI（GitHub Actions）运行。
+   *  若 `gh` 缺失/未认证、`cwd` 不是仓库，或仓库没有 Actions，
+   *  返回 `{ ok: false, error }`。 */
   githubCIRuns: (cwd: string): Promise<{ ok: boolean; runs?: CIRun[]; error?: string }> =>
     ipcRenderer.invoke('github:ciRuns', cwd),
 
-  // ─── Desktop notifications ───────────────────────────────────────────────────
-  /** Toggle native desktop notifications for agent lifecycle events. */
+  // ─── 桌面通知 ───────────────────────────────────────────────────
+  /** 切换 agent 生命周期事件的原生桌面通知。 */
   setNotifications: (v: boolean): Promise<HarnessConfig> =>
     ipcRenderer.invoke('app:setNotifications', v),
 
-  // ─── Reliability / OS integration (onboarding permissions step) ──────────────
-  /** Open a System Settings deep-link (or https URL) in the OS handler. Main
-   *  restricts the scheme; the renderer just points at the pane. */
+  // ─── 可靠性 / 系统集成（引导权限步骤） ──────────────
+  /** 在系统处理器中打开「系统设置」深链接（或 https URL）。主进程
+   *  限制协议；渲染进程只是指向该面板。 */
   openExternal: (url: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('app:openExternal', url),
-  /** Toggle macOS "Open at Login". Resolves to the resulting state (no prompt). */
+  /** 切换 macOS「登录时打开」。resolve 为最终状态（无提示）。 */
   setLoginItem: (enabled: boolean): Promise<boolean> =>
     ipcRenderer.invoke('app:setLoginItem', enabled),
 
-  // ─── Agent lifecycle (archival) ─────────────────────────────────────────────
-  /** Archive/unarchive a hive agent in the registry. Closing a terminal tab
-   *  archives it automatically via pty:kill; this is the explicit primitive. */
+  // ─── Agent 生命周期（归档） ─────────────────────────────────────────────
+  /** 在注册表中归档/取消归档 hive agent。关闭终端标签页会经由 pty:kill
+   *  自动归档；这是显式原语。 */
   hiveSetArchived: (id: string, archived: boolean): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('hive:setArchived', id, archived),
 
-  // ─── Slack integration (Slack message → Michael's queue) ─────────────────────
-  /** Register a listener for inbound Slack messages; returns an unsubscribe fn.
-   *  The message carries the thread coordinates needed to reply in-thread. */
+  // ─── Slack 集成（Slack 消息 → Michael 的队列） ─────────────────────
+  /** 为入站 Slack 消息注册监听器；返回取消订阅函数。
+   *  消息携带在线程内回复所需的线程坐标。 */
   onSlackMessage: (cb: (msg: { text: string; channel: string; ts: string; thread_ts: string; autonomyPreamble?: string; files?: { path: string; name: string; mimetype: string }[] }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, msg: { text: string; channel: string; ts: string; thread_ts: string; autonomyPreamble?: string; files?: { path: string; name: string; mimetype: string }[] }) => cb(msg);
     ipcRenderer.on('slack:incomingMessage', listener);
     return () => ipcRenderer.removeListener('slack:incomingMessage', listener);
   },
-  /** Start the Slack webhook server; returns the public tunnel URL to paste into
-   *  the Slack app's Event Subscriptions → Request URL. */
+  /** 启动 Slack webhook 服务器；返回要粘贴到 Slack 应用的
+   *  事件订阅 → 请求 URL 的公共隧道 URL。 */
   slackStart: (): Promise<{ ok: boolean; url?: string; error?: string }> =>
     ipcRenderer.invoke('slack:start'),
-  /** Stop the Slack webhook server + tunnel. */
+  /** 停止 Slack webhook 服务器 + 隧道。 */
   slackStop: (): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('slack:stop'),
-  /** Current connection state + last Request URL (so Settings can hydrate the
-   *  "Connected" badge and re-show the persisted tunnel URL on reopen). */
+  /** 当前连接状态 + 上次的请求 URL（使设置页能填充
+   *  「已连接」徽章，并在重新打开时再次显示持久化的隧道 URL）。 */
   slackStatus: (): Promise<{ running: boolean; url?: string }> =>
     ipcRenderer.invoke('slack:status'),
-  /** Post a reply into a Slack thread (the bot token stays in main). Used for the
-   *  renderer's immediate "queued" ack. */
+  /** 在 Slack 线程中发布回复（bot token 保留在主进程中）。用于
+   *  渲染进程即时的「已排队」确认。 */
   slackReply: (m: { channel: string; thread_ts: string; text: string }): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('slack:reply', m),
-  /** Absolute path to the bundled reply helper, for the office worker's
-   *  end-of-run "post your summary back to Slack" instruction. */
+  /** 内置回复辅助脚本的绝对路径，供办公室 worker 在运行结束时
+   *  「把总结发回 Slack」的指令使用。 */
   slackReplyScriptPath: (): Promise<string> =>
     ipcRenderer.invoke('slack:replyScriptPath'),
-  /** Persist Slack settings (and stop the server if disabled / secret cleared). */
+  /** 持久化 Slack 设置（若被禁用 / 密钥被清除则停止服务器）。 */
   slackSetConfig: (patch: {
     signingSecret?: string; botToken?: string; channelId?: string; port?: number; enabled?: boolean;
     proactivePosting?: boolean;
   }): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('slack:setConfig', patch),
 
-  // ─── Generic webhook + status API (POST → work, GET → status) ────────────────
-  /** Start the generic webhook server; returns the public endpoint URL callers
-   *  POST to (secret-gated) and GET a token's status from. */
+  // ─── 通用 Webhook + 状态 API（POST → 进入工作，GET → 查询状态） ────────────────
+  /** 启动通用 webhook 服务器；返回公共端点 URL，调用方
+   *  POST（受密钥门控）并 GET 某个 token 的状态。 */
   webhookStart: (): Promise<{ ok: boolean; url?: string; error?: string }> =>
     ipcRenderer.invoke('webhook:start'),
-  /** Stop the generic webhook server + tunnel. */
+  /** 停止通用 webhook 服务器 + 隧道。 */
   webhookStop: (): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('webhook:stop'),
-  /** Current state + last endpoint URL (so Settings can hydrate the badge/URL). */
+  /** 当前状态 + 上次的端点 URL（使设置页能填充徽章/URL）。 */
   webhookStatus: (): Promise<{ running: boolean; url?: string }> =>
     ipcRenderer.invoke('webhook:status'),
-  /** Mint + persist a fresh secret and return it for the user to copy. */
+  /** 铸造 + 持久化一个新密钥，并返回给用户复制。 */
   webhookGenerateSecret: (): Promise<{ ok: boolean; secret?: string }> =>
     ipcRenderer.invoke('webhook:generateSecret'),
-  /** Persist webhook settings (and stop the server if disabled / secret cleared). */
+  /** 持久化 webhook 设置（若被禁用 / 密钥被清除则停止服务器）。 */
   webhookSetConfig: (patch: {
     secret?: string; port?: number; enabled?: boolean;
   }): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('webhook:setConfig', patch),
 
-  // ─── Triggers: context (auto-compact / auto-clear) ──────────────────────────
-  /** The two context rules (cadence + pressure gate + message), deep-filled. */
+  // ─── 触发器：上下文（自动压缩 / 自动清除） ──────────────────────────
+  /** 两条上下文规则（节奏 + 压力闸 + 消息），已深度填充。 */
   getContextTrigger: (): Promise<ContextTriggerConfig> =>
     ipcRenderer.invoke('triggers:getContext'),
-  /** Persist both rules and RE-ARM main's timers; resolves to what was stored
-   *  (main clamps the cadence/percentages, so the echo is authoritative). */
+  /** 持久化两条规则并重新武装主进程的定时器；resolve 为实际存储的值
+   *  （主进程会钳制节奏/百分比，因此回显是权威的）。 */
   setContextTrigger: (cfg: ContextTriggerConfig): Promise<ContextTriggerConfig> =>
     ipcRenderer.invoke('triggers:setContext', cfg),
-  /** Fires when a context rule comes due. `rule` rides along because main owns
-   *  only the CADENCE — the renderer applies the per-agent pressure gate and
-   *  queues the command for each agent that qualifies. */
+  /** 上下文规则到期时触发。`rule` 一并携带，因为主进程只拥有
+   *  节奏——渲染进程应用每个 agent 的压力闸，并为每个符合条件的
+   *  agent 排队命令。 */
   onContextTrigger: (cb: (evt: { action: 'compact' | 'clear'; rule: ContextRule }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: { action: 'compact' | 'clear'; rule: ContextRule }) => cb(payload);
     ipcRenderer.on('trigger:context', listener);
     return () => ipcRenderer.removeListener('trigger:context', listener);
   },
 
-  // ─── Triggers: webhook endpoints (many endpoints, one server + tunnel) ──────
-  /** Every configured endpoint, enabled or not. */
+  // ─── 触发器：Webhook 端点（多端点共用一个服务器 + 隧道） ──────
+  /** 每个已配置的端点，无论是否启用。 */
   listWebhooks: (): Promise<WebhookTrigger[]> => ipcRenderer.invoke('webhooks:list'),
-  /** Replace the whole list; main normalises each row (a blank secret keeps the
-   *  stored one, an unknown mode keeps the stored one) and hot-swaps the running
-   *  server's endpoints WITHOUT a restart, so no other caller's URL changes. */
+  /** 替换整个列表；主进程规范化每一行（空白密钥保留已存密钥，
+   *  未知模式保留已存模式），并热切换运行中服务器的端点，
+   *  无需重启，因此其他调用方的 URL 不会改变。 */
   saveWebhooks: (list: WebhookTrigger[]): Promise<WebhookTrigger[]> =>
     ipcRenderer.invoke('webhooks:save', list),
-  /** Revoke one endpoint; resolves to the remaining list. */
+  /** 吊销一个端点；resolve 为剩余的列表。 */
   deleteWebhook: (id: string): Promise<WebhookTrigger[]> =>
     ipcRenderer.invoke('webhooks:delete', id),
-  /** Mint a 256-bit secret for the operator to paste into their caller. Not
-   *  persisted until the endpoint carrying it is saved. */
+  /** 为操作员铸造一个 256 位密钥粘贴到其调用方。在携带它的
+   *  端点保存之前不会持久化。 */
   generateWebhookSecret: (): Promise<string> => ipcRenderer.invoke('webhooks:generateSecret'),
-  /** Server state, the tunnel root, and each endpoint's full public URL (`url` is
-   *  '' until a tunnel has come up). */
+  /** 服务器状态、隧道根地址，以及每个端点的完整公共 URL（隧道
+   *  建立之前 `url` 为 ''）。 */
   webhooksStatus: (): Promise<{ running: boolean; url?: string; endpoints: { id: string; url: string }[] }> =>
     ipcRenderer.invoke('webhooks:status'),
 
-  // ─── Triggers: organisation (clone-node peer messaging) ─────────────────────
-  /** PERSISTENCE ONLY — the peer transport does not exist yet, so setting this
-   *  stores the key and mode and starts nothing. */
+  // ─── 触发器：组织（克隆节点对等消息） ─────────────────────
+  /** 仅持久化——对等传输尚不存在，因此设置它只会存储
+   *  密钥和模式，不启动任何东西。 */
   getOrgTrigger: (): Promise<OrgTriggerConfig> => ipcRenderer.invoke('org:getTrigger'),
   setOrgTrigger: (cfg: OrgTriggerConfig): Promise<OrgTriggerConfig> =>
     ipcRenderer.invoke('org:setTrigger', cfg),
 
-  // ─── Triggers: history ledger + approval gate ───────────────────────────────
-  /** The whole ledger, newest first (both directions, both sources). */
+  // ─── 触发器：历史账本 + 审批闸 ───────────────────────────────
+  /** 整个账本，最新在前（两个方向、两个来源）。 */
   listTriggerHistory: (): Promise<TriggerHistoryEntry[]> =>
     ipcRenderer.invoke('triggerHistory:list'),
-  /** Answer a held message. 'approved' RELEASES it to the hive (card + god
-   *  request, the same path an auto-allowed message takes); 'rejected' only flips
-   *  the verdict. Deciding an already-decided entry is a no-op, never a second
-   *  dispatch. Resolves to the updated row, or null when the id is gone. */
+  /** 答复一条被挂起的消息。'approved' 将其释放到 hive（卡片 + god
+   *  请求，与自动放行的消息走相同路径）；'rejected' 只翻转
+   *  裁决。对已裁决的条目再次裁决是空操作，绝不会二次派发。
+   *  resolve 为更新后的行，id 已不存在时为 null。 */
   decideTriggerHistory: (arg: { id: string; decision: 'approved' | 'rejected' }): Promise<TriggerHistoryEntry | null> =>
     ipcRenderer.invoke('triggerHistory:decide', arg),
-  /** Wipe the ledger, or just one source's half of it. */
+  /** 清空账本，或仅清空某个来源的那一半。 */
   clearTriggerHistory: (source?: 'webhook' | 'org'): Promise<void> =>
     ipcRenderer.invoke('triggerHistory:clear', source),
-  /** Fires whenever the ledger changes (an inbound arrived, a verdict landed, a
-   *  reply was paired), so the history tab live-refreshes. */
+  /** 每当账本变化时触发（入站到达、裁决落定、回复配对），
+   *  使历史标签页实时刷新。 */
   onTriggerHistoryUpdated: (cb: () => void): (() => void) => {
     const listener = (): void => cb();
     ipcRenderer.on('triggerHistory:updated', listener);
     return () => ipcRenderer.removeListener('triggerHistory:updated', listener);
   },
 
-  // ─── Free Flow (voice dictation → message queue) ─────────────────────────────
-  /** Persist Free Flow settings (flag / Groq key / model). The Groq key is stored
-   *  in main config; entry point B (hold-Option) is renderer-side, no hotkey here. */
+  // ─── Free Flow（语音听写 → 消息队列） ─────────────────────────────
+  /** 持久化 Free Flow 设置（开关 / Groq 密钥 / 模型）。Groq 密钥存储
+   *  在主进程配置中；入口点 B（按住 Option）在渲染进程侧，这里没有快捷键。 */
   freeflowSetConfig: (patch: {
     enabled?: boolean; apiKey?: string; model?: string;
   }): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('freeflow:setConfig', patch),
-  /** Transcribe one captured audio clip via Groq (the key stays in main; only the
-   *  audio bytes go in and the transcript comes back). Gated on the flag + a key. */
+  /** 通过 Groq 转写一段捕获的音频片段（密钥留在主进程；只有
+   *  音频字节进入，转录文本返回）。受开关 + 密钥门控。 */
   freeflowTranscribe: (arg: {
     audio: ArrayBuffer | Uint8Array; mimeType?: string; filename?: string; language?: string;
   }): Promise<{ ok: boolean; text?: string; error?: string }> =>
     ipcRenderer.invoke('freeflow:transcribe', arg),
 
-  // ─── Integrations registry (Phase 2 — labeled REST endpoints via the secret broker) ──
-  // Bridges the §6 IPC surface for the Settings UI. WRITE-ONLY secret contract end to
-  // end: `integrationsList` returns records with secretRef redacted to `hasSecret`;
-  // `integrationsSetSecret` takes a secret ONE WAY (never echoed); NO method ever
-  // returns a secret value to the renderer. Method names match registryClient's
-  // feature-detection (camelCase ↔ colon-channel), so its real path activates as-is.
+  // ─── 集成注册表（阶段 2 — 经密钥代理的带标签 REST 端点） ──
+  // 为设置 UI 桥接 §6 的 IPC 表面。端到端的只写密钥契约：
+  // `integrationsList` 返回 secretRef 脱敏为 `hasSecret` 的记录；
+  // `integrationsSetSecret` 单向接收密钥（绝不回显）；任何方法都
+  // 绝不向渲染进程返回密钥值。方法名匹配 registryClient 的
+  // 特性检测（camelCase ↔ 冒号通道），因此其真实路径按原样激活。
   integrationsList: (): Promise<IntegrationRecordView[]> =>
     ipcRenderer.invoke('integrations:list'),
   integrationsTemplates: (): Promise<IntegrationTemplate[]> =>
@@ -1282,18 +1273,18 @@ const api = {
     ipcRenderer.invoke('integrations:remove', req),
   integrationsTest: (req: { id: string; path?: string }): Promise<{ ok: boolean; status?: number; error?: string }> =>
     ipcRenderer.invoke('integrations:test', req),
-  // Per-CLI-provider BYOK keys — WRITE-ONLY. `providerKeySet` stores a backend key one
-  // way (never echoed); `providerKeyHas` returns only a boolean; no method ever returns
-  // the plaintext. Keys are materialized MAIN-ONLY at spawn.
+  // 每个 CLI provider 的 BYOK 密钥——只写。`providerKeySet` 单向存储后端密钥
+  // （绝不回显）；`providerKeyHas` 只返回布尔值；任何方法都绝不返回
+  // 明文。密钥仅在启动时于主进程中物化。
   providerKeySet: (req: { backend: string; key: string }): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('providerKey:set', req),
   providerKeyHas: (backend: string): Promise<boolean> =>
     ipcRenderer.invoke('providerKey:has', backend),
   providerKeyClear: (backend: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('providerKey:clear', backend),
-  // Realtime Michael (voice orchestrator) — MAIN mints a short-lived EPHEMERAL token
-  // from the BYOK OpenAI key; the real key NEVER crosses IPC. `realtimeHasOpenAiKey`
-  // is a presence boolean only (gates the voice toggle, like providerKeyHas).
+  // Realtime Michael（语音编排器）——主进程铸造短期临时 token
+  // 源自 BYOK OpenAI 密钥；真实密钥绝不跨越 IPC。`realtimeHasOpenAiKey`
+  // 只是存在性布尔值（门控语音开关，与 providerKeyHas 相同）。
   realtimeHasOpenAiKey: (): Promise<boolean> =>
     ipcRenderer.invoke('realtime:hasKey'),
   realtimeMintToken: (
@@ -1302,9 +1293,9 @@ const api = {
     | { ok: true; token: string; expiresAt: number | null; sessionConfig: { model: string } }
     | { ok: false; error: string; code?: string }
   > => ipcRenderer.invoke('realtime:mintToken', req ?? {}),
-  // rt-5 voice ACTIONS — the renderer holds NO policy; main (realtimeActions.ts) owns
-  // the tiering, two-step verbal confirm, hard allowlist, and michael-voice
-  // attribution. These just forward {verb,...args} and speak back `spoken`.
+  // rt-5 语音动作——渲染进程不持有任何策略；主进程（realtimeActions.ts）拥有
+  // 分级、两步口头确认、硬性白名单和 michael-voice
+  // 归属。这些只是转发 {verb,...args} 并把 `spoken` 说出来。
   realtimeAction: (
     payload: { verb: string } & Record<string, unknown>
   ): Promise<{ ok: boolean; spoken: string; needsConfirm?: boolean }> =>
@@ -1315,8 +1306,8 @@ const api = {
     ipcRenderer.invoke('realtime:action:confirm', req),
   realtimeActionCancel: (): Promise<{ ok: boolean; spoken: string; needsConfirm?: boolean }> =>
     ipcRenderer.invoke('realtime:action:cancel'),
-  // rt-12 completion seam — a voice-dispatched task finished. `summary` is the
-  // human-speakable line Michael relays; the rest is context for a toast/log.
+  // rt-12 完成接缝——一个语音派发的任务已完成。`summary` 是
+  // Michael 转述的、可对人类说出的一句话；其余是 toast/日志的上下文。
   onRealtimeCompletion: (
     cb: (evt: { correlationId: string; kind: string; targetAgentId: string; taskId?: string; summary: string; completedAt: number; objective?: string }) => void
   ): (() => void) => {
@@ -1324,96 +1315,95 @@ const api = {
     ipcRenderer.on('realtime:completion', listener);
     return () => ipcRenderer.removeListener('realtime:completion', listener);
   },
-  /** Tell main whether a live voice session is open (drives queue-vs-push for completions). */
+  /** 告知主进程实时语音会话是否开启（决定完成事件走排队还是推送）。 */
   realtimeSetSessionLive: (live: boolean): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('realtime:setSessionLive', live),
-  /** Drain completions that arrived while no session was open (warm-start catch-up). */
+  /** 清空在无会话开启时到达的完成事件（热启动追赶）。 */
   realtimeDrainCompletions: (): Promise<
     { correlationId: string; kind: string; targetAgentId: string; taskId?: string; summary: string; completedAt: number; objective?: string }[]
   > => ipcRenderer.invoke('realtime:drainCompletions'),
-  /** Block until a tracked task completes (or times out) — backs the wait_for tool. */
+  /** 阻塞直到被跟踪的任务完成（或超时）——支撑 wait_for 工具。 */
   realtimeWaitFor: (
     taskId: string,
     timeoutMs?: number
   ): Promise<{ summary: string; targetAgentId: string; taskId?: string } | { timedOut: true; taskId: string }> =>
     ipcRenderer.invoke('realtime:waitFor', taskId, timeoutMs),
-  /** v0.3.4: coalesced floor deltas pushed while a voice session is live — the
-   *  renderer injects them into the conversation as silent items. */
+  /** v0.3.4：语音会话存活期间推送的合并楼层增量——渲染进程
+   *  将它们作为静默项注入对话。 */
   onRealtimeFloorDelta: (cb: (evt: { text: string }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: { text: string }) => cb(payload);
     ipcRenderer.on('realtime:floorDelta', listener);
     return () => ipcRenderer.removeListener('realtime:floorDelta', listener);
   },
-  /** v0.3.4: main-staged queue insertions (voice clear_context) — the renderer
-   *  enqueues so delivery rides every existing safety gate. */
+  /** v0.3.4：主进程暂存的队列插入（语音 clear_context）——渲染进程
+   *  入队，使投递经过所有现有安全闸。 */
   onRealtimeEnqueue: (cb: (evt: { agentId: string; text: string }) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: { agentId: string; text: string }) => cb(payload);
     ipcRenderer.on('realtime:enqueue', listener);
     return () => ipcRenderer.removeListener('realtime:enqueue', listener);
   },
-  /** v0.3.4: app self-knowledge — version + newest changelog sections. */
+  /** v0.3.4：应用自我认知——版本 + 最新的更新日志段落。 */
   appInfo: (): Promise<{ version: string; changelog: string }> =>
     ipcRenderer.invoke('app:info'),
-  // ─── Roster mirror (agents + notes + queues, shared dev ↔ packaged) ─────────
-  /** Read the roster file beside the hive. SYNCHRONOUS on purpose: the zustand
-   *  store is created at module load, so an async read would arrive after the
-   *  first render and the floor would flash empty. One blocking round trip at
-   *  boot. `null` = no file (or unreadable) — the caller then uses localStorage. */
+  // ─── 花名册镜像（agents + 备注 + 队列，dev ↔ 打包版共享） ─────────
+  /** 读取 hive 旁的花名册文件。刻意同步：zustand store 在模块加载时
+   *  创建，异步读取会在首次渲染之后才到达，楼层会闪一下空白。
+   *  启动时一次阻塞往返。`null` = 无文件（或不可读）——调用方
+   *  随后改用 localStorage。 */
   rosterReadSync: (): RosterSnapshot | null => {
     try { return ipcRenderer.sendSync('roster:readSync') ?? null; } catch { return null; }
   },
-  /** Which hive is open, synchronously — same boot-time constraint as
-   *  `rosterReadSync`, and read in the same breath: the store has to know which
-   *  hive its localStorage keys belong to before it decides to trust them. */
+  /** 同步读取打开的是哪个 hive——与 `rosterReadSync` 相同的启动约束，
+   *  并在同一时刻读取：store 必须知道其 localStorage 键属于哪个
+   *  hive，才能决定信任它们。 */
   harnessHomeSync: (): string | null => {
     try { return ipcRenderer.sendSync('config:homeSync') ?? null; } catch { return null; }
   },
-  /** Mirror the roster to disk. Debounced by the caller; main keeps the previous
-   *  contents as a backup and refuses a first write that would empty a full file. */
+  /** 将花名册镜像到磁盘。由调用方防抖；主进程保留上一次内容
+   *  作为备份，并拒绝会清空完整文件的首次写入。 */
   rosterWrite: (snap: RosterSnapshot): Promise<{ ok: boolean; skipped?: string; error?: string }> =>
     ipcRenderer.invoke('roster:write', snap),
 
-  // ─── Auto-update (v0.3.4; full state model v0.3.7) ──────────────────────────
-  /** Push channel from main's updater — every stage of the pipeline, so the
-   *  toolbar badge can show "checking", download progress, and the staged
-   *  "restart to update" rather than only the terminal states. */
+  // ─── 自动更新（v0.3.4；完整状态模型 v0.3.7） ──────────────────────────
+  /** 来自主进程更新器的推送通道——管线的每个阶段，使工具栏徽章
+   *  能显示「检查中」、下载进度和暂存的「重启以更新」，
+   *  而不只是终态。 */
   onUpdateStatus: (cb: (status: UpdateStatus) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, payload: UpdateStatus) => cb(payload);
     ipcRenderer.on('update:status', listener);
     return () => ipcRenderer.removeListener('update:status', listener);
   },
-  /** The last known status — a reloaded window subscribes AFTER main may have
-   *  already emitted, so it pulls the current state instead of waiting 6h. */
+  /** 最后已知的状态——重载的窗口订阅时主进程可能已发出过事件，
+   *  因此它拉取当前状态，而不是等待 6 小时。 */
   updateCurrent: (): Promise<UpdateStatus> => ipcRenderer.invoke('update:current'),
-  /** Quit and install the downloaded update — only ever called from an explicit
-   *  "restart to update" click. */
+  /** 退出并安装已下载的更新——只能从显式的「重启以更新」点击调用。 */
   updateRestartAndInstall: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('update:restartAndInstall'),
-  /** Manual re-check. */
+  /** 手动重新检查。 */
   updateCheckNow: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('update:checkNow'),
-  /** Start the download for an already-detected update (autoDownload normally
-   *  beats the user to it; this is the explicit one-click path). */
+  /** 为已检测到的更新开始下载（autoDownload 通常会先于用户；
+   *  这是显式的一键路径）。 */
   updateDownload: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('update:download'),
-  /** Open the project's releases page for a notify-only update. */
+  /** 为仅通知型更新打开项目的 releases 页面。 */
   updateOpenRelease: (url?: string): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('update:openRelease', url),
-  /** Which OS this window runs on, for platform-specific copy. */
+  /** 此窗口运行在哪个操作系统上，用于平台特定的文案。 */
   platform: process.platform as string,
   arch: process.arch as string,
-  /** DEV ONLY — fabricate an update status so the toast can be inspected without
-   *  cutting a release. Refused (`{ok:false}`) in a packaged build; see the
-   *  handler in updater.ts. Call it from the devtools console:
-   *    await window.cth.updateSimulate()                       // notify-only digest toast
-   *    await window.cth.updateSimulate({ state: 'downloaded' }) // restart-to-update toast
-   *    await window.cth.updateSimulate({ drop: true })          // the centered release page
-   *    await window.cth.updateSimulate({ notes: '<!-- drop -->…' }) // your own drop */
+  /** 仅开发环境——伪造更新状态，以便不发布版本就能检查 toast。在打包
+   *  版本中被拒绝（`{ok:false}`）；见 updater.ts 中的处理器。从开发者
+   *  工具控制台调用：
+   *    await window.cth.updateSimulate()                       // 仅通知的摘要 toast
+   *    await window.cth.updateSimulate({ state: 'downloaded' }) // 重启以更新 toast
+   *    await window.cth.updateSimulate({ drop: true })          // 居中显示的发布页
+   *    await window.cth.updateSimulate({ notes: '<!-- drop -->…' }) // 你自己的发布页 */
   updateSimulate: (opts?: {
     state?: 'downloaded' | 'available-manual';
     version?: string;
     notes?: string;
-    /** Preview the centered release page using the default drop template. */
+    /** 使用默认发布页模板预览居中显示的发布页。 */
     drop?: boolean;
   }): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('update:simulate', opts)
 };

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useStore, selectedAgent } from '@/store/store';
 import { startMockLoop, stopMockLoop } from '@/store/mockEvents';
 import type { HarnessConfig } from '@/store/config';
@@ -33,15 +34,16 @@ import { IdePanel } from '@/ide/IdePanel';
 import { useHoldOptionToTalk } from '@/freeflow/holdOption';
 import brandLogo from '@brand/logo.png?url';
 
-// Injected at build time from package.json (see electron.vite.config.ts).
+// 构建时从 package.json 注入（见 electron.vite.config.ts）。
 declare const __APP_VERSION__: string;
 
 export function App() {
-  // Point every {{godName}} string at the orchestrator's real, renameable name.
+  const { t } = useTranslation();
+  // 将每个 {{godName}} 字符串指向编排器的真实、可重命名名称。
   useGodNameSync();
-  // Mirror the document only for a user who has picked an RTL app language.
+  // 仅为用户选择的 RTL 应用语言镜像文档方向。
   useDirectionSync();
-  // Let terminals that are ALREADY open follow a language switch too.
+  // 让已打开的终端也跟随语言切换。
   useArabicTerminalSync();
   const agent = useStore(selectedAgent);
   const agents = useStore(s => s.agents);
@@ -59,32 +61,31 @@ export function App() {
   const setIdeOpen = useStore(s => s.setIdeOpen);
 
   const [config, setConfig] = useState<HarnessConfig | null>(null);
-  // Whether the user has passed the launch-time hive picker this session. Starts
-  // true (skip the picker) right after a hive SWITCH — changeHome relaunches and
-  // leaves a one-shot localStorage flag so we don't bounce back onto the picker for
-  // the hive we just chose. Also set true on onboarding completion (below).
+  // 用户是否在本会话中已通过启动时的蜂巢选择器。在蜂巢切换后立即设为
+  // true（跳过选择器）——changeHome 重新拉起后留下一次性 localStorage 标记，
+  // 避免回到刚选择的蜂巢选择器。也在入门完成时设为 true（见下文）。
   const [hiveOpened, setHiveOpened] = useState<boolean>(() => {
     try {
       if (window.localStorage.getItem('cth.skipHivePickerOnce')) {
         window.localStorage.removeItem('cth.skipHivePickerOnce');
         return true;
       }
-    } catch { /* localStorage unavailable — show the picker */ }
+    } catch { /* localStorage 不可用 — 显示选择器 */ }
     return false;
   });
   const [settingsOpen, setSettingsOpen] = useState(false);
-  /** Which tab Settings opens on. Set by a `cth:open-settings` deep link, reset
-   *  to undefined (→ General) whenever the modal is opened the normal way. */
+  /** 设置面板打开到哪个标签页。由 `cth:open-settings` 深度链接设置，正常打开
+   *  时重置为 undefined（→ 常规）。 */
   const [settingsSection, setSettingsSection] = useState<SettingsSection | undefined>(undefined);
   const [quitWarn, setQuitWarn] = useState<{ ptyCount: number } | null>(null);
   const [closing, setClosing] = useState<ClosingTimeState | null>(null);
   const [vpWidth, setVpWidth] = useState<number>(window.innerWidth);
 
-  // Deep link into Settings from anywhere in the tree. Settings' open state is
-  // local to App, so a nested control (e.g. "set it now" beside a disabled Talk
-  // button) has no path to it without threading a prop through every layer
-  // between; a window event keeps that plumbing out of the components in
-  // between, matching the existing `cth:` CustomEvent convention.
+  // 从树中任意位置深度链接到设置。设置的打开状态
+  // 是 App 本地的，因此嵌套控件（如禁用"对话"
+  // 按钮旁的"立即设置"）没有路径访问它，除非在每个层之间传递 prop；
+  // window 事件将这种管道逻辑保持在组件之外，
+  // 匹配现有的 `cth:` CustomEvent 约定。
   useEffect(() => {
     const onOpenSettings = (e: Event): void => {
       const section = (e as CustomEvent<{ section?: SettingsSection }>).detail?.section;
@@ -95,56 +96,60 @@ export function App() {
     return () => window.removeEventListener('cth:open-settings', onOpenSettings);
   }, []);
 
-  // Initial config load
+  // 初始配置加载
   useEffect(() => {
     let cancelled = false;
     window.cth.getConfig().then(c => {
       if (cancelled) return;
       setConfig(c);
-      // Mirror the Free Flow flag into the store so the composer mic button shows
-      // only when enabled (Settings keeps this in sync on save).
+      // 预配置安装：配置已包含入门信息和
+      // harnessHome（D:盘上的用户数据），因此冷启动不应反弹
+      // 通过启动时的蜂巢选择器——直接进入蜂巢，恰好
+      // 如入门完成时一样（见下文）。
+      if (c.onboardingComplete && c.harnessHome) setHiveOpened(true);
+      // 将 Free Flow 标志镜像到存储中，使作曲家麦克风按钮仅在启用时显示
+      // （设置保存时保持同步）。
       useStore.getState().setFreeflowEnabled(!!c.freeflowEnabled);
-      // Mirror boolean key-presence ONLY (never the key value) so the composer can
-      // show the voice button disabled-with-tooltip when Free Flow is on but no
-      // Groq key is set (Settings keeps this in sync on save).
+      // 仅镜像布尔键存在性（从不键值），使作曲家可以
+      // 在 Free Flow 开启但没有设置
+      // Groq 密钥时显示禁用带提示的语音按钮（设置保存时保持同步）。
       useStore.getState().setHasGroqKey(!!c.groqApiKey);
-      // Mirror the active office theme so OfficeFloor renders it (gated on the
-      // tvShowOffices flag; off = always the office). Settings keeps this synced.
-      useStore.getState().setOfficeTheme(c.tvShowOffices ? (c.officeTheme ?? 'office') : 'office');
-      // Mirror the triggers so Settings → Connections and the Command Center's
-      // Triggers tab read one list, not two copies that drift — whichever surface
-      // saves calls these same setters and the other repaints. No extra IPC: main
-      // deep-fills both fields on every config read (withTriggerDefaults), so
-      // getConfig() already serves what listWebhooks()/getOrgTrigger() would.
-      // `c` is typed as the PRELOAD's HarnessConfig, which hasn't picked the two
-      // fields up yet (another lane's file); the renderer mirror type declares them.
+      // 镜像活跃的办公室主题以便 OfficeFloor 渲染（由 tvShowOffices 标志控制；
+      // 关闭 = 始终是办公室）。设置保持同步。
+      // 镜像触发器，使设置 → 连接 和指挥中心
+      // 触发器标签页读取一个列表，而不是两个可能漂移的副本——哪个表面
+      // 保存会调用这些相同的设置器，另一个重绘。无额外 IPC：主进程
+      // 在每次配置读取时深度填充两个字段（withTriggerDefaults），因此
+      // getConfig() 已提供 listWebhooks()/getOrgTrigger() 会提供的服务。
+      // `c` 类型化为预加载的 HarnessConfig，尚未获取这两个
+      // 字段（另一路径的文件）；渲染器镜像类型声明了它们。
       const withTriggers = c as HarnessConfig;
       useStore.getState().setWebhookTriggers(withTriggers.webhookTriggers ?? []);
       useStore.getState().setOrgTrigger(withTriggers.orgTrigger ?? DEFAULT_ORG_TRIGGER);
     });
-    // Mirror BYOK OpenAI key presence (boolean only; the key never leaves main) so the
-    // Realtime Michael voice toggle can gate on it. Lives in the secret broker, not
-    // config — so fetch it rather than derive from c.
+    // 镜像 BYOK OpenAI 密钥存在性（仅布尔值；密钥永远不会离开主进程）以便
+    // 实时迈克尔语音切换可以基于它。位于密钥代理器中，不在
+    // 配置中——因此获取它而不是从 c 推导。
     window.cth.realtimeHasOpenAiKey().then(has => {
       if (!cancelled) useStore.getState().setHasOpenAiKey(has);
     });
     return () => { cancelled = true; };
   }, []);
 
-  // Free Flow entry point B — hold-Option (⌥) to talk. In-renderer push-to-talk
-  // for whichever agent the user is viewing; gated on the flag, terminal-safe
-  // (solo-hold threshold, aborts on any other key). See freeflow/holdOption.ts.
+  // Free Flow 入口 B —— 按住 Option (⌥) 说话。渲染器内针对
+  // 用户正在查看的任一代理的即时通话；由标志控制，终端安全
+  // （单人按住阈值，其他按键时中止）。见 freeflow/holdOption.ts。
   useHoldOptionToTalk();
 
-  // Config subscription — the copy loaded above would otherwise go stale the
-  // moment anything saves a setting.
+  // 配置订阅——上面加载的副本否则会在
+  // 保存任何设置时立即过期。
   useEffect(() => window.cth.onConfigChanged(setConfig), []);
 
-  // Quit warning subscription
+  // 退出警告订阅
   useEffect(() => window.cth.onCloseRequested((info) => setQuitWarn(info)), []);
 
-  // Shareable hires: a validated manifest arriving via the munderdifflin://
-  // deep link (or file import) pre-fills the Add-Agent modal. Never spawns by itself.
+  // 可共享招聘：通过 munderdifflin://
+  // 深度链接（或文件导入）到达的已验证清单预填充添加代理模态。从不自行生成。
   const enqueuePendingHires = useStore(s => s.enqueuePendingHires);
   const closeAddAgentReview = () => {
     clearPendingHires();
@@ -155,8 +160,8 @@ export function App() {
       enqueuePendingHires([m]);
       setAddAgentOpen(true);
     });
-    // Pull anything that arrived before this subscription existed (cold-start
-    // deep links; packaged renderers load too fast for push-on-load).
+    // 拉取在此订阅存在之前到达的任何内容（冷启动
+    // 深度链接；打包渲染器加载太快，无法在加载时推送）。
     void window.cth.drainPendingHires?.().then((queued) => {
       if (queued && queued.length > 0) {
         enqueuePendingHires(queued);
@@ -169,9 +174,9 @@ export function App() {
     console.error('[hire] import failed:', info.error);
   }), []);
 
-  // Closing-time progress: drives the quit dialog's "wrapping up" view. The
-  // dialog stays up through the whole protocol; on 'complete' the main process
-  // tears down and quits by itself moments later.
+  // 关闭时间进度：驱动退出对话框的"正在收尾"视图。对话框
+  // 在整个协议期间保持打开；在'complete'时主进程
+  // 会自行销毁并在片刻后退出。
   useEffect(() => window.cth.onClosingTime?.((ev) => {
     if (ev.phase === 'cancelled') { setClosing(null); return; }
     setClosing({ phase: ev.phase, acked: ev.acked, total: ev.total });
@@ -187,24 +192,24 @@ export function App() {
     setClosing(null);
   };
 
-  // The hive: god-agent bootstrap, hook-driven avatars, idle-agent waking. Held
-  // off until the user opens a hive in the launch picker (passing null no-ops the
-  // hook) so Michael doesn't boot against the current home while the user may be
-  // about to switch to a different one.
+  // 蜂巢：神代理引导、钩子驱动头像、空闲代理唤醒。保持
+  // 关闭直到用户在启动选择器中打开蜂巢（传递 null 使
+  // 钩子无效）以便迈克尔不会在当前 home 上引导，而用户可能正在
+  // 切换到不同的 home。
   useHive(hiveOpened ? config : null);
 
-  // Pre-warm a persistent terminal for every live agent so its output is
-  // buffered from spawn. Switching agents then re-attaches an already-rendered
-  // terminal instantly (with full history) instead of building a blank one.
+  // 为每个活动代理预热持久终端，使其输出在
+  // 生成时缓冲。切换代理然后立即重新附加已渲染的
+  // 终端（带完整历史），而不是构建空白终端。
   useEffect(() => {
     for (const a of agents) if (a.ptyId) acquireTerminal(a.ptyId);
   }, [agents]);
 
-  // Synthetic demo loop — CAGED (#5B). It must never animate alongside a live
-  // hive (it would fire fake envelope handoffs and step seeded agents). Run it
-  // only as an explicit showcase (VITE_CTH_DEMO=1 in dev) or on a genuinely
-  // empty floor, and stop it the instant the first real PTY agent appears
-  // (Michael always spawns, so in normal operation it effectively never runs).
+  // 合成演示循环——CAGED (#5B)。绝不能与活动
+  // 蜂巢一起动画（它会触发虚假信封交接和步进种子代理）。仅作为
+  // 显式展示运行（VITE_CTH_DEMO=1 在开发中）或在真正空
+  // 闲的地板，在第一真实 PTY 代理出现时立即停止
+  // （迈克尔总是生成，因此在正常操作中它实际上从不运行）。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     const DEMO = import.meta.env.DEV && import.meta.env.VITE_CTH_DEMO === '1';
@@ -218,34 +223,33 @@ export function App() {
     return () => { unsub(); stopMockLoop(); };
   }, [config?.onboardingComplete]);
 
-  // Reconcile restored agents against the PTYs still alive in the main process.
-  // After a renderer reload (e.g. the laptop slept and Vite reloaded the page),
-  // this keeps agents whose process survived and drops any that truly died.
+  // 将恢复的代理与主进程中仍然存活的 PTY 进行协调。
+  // 渲染器重新加载后（例如笔记本电脑睡眠且 Vite 重新加载页面），
+  // 这保留进程存活其的代理并丢弃真正死亡的代理。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     let cancelled = false;
     window.cth.listPtys().then((list) => {
       if (cancelled) return;
       useStore.getState().reconcileWithLivePtys(list.map((p) => p.id));
-    }).catch(() => { /* ignore — keep restored agents as-is */ });
+    }).catch(() => { /* 忽略——保持恢复的代理原样 */ });
     return () => { cancelled = true; };
   }, [config?.onboardingComplete]);
 
-  // Re-apply the persisted focus-mode preference as the roster fills in.
+  // 重新应用持久化的专注模式偏好，作为名单填充。
   //
-  // Not a one-shot at store construction: at launch every restored agent still
-  // carries the PREVIOUS session's PTY id, so the reconcile above prunes the lot
-  // and correctly drops focus mode to null before god has respawned. The
-  // preference therefore has to be re-checked once agents with live terminals
-  // actually exist. `restoreFocusMode` is a no-op unless the preference is on and
-  // focus mode is currently off, so re-running it on every roster change is safe
-  // and pressing Esc stays sticky.
+  // 不是在存储构造时的一次性操作：在启动时每个恢复的代理仍然
+  // 携带前一次会话的 PTY id，因此上面的协调修剪所有内容
+  // 并正确将专注模式降为 null，直到神重新生成。因此
+  // 一旦有活动终端的代理实际存在，必须重新检查偏好。`restoreFocusMode` 是一个 no-op，除非偏好开启且
+  // 专注模式当前关闭，因此在每次名单更改时重新运行它是安全的
+  // 按 Esc 保持粘滞。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     useStore.getState().restoreFocusMode();
   }, [config?.onboardingComplete, agents]);
 
-  // Track viewport width for splitter clamping
+  // 跟踪视口宽度以进行分割器夹紧
   useEffect(() => {
     const onResize = () => setVpWidth(window.innerWidth);
     window.addEventListener('resize', onResize);
@@ -257,13 +261,13 @@ export function App() {
   }
 
   if (!config.onboardingComplete) {
-    // Just-onboarded users go straight into the hive they set up — skip the picker.
+    // 刚入门的用户直接进入他们设置的蜂巢——跳过选择器。
     return <OnboardingWizard onComplete={(next) => { setConfig(next); setHiveOpened(true); }} />;
   }
 
-  // Launch-time hive picker: on reopen, let the user open their current hive,
-  // switch to a recent one, or open/create another. Skipped right after onboarding
-  // and right after a switch-relaunch (see hiveOpened init).
+  // 启动时蜂巢选择器：重新打开时，让用户打开当前蜂巢，
+  // 切换到最近的蜂巢，或打开/创建另一个。在入门后
+  // 和切换重新拉起后立即跳过（见 hiveOpened 初始化）。
   if (!hiveOpened) {
     return <HivePicker config={config} onOpenCurrent={() => setHiveOpened(true)} />;
   }
@@ -274,13 +278,13 @@ export function App() {
       width: '100vw', height: '100vh',
       overflow: 'hidden'
     }}>
-      {/* rt-12: global fixed-overlay toast for voice-Michael completions ("Oscar
-          finished X"). Self-positions bottom-right; renders null until one arrives. */}
+      {/* rt-12: 语音迈克尔完成的全局固定覆盖通知（"Oscar
+          完成 X"）。自我定位右下角；在到达前渲染 null。 */}
       <CompletionToast />
-      {/* v0.3.4: background-update toast ("restart to update"); renders null until
-          main's updater pushes a status. */}
+      {/* v0.3.4: 后台更新通知（"重启以更新"）；在主
+          更新器推送状态前渲染 null。 */}
       <UpdateToast />
-      {/* Title bar */}
+      {/* 标题栏 */}
       <div
         className="cth-titlebar-drag"
         style={{
@@ -300,8 +304,8 @@ export function App() {
           alt="Munder Difflin"
           style={{ height: 20, width: 'auto', display: 'block' }}
         />
-        {/* v0.3.7: the version is no longer inert text — it doubles as the
-            update control (check / download / restart to update). */}
+        {/* v0.3.7: 版本不再是惰性文本——它作为
+            更新控件（检查/下载/重启更新）。 */}
         <UpdateBadge />
         <span style={{
           fontFamily: 'var(--cth-font-ui)',
@@ -310,28 +314,28 @@ export function App() {
         }}>
           {config.autoMode ? 'auto mode on' : 'auto mode off'}
         </span>
-        {/* v0.3.4: theme + fullscreen live HERE (top right), not buried in the
-            terminal header — and the theme darkens the whole app, terminals
-            included (design/theme.ts + tokens.css dark block). */}
+        {/* v0.3.4: 主题 + 全屏在此处（右上角），不埋在
+            终端头部——主题变暗整个应用，包括终端
+            （design/theme.ts + tokens.css 深色块）。 */}
         <button
           className="cth-titlebar-nodrag cth-tip"
           onClick={() => {
             const next = toggleAppTheme();
-            // Tell every RUNNING program the theme flipped. xterm repaints its own
-            // cells, but a TUI that painted its panels with explicit colours keeps
-            // them until it redraws, which left OpenCode's boxes in the old palette
-            // until the agent restarted. Only programs that enabled DEC mode 2031
-            // are told, and it is every pooled terminal rather than the visible one,
-            // so a background agent is not stale when you switch to it.
+            // 告诉每个正在运行的程序主题已翻转。xterm 重绘自己的
+            // 单元格，但用显式颜色绘制面板的 TUI 保持
+            // 它们直到重绘，这使 OpenCode 的框留在旧调色板中
+            // 直到代理重启。只有启用了 DEC 模式 2031 的程序
+            // 才会被通知，并且是每个池化终端而不是可见的一个，
+            // 因此后台代理在切换到时不会过期。
             notifyThemeChangeAll(next === 'dark' ? 'dark' : 'light');
-            // Mirror into the harness config: every agent (re)spawned from now
-            // on gets the matching `theme` in its per-session Claude settings,
-            // so the TUI's truecolor palette fits the terminal. Scoped to
-            // harness agents — the user's global Claude theme is never touched.
+            // 镜像到控制架配置：从现在开始每个代理（重新）生成时
+            // 在其每个会话 Claude 设置中获得匹配的 `theme`，
+            // 因此 TUI 的真彩色调色板适合终端。限制在
+            // 控制架代理——用户的全球 Claude 主题永远不会触碰。
             void window.cth.updateConfig({ terminalTheme: next });
           }}
-          data-tip={appThemeNow === 'dark' ? 'Light theme' : 'Dark theme'}
-          aria-label="Toggle dark mode"
+          data-tip={appThemeNow === 'dark' ? t('app.lightTheme') : t('app.darkTheme')}
+          aria-label={t('app.toggleDarkMode')}
           style={{
             marginLeft: 'auto',
             display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
@@ -344,13 +348,13 @@ export function App() {
         >
           {appThemeNow === 'dark' ? '☀' : '☾'}
         </button>
-        {/* v0.3.4: the IDE button moved to agent level — every agent's header
-            (sidebar detail, god Command Center, fullscreen) carries it. */}
+        {/* v0.3.4: IDE 按钮移到代理级别——每个代理的头
+            （侧边栏详情、神指挥中心、全屏）携带它。 */}
         <button
           className="cth-titlebar-nodrag cth-settings-btn cth-tip"
           onClick={() => { setSettingsSection(undefined); setSettingsOpen(true); }}
           data-tip="Settings"
-          aria-label="Settings"
+          aria-label={t('app.settingsAria')}
           style={{
             display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
             width: 28, height: 28, padding: 0,
@@ -362,10 +366,10 @@ export function App() {
         >
           <GearGlyph />
         </button>
-        {/* Fullscreen. The title bar is chrome, not canvas, so these two use
-            clean stroke icons rather than the 16x16 pixel set the rest of the UI
-            is drawn in — at 16-18px a pixel-grid glyph reads as a rendering
-            artifact next to the OS window controls, not as a style choice. */}
+        {/* 全屏。标题栏是 chrome，不是 canvas，因此这两个使用
+            干净的描边图标而不是其余 UI 绘制的 16x16 像素集
+            ——在 16-18px 时像素网格图标在 OS 窗口控件旁边
+            读取为渲染伪像，而不是风格选择。 */}
         <button
           className="cth-titlebar-nodrag cth-tip"
           onClick={() => {
@@ -376,8 +380,8 @@ export function App() {
               ?? all.find((x) => x.ptyId);
             if (target) useStore.getState().setFullscreen(target.id);
           }}
-          data-tip={fullscreenAgentId ? 'Exit focus mode (Esc)' : 'Focus mode'}
-          aria-label="Toggle focus mode"
+          data-tip={fullscreenAgentId ? t('app.exitFocusMode') : t('app.focusMode')}
+          aria-label={t('app.toggleFocusMode')}
           style={{
             display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
             width: 28, height: 28, padding: 0,
@@ -409,14 +413,14 @@ export function App() {
               pointerEvents: 'none'
             }}>
               <div style={{ pointerEvents: 'auto', width: 360 }}>
-                <PixelPanel variant="dialog" title="EMPTY FLOOR" noPadding>
+                <PixelPanel variant="dialog" title={t('app.emptyFloorTitle')} noPadding>
                   <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10 }}>
                     <p style={{ margin: 0, fontSize: 13, lineHeight: '20px' }}>
-                      No agents on the floor yet. Spawn one to see real claude output stream in here.
+                      {t('app.emptyFloorDesc')}
                     </p>
                     <PixelButton variant="primary" size="md" onClick={() => setAddAgentOpen(true)}>
                       <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
-                        <Icon name="plus" /> add agent
+                        <Icon name="plus" /> {t('app.addAgent')}
                       </span>
                     </PixelButton>
                   </div>
@@ -447,10 +451,10 @@ export function App() {
               <div style={{
                 fontFamily: 'var(--cth-font-display)', fontSize: 10, lineHeight: '14px',
                 color: 'var(--cth-ink-500)'
-              }}>WAKING THE FLOOR</div>
+              }}>{t('app.wakingTheFloor')}</div>
               <p style={{ margin: 0, fontSize: 13, textAlign: 'center', color: 'var(--cth-ink-700)' }}>
-                {bootingGodName} is clocking in.<br />
-                The terminal will land here once he's seated.
+                {t('app.clockingIn', { name: bootingGodName })}<br />
+                {t('app.terminalWillLand')}
               </p>
             </PixelPanel>
           ) : (
@@ -462,14 +466,14 @@ export function App() {
               <div style={{
                 fontFamily: 'var(--cth-font-display)', fontSize: 10, lineHeight: '14px',
                 color: 'var(--cth-ink-500)'
-              }}>NO AGENT SELECTED</div>
+              }}>{t('app.noAgentSelected')}</div>
               <p style={{ margin: 0, fontSize: 13, textAlign: 'center', color: 'var(--cth-ink-700)' }}>
-                Spawn an agent from the strip below.<br />
-                The terminal and command bar will land here.
+                {t('app.spawnFromStrip')}<br />
+                {t('app.terminalAndCmdBar')}
               </p>
               <PixelButton variant="secondary" size="md" onClick={() => setAddAgentOpen(true)}>
                 <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
-                  <Icon name="plus" /> add agent
+                  <Icon name="plus" /> {t('app.addAgent')}
                 </span>
               </PixelButton>
             </PixelPanel>
@@ -516,13 +520,12 @@ export function App() {
   );
 }
 
-/* ── Title-bar glyphs ────────────────────────────────────────────────────────
-   Stroke icons on a 16 unit box, inheriting `currentColor` so they follow the
-   theme exactly as the pixel set does. Deliberately NOT added to
-   components/Icon.tsx: that library is the app's pixel-art identity and is used
-   at tab and card scale, where the pixel grid is the point. These three sit
-   beside the OS traffic lights, which is the one place that identity reads as a
-   blurry asset rather than a decision. */
+/* ── 标题栏图标 ────────────────────────────────────────────────────────
+   在 16 单位框上绘制描边图标，继承 `currentColor` 以跟随主题，
+   与像素集完全一致。故意不添加到
+   components/Icon.tsx：该库是应用的像素艺术身份，用于标签和卡片
+   比例，像素网格是重点。这三个图标位于
+   OS 交通灯旁边，这是身份阅读模糊资产而非决策的唯一地方。 */
 function Glyph({ children }: { children: React.ReactNode }) {
   return (
     <svg
@@ -534,7 +537,7 @@ function Glyph({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Four outward corner brackets — enter fullscreen. */
+/** 四个向外角的括号——进入全屏。 */
 function ExpandGlyph() {
   return (
     <Glyph>
@@ -543,7 +546,7 @@ function ExpandGlyph() {
   );
 }
 
-/** The same brackets turned inward — leave fullscreen. */
+/** 相同的括号向内转——退出全屏。 */
 function CollapseGlyph() {
   return (
     <Glyph>
@@ -552,11 +555,11 @@ function CollapseGlyph() {
   );
 }
 
-/** A wrench. The previous glyph was a hub with eight radiating spokes, which at
- *  18px is indistinguishable from a sun — sitting immediately beside a theme
- *  toggle whose light-mode icon IS a sun. A tool shape carries "settings"
- *  without competing with its neighbour. Drawn on a 24 box for curve headroom
- *  and rendered at 16. */
+/** 一把扳手。之前的图标是一个有八条辐射辐条的轮毂，在
+ *  18px 时与太阳无法区分——紧挨着一个主题
+ *  切换按钮，其浅色模式图标就是一个太阳。工具形状传达"设置"
+ *  而不与邻居竞争。在 24 框上绘制以保留曲线空间，
+ *  渲染为 16px。 */
 function GearGlyph() {
   return (
     <svg

--- a/src/renderer/src/components/AddAgentModal.tsx
+++ b/src/renderer/src/components/AddAgentModal.tsx
@@ -33,7 +33,7 @@ import { useRtl } from '@/i18n/useDirection';
 
 const ACCENTS: AccentColorName[] = ['coral', 'mint', 'sky', 'lemon', 'lilac', 'peach'];
 
-// OSS quick-pick chip styling (ondev-c) — mirrors the model-picker chips.
+// OSS 快速选择芯片样式 (ondev-c) —— 与模型选择器芯片保持一致。
 const ossChip = (active: boolean, accent: AccentColorName): CSSProperties => ({
   padding: '3px 8px 1px',
   background: active ? `var(--cth-${accent}-light)` : 'var(--cth-cream-100)',
@@ -47,77 +47,76 @@ const ossGroupHead: CSSProperties = {
 };
 const ossLink: CSSProperties = { color: 'var(--cth-ink-900)', textDecoration: 'underline', cursor: 'pointer' };
 
-// One-click briefing templates — fill Description + Goal with a sharp, ready-to-run
-// role so a user isn't staring at a blank field (item 7). The template BRIEFINGS
-// stay English (they become agent prompts — see the i18n report); only the
-// picker labels are translated.
+// 一键简报模板 —— 用一句精炼、开箱即用的角色描述填充「描述 + 目标」，
+// 避免用户面对空白字段（第 7 项）。模板 BRIEFINGS 保持英文（它们会成为
+// 代理提示词 —— 参见 i18n 报告）；只有选择器标签被翻译。
 const DESCRIPTION_TEMPLATES: { labelKey: string; description: string; goal: string }[] = [
   {
     labelKey: 'addAgent.templatesHint.repoJanitor.label',
-    description: 'keeps the codebase tidy and healthy',
-    goal: 'Continuously hunt for dead code, lint errors, flaky tests, and small safe refactors. Fix the safe ones and leave a note for anything risky. Never change behavior without flagging it.'
+    description: '让代码库保持整洁健康',
+    goal: '持续寻找死代码、lint 错误、不稳定测试和小型安全重构。修复安全的部分，对有风险的部分留备注。未经标注不改变行为。'
   },
   {
     labelKey: 'addAgent.templatesHint.docsWriter.label',
-    description: 'keeps docs in sync with the code',
-    goal: 'Watch for code changes that outdate the README and docs, then update them. Write for newcomers and prefer concrete examples over prose.'
+    description: '让文档与代码保持同步',
+    goal: '关注使 README 和文档过时的代码变更并及时更新。面向新人写作，多用具体示例，少用空泛叙述。'
   },
   {
     labelKey: 'addAgent.templatesHint.bugTriager.label',
-    description: 'investigates and root-causes bugs',
-    goal: 'For each reported issue: reproduce it, find the root cause, then propose a minimal fix with evidence. No fixes without a confirmed root cause.'
+    description: '调查并定位 bug 根因',
+    goal: '对每个报告的问题：先复现，再定位根因，然后提出带证据的最小修复。未确认根因不修复。'
   },
   {
     labelKey: 'addAgent.templatesHint.researchAssistant.label',
-    description: 'gathers and summarizes information',
-    goal: 'Research the questions you are given across multiple sources, verify the key claims, and return a concise, cited summary.'
+    description: '收集并汇总信息',
+    goal: '对给出的问题跨多个来源进行研究，核实关键结论，返回简洁、有引用的摘要。'
   },
   {
     labelKey: 'addAgent.templatesHint.releaseManager.label',
-    description: 'prepares and ships releases',
-    goal: 'Track what has shipped since the last release, update the changelog and version, and draft clear release notes.'
+    description: '准备并发布版本',
+    goal: '追踪自上次发布以来上线的内容，更新变更日志和版本号，起草清晰的发布说明。'
   }
 ];
 
-// Copy-paste prompt the user hands to any AI to generate a hire manifest. It pins
-// the exact JSON shape the importer accepts and ends with a fill-in section so the
-// user adds their own details (item 7). Kept in sync with the HireManifest schema
-// (src/shared/hire.ts) — provider allowlist is claude | codex | antigravity | cursor.
-const HIRE_PROMPT = `You are designing a "hire" — a ready-to-spawn AI agent for Munder Difflin, an app that runs a team of CLI coding agents. Output ONE JSON object (a hire manifest) and nothing else.
+// 用户交给任意 AI 以生成 hire 清单（hire manifest）的复制粘贴提示词。它固定了
+// 导入器接受的确切 JSON 结构，并以需要填写的段落收尾，让用户补充自己的细节
+// （第 7 项）。与 HireManifest 模式保持同步（src/shared/hire.ts）——provider
+// 白名单是 claude | codex | kimi | qwen。
+const HIRE_PROMPT = `你正在设计一个 "hire"——为 Munder Difflin（一个运行一组 CLI 编码代理的应用）准备一个可直接生成（spawn）的 AI 代理。只输出一个 JSON 对象（hire manifest），除此之外什么都不输出。
 
-Make the agent genuinely useful: give it a sharp role, a concrete standing goal, and a description that makes it behave like an expert operator of its CLI engine (Claude Code, Codex, or Antigravity/Gemini). It should know how to use the terminal, read and edit files, run and inspect commands, lean on available skills and MCP tools, keep notes in memory, and work autonomously toward its goal without hand-holding.
+让这个代理真正有用：给它一个鲜明的角色、一个具体的长驻目标，以及一段能让它表现得像其 CLI 引擎（Claude Code、Codex、Kimi Code 或 Qwen Code）专家操作者的描述。它应当知道如何使用终端、读写文件、运行和检查命令、善用可用的 skills 与 MCP 工具、在 memory 里做笔记，并在无人手把手的情况下自主朝目标工作。
 
-Return EXACTLY this shape (omit optional fields you don't need; keep the spec string verbatim):
+返回 EXACTLY 这个结构（省略你不需要的可选字段；保持 spec 字符串原样）：
 
 {
   "spec": "munder-difflin/hire@1",
   "name": "Jim",
-  "description": "one-line role — what this agent is for",
-  "goal": "standing directive injected on every prompt — specific and outcome-oriented",
+  "description": "一行角色说明——这个代理是干什么的",
+  "goal": "注入到每次提示的长驻指令——具体且以结果为导向",
   "provider": "claude",
   "model": "claude-opus-4-8[1m]",
   "capabilities": ["code-review", "docs"],
   "isolate": false,
   "tokenCap": 2000000,
-  "author": "your name"
+  "author": "你的名字"
 }
 
-Rules:
-- "provider" MUST be one of: cursor | claude | codex | antigravity. "model" must be a real model id for that provider (e.g. gpt-5.6-luna-high, claude-opus-4-8[1m], gpt-5-codex, "Gemini 3.1 Pro (High)").
-- Do NOT include shell commands or any flags beyond these fields.
-- Make "description" + "goal" concrete enough that the agent knows exactly what to do on its first turn.
+规则：
+- "provider" 必须是以下之一：claude | codex | kimi | qwen。"model" 必须是该 provider 的真实模型 id（例如 claude-opus-4-8[1m]、gpt-5.6-luna、kimi-code/k3、qwen3-coder-plus）。
+- 不要包含 shell 命令或这些字段之外的任何标志。
+- 让 "description" + "goal" 足够具体，使代理在第一个回合就知道该做什么。
 
---- ADD YOUR DETAILS BELOW (the AI should use these) ---
-Role / what I want this agent to do:
-Preferred engine (claude / codex / antigravity), if any:
-Repos, tools, style, or constraints to respect:
+--- 在下方补充你的细节（AI 应使用这些） ---
+角色 / 我希望这个代理做什么：
+首选引擎（claude / codex / kimi / qwen），如果有的话：
+要遵守的仓库、工具、风格或约束：
 `;
 
-// The Add Agent form has 11+ fields, so it's grouped into sections the user jumps
-// between via a left sidebar index (one section shown at a time). Engine carries
-// Command (it's the spawn command assembled from provider+model+flags); Workspace
-// clusters Folder + Git isolation + Resume (all "where/how it runs"). Capabilities
-// isn't a field here — it rides an imported hire manifest (the pinned banner).
+// 「添加代理」表单有 11+ 个字段，因此按分区组织，用户通过左侧栏索引在各区之间
+// 跳转（一次只显示一个区）。Engine 承载 Command（它是由 provider+model+flags
+// 组装出的 spawn 命令）；Workspace 把 Folder + Git isolation + Resume 聚合在一起
+// （都是「在哪里/如何运行」）。Capabilities 在这里不是字段——它来自导入的 hire
+// 清单（固定在顶部的横幅）。
 type SectionKey = 'identity' | 'workspace' | 'engine' | 'briefing';
 const SECTIONS: { key: SectionKey; labelKey: string; hintKey: string }[] = [
   { key: 'identity',  labelKey: 'addAgent.sections.identity.label',  hintKey: 'addAgent.sections.identity.hint' },
@@ -137,8 +136,8 @@ function uniqueId(name: string): string {
 export interface AddAgentModalProps {
   onClose: () => void;
   config: HarnessConfig;
-  /** Lift config changes (e.g. a project registered from this modal) back up to
-   *  App so the rest of the UI — and the next time this modal opens — sees them. */
+  /** 把配置变更（例如从本弹窗注册的项目）提升回 App，让其余 UI——以及本弹窗
+   *  下次打开时——都能看到它们。 */
   onConfigChange?: (config: HarnessConfig) => void;
 }
 
@@ -146,8 +145,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   const { t: tr } = useTranslation();
   const rtl = useRtl();
   const addAgent = useStore(s => s.addAgent);
-  // Deep links and file batches share one FIFO. The head alone seeds the form;
-  // every item still requires an explicit spawn or skip.
+  // 深链接和文件批次共用同一个 FIFO。只有队首会填充表单；每个条目仍然需要
+  // 显式的 spawn 或跳过。
   const hireQueue = useStore(s => s.hireQueue);
   const enqueuePendingHires = useStore(s => s.enqueuePendingHires);
   const finishPendingHire = useStore(s => s.finishPendingHire);
@@ -158,33 +157,31 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     (OFFICE_CAST.some(m => m.name === c) ? (c as OfficeCharacterName) : DEFAULT_CHARACTER);
   const knownAccent = (a?: string): AccentColorName =>
     (ACCENTS.includes(a as AccentColorName) ? (a as AccentColorName) : 'sky');
-  /** The cast member a typed name refers to, if any.
+  /** 输入的名字所对应的剧组成员（如果有）。
    *
-   *  The character tiles already set the name (clicking Meredith names the agent
-   *  Meredith), but the coupling ran ONE WAY, so typing "Meredith" left the
-   *  avatar on whatever was selected, in practice the Jim default. Same missing
-   *  default as issue #191 from the other direction, where a manifest that omits
-   *  `character` always lands on Jim.
+   *  角色方块已经会设置名字（点击 Meredith 会把代理命名为 Meredith），但
+   *  这种耦合是单向的，所以输入 "Meredith" 时头像仍停留在之前选中的角色上，
+   *  实际是 Jim 默认。这与 issue #191 是同一缺失默认值的另一个方向——那里
+   *  是省略 `character` 的清单总是落到 Jim。
    *
-   *  Returns null on no match, and the caller leaves the avatar alone, so a
-   *  deliberate pick is never overwritten by continuing to type. */
+   *  无匹配时返回 null，调用方不去动头像，因此刻意选择的头像不会被继续输入
+   *  覆盖。 */
   const characterForName = (n: string): OfficeCharacterName | null => {
     const q = n.trim().toLowerCase();
     if (!q) return null;
     const hit = OFFICE_CAST.find(c => c.displayName.toLowerCase() === q || c.name === q);
     return hit ? hit.name : null;
   };
-  /** The locally-built spawn command for a manifest: provider preset + model
-   *  from the LOCAL config builder, with the manifest's validated flags
-   *  appended. A manifest can never name the binary itself. */
+  /** 为清单本地构建的 spawn 命令：来自本地配置构建器的 provider 预设 + model，
+   *  并追加清单中已验证的 flags。清单永远不能自行指定二进制程序。 */
   const hireCommand = (m: HireManifest): string => {
     const prov: AgentProvider = m.provider ?? inferAgentProvider(config.defaultCommand);
     const base = buildSpawnCommand(config, m.model, prov);
     return m.commandFlags?.length ? `${base} ${m.commandFlags.join(' ')}` : base;
   };
 
-  // Default provider follows whatever the global default command is (claude
-  // unless the user reconfigured it); the model only carries over for Claude.
+  // 默认 provider 跟随全局默认命令（除非用户重新配置，否则是 claude）；
+  // 只有 Claude 会继承模型。
   const initialProvider = inferAgentProvider(config.defaultCommand);
   const initialModel = isClaudeProvider(initialProvider) ? config.defaultModel : undefined;
 
@@ -192,8 +189,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   const [character, setCharacter] = useState<OfficeCharacterName>(knownCharacter(pendingHire?.character));
   const [accent, setAccent] = useState<AccentColorName>(knownAccent(pendingHire?.accent));
   const [cwd, setCwd] = useState<string>(config.registeredRepos[0] ?? '');
-  // Local mirror of the registered projects so one added from here shows as a
-  // quick-pick immediately (the `config` prop is a snapshot taken at open time).
+  // 已注册项目的本地镜像，这样从这里添加的项目会立即显示为快速选项
+  // （`config` prop 是打开时拍摄的快照）。
   const [repos, setRepos] = useState<string[]>(config.registeredRepos);
   const [provider, setProvider] = useState<AgentProvider>(pendingHire?.provider ?? initialProvider);
   const [model, setModel] = useState<string | undefined>(
@@ -205,21 +202,20 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   const [description, setDescription] = useState(pendingHire?.description ?? 'a fresh harness');
   const [hireMeta, setHireMeta] = useState<HireManifest | null>(pendingHire);
 
-  // Picking a model rebuilds the command; the command field stays editable for
-  // power users (it's the source of truth for the actual spawn).
+  // 选择模型会重建命令；命令字段对高级用户保持可编辑（它才是实际 spawn 的
+  // 事实来源）。
   const pickModel = (id?: string) => {
     setModel(id);
     setCommand(buildSpawnCommand(config, id, provider));
   };
-  // Switching provider resets the model to that CLI's default and rebuilds the
-  // command from the provider's preset binary (so Antigravity spawns `agy` and
-  // Codex spawns `codex`, not the configured `claude`). For 'custom' we keep the
-  // user's typed command rather than blanking it.
+  // 切换 provider 会把模型重置为该 CLI 的默认值，并从 provider 的预设二进制
+  // 重建命令（所以 Antigravity spawn `agy`、Codex spawn `codex`，而不是配置的
+  // `claude`）。对于 'custom'，我们保留用户输入的命令而不是清空它。
   const pickProvider = (id: AgentProvider) => {
     setProvider(id);
-    // Seed the model: Claude from the global defaultModel; other engines from the
-    // per-engine default set in Settings → AI Engines (providerDefaultModels), else
-    // the CLI default. This is what makes that Settings field live (Dwight NIT-1).
+    // 预填模型：Claude 用全局 defaultModel；其他引擎用 Settings → AI Engines
+    // 中按引擎设置的默认值（providerDefaultModels），否则用 CLI 默认值。
+    // 这正是让那个 Settings 字段生效的关键（Dwight NIT-1）。
     const nextModel = isClaudeProvider(id) ? config.defaultModel : config.providerDefaultModels?.[id];
     setModel(nextModel);
     const nextPreset = providerPreset(id);
@@ -236,17 +232,17 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
   const preset = providerPreset(provider);
   const [goal, setGoal] = useState(pendingHire?.goal ?? '');
   const [isolate, setIsolate] = useState(pendingHire?.isolate ?? false);
-  // #2 — optional Claude session id to continue. When set, the spawn seeds that
-  // session's transcript into the cwd's project dir and launches `--resume`.
+  // #2 —— 可选的、用于继续的 Claude session id。设置后，spawn 会把该会话的
+  // 转录写入 cwd 的项目目录，并以 `--resume` 启动。
   const [resumeSessionId, setResumeSessionId] = useState('');
   const resuming = resumeSessionId.trim().length > 0;
-  // Note shown when the folder was auto-filled from the pasted session id.
+  // 当文件夹由粘贴的 session id 自动填充时显示的提示。
   const [folderNote, setFolderNote] = useState<string | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [busy, setBusy] = useState(false);
-  // Which config section the left sidebar index is showing.
+  // 左侧栏索引当前显示的是哪个配置区。
   const [section, setSection] = useState<SectionKey>('identity');
-  // "Generate a hire with AI" helper — reveals a copy-paste prompt (item 7).
+  // 「用 AI 生成 hire」辅助——显示一段复制粘贴提示词（第 7 项）。
   const [showHirePrompt, setShowHirePrompt] = useState(false);
   const [copiedPrompt, setCopiedPrompt] = useState(false);
   const copyHirePrompt = async () => {
@@ -254,11 +250,11 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       await navigator.clipboard.writeText(HIRE_PROMPT);
       setCopiedPrompt(true);
       setTimeout(() => setCopiedPrompt(false), 1500);
-    } catch { /* clipboard blocked — the textarea below is selectable as a fallback */ }
+    } catch { /* 剪贴板被阻止 —— 下方的 textarea 可选作后备 */ }
   };
 
-  // Close only the modal on Esc. Capture prevents the fullscreen terminal's
-  // window-level handler from also closing the view underneath.
+  // Esc 只关闭本弹窗。Capture 可以阻止全屏终端的窗口级处理器也去关闭下面的
+  // 视图。
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
@@ -270,10 +266,9 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     return () => window.removeEventListener('keydown', onKey, true);
   }, [onClose]);
 
-  // Zero-step resume: when a session id is entered, look up the cwd it originally
-  // ran in (from the transcript) and pre-fill the Folder so the user doesn't have
-  // to find the worktree. They can still override the folder afterwards. Runs on
-  // blur so we don't hit the resolver on every keystroke.
+  // 零步骤恢复：输入 session id 后，从转录中查它最初运行所在的 cwd，并预填
+  // Folder，这样用户不必自己去找 worktree。之后仍可覆盖文件夹。在 blur 时运行，
+  // 避免每次按键都触发解析器。
   const resolveFolderFromSession = async () => {
     const sid = resumeSessionId.trim();
     if (!sid) { setFolderNote(undefined); return; }
@@ -289,8 +284,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     else if (res.error !== 'cancelled') setError(res.error);
   };
 
-  /** Register `path` as a project (folder quick-pick) right now: dedupe-prepend,
-   *  select it, persist to config, and lift the change up so it sticks. */
+  /** 立即把 `path` 注册为项目（文件夹快速选项）：去重后前插、选中它、持久化到
+   *  配置，并把变更提升上去使其生效。 */
   const registerProject = async (path: string) => {
     const p = path.trim();
     if (!p) return;
@@ -299,21 +294,20 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     setCwd(p);
     try {
       const updated = await window.cth.updateConfig({ registeredRepos: next });
-      // Main expands `~` when it persists registeredRepos, so adopt the stored
-      // (absolute) list — otherwise a typed "~/dev/foo" stays literal in this
-      // modal's state and rides along into the spawn.
+      // Main 在持久化 registeredRepos 时会展开 `~`，所以要采纳存储后的
+      // （绝对路径）列表——否则输入的 "~/dev/foo" 在本弹窗的状态里保持字面值，
+      // 并跟着进入 spawn。
       const stored = updated.registeredRepos ?? next;
       setRepos(stored);
       if (stored[0]) setCwd(stored[0]);
       onConfigChange?.(updated);
-    } catch { /* best-effort persist */ }
+    } catch { /* 尽力持久化 */ }
   };
 
-  /** Drop `path` from the project quick-picks.
+  /** 从项目快速选项中去掉 `path`。
    *
-   *  Removes it from the LISTING only. The folder on disk is never touched, which
-   *  is the whole point: a project you are done with should stop cluttering the
-   *  picker without anything being deleted. */
+   *  只是从列表中移除。磁盘上的文件夹绝不被触碰，这正是要点：用完的项目应该
+   *  停止占据选择器，而不删除任何东西。 */
   const unregisterProject = async (path: string) => {
     const next = repos.filter((r) => r !== path);
     setRepos(next);
@@ -321,10 +315,10 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       const updated = await window.cth.updateConfig({ registeredRepos: next });
       setRepos(updated.registeredRepos ?? next);
       onConfigChange?.(updated);
-    } catch { /* best-effort persist */ }
+    } catch { /* 尽力持久化 */ }
   };
 
-  /** Pick a brand-new folder and register it as a project in one step. */
+  /** 一步完成：挑选一个全新的文件夹并把它注册为项目。 */
   const addProject = async () => {
     setError(undefined);
     const res = await window.cth.chooseFolder();
@@ -332,14 +326,14 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     else if (res.error !== 'cancelled') setError(res.error);
   };
 
-  /** Apply an imported manifest to every form field (file import path). The
-   *  command is rebuilt locally from the provider preset + validated flags — a
-   *  manifest can never inject the spawn binary. Import never spawns. */
+  /** 把导入的清单应用到每个表单字段（文件导入路径）。命令从 provider 预设 +
+   *  已验证的 flags 在本地重建——清单永远无法注入 spawn 二进制。导入从不
+   *  spawn。 */
   const applyManifest = (m: HireManifest) => {
     setHireMeta(m);
     setName(m.name);
-    // A manifest that names an agent but omits `character` should get the
-    // matching avatar rather than the Jim default (issue #191).
+    // 清单若指定了代理名却省略 `character`，应获得匹配的头像而不是 Jim 默认
+    // 头像（issue #191）。
     setCharacter(m.character ? knownCharacter(m.character) : (characterForName(m.name ?? '') ?? knownCharacter(undefined)));
     setAccent(knownAccent(m.accent));
     setProvider(m.provider ?? initialProvider);
@@ -353,19 +347,18 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     setSection('identity');
   };
 
-  // Advancing a batch keeps this modal mounted. Re-seed every form field when
-  // the queue head changes so edits made while reviewing one hire cannot leak
-  // into the next.
+  // 推进批次时会保持本弹窗挂载。当队列头变化时重新填充每个表单字段，这样在
+  // 审查一个 hire 时所做的编辑不会泄漏到下一个。
   useLayoutEffect(() => {
     if (pendingHire) applyManifest(pendingHire);
-  // applyManifest intentionally closes over the config snapshot used by this
-  // open modal; queue advances do not replace that snapshot.
+  // applyManifest 有意闭包捕获这个已打开弹窗使用的配置快照；队列推进不会
+  // 替换该快照。
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingHire]);
 
   const advanceHireReview = () => {
     const next = hireQueue.pending[1];
-    // The pendingHire effect re-seeds every form field from the new queue head.
+    // pendingHire effect 会用新的队首重新填充每个表单字段。
     finishPendingHire();
     if (!next) onClose();
   };
@@ -375,8 +368,7 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     const res = await window.cth.importHireFiles();
     if (res.manifests.length > 0) enqueuePendingHires(res.manifests);
     if (res.errors.length > 0) {
-      const noun = res.errors.length === 1 ? 'file' : 'files';
-      setError(`Skipped ${res.errors.length} invalid ${noun}: ${res.errors.join(' · ')}`);
+      setError(`已跳过 ${res.errors.length} 个无效文件: ${res.errors.join(' · ')}`);
     } else if (!res.ok && res.error && res.error !== 'cancelled') {
       setError(res.error);
     }
@@ -390,8 +382,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
 
   const submit = async () => {
     setError(undefined);
-    // A required field can live in a section the user hasn't opened, so jump to
-    // the offending section as we surface the error — the field is never hidden.
+    // 必填字段可能位于用户尚未打开的分区，所以在提示错误的同时跳到出问题的
+    // 分区——该字段绝不会被隐藏。
     if (!name.trim()) { setError(tr('addAgent.errName')); setSection('identity'); return; }
     if (!cwd) { setError(tr('addAgent.errFolder')); setSection('workspace'); return; }
     if (!command.trim()) { setError(tr('addAgent.errCommand')); setSection('engine'); return; }
@@ -399,9 +391,9 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
     setBusy(true);
     const id = uniqueId(name);
     const ptyId = `pty-${id}`;
-    // Split the editable command field into argv-style pieces for node-pty.
-    // Quote-aware so an agy model label like "Gemini 3.1 Pro (High)" — or any
-    // auto-mode flags appended to the command — stays one argument.
+    // 把可编辑的命令字段拆成 argv 风格的片段交给 node-pty。
+    // 感知引号，这样类似 "Gemini 3.1 Pro (High)" 的 agy 模型标签——或命令上
+    // 追加的任何 auto-mode flags——仍作为单个参数。
     const [exe, ...args] = tokenizeCommand(command.trim());
     const spawnRes = await window.cth.spawnPty({
       id: ptyId,
@@ -411,44 +403,43 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       args,
       cols: 100,
       rows: 30,
-      // When set, the main process spawns this agent in its own git worktree.
-      // Forced OFF when resuming a session — `--resume` needs the real cwd's
-      // transcript, not a fresh worktree with a different (empty) project dir.
+      // 设置后，主进程会在自己的 git worktree 中 spawn 该代理。
+      // 恢复会话时强制关闭——`--resume` 需要真实 cwd 的转录，而不是一个带
+      // 不同（空）项目目录的全新 worktree。
       isolate: resuming ? false : isolate,
-      // #2 — continue an existing Claude session in this agent's cwd.
+      // #2 —— 在此代理的 cwd 中继续一个已有的 Claude 会话。
       resumeSessionId: resuming ? resumeSessionId.trim() : undefined,
-      // Provision this agent in the hive (memory + mailbox + identity/protocol).
+      // 在 hive 中为这个代理做供给（memory + mailbox + identity/protocol）。
       hive: {
         id,
         name: name.trim(),
         provider,
         cwd,
         role: description.trim() || undefined,
-        // A hire manifest may carry validated capability tags (routing hints).
+        // hire 清单可能携带已验证的 capability 标签（路由提示）。
         capabilities: hireMeta?.capabilities
       }
     });
     if (!spawnRes.ok) {
       setBusy(false);
-      setError(spawnRes.error ?? 'spawn failed');
+      setError(spawnRes.error ?? '生成失败');
       return;
     }
-    // #2 — the requested resume session id wasn't found anywhere; main fell back
-    // to a fresh session. Don't block the spawn, but make it visible.
+    // #2 —— 请求的 resume session id 在哪里都找不到；main 回退到了全新会话。
+    // 不阻塞 spawn，但要让它可见。
     if (resuming && spawnRes.resumeNotFound) {
       console.warn(`[add-agent] resume session "${resumeSessionId.trim()}" not found — started a fresh session`);
     }
 
-    // Main expands `~` at ingestion and echoes back the absolute path it actually
-    // spawned into — record THAT, so this agent's cwd matches the hive registry
-    // (and survives a restart, where nothing re-expands it).
+    // Main 在接收时展开 `~`，并回显它实际 spawn 进的绝对路径——记录那个路径，
+    // 这样该代理的 cwd 与 hive 注册表一致（并且重启后仍然有效，因为重启后
+    // 没有任何东西会重新展开它）。
     const spawnedCwd = spawnRes.cwd || cwd;
-    // With git isolation the agent RUNS in its own worktree, but its PROJECT is
-    // still the folder the user picked. Labelling the agent with the worktree's
-    // name was the visible half; the damaging half was promoting that worktree
-    // into registeredRepos below, which turned the project quick-picks into a
-    // list of throwaway worktrees. Mirrors the `isolate` sent to main, which is
-    // forced off while resuming.
+    // 启用 git isolation 时，代理在自己的 worktree 中运行，但其 PROJECT 仍然是
+    // 用户挑选的文件夹。用 worktree 的名字标记代理只是可见的一半；有害的一半是
+    // 把那个 worktree 提升进下面的 registeredRepos，导致项目快速选项变成一列
+    // 一次性的 worktree。与发送给 main 的 `isolate` 保持一致，后者在恢复会话时
+    // 被强制关闭。
     const projectCwd = (!resuming && isolate) ? cwd.trim() : spawnedCwd;
     const agent: Agent = {
       id,
@@ -461,25 +452,24 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
       cwd: spawnedCwd,
       goal: goal.trim() || undefined,
       status: 'idle',
-      action: resuming && spawnRes.resumeNotFound ? 'session not found — fresh start' : 'starting up',
+      action: resuming && spawnRes.resumeNotFound ? '会话不存在——全新开始' : '正在启动',
       progress: 0,
       currentStation: 'desk',
       ptyId,
       command: command.trim(),
       provider,
       model,
-      // Persist the resolved worktree path (set only when isolation provisioned
-      // one) so a restart can re-enter this exact worktree — see restoreTeam.
+      // 持久化解析出的 worktree 路径（仅当 isolation 确实供给了一个时才设置），
+      // 以便重启后能重新进入这个确切的 worktree——参见 restoreTeam。
       worktreePath: spawnRes.worktreePath,
-      // Crush (seedDelivery:'type-into-tui') hands its hive protocol back here
-      // instead of on argv; useHive types it into the TUI after boot. (ondev-b)
+      // Crush（seedDelivery:'type-into-tui'）把它的 hive 协议交回这里，而不是放在
+      // argv 上；useHive 会在启动后把它输入到 TUI 中。(ondev-b)
       seedPrompt: spawnRes.seedPrompt,
       recentTextTs: Date.now()
     };
     addAgent(agent);
-    // Remember the folder for the next hire: promote it to the front of the
-    // registeredRepos quick-picks (the modal's default cwd) so back-to-back
-    // hires land in the same project without re-picking.
+    // 为下一次 hire 记住这个文件夹：把它提升到 registeredRepos 快速选项的最前
+    // （弹窗的默认 cwd），这样连续 hire 会落在同一项目里，无需重新挑选。
     if (projectCwd && repos[0] !== projectCwd) {
       const nextRepos = [projectCwd, ...repos.filter((r) => r !== projectCwd && r !== cwd)];
       try {
@@ -487,9 +477,9 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
         onConfigChange?.(updated);
       } catch { /* best-effort */ }
     }
-    // A hire manifest may carry a per-agent token budget — apply it to the
-    // latest agentTokenCaps map in main. Await it before advancing a batch: the
-    // next hire reuses this mounted modal and must not race a stale config write.
+    // hire 清单可能携带按代理计算的 token 预算——把它应用到 main 中最新的
+    // agentTokenCaps 映射。推进批次前要 await 它：下一个 hire 会复用这个挂载中
+    // 的弹窗，绝不能与过期的配置写入竞争。
     if (hireMeta?.tokenCap) {
       try {
         const updated = await window.cth.setAgentTokenCap(id, hireMeta.tokenCap);
@@ -511,8 +501,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
         position: 'fixed', inset: 0,
         background: 'rgba(26, 19, 32, 0.6)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
-        // Must sit above fullscreen terminal/file overlays (250/280) and their
-        // hover popovers. The fullscreen Add Agent button uses this same modal.
+        // 必须位于全屏终端/文件浮层（250/280）及其悬停弹出层之上。全屏的「添加代理」
+        // 按钮也使用这同一个弹窗。
         zIndex: 500
       }}
     >
@@ -523,12 +513,11 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
           style={{ padding: 16 }}
           noPadding
         >
-          {/* Sectioned config with a left sidebar index. The form has 11+ fields,
-              so they're grouped into 4 sections (Identity / Workspace / Engine /
-              Briefing) shown one at a time; the sidebar jumps between them. The
-              hire-import review banner, the error, and the footer stay pinned
-              around the section pane. maxHeight keeps the dialog within the
-              viewport (title bar stays pinned). */}
+          {/* 带左侧边栏索引的分区配置。表单有 11+ 个字段，因此按 4 个区块
+              （身份 / 工作区 / 引擎 / 简报）分组，一次只显示一个；侧边栏在
+              它们之间跳转。hire 导入审核横幅、错误信息和底部操作区固定
+              在区块面板四周。maxHeight 让对话框保持在视口内
+              （标题栏保持固定）。 */}
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 16, maxHeight: '86vh', overflowY: 'auto' }}>
             {hireMeta && (
               <div style={{
@@ -629,10 +618,10 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
               </div>
             )}
 
-            {/* sidebar index + the active section's fields */}
+            {/* 侧边栏索引 + 当前活动区块的字段 */}
             <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
-              {/* LEFT — section index. Capabilities isn't a nav item: it isn't a
-                  user field, it rides the imported hire manifest (banner above). */}
+              {/* 左侧 —— 区块索引。Capabilities 不是导航项：它不是用户字段，
+                  它随导入的 hire manifest 一起带入（见上方横幅）。 */}
               <nav style={{ width: 168, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
                 {SECTIONS.map((s, i) => {
                   const active = section === s.key;
@@ -665,7 +654,7 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                 })}
               </nav>
 
-              {/* RIGHT — the active section's fields */}
+              {/* 右侧 —— 当前活动区块的字段 */}
               <div style={{ flex: 1, minWidth: 0, minHeight: 260, display: 'flex', flexDirection: 'column', gap: 12 }}>
                 {section === 'identity' && (
                   <>
@@ -756,10 +745,9 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                       {repos.length > 0 && (
                         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 6 }}>
                           {repos.map((r) => (
-                            /* Two buttons per chip: pick the project, or drop it
-                               from this list. Nested in a span rather than one
-                               button so the remove control is not a button inside
-                               a button. */
+                            /* 每个 chip 两个按钮：选择该项目，或把它从这个列表中去掉。
+                               嵌套在 span 里而不是用一个按钮，这样移除控件不会
+                               成为按钮里的按钮。 */
                             <span
                               key={r}
                               style={{
@@ -882,10 +870,8 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                               key={p.id}
                               onClick={() => pickProvider(p.id)}
                               title={
-                                p.id === 'antigravity'
-                                  ? tr('addAgent.providerAntigravity')
-                                  : p.id === 'codex'
-                                    ? tr('addAgent.providerCodex')
+                                p.id === 'codex'
+                                  ? tr('addAgent.providerCodex')
                                     : p.id === 'custom'
                                       ? tr('addAgent.providerCustom')
                                       : p.label
@@ -912,10 +898,9 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                     {preset.supportsModel && <Row label={tr('addAgent.model')}>
                       <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                         {(() => {
-                          // An imported hire may name a model newer than this picker's
-                          // hardcoded list (e.g. claude-fable-5). Surface it as a real,
-                          // selected card instead of leaving the picker looking unset —
-                          // the command field already carries it either way.
+                          // 导入的 hire 可能指定比此选择器硬编码列表更新的模型（例如
+                          // claude-fable-5）。把它作为一张真实选中的卡片展示出来，而
+                          // 不是让选择器看起来像没设置——无论如何命令字段都已承载它。
                           const known = modelsForProvider(provider);
                           return model && !known.some((m) => m.id === model)
                             ? [...known, { id: model, label: tr('addAgent.fromHire', { model }) }]
@@ -944,11 +929,10 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                       </div>
                     </Row>}
 
-                    {/* OSS-model quick-picks (ondev-c) — local + third-party-provider
-                        shortlists from the verified catalog. Clicking sets the
-                        engine-correct slug (OpenCode `local/<tag>`, Crush/pi
-                        `ollama/<tag>`; provider slugs are identical across engines)
-                        and rebuilds the command. */}
+                    {/* OSS 模型快速选择 (ondev-c) —— 来自已验证目录的本地 + 第三方提供方
+                        候选清单。点击会设置引擎正确的 slug（OpenCode `local/<tag>`、Crush/pi
+                        `ollama/<tag>`；provider slug 在各引擎间一致）
+                        并重建命令。 */}
                     {hasOssQuickPicks(provider) && (
                       <Row label={tr('addAgent.ossModels')}>
                         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
@@ -993,7 +977,7 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                       </Row>
                     )}
 
-                    {(provider === 'opencode' || provider === 'crush' || provider === 'pi' || provider === 'qwen') && (
+                    {(provider === 'qwen') && (
                       <div style={{ fontSize: 12, color: 'var(--cth-ink-500)', lineHeight: '16px', margin: '2px 0 6px' }}>
                         {tr('addAgent.byokNote')}
                         {' '}
@@ -1016,9 +1000,7 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
                         value={command}
                         onChange={(e) => setCommand(e.target.value)}
                         placeholder={
-                          provider === 'antigravity'
-                            ? 'agy'
-                            : provider === 'codex'
+                          provider === 'codex'
                               ? 'codex'
                               : provider === 'custom'
                                 ? 'your-agent-cli'
@@ -1089,7 +1071,7 @@ export function AddAgentModal({ onClose, config, onConfigChange }: AddAgentModal
               </div>
             )}
 
-            {/* Import-hire explainer + AI prompt generator (item 7) */}
+            {/* 导入 hire 说明 + AI 提示词生成器（第 7 项） */}
             <div style={{
               padding: '8px 10px',
               background: 'var(--cth-cream-100)',

--- a/src/renderer/src/components/AgentCard.tsx
+++ b/src/renderer/src/components/AgentCard.tsx
@@ -15,44 +15,43 @@ export interface AgentCardProps {
   character: OfficeCharacterName;
   accent: AccentColorName;
   status: StatusKind;
-  /** This agent's pty, if it has one. Only used to notice that the USER has
-   *  unsent text on its prompt — which holds the agent's queue, and otherwise
-   *  looks identical to an idle agent with nothing to do. */
+  /** 此代理的 pty（如果有）。仅用于感知 USER 在其提示符上有未发送的文本——
+   *  这会占住代理的队列；除此之外它看起来和没有任务的空闲代理完全一样。 */
   ptyId?: string;
   project: string;
   action?: string;
-  /** Context gauge: 0..8 segments filled (session context ÷ context limit). */
+  /** 上下文仪表：0..8 段填充（会话上下文 ÷ 上下文上限）。 */
   progress?: number;
-  /** Live context size (tokens) — shown in the gauge tooltip. */
+  /** 实时上下文大小（tokens）——显示在仪表 tooltip 中。 */
   contextTokens?: number;
-  /** Context-window limit (tokens) assumed for the agent's model. */
+  /** 该代理模型假定的上下文窗口上限（tokens）。 */
   contextLimit?: number;
   selected?: boolean;
-  /** Your clone — gets a persistent accent frame + BOSS tag so it stands out.
-   *  (`isGod` / the `god` agent id stay as-is internally; this is display only.) */
+  /** 你的克隆体——获得持久的强调色边框 + BOSS 标签以便突出显示。
+   *  （`isGod` / `god` 代理 id 内部保持不变；这只是显示层面的东西。） */
   isGod?: boolean;
   onClick?: () => void;
-  /** Persists an inline display-name edit; identity and hive paths stay unchanged. */
+  /** 持久化一次内联的显示名编辑；身份与 hive 路径保持不变。 */
   onRename?: (name: string) => Promise<{ ok: boolean; error?: string }>;
-  /** Number of ledger tasks this agent is actively DOING — rendered as a blue
-   *  sticky note stuck to the card. Clicking it opens the first task's detail. */
+  /** 此代理正在实际执行的 ledger 任务数量——渲染为贴在卡片上的蓝色
+   *  便签。点击它会打开第一个任务的详情。 */
   doingCount?: number;
   onTaskNoteClick?: () => void;
-  draggable?: boolean; // must sit on the <button> itself — Chromium won't start a drag on an ancestor from inside a form control
-  /** Private note — rendered as the card's own row (v0.3.4) so it can never
-   *  cover the context gauge. First line only; full text in the tooltip. */
+  draggable?: boolean; // 必须放在 <button> 本身上——Chromium 不会从表单控件内部的祖先元素上开始拖拽
+  /** 私密备注——渲染为卡片自己的行（v0.3.4），这样它永远不会
+   *  盖住上下文仪表。只显示第一行；完整文本在 tooltip 中。 */
   note?: string;
-  /** Opens the note editor (the strip owns the editing overlay). When set, the
-   *  card shows a small ✎ affordance on its note row. */
+  /** 打开备注编辑器（该操作条拥有编辑浮层）。设置后，卡片会在备注行上
+   *  显示一个小的 ✎ 提示。 */
   onEditNote?: () => void;
 }
 
 const fmtK = (n: number): string => `${Math.round(n / 1000)}k`;
 
 /**
- * v0.3.4 compact redesign: one identity row (name + status), one context line
- * (action while working, repo while idle — both in the tooltip), one note row,
- * and a slim gauge pinned to the bottom edge. Nothing overlaps anything.
+ * v0.3.4 紧凑重设计：一行身份（名字 + 状态）、一行上下文（工作时显示动作，
+ * 空闲时显示仓库——都在 tooltip 中）、一行备注，以及一条贴在底部边缘的
+ * 细仪表。任何东西都不会互相重叠。
  */
 export function AgentCard({
   name, character, accent, status, ptyId, project, action, progress = 0,
@@ -62,28 +61,26 @@ export function AgentCard({
   const { t } = useTranslation();
   const [hover, setHover] = useState(false);
   const typing = useHasTerminalDraft(ptyId);
-  // IDENTITY and SELECTION are two different things, and conflating them is why
-  // selecting Michael appeared to do nothing.
+  // 身份（IDENTITY）和选中（SELECTION）是两回事，把它们混为一谈正是
+  // 「选中 Michael 却看起来什么都没发生」的原因。
   //
-  // The card used to pass `isGod || selected` into PixelPanel's 'active' variant,
-  // whose frame is `inset 1px + 3px accent + 5px ink` — five pixels of border in
-  // the agent's OWN accent. Three problems in one: the selection cue changed
-  // colour per agent (the "blue halo" on a sky agent), it was invisible on god
-  // because god was framed unconditionally, and stacking the selection ring
-  // outside it made the boss card visibly fatter than its neighbours.
+  // 过去卡片把 `isGod || selected` 传入 PixelPanel 的 'active' 变体，其边框是
+  // `inset 1px + 3px accent + 5px ink`——五像素的边框，用的是代理自己颜色的
+  // 强调色。这一下带来三个问题：选中提示随代理而变色（sky 代理出现「蓝色光晕」）、
+  // 在 god 上不可见（因为 god 无条件带边框）、在它外面再叠加选中环让老板卡片
+  // 明显比邻居更胖。
   //
-  // Now: god is marked by its SURFACE (see godSurface), everyone shares the same
-  // 1px panel border, and selection is one accent-independent ring — identical on
-  // every card, god included.
+  // 现在：god 由其表面（SURFACE）标记（见 godSurface），所有卡片共用同一条
+  // 1px 面板边框，选中则是一个与强调色无关的环——每张卡片上完全一致，god
+  // 也不例外。
 
-  // The selected card wears an ink ring OUTSIDE its border. ink-900 rather than
-  // an accent so the cue is identical on every agent, and it flips with the
-  // theme (near-black on cream, near-white on the dark ground), staying legible
-  // over whatever accent the card already carries.
+  // 被选中的卡片在边框外戴一个 ink 色环。用 ink-900 而不是强调色，这样提示在
+  // 每个代理上完全一致，并且会随主题翻转（米色底上近黑、深色底上近白），在
+  // 卡片自带的任何强调色之上都清晰可辨。
   const selectionRing = selected ? '0 0 0 2px var(--cth-ink-900)' : '';
 
-  // Context gauge as ONE clean fill (0..8 → 0..100%). Colour escalates as the
-  // window fills: accent while comfortable, amber from 6/8, coral from 7/8.
+  // 上下文仪表是一整条干净的填充（0..8 → 0..100%）。颜色随窗口填满而升级：
+  // 舒适时用强调色，6/8 起变琥珀色，7/8 起变珊瑚色。
   const pct = Math.min(8, Math.max(0, progress)) / 8 * 100;
   const gaugeColor = progress >= 7 ? 'var(--cth-coral)'
     : progress >= 6 ? 'var(--cth-lemon)'
@@ -92,25 +89,21 @@ export function AgentCard({
     ? t('agentCard.contextTitle', { used: fmtK(contextTokens), limit: fmtK(contextLimit), pct: Math.round((contextTokens / contextLimit) * 100) })
     : t('agentCard.contextGaugeTitle');
 
-  // ONE card size for every agent. God used to be 216x86 against everyone
-  // else's 196x76, so the dock never lined up — and once the selection ring was
-  // added outside its 5px accent frame, the boss card grew a visibly thicker
-  // edge than any other. Distinction now comes from the card's SURFACE, not from
-  // making its box bigger or its border heavier.
-  // 196 was too tight once god's row carried NAME + BOSS + status: the name
-  // truncated to "MIC…" — the one word on the card that must never be the thing
-  // that gets cut. Widened for every card so the dock stays uniform, with enough
-  // slack that Talk's info mark (which only appears when the OpenAI key is
-  // missing) has somewhere to sit rather than pushing the row apart.
+  // 所有代理使用同一种卡片尺寸。过去 god 是 216x86，其他代理是 196x76，
+  // 导致停靠栏永远对不齐——而且一旦在其 5px 强调色边框外加了选中环，老板卡片的
+  // 边缘就明显比其他卡片更粗。现在区别来自卡片的表面（SURFACE），而不是把盒子
+  // 做大或把边框加粗。
+  // 一旦 god 的行需要容纳 NAME + BOSS + status，196 就太挤了：名字被截成
+  // "MIC…"——而名字是卡片上唯一绝不能成为被截断对象的内容。为每张卡片加宽，
+  // 让停靠栏保持统一，同时留出足够余量，使 Talk 的信息标记（只在 OpenAI key
+  // 缺失时出现）有地方安放，而不是把这一行撑开。
   const width = 220;
   const height = 78;
   const lift = (isGod ? -2 : 0) - (hover ? 1 : 0) - (selected ? 1 : 0);
-  /** God's distinction: a tinted surface plus a thin accent border all the way
-   *  around — NOT the 3px rule that used to sit on the top edge alone. That rule
-   *  read as a stray yellow bar rather than as part of the card, and an edge
-   *  treatment that only exists on one side always looks like a mistake or a
-   *  progress bar. Same 1px geometry as every other card, so the box is
-   *  unchanged and the selection ring still means exactly one thing everywhere. */
+  /** God 的区分：一层淡色表面外加一圈细强调色边框——而不是过去只放在顶部边缘的
+   *  3px 规则。那条规则读起来像一条游离的黄色横条，而不是卡片的一部分；而且只
+   *  出现在单侧的边缘处理总会被看成错误或进度条。与其他所有卡片同样的 1px
+   *  几何结构，因此盒子不变，选中环在任何地方仍然只表达唯一一种含义。 */
   const godSurface: React.CSSProperties = isGod
     ? {
         background: `var(--cth-${accent}-light)`,
@@ -120,11 +113,11 @@ export function AgentCard({
   const dropShadow = isGod
     ? `2px 3px 0 0 rgba(26,19,32,${hover ? 0.2 : 0.14})`
     : (hover ? '1px 2px 0 0 rgba(26,19,32,0.12)' : 'none');
-  // Ring first so it sits tight to the card, then the existing drop shadow.
+  // 环放在最前，紧贴卡片；然后是现有的投影。
   const outerShadow = [selectionRing, dropShadow === 'none' ? '' : dropShadow]
     .filter(Boolean).join(', ') || 'none';
 
-  // One context line: what it's DOING while working, WHERE it lives while idle.
+  // 一行上下文：工作时显示在做什么，空闲时显示它存在于哪里。
   const infoLine = (status !== 'idle' && action) ? action : project;
   const noteFirstLine = (note ?? '').split('\n').find((l) => l.trim()) ?? '';
 
@@ -143,8 +136,8 @@ export function AgentCard({
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       draggable={draggable}
-      // The ring is the visual answer to "which terminal is open"; this is the
-      // same answer for a screen reader. Matches SidebarRow in fullscreen.
+      // 这个环是「哪个终端开着」的视觉答案；这里是同一个答案的屏幕阅读器版本。
+      // 与全屏模式中的 SidebarRow 保持一致。
       aria-current={selected ? 'true' : undefined}
       className="cth-titlebar-nodrag"
       style={{
@@ -156,8 +149,8 @@ export function AgentCard({
         transition: 'transform 90ms steps(2, end), box-shadow 90ms steps(2, end)'
       }}
     >
-      {/* The taken note, stuck to the card like on the desk: this worker is
-          actively DOING a ledger task. Click → the task's detail overlay. */}
+      {/* 便签，像贴在桌面上那样贴在卡片上：这个 worker 正在实际执行一个
+          ledger 任务。点击 → 该任务的详情浮层。 */}
       {doingCount > 0 && (
         <span
           title={doingCount === 1
@@ -184,16 +177,15 @@ export function AgentCard({
         noPadding
       >
         <div style={{ display: 'flex', gap: 8, height: '100%' }}>
-          {/* Portrait tile — vertically centred so the card reads calm and even. */}
+          {/* 头像方块——垂直居中，让卡片看起来平静而整齐。 */}
           <div style={{
             width: 36, height: isGod ? 50 : 46, alignSelf: 'center',
-            // God's CARD is now accent-light, so the tile cannot be — it would
-            // vanish into its own background. Paper reads as an inset frame
-            // against the tint, which is what the tile is meant to look like.
+            // God 的卡片现在是浅强调色底，所以方块不能再是——否则会融入自己的
+            // 背景。纸色在浅色底上读起来像一圈内嵌边框，这正是方块应有的样子。
             background: isGod ? 'var(--cth-paper-100)' : `var(--cth-${accent}-light)`,
             boxShadow: `inset 0 0 0 1px var(--cth-ink-${isGod ? '300' : '100'})`,
-            // Anchor the sprite's TOP: the 56px-tall portrait overflows this
-            // tile, and bottom-anchoring cropped the head — crop feet, not face.
+            // 锚定精灵图的顶部：56px 高的肖像会溢出这个方块，底部锚定会裁掉
+            // 头部——裁脚不裁脸。
             display: 'flex', alignItems: 'flex-start', justifyContent: 'center', overflow: 'hidden',
             flexShrink: 0
           }}>
@@ -201,7 +193,7 @@ export function AgentCard({
           </div>
 
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
-            {/* Identity row: name (+ BOSS tag) + status. */}
+            {/* 身份行：名字（+ BOSS 标签）+ 状态。 */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'space-between', minWidth: 0 }}>
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, minWidth: 0, flex: 1 }}>
                 {onRename ? (
@@ -223,14 +215,13 @@ export function AgentCard({
                     padding: '1px 4px 0', flexShrink: 0
                   }}>{t('agentCard.boss')}</span>                )}
               </span>
-              {/* flexShrink:0 — the badge is a fixed 2-to-5 character chip; when
-                  it was allowed to shrink, the browser resolved the overflow by
-                  eating the NAME instead. Truncation should land on the longest,
-                  most redundant thing, not on the identity. */}
+              {/* flexShrink:0 —— 徽章是一个固定的 2 到 5 字符小块；如果允许它
+                  收缩，浏览器会通过吞掉名字来解决溢出。截断应该落在最长、
+                  最冗余的内容上，而不是落在身份上。 */}
               <PixelBadge status={typing ? 'typing' : status} style={{ flexShrink: 0 }} />
             </div>
 
-            {/* Context line: action while working, repo while idle. */}
+            {/* 上下文行：工作时显示动作，空闲时显示仓库。 */}
             <div
               title={`${project}${action && status !== 'idle' ? ` — ${action}` : ''}`}
               style={{
@@ -240,14 +231,13 @@ export function AgentCard({
               }}
             >{infoLine}</div>
 
-            {/* God: voice on its own compact row. Workers: the private note row.
-                Both sit ABOVE the gauge, so it is never covered. */}
+            {/* God：声音独占一行紧凑的行。Worker：私密备注行。
+                两者都在仪表上方，所以仪表永远不会被盖住。 */}
             {isGod ? (
-              // Talk grows an info mark when the OpenAI key is missing, so this
-              // row can hold three things instead of two. `overflow: hidden` is
-              // the guard: the toggle's label shrinks first (it has minWidth:0),
-              // and if it still does not fit, the row clips INSIDE the card
-              // instead of spilling over its border.
+              // OpenAI key 缺失时 Talk 会多出一个信息标记，所以这一行要容纳
+              // 三样东西而不是两样。`overflow: hidden` 是防护：开关的标签会
+              // 先收缩（它有 minWidth:0），如果仍然放不下，这一行会在卡片
+              // 内部裁剪，而不是溢出到边框外。
               <div
                 style={{
                   display: 'flex', alignItems: 'center', gap: 6,
@@ -287,7 +277,7 @@ export function AgentCard({
                       flexShrink: 0, width: 15, height: 14,
                       display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
                       fontSize: 10, lineHeight: 1, cursor: 'pointer',
-                      // Quiet until the card is hovered — discoverable, not noisy.
+                      // 卡片悬停前保持低调——可被发现，但不聒噪。
                       color: hover ? 'var(--cth-ink-500)' : 'var(--cth-ink-300)'
                     }}
                   >✎</span>
@@ -295,7 +285,7 @@ export function AgentCard({
               </div>
             )}
 
-            {/* Context gauge — slim fill bar pinned to the card's bottom edge. */}
+            {/* 上下文仪表——固定在卡片底部边缘的细填充条。 */}
             <div style={{ marginTop: 'auto' }} title={gaugeTitle}>
               <div style={{
                 height: 4, width: '100%',

--- a/src/renderer/src/components/AgentControlStrip.tsx
+++ b/src/renderer/src/components/AgentControlStrip.tsx
@@ -5,25 +5,23 @@ import { AgentHoldButton } from './AgentHoldButton';
 import { isComposingKey } from '@shared/imeGuard';
 
 /**
- * Operator control for one agent (#7C.1-7C.3) — pause (deny tools at the next
- * boundary), graceful halt (clean stop), and mid-run steering (inject context
- * without typing into the TUI). All ride Claude Code's hook-return protocol; no
- * PTY keystrokes. A thin strip under the agent header.
+ * 单个代理的操作控制（#7C.1-7C.3）——暂停（在下一个边界处拒绝工具调用）、
+ * 优雅停止（干净收尾）、以及运行中途的引导（无需在 TUI 中输入即可注入上下文）。
+ * 全部走 Claude Code 的 hook-return 协议，不发送 PTY 按键。是代理头部下方的一条
+ * 细操作条。
  *
- * The labels used to be "CONTROL", "pause", "halt", "steer", which told you the
- * mechanism and nothing about the consequence. "Control" what, and what is the
- * difference between pausing and halting? Both stop something; only one is
- * recoverable in the same breath. So each button says what HAPPENS, and the
- * explanations are on a styled hover tip rather than a native `title` that
- * waits a second and then renders an unstyled OS bubble.
+ * 标签过去是 "CONTROL"、"pause"、"halt"、"steer"，只说明了机制，完全没说明后果。
+ * 到底「控制」什么？暂停和停止又有什么区别？两者都会停下某件事，但只有其中一个
+ * 能在同一口气里恢复。所以每个按钮现在都说清楚会发生什么（HAPPENS），说明文字放在
+ * 样式化的悬停提示里，而不是放在原生 `title` 上——那种要等一秒、然后弹出一个
+ * 无样式 OS 气泡。
  *
- * The heading is gone: once the buttons read as sentences it was labelling the
- * obvious, and a row of three clear verbs needs no title above it.
+ * 标题被去掉了：按钮读起来已经是完整的句子后，标题只是在标注显而易见的东西，
+ * 三个清晰动词排成一行，上面不需要再放标题。
  *
- * The 1:1 hold sits here too. It is a different KIND of control — the other two
- * restrain the AGENT, 1:1 restrains MICHAEL, and the agent keeps running and
- * answering you — so that distinction now lives in its tooltip rather than in
- * the layout.
+ * 1:1 hold 也放在这里。它是另一种「控制」——另外两个约束的是 AGENT，1:1 约束的
+ * 是 MICHAEL，而且代理会继续运行并继续回答你——所以这个区别现在体现在它的
+ * tooltip 里，而不是体现在布局上。
  */
 interface Snapshot {
   paused: boolean;
@@ -78,9 +76,8 @@ export function AgentControlStrip({ agentId }: { agentId: string }) {
       borderBottom: '1px solid var(--cth-ink-300)', flexShrink: 0
     }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        {/* Neither of these kills anything, and the old two-word labels never
-            said so — the difference is WHEN the agent stops and whether it keeps
-            its session. Say the consequence on the button, the detail on hover. */}
+        {/* 这两个都不会杀死任何东西，而旧的二字标签从未说明这一点 ——
+            区别在于代理何时停止、以及是否保留会话。按钮上写明后果，悬停时给出细节。 */}
         <PixelButton variant={snap?.paused ? 'primary' : 'secondary'} size="sm" onClick={togglePause}>
           <span
             className="cth-tip cth-tip-left cth-tip-wrap"
@@ -101,13 +98,12 @@ export function AgentControlStrip({ agentId }: { agentId: string }) {
             {t('agentControl.stopAfterStep')}
           </span>
         </PixelButton>
-        {/* Sits with them at the founder's call. It is a different KIND of
-            control — the two above restrain the agent, this one restrains
-            Michael — so the tooltip carries that distinction now that the
-            grouping no longer does. */}
+        {/* 它与这两个按钮同排，听从创始人的调遣。它是另一种「控制」——
+            上面两个约束的是 agent，这个约束的是 Michael —— 既然分组不再
+            表达这个区别，就由 tooltip 来承担。 */}
         <AgentHoldButton agentId={agentId} />
-        {/* v0.3.4: the auto-delivery switch moved to the god's Command Center
-            header — ONE floor-wide control instead of a per-agent toggle. */}
+        {/* v0.3.4：自动投递开关移到了 god 的 Command Center 头部 ——
+            一个整层级的控制，取代了每个 agent 各自的开关。 */}
         {snap?.autoDeliveryPaused && (
           <span style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>{t('agentControl.deliveryPaused')}</span>
         )}

--- a/src/renderer/src/components/AgentDetailPanel.tsx
+++ b/src/renderer/src/components/AgentDetailPanel.tsx
@@ -31,37 +31,31 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
   const [editOpen, setEditOpen] = useState(false);
 
   /**
-   * THE HEADER STRIP HAS TO GIVE SOMETHING UP WHEN THE SIDEBAR IS DRAGGED IN.
+   * 当侧栏被拖进来时，顶部操作条必须让出一些东西。
    *
-   * Four buttons with icon+label need about 246px on their own, and the
-   * portrait and gaps take another 72. The sidebar can be dragged down to
-   * 320px total (SidebarSplitter's `min`), so past a point there is simply
-   * not enough room for the labels AND the agent's name.
+   * 四个「图标 + 文字」按钮本身大约需要 246px，头像和间距还要再占 72。
+   * 侧栏最窄可以拖到 320px 总宽（SidebarSplitter 的 `min`），所以超过某个
+   * 点之后，放得下文字标签就放不下代理的名字。
    *
-   * Something has to yield, and the name is the one thing in this row that
-   * cannot: it is how you know WHICH agent you are looking at. So below the
-   * threshold the buttons drop their words and keep their icons — the tooltip
-   * and aria-label on each already carry the full explanation, so nothing is
-   * actually lost, and the ~110px that frees goes back to the name.
+   * 总得有东西让步，而这行里唯一不能让的就是名字：它是你判断「正在看哪个
+   * 代理」的依据。因此在阈值以下时，按钮只保留图标、去掉文字——每个按钮的
+   * tooltip 和 aria-label 已经带有完整说明，实际上并没有丢失信息，腾出的
+   * ~110px 全部还给了名字。
    *
-   * Measured on the strip itself rather than on `sidebarWidth`, because the
-   * strip's width is set by its container and NOT by what is inside it. That
-   * is what makes a single threshold safe here: swapping labels for icons
-   * cannot change the number being compared, so the row cannot oscillate.
+   * 这里按操作条本身的宽度测量，而不是 `sidebarWidth`，因为操作条的宽度由
+   * 它的容器决定，而不是由内部内容决定。这正是单个阈值在此安全的原因：
+   * 把文字换成图标不会改变被比较的那个数，因此这一行不会来回抖动。
    *
-   * WHERE 440 COMES FROM. Everything that is not the name costs ~318px: the
-   * four buttons measure ~246 at Inter 13px, the portrait 32, and the five
-   * 8px gaps another 40. The name is set in Press Start 2P, which is a
-   * fixed-advance pixel font — at fontSize 10 that is a flat 10px per
-   * character, plus 17 for the rename pencil beside it. Ten readable
-   * characters therefore need 117, and 318 + 117 rounds to 440.
+   * 440 从何而来。除名字外的所有东西大约占 318px：四个按钮在 Inter 13px
+   * 下实测约 246，头像 32，五个 8px 间距又占 40。名字使用 Press Start 2P
+   * 这种等宽像素字体——在 fontSize 10 下每个字符恰好 10px，再加上旁边重命名
+   * 铅笔的 17。十个可读字符因此需要 117，318 + 117 四舍五入就是 440。
    *
-   * That threshold deliberately puts the DEFAULT 420px sidebar in compact
-   * mode. It has to: at 420 the labelled row leaves the name about 67px,
-   * which is six pixel-font characters — the "DWIGHT S." truncation this was
-   * reported as. Icons at the default width is the fix, not a side effect.
+   * 这个阈值有意让默认的 420px 侧栏进入紧凑模式。必须如此：在 420 时，带
+   * 文字标签的行只能给名字留约 67px，也就是六个像素字宽——这正是被报告为
+   * "DWIGHT S." 截断的情况。默认宽度下只显示图标才是修复，而非副作用。
    *
-   * Recompute the number if a fifth button lands in this row or a label grows.
+   * 如果这一行再加入第五个按钮，或某个标签变长，请重新计算这个数值。
    */
   const headerRef = useRef<HTMLDivElement | null>(null);
   const [compactHeader, setCompactHeader] = useState(false);
@@ -83,16 +77,15 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
   const sidebarTab = useStore(s => s.sidebarTab);
   const setSidebarTab = useStore(s => s.setSidebarTab);
   const isReal = !!agent.ptyId;
-  // While this agent is shown in the fullscreen overlay, the fullscreen view
-  // owns the pty (it sizes it to fill the screen). Keeping the embedded terminal
-  // mounted too means two xterms fight over the pty's cols/rows — which corrupts
-  // the display and breaks scrolling. So we unmount the embedded one here; it
-  // re-mounts and re-fits when fullscreen closes.
+  // 当此代理显示在全屏浮层中时，全屏视图拥有这个 pty（它会调整大小以铺满
+  // 屏幕）。如果同时挂载内嵌终端，两个 xterm 会争抢 pty 的 cols/rows——
+  // 导致显示损坏、滚动失灵。所以这里卸载内嵌终端；全屏关闭后它会重新挂载
+  // 并重新适配。
   const isFullscreenedHere = fullscreenAgentId === agent.id;
 
   const onPtyStream = usePtyParser(agent.id);
 
-  // Michael gets the full command-center dashboard instead of the plain panel.
+  // Michael 会看到完整的指挥中心仪表盘，而不是普通面板。
   if (agent.isGod) return <CommandCenterPanel agent={agent} />;
 
   const openTerminal = async () => {
@@ -105,7 +98,7 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
         setTimeout(() => setOpenTerminalState('idle'), 1500);
       } else {
         setOpenTerminalState('error');
-        setOpenTerminalError(result.error ?? 'unknown error');
+        setOpenTerminalError(result.error ?? '未知错误');
         setTimeout(() => setOpenTerminalState('idle'), 4000);
       }
     } catch (e) {
@@ -135,7 +128,7 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
       }}
       noPadding
     >
-      {/* Thin header strip */}
+      {/* 细头部条 */}
       <div ref={headerRef} style={{
         display: 'flex', alignItems: 'center', gap: 8,
         padding: '6px 8px',
@@ -176,14 +169,14 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
           <span
             className="cth-tip cth-tip-wrap"
             data-tip={`Edit ${agent.name}: their name and face, which engine they run on, and the briefing that tells them what they are for.`}
-            aria-label="Edit this agent"
+            aria-label={t('agentDetail.editAria')}
             style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
           >
             <Icon name="edit" />{!compactHeader && ' edit'}
           </span>
         </PixelButton>
-        {/* v0.3.4: the IDE lives at agent level (replaces the old files tab) —
-            opens the full-window Monaco editor rooted at this agent's workspace. */}
+        {/* v0.3.4：IDE 位于 agent 层级（取代了旧的 files 标签）——
+            打开以该 agent 工作区为根的整窗 Monaco 编辑器。 */}
         <PixelButton variant="secondary" size="sm" onClick={() => useStore.getState().setIdeOpen(true, agent.id)}>
           <span
             className="cth-tip cth-tip-wrap"
@@ -195,9 +188,9 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
           </span>
         </PixelButton>
         <PixelButton variant="secondary" size="sm" onClick={openTerminal} disabled={openTerminalState === 'opening'}>
-          {/* "open" said nothing about WHAT opens, sitting in a row where IDE
-              and Talk both also open something. The label names the thing you
-              get; the tip names the folder you get it in. */}
+          {/* "open" 没说明打开的是什么，而这排里 IDE 和 Talk
+              也都会打开某种东西。标签写清楚你得到什么；
+              提示则写明你在哪个文件夹里得到它。 */}
           <span
             className="cth-tip cth-tip-wrap"
             data-tip={t('agentDetail.terminalTip', { cwd: agent.cwd })}
@@ -205,9 +198,8 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
             style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
           >
             <Icon name="terminal" />
-            {/* The transient states survive compact mode: they are feedback on
-                a click you just made, and they are two characters wide. Only
-                the resting word "terminal" is worth its space. */}
+            {/* 瞬时状态在紧凑模式下保留：它们是对你刚做的点击的反馈，
+                且只有两个字符宽。只有静止的 "terminal" 一词才值得占据空间。 */}
             {openTerminalState === 'opening' ? t('agentDetail.opening')
               : openTerminalState === 'ok' ? t('agentDetail.ok')
               : openTerminalState === 'error' ? t('agentDetail.err')
@@ -230,13 +222,13 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
         }}>{openTerminalError}</div>
       )}
 
-      {/* #7C — operator control (pause / halt / steer) for live agents */}
+      {/* #7C —— 在线 agent 的操作控制（暂停 / 停止 / 引导） */}
       {isReal && <AgentControlStrip agentId={agent.id} />}
 
-      {/* Tabs */}
+      {/* 标签页 */}
       <SidebarTabs current={sidebarTab} accent={agent.accent} onChange={setSidebarTab} />
 
-      {/* Active tab body — fills remaining space */}
+      {/* 当前标签页主体 —— 填充剩余空间 */}
       <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
         {sidebarTab === 'terminal' && (
           isReal && agent.ptyId ? (

--- a/src/renderer/src/components/AgentHoldButton.tsx
+++ b/src/renderer/src/components/AgentHoldButton.tsx
@@ -4,33 +4,31 @@ import { Icon } from './Icon';
 import { useStore } from '@/store/store';
 
 /**
- * 1:1 — "I have this agent, Michael stop sending it work."
+ * 1:1 —— "我要单独占用这个 agent，Michael 别再派活给它了。"
  *
- * Lives in `AgentControlStrip` beside "block tools" and "stop after this step",
- * so it is present in both sidebar and focus mode. It was briefly in the title
- * bar, which focus mode covers, making it invisible in the one mode you are
- * most likely to be in during a 1:1.
+ * 位于 `AgentControlStrip` 中，紧挨"屏蔽工具"和"本步之后停止"，
+ * 因此在侧边栏和焦点模式中都可见。它曾短暂出现在标题栏，
+ * 而标题栏会被焦点模式遮住，使它在 1:1 时最可能用到的那个模式里不可见。
  *
- * It is a different KIND of control from the two it sits with, and the tooltip
- * carries that since the grouping no longer does: those two restrain the AGENT
- * (take its tools, or stop it after this step), while this one restrains
- * MICHAEL. The agent keeps running and keeps answering you. "Stop after this
- * step" is in fact the worst thing to reach for in a 1:1, because it stops the
- * agent you wanted to talk to.
+ * 它与旁边的两个控件是不同"种类"，由于分组不再能表达这一点，
+ * 就由 tooltip 承担：那两者约束的是 AGENT（拿走它的工具，或在本步之后
+ * 停止它），而这个控件约束的是 MICHAEL。agent 继续运行、继续回答你。
+ * 事实上，在 1:1 中"本步之后停止"是最不该用的，因为它会停掉
+ * 你想对话的那个 agent。
  *
- * Never rendered for Michael himself: telling the orchestrator to stop routing
- * work to itself is not a state worth having.
+ * 绝不为 Michael 本人渲染：告诉编排器停止把活派给它自己，
+ * 并不是一个值得存在的状态。
  */
 export function AgentHoldButton({ agentId }: { agentId: string }) {
   const agent = useStore((s) => s.agents.find((a) => a.id === agentId));
   const godName = useStore((s) => s.agents.find((a) => a.isGod)?.name) ?? 'the orchestrator';
   const [busy, setBusy] = useState(false);
-  /** Last failure, shown on the button itself. A control that silently does
-   *  nothing is worse than one that says why. */
+  /** 最近一次失败，显示在按钮本身上。一个默默无作为的控件
+   *  比一个会说明原因的控件更糟。 */
   const [err, setErr] = useState<string | null>(null);
 
-  // The registry is the record and it survives restarts, so the store's copy
-  // can be stale on a fresh launch. Read it back once per agent.
+  // 注册表才是记录，并且能跨重启存活，因此 store 的副本在全新启动时
+  // 可能已经过期。每个 agent 只回读一次。
   useEffect(() => {
     let alive = true;
     window.cth.hiveRegistry?.().then((reg) => {
@@ -39,7 +37,7 @@ export function AgentHoldButton({ agentId }: { agentId: string }) {
       if (onHold !== !!useStore.getState().agents.find((a) => a.id === agentId)?.onHold) {
         useStore.getState().updateAgent(agentId, { onHold });
       }
-    }).catch(() => { /* no hive — the button is harmless either way */ });
+    }).catch(() => { /* 无 hive —— 按钮在两种情况下都无害 */ });
     return () => { alive = false; };
   }, [agentId]);
 
@@ -53,20 +51,20 @@ export function AgentHoldButton({ agentId }: { agentId: string }) {
       disabled={busy}
       onClick={() => {
         setBusy(true);
-        // Promise.resolve().then(...) rather than calling straight into the
-        // bridge: on a dev build whose PRELOAD predates this feature the method
-        // is undefined, and the resulting TypeError is thrown SYNCHRONOUSLY out
-        // of onClick, so `finally` never runs and the button stays disabled
-        // until React remounts it. Which is exactly how this was reported.
-        // Preload is not hot-reloaded; only a restart picks it up.
+        // 用 Promise.resolve().then(...) 而不是直接调用 bridge：
+        // 在 PRELOAD 早于该功能的开发构建中，该方法未定义，
+        // 由此产生的 TypeError 会从 onClick 中同步抛出，
+        // 于是 `finally` 永远不执行，按钮会一直处于禁用状态，
+        // 直到 React 重新挂载它。这正是当初报告的故障。
+        // Preload 不会热重载；只有重启才能让它生效。
         void Promise.resolve()
           .then(() => window.cth.hiveSetAgentHold?.(agentId, !on)
-            ?? Promise.reject(new Error('restart the app: this build\'s preload predates the 1:1 control')))
-          // Mirror locally only after main confirms the write. Flipping
-          // optimistically would show a hold Michael never heard about.
+            ?? Promise.reject(new Error('重启应用：此构建的 preload 早于 1:1 控制功能')))
+          // 仅在主进程确认写入后再在本地镜像。乐观翻转会显示一个
+          // Michael 从未听说过的 hold。
           .then((r) => {
             if (r?.ok) { setErr(null); useStore.getState().updateAgent(agentId, { onHold: !on }); }
-            else setErr(r?.error ?? 'could not set the hold');
+            else setErr(r?.error ?? '无法设置 hold');
           })
           .catch((e: unknown) => setErr(e instanceof Error ? e.message : String(e)))
           .finally(() => setBusy(false));
@@ -75,12 +73,12 @@ export function AgentHoldButton({ agentId }: { agentId: string }) {
       <span
         className="cth-tip cth-tip-wrap"
         data-tip={err ? err : on
-          ? `End the 1:1. ${godName} can hand ${agent.name} work again.`
-          : `Take ${agent.name} aside. ${godName} stops sending them work until you end it. Unlike the two buttons here, this does not restrain the agent: they keep running and keep answering you.`}
-        aria-label={on ? `End the 1:1 and release this agent to ${godName}` : 'Take this agent aside for a 1:1'}
+          ? `结束 1:1。${godName} 可以重新把工作交给 ${agent.name}。`
+          : `把 ${agent.name} 拉到一边。在你结束之前，${godName} 不会再给它派活。与这里的两个按钮不同，这并不会限制 agent：它照常运行、照常回答你。`}
+        aria-label={on ? `结束 1:1，将 agent 交还给 ${godName}` : '把 agent 拉到一边进行 1:1'}
         style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
       >
-        <Icon name={on ? 'pause' : 'play'} /> {err ? '1:1 failed' : on ? 'in 1:1' : '1:1'}
+        <Icon name={on ? 'pause' : 'play'} /> {err ? '1:1 失败' : on ? '1:1 进行中' : '1:1'}
       </span>
     </PixelButton>
   );

--- a/src/renderer/src/components/AgentNameEditor.tsx
+++ b/src/renderer/src/components/AgentNameEditor.tsx
@@ -1,21 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { isComposingKey } from '@shared/imeGuard';
 
 export interface AgentNameEditorProps {
   name: string;
   onCommit: (name: string) => Promise<{ ok: boolean; error?: string }>;
-  /** Cards render names in their established all-caps display style. */
+  /** 卡片以既定的大写显示样式渲染名称。 */
   uppercase?: boolean;
   fontSize?: number | string;
 }
 
-/** Inline display-name editor shared by the floor card and agent detail header. */
+/** 由底层卡片和 agent 详情头部共享的内联显示名编辑器。 */
 export function AgentNameEditor({
   name,
   onCommit,
   uppercase = false,
   fontSize = 'var(--cth-text-display-sm)'
 }: AgentNameEditorProps) {
+  const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(name);
   const [error, setError] = useState<string>();
@@ -36,7 +38,7 @@ export function AgentNameEditor({
     if (committing.current || cancelling.current) return;
     const nextName = draft.trim();
     if (!nextName) {
-      setError('Name is required');
+      setError(t('agentNameEditor.nameRequired'));
       return;
     }
     if (nextName === name) {
@@ -49,9 +51,9 @@ export function AgentNameEditor({
     try {
       const result = await onCommit(nextName);
       if (result.ok) setEditing(false);
-      else setError(result.error ?? 'Could not rename agent');
+      else setError(result.error ? t('agentNameEditor.renameFailedPrefix', { err: result.error }) : t('agentNameEditor.renameFailed'));
     } catch (commitError) {
-      setError(commitError instanceof Error ? commitError.message : 'Could not rename agent');
+      setError(commitError instanceof Error ? commitError.message : t('agentNameEditor.renameFailed'));
     } finally {
       committing.current = false;
     }
@@ -63,7 +65,7 @@ export function AgentNameEditor({
         autoFocus
         draggable={false}
         value={draft}
-        aria-label={`Rename ${name}`}
+        aria-label={t('agentNameEditor.renameAria', { name })}
         title={error}
         onFocus={(event) => event.currentTarget.select()}
         onChange={(event) => setDraft(event.target.value)}
@@ -72,8 +74,8 @@ export function AgentNameEditor({
         onBlur={() => { void commit(); }}
         onKeyDown={(event) => {
           event.stopPropagation();
-          // Still stop propagation for a composition key: it belongs to this
-          // input's IME, not to a global hotkey.
+          // 仍要为组合键停止事件传播：它属于这个输入框的 IME，
+          // 而不是全局热键。
           if (isComposingKey(event)) return;
           if (event.key === 'Enter') {
             event.preventDefault();

--- a/src/renderer/src/components/AgentStrip.tsx
+++ b/src/renderer/src/components/AgentStrip.tsx
@@ -9,8 +9,8 @@ import { useRestoreTeam } from '@/hooks/useRestoreTeam';
 import { useRtl } from '@/i18n/useDirection';
 
 export interface AgentStripProps {
-  /** Needed to rebuild a spawn command when a restorable agent predates the
-   *  persisted `command` field. Optional so the strip renders without config. */
+  /** 当可恢复 agent 早于持久化的 `command` 字段时，用于重建 spawn 命令。
+   *  可选，使条带在无配置时也能渲染。 */
   config?: HarnessConfig | null;
 }
 
@@ -26,12 +26,12 @@ export function AgentStrip({ config }: AgentStripProps) {
   const reorderAgents = useStore(s => s.reorderAgents);
   const renameAgent = useStore(s => s.renameAgent);
   const setAgentNote = useStore(s => s.setAgentNote);
-  // Shared with the fullscreen roster so both show one restore in progress.
+  // 与全屏花名册共享，让两侧都只显示一个"恢复中"状态。
   const { restoring, autoRestoring, restoreTeam } = useRestoreTeam(config);
-  // ONE restore control (bottom-right): a button whose dropdown OPENS UPWARD and
-  // lists last session's agents with per-agent dismiss. The menu is position:
-  // fixed (anchored off the button's rect) because the strip scrolls with
-  // overflow hidden — an absolute child would be clipped.
+  // 单个恢复控件（右下角）：一个向上展开的按钮下拉菜单，
+  // 列出上一会话的 agents 并支持逐个 dismiss。菜单用 position: fixed
+  // （以按钮矩形为锚点）定位，因为条带随 overflow hidden 滚动——
+  // 绝对定位的子元素会被裁剪。
   const [restoreMenuOpen, setRestoreMenuOpen] = useState(false);
   const [restoreMenuPos, setRestoreMenuPos] = useState<{ right: number; bottom: number } | null>(null);
   const restoreBtnRef = useRef<HTMLSpanElement>(null);
@@ -49,17 +49,17 @@ export function AgentStrip({ config }: AgentStripProps) {
     });
     setRestoreMenuOpen(true);
   };
-  // Drag-to-reorder the roster: dragId = the card being dragged, overId = the card
-  // currently hovered as a drop target (drives the insertion-line cue).
+  // 拖拽重排花名册：dragId = 正在拖拽的卡片，overId = 当前悬停作为
+  // 放置目标的卡片（驱动插入线提示）。
   const [dragId, setDragId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
-  // Note editing is EXPLICIT (✎ toggles the editor) — nothing appears on hover.
-  // The editor is a fixed popover ABOVE the card (anchored off its rect): the
-  // strip clips overflow and the compact cards have no room for an inline box.
+  // 备注编辑是显式的（✎ 切换编辑器）——悬停不会弹出任何东西。
+  // 编辑器是卡片上方的固定弹层（以卡片矩形为锚点）：条带会裁剪
+  // 溢出内容，而紧凑卡片也没有空间容纳内联输入框。
   const [noteEditId, setNoteEditId] = useState<string | null>(null);
   const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
-  // Each worker's actively-DOING ledger tasks, polled from hive/tasks.json —
-  // rendered as a sticky note on the avatar card (click → task detail).
+  // 每个 worker 正在执行中的台账任务，从 hive/tasks.json 轮询——
+  // 渲染为头像卡片上的便利贴（点击 → 任务详情）。
   const [doingByAgent, setDoingByAgent] = useState<Record<string, string[]>>({});
   useEffect(() => {
     let cancelled = false;
@@ -74,7 +74,7 @@ export function AgentStrip({ config }: AgentStripProps) {
           }
         }
         setDoingByAgent(map);
-      } catch { /* keep last good */ }
+      } catch { /* 保留上次有效数据 */ }
     };
     void poll();
     const iv = setInterval(() => { void poll(); }, 5000);
@@ -90,16 +90,16 @@ export function AgentStrip({ config }: AgentStripProps) {
       overflowY: 'hidden',
       borderTop: '1px solid var(--cth-ink-300)',
       background: 'var(--cth-cream-200)',
-      // Tall enough for the god card to stand proud of the row (it's taller and
-      // rides a drop shadow) plus the hover-lift on every card, without clipping.
+      // 高度要足以让 god 卡片在行中傲然挺立（它更高并带有投影），
+      // 还要容纳每张卡片的悬停上浮，且不能裁剪。
       height: 112,
       minHeight: 112,
       alignItems: 'center'
     }}>
       {agents.map(a => (
-        // Draggable wrapper: reorder the roster by dragging one card onto another.
-        // Native HTML5 DnD (no dep). A plain click still selects — a drag only
-        // starts on movement — so AgentCard's onClick is unaffected.
+        // 可拖拽包装：把一张卡片拖到另一张上来重排花名册。
+        // 原生 HTML5 DnD（无依赖）。普通点击仍会选择——只有移动才会
+        // 开始拖拽——因此 AgentCard 的 onClick 不受影响。
         <div
           key={a.id}
           ref={(el) => { cardRefs.current[a.id] = el; }}
@@ -124,7 +124,7 @@ export function AgentStrip({ config }: AgentStripProps) {
             flexShrink: 0,
             cursor: 'grab',
             opacity: dragId === a.id ? 0.4 : 1,
-            // Insertion-line cue on the hovered drop target.
+            // 悬停放置目标上的插入线提示。
             boxShadow: overId === a.id && dragId && dragId !== a.id
               ? 'inset 3px 0 0 0 var(--cth-ink-900)'
               : 'none',
@@ -155,10 +155,10 @@ export function AgentStrip({ config }: AgentStripProps) {
             note={a.note}
             onEditNote={a.isGod ? undefined : () => setNoteEditId(a.id)}
           />
-          {/* The note itself lives INSIDE the card (its own row above the gauge).
-              This is the transient EDITOR: a fixed popover ABOVE the card —
-              the compact card has no room for an inline box, and the strip
-              clips overflow. ✎ opens it; Esc / ✕ / click-away closes. */}
+          {/* 备注本身位于卡片内部（仪表上方自带一行）。
+              这是瞬态编辑器：卡片上方的一个固定弹层——
+              紧凑卡片没有容纳内联输入框的空间，且条带会裁剪溢出内容。
+              ✎ 打开它；Esc / ✕ / 点击外部关闭。 */}
           {noteEditId === a.id && !dragId && (() => {
             const rect = cardRefs.current[a.id]?.getBoundingClientRect();
             if (!rect) return null;
@@ -167,7 +167,7 @@ export function AgentStrip({ config }: AgentStripProps) {
             const bottom = Math.max(8, window.innerHeight - rect.top + 8);
             return (
               <>
-                {/* click-away backdrop */}
+                {/* 点击外部关闭的背景层 */}
                 <div
                   onClick={() => setNoteEditId(null)}
                   style={{ position: 'fixed', inset: 0, zIndex: 349, background: 'transparent' }}
@@ -201,9 +201,8 @@ export function AgentStrip({ config }: AgentStripProps) {
                       }}
                     >✕</button>
                   </div>
-                  {/* A textarea, not an input: the note is a bullet list (one
-                      line per bullet) and the fullscreen roster renders every
-                      line — an <input> would silently eat the newlines. */}
+                  {/* 用 textarea 而非 input：备注是项目符号列表（每行一条），
+                      全屏花名册会渲染每一行——用 <input> 会悄悄吞掉换行。 */}
                   <textarea
                     dir={rtl ? 'auto' : undefined}
                     autoFocus
@@ -241,11 +240,10 @@ export function AgentStrip({ config }: AgentStripProps) {
           <Icon name="plus" /> {t('agentStrip.addAgent')}
         </span>
       </PixelButton>
-      {/* ONE restore control, pinned to the strip's right edge. Busy (manual OR
-          boot auto-restore) collapses to a single disabled "restoring your
-          team…"; otherwise the button opens an upward dropdown listing last
-          session's agents (per-agent ✕ dismiss + restore all). No outcome note
-          is rendered afterwards — the restored agents appearing IS the outcome. */}
+      {/* 单个恢复控件，固定在条带右缘。忙碌时（手动 OR 开机自动恢复）
+          折叠成单个禁用的"正在恢复你的团队…"；否则按钮打开一个
+          向上展开的下拉菜单，列出上一会话的 agents（逐个 ✕ dismiss + 全部恢复）。
+          之后不渲染任何结果说明——恢复出的 agents 出现本身就说明成功了。 */}
       {(restorableAgents.length > 0 || restoreBusy) && (
         <span
           ref={restoreBtnRef}
@@ -269,7 +267,7 @@ export function AgentStrip({ config }: AgentStripProps) {
       )}
       {restoreMenuOpen && restoreMenuPos && restorableAgents.length > 0 && (
         <>
-          {/* click-away backdrop */}
+          {/* 点击外部关闭的背景层 */}
           <div
             onClick={() => setRestoreMenuOpen(false)}
             style={{ position: 'fixed', inset: 0, zIndex: 349, background: 'transparent' }}
@@ -288,9 +286,9 @@ export function AgentStrip({ config }: AgentStripProps) {
             }}>
               {t('agentStrip.previousSession')}
             </span>
-            {/* Per-agent dismiss wires straight to removeRestorableAgent
-                (filters + persistRestorable), so a dismissed agent never
-                reappears after reload. */}
+            {/* 逐 agent dismiss 直接接到 removeRestorableAgent
+                （过滤 + persistRestorable），因此被 dismiss 的 agent
+                在重载后再也不会出现。 */}
             {restorableAgents.map((a: Agent) => (
               <span
                 key={a.id}

--- a/src/renderer/src/components/AiEnginesSettings.tsx
+++ b/src/renderer/src/components/AiEnginesSettings.tsx
@@ -7,18 +7,18 @@ import { OSS_BLOG_LINKS } from '@shared/ossModels';
 import { useStore } from '@/store/store';
 
 /**
- * AiEnginesSettings — the v0.3.1 per-provider config surface for the BYOK CLI
- * engines (OpenCode · Crush · pi.dev · Qwen). Two stores by what the datum is:
- *  - API keys → WRITE-ONLY in the secret broker (`providerKey:*` IPC). Keyed by the
- *    BACKEND model-provider (anthropic/openai/…). The field shows only set/not-set;
- *    the plaintext is never read back to the renderer (materialized MAIN-only at spawn).
- *  - Local base-URL + default model → HarnessConfig (`providerBaseUrls` /
- *    `providerDefaultModels`), keyed by CLI provider. Non-secret; normal config save.
- * See hive/shared/cli-agents/settings-ui-schema.md.
+ * AiEnginesSettings —— BYOK CLI 引擎（OpenCode · Crush · pi.dev · Qwen）的
+ * v0.3.1 按 provider 的配置界面。按数据类型分成两类存储：
+ *  - API 密钥 → 在 secret broker 中只写（`providerKey:*` IPC）。按
+ *    BACKEND 模型提供方（anthropic/openai/…）键控。字段只显示已设置/未设置；
+ *    明文永远不会回读给 renderer（在 spawn 时仅于 MAIN 侧物化）。
+ *  - 本地 base-URL + 默认模型 → HarnessConfig（`providerBaseUrls` /
+ *    `providerDefaultModels`），按 CLI provider 键控。非机密；普通配置保存。
+ * 参见 hive/shared/cli-agents/settings-ui-schema.md。
  */
 
-/** Backend model-providers whose keys the CLIs read from standard env vars. Must
- *  match BACKEND_KEY_ENV in src/main/index.ts. */
+/** CLI 从标准环境变量读取其密钥的后端模型提供方。必须
+ *  与 src/main/index.ts 中的 BACKEND_KEY_ENV 匹配。 */
 const BACKENDS: Array<{ id: string; label: string; envVar: string }> = [
   { id: 'anthropic', label: 'Anthropic', envVar: 'ANTHROPIC_API_KEY' },
   { id: 'openai', label: 'OpenAI', envVar: 'OPENAI_API_KEY' },
@@ -27,13 +27,10 @@ const BACKENDS: Array<{ id: string; label: string; envVar: string }> = [
   { id: 'groq', label: 'Groq', envVar: 'GROQ_API_KEY' }
 ];
 
-/** CLI engines that take a per-provider local base-URL + default model. `hint`
- *  values are technical endpoint descriptions — kept English (technical data). */
+/** 接受按 provider 的本地 base-URL + 默认模型的 CLI 引擎。`hint`
+ *  值是技术性的端点描述——保持英文（技术数据）。 */
 const CLIS: Array<{ id: AgentProvider; label: string; hint: string }> = [
-  { id: 'opencode', label: 'OpenCode', hint: 'http://localhost:11434/v1 (Ollama) — injected as a local provider' },
-  { id: 'crush', label: 'Crush', hint: 'OpenAI-compatible endpoint — used as the proxy upstream' },
-  { id: 'pi', label: 'Pi', hint: 'local models are file-based (models.json); base-URL reserved' },
-  { id: 'qwen', label: 'Qwen', hint: 'OpenAI-compatible endpoint — used as the proxy upstream' }
+  { id: 'qwen', label: 'Qwen', hint: 'OpenAI 兼容端点——用作代理上游' }
 ];
 
 const inputStyle: CSSProperties = {
@@ -62,16 +59,16 @@ const linkStyle: CSSProperties = { color: 'var(--cth-ink-900)', textDecoration: 
 
 export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
   const { t } = useTranslation();
-  // Keep the global "OpenAI key present" signal (boolean only) live so the Talk
-  // button's missing-key warning clears the instant the user saves their OpenAI key
-  // here — without it the gate only refreshes on next app start. apikey:openai is
-  // the same key the Realtime mint reads; saving/clearing it flips the gate.
+  // 让全局"存在 OpenAI 密钥"信号（仅布尔值）保持最新，这样 Talk 按钮的
+  // 缺密钥警告会在用户在此保存 OpenAI 密钥的瞬间立即消失——没有它，
+  // 该门只在下次应用启动时才刷新。apikey:openai 正是 Realtime mint
+  // 读取的同一把密钥；保存/清除它会翻转该门。
   const setHasOpenAiKey = useStore((s) => s.setHasOpenAiKey);
-  // Which backends already have a key stored (boolean only — never the value).
+  // 哪些后端已经存了密钥（仅布尔值——绝不含值本身）。
   const [hasKey, setHasKey] = useState<Record<string, boolean>>({});
   const [draftKey, setDraftKey] = useState<Record<string, string>>({});
   const [note, setNote] = useState<Record<string, string>>({});
-  // Base-URL + default-model drafts, seeded from config.
+  // Base-URL + 默认模型草稿，从配置中播种。
   const [baseUrls, setBaseUrls] = useState<Partial<Record<AgentProvider, string>>>(
     config.providerBaseUrls ?? {}
   );
@@ -79,7 +76,7 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
     config.providerDefaultModels ?? {}
   );
 
-  // Reseed set/not-set flags on mount (write-only — only the boolean is fetched).
+  // 挂载时重新播种已设置/未设置标志（只写——只取回布尔值）。
   useEffect(() => {
     let alive = true;
     (async () => {
@@ -101,7 +98,7 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
         setHasKey((s) => ({ ...s, [backend]: true }));
         setDraftKey((s) => ({ ...s, [backend]: '' }));
         setNote((s) => ({ ...s, [backend]: t('aiEngines.saved') }));
-        // OpenAI key gates Talk — mirror presence to the store so the warning clears now.
+        // OpenAI 密钥控制 Talk——镜像存在性到 store，让警告立即清除。
         if (backend === 'openai') setHasOpenAiKey(true);
       } else setNote((s) => ({ ...s, [backend]: r.error ?? t('aiEngines.failed') }));
     } catch (e) { setNote((s) => ({ ...s, [backend]: e instanceof Error ? e.message : String(e) })); }
@@ -111,7 +108,7 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
       await window.cth.providerKeyClear(backend);
       setHasKey((s) => ({ ...s, [backend]: false }));
       setNote((s) => ({ ...s, [backend]: t('aiEngines.cleared') }));
-      // OpenAI key gates Talk — clearing it disables Talk; reflect that immediately.
+      // OpenAI 密钥控制 Talk——清除它会禁用 Talk；立即反映出来。
       if (backend === 'openai') setHasOpenAiKey(false);
     } catch { /* noop */ }
   };
@@ -136,7 +133,7 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
         </div>
       </div>
 
-      {/* Backend API keys (write-only) */}
+      {/* 后端 API 密钥（只写） */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
         <div style={headStyle}>{t('aiEngines.apiKeys')}</div>
         {BACKENDS.map((b) => (
@@ -163,7 +160,7 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
         ))}
       </div>
 
-      {/* Per-CLI local endpoint + default model */}
+      {/* 按 CLI 的本地端点 + 默认模型 */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={headStyle}>{t('aiEngines.localEndpoint')}</div>
         {CLIS.map((c) => (
@@ -187,7 +184,7 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
             </div>
           </div>
         ))}
-        {/* Local-setup guides (ondev-c part-3) — link the two how-to blogs. */}
+        {/* 本地搭建指南（ondev-c part-3）——链接两篇 how-to 博客。 */}
         <div style={{ fontSize: 12, color: 'var(--cth-ink-700)', lineHeight: '17px' }}>
           {t('aiEngines.runningOpenModels')}{' '}
           <a
@@ -204,7 +201,7 @@ export function AiEnginesSettings({ config }: { config: HarnessConfig }) {
         </div>
       </div>
 
-      {/* Unsandboxed-in-auto caveat (Pam guardrail #6) */}
+      {/* 自动模式下非沙箱的注意事项（Pam 护栏 #6） */}
       <div style={{
         fontSize: 12, color: 'var(--cth-ink-700)', lineHeight: '17px',
         padding: 8, boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)', background: 'var(--cth-paper-100)'

--- a/src/renderer/src/components/AskMeTab.tsx
+++ b/src/renderer/src/components/AskMeTab.tsx
@@ -10,21 +10,20 @@ import { isComposingKey } from '@shared/imeGuard';
 import { useRtl } from '@/i18n/useDirection';
 
 /**
- * ASK ME — first-class human feedback through the task system.
+ * ASK ME —— 通过任务系统提供的一等公民式人工反馈。
  *
- * Tasks the god can only move with the human's input sit here. An entry isn't
- * necessarily a question — it can be a TO-DO only the human can perform
- * (create an account, approve a purchase, provide credentials, test on a real
- * device). Each card shows the open ask, a place to respond (an answer, or a
- * "done, here's the result" confirmation), and the CASCADE of downstream
- * tasks stuck waiting on this one — so "why isn't X done?" reads as "ah,
- * because I still owe something here."
+ * 只有依赖人类输入 god 才能推进的任务都放在这里。一条记录未必是问题——
+ * 它也可以是人类才能完成的待办事项（创建账号、审批购买、提供凭证、
+ * 在真实设备上测试）。每张卡片都显示未解决的询问、一个回复的位置
+ * （一个答案，或一句"完成，这是结果"的确认），以及下游那些
+ * 卡在这条上的任务级联 —— 于是"为什么 X 还没做完？"读起来就是
+ * "啊，因为我在这里还欠着些什么。"
  *
- * Sending an answer does two things:
- *   1. writes it into the card's humanQA entry in hive/tasks.json (the
- *      decision is documented ON the task, forever), and
- *   2. mails the god so it picks the answer up, unblocks the card, and the
- *      work continues — no separate HumanQuestion.md side-channel anymore.
+ * 发送答案会做两件事：
+ *   1. 把它写进卡片在 hive/tasks.json 中的 humanQA 条目（该决定会
+ *      永久记录在任务上），以及
+ *   2. 给 god 发信，让它接收答案、解锁卡片、继续工作——
+ *      不再需要单独的 HumanQuestion.md 旁路通道。
  */
 
 const POLL_MS = 5000;
@@ -36,7 +35,7 @@ function parse(raw: unknown): HiveTask[] {
   return list.filter((t) => !!t && typeof t === 'object');
 }
 
-/** All tasks transitively waiting on `id` (dependents chain), cycle-safe. */
+/** 所有传递性等待 `id` 的任务（依赖链），循环安全。 */
 function dependentsTree(id: string, all: HiveTask[], seen = new Set<string>()): HiveTask[] {
   if (seen.has(id)) return [];
   seen.add(id);
@@ -50,8 +49,8 @@ export function AskMeTab() {
   const agents = useStore((s) => s.agents);
   const restorable = useStore((s) => s.restorableAgents);
   const [tasks, setTasks] = useState<HiveTask[]>([]);
-  // Drafts live in the STORE (keyed by task id) — switching tabs unmounts this
-  // view, and a half-typed answer must survive the round trip.
+  // 草稿存在 STORE 中（按任务 id 键控）——切换标签页会卸载本视图，
+  // 打了一半的答案必须在往返过程中存活下来。
   const drafts = useStore((s) => s.answerDrafts);
   const setAnswerDraft = useStore((s) => s.setAnswerDraft);
   const openTaskDetail = useStore((s) => s.openTaskDetail);
@@ -59,7 +58,7 @@ export function AskMeTab() {
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
-    try { setTasks(parse(await window.cth.hiveTasks())); } catch { /* keep last good */ }
+    try { setTasks(parse(await window.cth.hiveTasks())); } catch { /* 保留上次有效数据 */ }
   }, []);
 
   useEffect(() => {
@@ -71,27 +70,25 @@ export function AskMeTab() {
   const nameFor = (id?: string): string | undefined =>
     id ? (agents.find((a) => a.id === id)?.name ?? restorable.find((a) => a.id === id)?.name ?? id) : undefined;
 
-  // Newest ask at the top, oldest at the bottom. Before this the board had no
-  // comparator at all, so a question's position was an accident of where its
-  // card sat in tasks.json. `filter` already returns a fresh array, so sorting
-  // in place never touches the store's own ordering. The ask each card is
-  // ranked by comes from openQuestion() — the same predicate waitsOnHuman uses
-  // — and only this OUTER list is sorted; a card's humanQA history stays
-  // chronological (see askMeOrder.ts).
+  // 最新的询问在最上面，最旧的在最下面。在此之前看板完全没有比较器，
+  // 因此问题的位置取决于它的卡片在 tasks.json 中的位置，纯属偶然。
+  // `filter` 返回的本来就是新数组，所以原地排序绝不会触碰 store 自身的顺序。
+  // 每张卡片用来排名的询问来自 openQuestion() —— 与 waitsOnHuman 使用的
+  // 是同一个谓词 —— 并且只有这层外层列表被排序；卡片的 humanQA 历史
+  // 始终保持时间顺序（见 askMeOrder.ts）。
   const waiting = tasks
     .filter(waitsOnHuman)
     .sort((a, b) => compareByNewestAsk(openQuestion(a), openQuestion(b)));
 
   /**
-   * Apply `patch` to the OPEN humanQA entry of one card, on the RAW ledger.
-   * Returns whether it landed.
+   * 在原始账本上把 `patch` 应用到一张卡片的 OPEN humanQA 条目上。
+   * 返回是否落地成功。
    *
-   * Re-reads tasks.json first rather than writing this view's 5s-old snapshot,
-   * because `hive:writeTasks` treats the incoming array as the card MEMBERSHIP:
-   * writing our snapshot back would delete any card the god added since the last
-   * poll. Re-locating the open question by its text also means an answer can
-   * never land on a different question the god swapped in underneath us — in
-   * that case nothing is written and the draft is kept.
+   * 先重新读取 tasks.json，而不是写入本视图那份 5 秒前的快照，
+   * 因为 `hive:writeTasks` 把传入的数组当作卡片 MEMBERSHIP（成员集合）：
+   * 若把我们自己的快照写回去，就会删掉自上次轮询以来 god 新增的任何卡片。
+   * 按文本重新定位未解决的问题还意味着答案绝不会落到 god 在
+   * 我们脚下换掉的另一个问题上——那种情况下什么都不写，草稿被保留。
    */
 
   const sendAnswer = async (task: HiveTask) => {
@@ -100,7 +97,7 @@ export function AskMeTab() {
     if (!text || !open || sending) return;
     setSending(task.id);
     try {
-      // 1) Document the answer ON the card.
+      // 1) 把答案记录在卡片上。
       const next = tasks.map((t) => {
         if (t.id !== task.id) return t;
         const qa = (t.humanQA ?? []).map((e) =>
@@ -114,30 +111,30 @@ export function AskMeTab() {
       const result = updated
         ? await window.cth.hivePatchTask(task.id, { humanQA: updated.humanQA })
         : { ok: false };
-      if (!result.ok) throw new Error('task changed before answer could be saved');
+      if (!result.ok) throw new Error('答案保存前任务已发生变化');
       setTasks(next);
-      // 2) Tell the god, so the card gets unblocked and work continues.
+      // 2) 告知 god，让卡片被解锁并继续工作。
       await window.cth.hiveSend({
         to: 'god',
         act: 'inform',
-        subject: `HUMAN ANSWER on task "${task.title}"`,
+        subject: `用户已作答，任务「${task.title}」`,
         body: [
-          `The human answered the open question on task ${task.id} ("${task.title}"):`,
-          `Q: ${open.q}`,
-          `A: ${text}`,
-          'The answer is also recorded in the card\'s humanQA. Act on it, unblock the card, and continue the work.'
+          `用户已回答了任务 ${task.id}（"${task.title}"）上的开放问题：`,
+          `问：${open.q}`,
+          `答：${text}`,
+          '该答案也已记录在卡片的 humanQA 中。请据此处理、解锁卡片，并继续工作。'
         ].join('\n')
       }, 'human');
       setAnswerDraft(task.id, '');
-    } catch { /* leave the draft so the user can retry */ }
+    } catch { /* 保留草稿以便用户重试 */ }
     setSending(null);
   };
 
-  // Dismiss the open ask off the ASK ME board WITHOUT answering it. We mark the
-  // open humanQA entry `dismissedAt` (no fabricated answer) so openQuestion()
-  // stops returning it and the card leaves this view — the question itself stays
-  // on the card, so the Q&A history is never dropped (protocol). The task stays
-  // blocked on the kanban; the god can re-ask by appending a fresh humanQA entry.
+  // 在不作答的情况下把未解决的询问从 ASK ME 看板上移除。我们把未解决的
+  // humanQA 条目标记为 `dismissedAt`（不编造答案），这样 openQuestion()
+  // 就不再返回它、卡片离开本视图——问题本身仍留在卡片上，
+  // 所以问答历史永远不会丢失（协议）。任务在看板上保持 blocked；
+  // god 可以追加一条新的 humanQA 条目来重新提问。
   const dismiss = async (task: HiveTask) => {
     const open = openQuestion(task);
     if (!open || sending === task.id) return;
@@ -150,22 +147,22 @@ export function AskMeTab() {
       );
       return { ...t, humanQA: qa };
     });
-    setTasks(next); // optimistic — the card disappears immediately
+    setTasks(next); // 乐观更新 —— 卡片立即消失
     try {
       const updated = next.find((candidate) => candidate.id === task.id);
       const result = updated
         ? await window.cth.hivePatchTask(task.id, { humanQA: updated.humanQA })
         : { ok: false };
-      if (!result.ok) throw new Error('task changed before ask could be dismissed');
+      if (!result.ok) throw new Error('在问询被关闭前任务已发生变化');
     } catch {
-      setTasks(tasks); // restore on failure so the user can retry
+      setTasks(tasks); // 失败时还原，让用户可以重试
     }
   };
 
   return (
-    // Body text is set in the mono face (VT323) — the same readable font the
-    // memory viewer uses. Pixelify Sans (font-ui) is too chunky for prose like
-    // questions and answers. Display/badge bits keep their explicit faces.
+    // 正文文本使用等宽字体（VT323）——与内存查看器相同的可读字体。
+    // Pixelify Sans（font-ui）对问答这类散文来说太厚重。
+    // 显示/徽章部分保留各自明确指定的字体。
     <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--cth-paper-200)', padding: 10, display: 'flex', flexDirection: 'column', gap: 10, fontFamily: 'var(--cth-font-mono)' }}>
       {waiting.length === 0 && (
         <div style={{ textAlign: 'center', padding: '24px 12px', color: 'var(--cth-ink-500)', fontSize: 12 }}>
@@ -183,7 +180,7 @@ export function AskMeTab() {
             background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
             display: 'flex', flexDirection: 'column'
           }}>
-            {/* header: title + assignee */}
+            {/* 头部：标题 + 负责人 */}
             <div style={{
               display: 'flex', alignItems: 'center', gap: 8, padding: '6px 9px',
               background: 'var(--cth-lilac-light, #ece2f5)', boxShadow: 'inset 0 -1px 0 var(--cth-ink-700)'
@@ -200,9 +197,8 @@ export function AskMeTab() {
                 {t.title}
               </button>
               {nameFor(t.assignee) && <PixelBadge status="blocked" label={nameFor(t.assignee)!} />}
-              {/* Dismiss — clears this ask off the board without answering it.
-                  The card's Q&A history is preserved (the question stays on the
-                  card, just marked dismissed). */}
+              {/* Dismiss —— 把此询问从看板移除但不作答。
+                  卡片的问答历史会被保留（问题仍留在卡片上，只是标记为已驳回）。 */}
               <button
                 onClick={() => void dismiss(t)}
                 disabled={sending === t.id}
@@ -221,16 +217,15 @@ export function AskMeTab() {
             </div>
 
             <div style={{ padding: 9, display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {/* The question, rendered as markdown. The god writes these with
-                  emphasis, lists, `code` and links; as plain text the asterisks
-                  and backticks were on screen literally. The card variant keeps
-                  this card's mono face and turns a single newline into a break, so
-                  a question with no markdown in it looks exactly as it did. */}
+              {/* 问题，以 markdown 渲染。god 写问题时带强调、列表、`code`
+                  和链接；若按纯文本显示，星号和反引号就会原样出现在屏幕上。
+                  card 变体保留本卡片的等宽字体，并把单个换行转成换行符，
+                  因此不含 markdown 的问题看起来和之前完全一样。 */}
               <div dir={rtl ? 'auto' : undefined} style={{ fontSize: 15, lineHeight: '19px', color: 'var(--cth-ink-900)' }}>
                 <MarkdownPreview source={open.q} variant="card" />
               </div>
 
-              {/* answer box */}
+              {/* 回答框 */}
               <textarea
                 dir={rtl ? 'auto' : undefined}
                 value={drafts[t.id] ?? ''}
@@ -274,7 +269,7 @@ export function AskMeTab() {
                 )}
               </div>
 
-              {/* the cascade: what's stuck behind this answer */}
+              {/* 级联：卡在这个答案后面的内容 */}
               {stuck.length > 0 && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                   <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 8, color: 'var(--cth-coral)' }}>

--- a/src/renderer/src/components/CodeEditor.tsx
+++ b/src/renderer/src/components/CodeEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import CodeMirror from '@uiw/react-codemirror';
 import { EditorView } from '@codemirror/view';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
@@ -13,7 +14,7 @@ import { yaml } from '@codemirror/lang-yaml';
 import { Icon } from './Icon';
 import { PixelButton } from './PixelButton';
 
-// ─── Theme matching CTH palette ─────────────────────────────────────────────
+// ─── 与 CTH 调色板匹配的主题 ─────────────────────────────────────────────
 const cthEditorTheme = EditorView.theme({
   '&': {
     background: '#FCFAF0',
@@ -67,10 +68,10 @@ function extensionsFor(filename: string) {
 
 export interface CodeEditorProps {
   root: string;
-  /** Relative file path within `root` */
+  /** `root` 内的相对文件路径 */
   filePath: string | null;
-  /** Escalate this file into the IDE. The sidebar editor is deliberately
-   *  small; the IDE is where tabs, the tree, git, and markdown preview live. */
+  /** 把此文件升级到 IDE 中。侧边栏编辑器刻意做得很小；
+   *   IDE 才是标签页、目录树、git 与 markdown 预览所在之处。 */
   onOpenInIde?: () => void;
   onCopyPath?: () => void;
 }
@@ -78,6 +79,7 @@ export interface CodeEditorProps {
 export function CodeEditor({
   root, filePath, onOpenInIde, onCopyPath
 }: CodeEditorProps) {
+  const { t } = useTranslation();
   const [content, setContent] = useState<string>('');
   const [originalContent, setOriginalContent] = useState<string>('');
   const [loading, setLoading] = useState(false);
@@ -85,7 +87,7 @@ export function CodeEditor({
   const [absPath, setAbsPath] = useState<string | undefined>();
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
 
-  // Load file on path change
+  // 路径变化时加载文件
   useEffect(() => {
     let cancelled = false;
     if (!filePath) {
@@ -129,7 +131,7 @@ export function CodeEditor({
     }
   }, [filePath, dirty, content, root]);
 
-  // Cmd-S to save
+  // Cmd-S 保存
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
@@ -162,13 +164,13 @@ export function CodeEditor({
           textTransform: 'uppercase', letterSpacing: 1,
           color: 'var(--cth-ink-700)'
         }}>
-          No file open
+          {t('codeEditor.noFileOpen')}
         </div>
         <div style={{
           fontFamily: 'var(--cth-font-ui)', fontSize: 13,
           color: 'var(--cth-ink-500)'
         }}>
-          Pick a file from the tree to view it here.
+          {t('codeEditor.pickFileToView')}
         </div>
       </div>
     );
@@ -180,7 +182,7 @@ export function CodeEditor({
       display: 'flex', flexDirection: 'column',
       background: 'var(--cth-paper-100)'
     }}>
-      {/* Mini header */}
+      {/* 迷你头部 */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 6,
         padding: '4px 8px',
@@ -196,23 +198,23 @@ export function CodeEditor({
         {onCopyPath && (
           <button
             onClick={onCopyPath}
-            title="Copy absolute path"
+            title={t('codeEditor.copyAbsolutePath')}
             style={editorBtn}
-          >copy path</button>
+          >{t('codeEditor.copyPath')}</button>
         )}
         <button
           onClick={save}
           disabled={!dirty || saveState === 'saving'}
-          title="Save (Cmd-S)"
+          title={t('codeEditor.saveTitle')}
           style={{ ...editorBtn, opacity: dirty ? 1 : 0.5 }}
         >
-          {saveState === 'saving' ? '...' : saveState === 'saved' ? 'saved' : saveState === 'error' ? 'err' : 'save'}
+          {saveState === 'saving' ? '...' : saveState === 'saved' ? t('codeEditor.saved') : saveState === 'error' ? t('codeEditor.err') : t('codeEditor.save')}
         </button>
         {onOpenInIde && (
           <button
             onClick={onOpenInIde}
-            title="Open in the IDE"
-            aria-label="Open in the IDE"
+            title={t('codeEditor.openInIde')}
+            aria-label={t('codeEditor.openInIdeAria')}
             style={editorBtn}
           >
             <Icon name="code" />
@@ -220,7 +222,7 @@ export function CodeEditor({
         )}
       </div>
 
-      {/* Body */}
+      {/* 主体 */}
       <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
         {loading ? (
           <div style={{ padding: 12, color: 'var(--cth-ink-500)' }}>loading…</div>

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -38,23 +38,22 @@ import { canReceiveInbox } from '@shared/agentProvider';
 import { isComposingKey } from '@shared/imeGuard';
 import { useRtl } from '@/i18n/useDirection';
 
-/** Michael's control surface. Shown instead of the plain terminal/files panel
- *  when the god agent is selected: terminal + queue, the floor roster (with
- *  per-agent model + dispatch + assistant access), a memory view, and a live
- *  activity feed / board / usage meter. */
+/** Michael 的控制面板。当选中 god agent 时，替代普通终端/文件面板显示：
+ *  终端 + 队列、底层花名册（含每个 agent 的模型 + 分发 + 助手访问）、
+ *  记忆视图，以及实时活动流 / 看板 / 用量表。 */
 
-// Both the AskMe (#human) tab and the Triggers tab live here. Triggers replaced
-// the old Schedules tab: schedules are now one of four trigger types, and the
-// whole surface lives in ./triggers (see src/shared/triggers.ts for the contract).
+// AskMe（#human）标签页和 Triggers 标签页都在这里。Triggers 取代了
+// 旧的 Schedules 标签页：schedule 现在只是四种触发器类型之一，
+// 整个界面位于 ./triggers（契约见 src/shared/triggers.ts）。
 type CCTab = 'terminal' | 'floor' | 'tasks' | 'human' | 'triggers' | 'trigger-history'
   | 'memory' | 'graph' | 'activity' | 'skills' | 'workers';
 
-/** Fallback denominator for the per-agent token meter when no floor token budget
- *  is configured — so the bar reads as a budget estimate (filled + remaining)
- *  rather than being pinned to 100% for whichever agent burns the most tokens. */
+/** 当未配置底层 token 预算时，每个 agent token 表的回退分母——
+ *  这样进度条读作"预算估算（已用 + 剩余）"，而不会因为某个
+ *  agent 烧 token 最多就被钉死在 100%。 */
 const DEFAULT_TOKEN_CAP = 1_000_000;
 
-/** A GitHub issue as returned by `window.cth.githubIssues` (labels/assignees flattened). */
+/** `window.cth.githubIssues` 返回的 GitHub issue（labels/assignees 已扁平化）。 */
 interface GHIssue {
   number: number;
   title: string;
@@ -64,7 +63,7 @@ interface GHIssue {
   assignees: string[];
 }
 
-/** Canonical tab order. Not every entry is always shown — see `visibleTabs`. */
+/** 规范标签页顺序。并非每个条目始终显示——见 `visibleTabs`。 */
 const TABS: { key: CCTab; labelKey: string; icon: Parameters<typeof Icon>[0]['name'] }[] = [
   { key: 'terminal', labelKey: 'commandCenter.tabs.terminal', icon: 'terminal' },
   { key: 'floor', labelKey: 'commandCenter.tabs.floor', icon: 'mcp' },
@@ -79,66 +78,65 @@ const TABS: { key: CCTab; labelKey: string; icon: Parameters<typeof Icon>[0]['na
   { key: 'workers', labelKey: 'commandCenter.tabs.workers', icon: 'gear' }
 ];
 
-/** @param fullscreen this instance IS the fullscreen overlay, so it owns the pty
- *  and renders the real terminal. The docked instance renders the "open in
- *  fullscreen" placeholder instead — two live xterms on one pty fight over its
- *  cols/rows and corrupt the display. */
+/** @param fullscreen 此实例就是全屏遮罩，因此它拥有 pty
+ *  并渲染真实终端。停靠实例渲染"在全屏中打开"占位符——
+ *  一个 pty 上两个实时 xterm 会争夺它的 cols/rows 并破坏显示。 */
 export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent; fullscreen?: boolean }) {
   const { t } = useTranslation();
   const [tab, setTab] = useState<CCTab>('terminal');
-  // The trigger-history ledger has nothing to say until an outside party can
-  // reach us, so its tab appears only once an org key or a webhook exists. This
-  // is the first config-gated tab in the panel: TABS stays the canonical order
-  // and the gate is applied at render, so nothing else has to know about it.
-  // The rule itself lives in the store (`triggerHistoryVisible`) beside the two
-  // mirrors it reads — a second copy here would drift from Settings.
+  // 在外部一方能触达我们之前，触发器历史台账没什么可显示的，
+  // 所以只有当存在 org key 或 webhook 时它的标签页才出现。这是
+  // 面板里第一个受配置门控的标签页：TABS 保持规范顺序，
+  // 门在渲染时应用，因此其他任何地方都不用知道它。
+  // 规则本身放在 store（`triggerHistoryVisible`）里，与它所读的
+  // 两面镜子相邻——这里再抄一份会与 Settings 脱节。
   const showHistory = useStore(triggerHistoryVisible);
-  // Never leave the panel parked on a tab that has just been hidden.
+  // 绝不让面板停留在一个刚刚被隐藏的标签页上。
   useEffect(() => {
     if (!showHistory && tab === 'trigger-history') setTab('terminal');
   }, [showHistory, tab]);
   const visibleTabs = TABS.filter((t) => t.key !== 'trigger-history' || showHistory);
 
-  // External tab requests (the office task board → 'tasks', the boss-room
-  // calendar → 'triggers'). seq-keyed so clicking again re-opens the tab even
-  // if it was already requested.
+  // 外部标签页请求（办公室任务看板 → 'tasks'，老板办公室的
+  // 日历 → 'triggers'）。按 seq 键控，这样即使标签页已被请求过，
+  // 再次点击仍会重新打开它。
   const ccTabRequest = useStore((s) => s.ccTabRequest);
   useEffect(() => {
     if (!ccTabRequest) return;
     const key = ccTabRequest.tab as CCTab;
     if (!TABS.some((t) => t.key === key)) return;
-    // Read the gate live rather than depending on it — as a dependency it would
-    // re-fire a stale request the moment the tab appeared.
+    // 实时读取门而不是依赖它——把它当作依赖的话，
+    // 会在标签页出现的那一刻重新触发一个过期的请求。
     if (key === 'trigger-history' && !triggerHistoryVisible(useStore.getState())) return;
     setTab(key);
   }, [ccTabRequest]);
-  // A task-detail "assign" pre-fills the Floor dispatch box and jumps to it.
-  // Seeded via the store one-shot (the detail overlay lives app-wide now);
-  // { seq } makes every assign distinct so identical text re-seeds.
+  // 任务详情的"assign"会预填 Floor 分发框并跳转到它。
+  // 通过 store 的一次性投递播种（详情浮层现在全应用范围共用）；
+  // { seq } 让每次 assign 都互不相同，因此相同的文本也能重新播种。
   const [dispatchSeed, setDispatchSeed] = useState<{ text: string; seq: number }>({ text: '', seq: 0 });
   const dispatchSeedRequest = useStore((s) => s.dispatchSeedRequest);
   useEffect(() => {
     if (!dispatchSeedRequest) return;
     setDispatchSeed({ text: dispatchSeedRequest.text, seq: dispatchSeedRequest.seq });
   }, [dispatchSeedRequest]);
-  // Lifted so the memory-graph tab can jump to a specific agent's memory file.
+  // 提升到这里，让记忆图标签页能跳到某个特定 agent 的记忆文件。
   const [selectedMemoryAgent, setSelectedMemoryAgent] = useState<string | null>(null);
   const updateAgent = useStore((s) => s.updateAgent);
   const setFullscreen = useStore((s) => s.setFullscreen);
   const fullscreenAgentId = useStore((s) => s.fullscreenAgentId);
   const onPtyStream = usePtyParser(agent.id);
-  // True only for the DOCKED panel while the overlay holds this agent.
+  // 仅在遮罩持有此 agent 时的 DOCKED 面板中为 true。
   const isFullscreenedHere = fullscreenAgentId === agent.id && !fullscreen;
-  // v0.3.4: ONE floor-wide auto-delivery switch, moved off the per-agent
-  // control strips — toggling applies to every live agent, god included.
-  // Seeded from the god's own control state (the floor is kept in sync by
-  // this single control, so any agent's state reflects the floor's).
+  // v0.3.4: 单个全大厅自动投递开关，从逐 agent 控制条上移到这里——
+  // 切换会对每个在线 agent 生效，god 也包括在内。
+  // 从 god 自身的控制状态播种（大厅由这个单一控件保持同步，
+  // 因此任何 agent 的状态都反映大厅的状态）。
   const [floorDeliveryPaused, setFloorDeliveryPaused] = useState(false);
   useEffect(() => {
     let alive = true;
     window.cth.controlSnapshot(agent.id)
       .then((s) => { if (alive && s) setFloorDeliveryPaused(s.autoDeliveryPaused); })
-      .catch(() => { /* none */ });
+      .catch(() => { /* 无 */ });
     return () => { alive = false; };
   }, [agent.id]);
   const toggleFloorDelivery = async () => {
@@ -154,7 +152,7 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
       noPadding
       style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: 0, overflow: 'hidden' }}
     >
-      {/* Header */}
+      {/* 头部 */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 8,
         padding: '6px 8px', background: 'var(--cth-cream-100)',
@@ -167,10 +165,10 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
         }}>
           <SpritePortrait character={agent.character} scale={1} />
         </div>
-        {/* Title + subtitle truncate; the control cluster never shrinks. At
-            sidebar width the old header wrapped its 24-char display-font title
-            onto three lines and "runs the floor" word-per-line under the two
-            wide buttons — everything here is single-line by construction. */}
+        {/* 标题 + 副标题截断；控件簇永不收缩。在侧边栏宽度下，
+            旧头部把 24 字符的 display 字体标题折成三行，并在两个
+            宽按钮下面把"runs the floor"逐词断行——这里的一切
+            构造上都是单行。 */}
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{
             fontFamily: 'var(--cth-font-display)', fontSize: 10, lineHeight: '14px', color: 'var(--cth-ink-900)',
@@ -184,9 +182,9 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
             }}>{t('commandCenter.runsTheFloor', { name: agent.name })}</span>
           </div>
         </div>
-        {/* v0.3.4: floor-wide auto-delivery lives HERE (one switch for every
-            agent's queue), and the IDE opens from agent level, not the toolbar.
-            Short labels — the tooltips carry the full explanation. */}
+        {/* v0.3.4: 全大厅自动投递就在这里（每个 agent 队列共用一个开关），
+            IDE 从 agent 层级打开，而不是工具栏。
+            短标签——tooltip 承载完整说明。 */}
         <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
           <PixelButton
             variant={floorDeliveryPaused ? 'primary' : 'secondary'}
@@ -207,9 +205,9 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
               {floorDeliveryPaused ? t('commandCenter.deliveryPaused') : t('commandCenter.deliveryAuto')}
             </span>
           </PixelButton>
-          {/* Floor-level surface with no agent of its own: the honest target is
-              whoever is selected, stated explicitly rather than left to the
-              IDE's fallback so the intent is visible at the call site. */}
+          {/* 无自身 agent 的大厅级界面：诚实的对象是当前选中的那个，
+              显式写出而不是留给 IDE 的回退逻辑，
+              这样意图在调用处就可见。 */}
           <PixelButton variant="secondary" size="sm" onClick={() => {
             const s = useStore.getState();
             s.setIdeOpen(true, s.selectedId);
@@ -226,35 +224,34 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
         </div>
       </div>
 
-      {/* Tab bar — ONE row, tabs at their natural width, scrolling only if the
-          panel is genuinely too narrow for all of them.
+      {/* 标签栏——单行，标签按自然宽度排列，仅在面板
+          确实窄到放不下所有标签时才滚动。
 
-          This was an auto-fit grid of equal-width cells, which had a failure mode
-          the equal widths caused: every column is sized to the WIDEST tab, so the
-          track count is set by the longest label rather than by the total width
-          the labels actually need. Adding a 12th tab tipped it over at fullscreen
-          width and dropped `setup` onto a second row with most of the first row's
-          space still unused — the tabs need ~1320px of content and had ~1610px.
+          这曾是一个等宽单元格的自动适配网格，等宽正是它的失败模式：
+          每列都按最宽的标签取宽，于是轨道数量由最长的标签决定，
+          而不是标签实际需要的总宽度。加入第 12 个标签后，
+          它在全屏宽度下被挤爆，把 `setup` 丢到第二行，
+          而第一行还有大量空间没用——这些标签需要约 1320px 内容，
+          当时却有约 1610px。
 
-          Content-sized tabs fit all twelve on one line with room to spare, and the
-          `.cth-tabbar` rules in global.css (scrollbar-width: none, ::-webkit-
-          scrollbar { height: 0 }) already exist for exactly this: a single row that
-          scrolls with the scrollbar hidden. The grid never scrolled, so those rules
-          have been dead code since it landed.
+          按内容定宽的标签能把全部十二个放进一行还有富余，而且
+          global.css 里的 `.cth-tabbar` 规则（scrollbar-width: none,
+          ::-webkit-scrollbar { height: 0 }）正是为此而存在：
+          一行、滚动、滚动条隐藏。网格从不滚动，
+          所以这些规则自它落地以来就是死代码。
 
-          Trade-off, deliberate: in the NARROW docked panel the far-right tabs now
-          scroll out of view instead of wrapping to a visible second row. One row
-          that sometimes needs a scroll beats two rows where one is nearly empty —
-          and the grid's own reason for existing (keeping wrapped rows aligned)
-          stops applying the moment there is only ever one row. */}
+          权衡是刻意的：在窄的停靠面板里，最右侧的标签现在会
+          滚出视野，而不是折成可见的第二行。一行（偶尔需要滚动）
+          胜过两行其中一行几乎全空——而且网格存在的理由本身
+          （让折行后的行对齐）在只有一行的时候就不再适用。 */}
       <div className="cth-tabbar" style={{
         display: 'flex', gap: 4,
-        // Docked in the sidebar the panel is narrow, so tabs WRAP: a second row
-        // costs a few pixels of a tall column, while a horizontal scroll there
-        // would hide half the tabs behind a gesture with no affordance.
-        // In focus mode the panel is wide and vertical space is the scarce
-        // resource, so it stays ONE row and scrolls instead. `.cth-tabbar` in
-        // global.css already hides that scrollbar.
+        // 停靠在侧边栏时面板很窄，所以标签会换行：第二行
+        // 只花去高列的几个像素，而横向滚动会把一半标签藏在一个
+        // 毫无提示的手势后面。
+        // 焦点模式下面板很宽，垂直空间才是稀缺资源，
+        // 所以保持一行并改为滚动。global.css 里的 `.cth-tabbar`
+        // 已经隐藏了那条滚动条。
         flexWrap: fullscreen ? 'nowrap' : 'wrap',
         overflowX: fullscreen ? 'auto' : 'visible',
         padding: '6px 8px', background: 'var(--cth-cream-100)',
@@ -266,17 +263,17 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
             onClick={() => setTab(tabDef.key)}
             style={{
               whiteSpace: 'nowrap',
-              // grow to share any spare width (so the strip still spans the panel
-              // exactly as the old grid did), never shrink below the label (a
-              // squashed tab is unreadable — overflow into the scroll instead).
+              // 增长以分摊多余宽度（这样条带仍像旧网格那样
+              // 恰好横跨面板），但绝不缩到标签以下（被压扁的
+              // 标签不可读——溢出到滚动里即可）。
               flex: '1 0 auto',
               display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4,
               padding: '4px 8px 3px', border: 'none', cursor: 'pointer',
               background: tab === tabDef.key ? `var(--cth-${agent.accent})` : 'var(--cth-cream-200)',
-              // The selected tab is filled with the agent's accent, which is a
-              // LIGHT colour in both themes. ink-900 flips to near-white in dark
-              // mode, so the active tab's label was pale-on-pale — the one tab
-              // you most need to read. On-accent text is dark in both themes.
+              // 选中标签用 agent 的强调色填充，它在两个主题下都是
+              // 浅色。ink-900 在深色模式下翻转为近白色，所以活动标签
+              // 的文字曾因浅上加浅而几乎看不清——而那正是你最需要
+              // 读的那个标签。on-accent 文字在两个主题下都是深色。
               color: tab === tabDef.key ? 'var(--cth-on-accent)' : 'var(--cth-ink-900)',
               boxShadow: tab === tabDef.key
                 ? 'inset 0 0 0 1px var(--cth-ink-300)'
@@ -289,7 +286,7 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
         ))}
       </div>
 
-      {/* Body */}
+      {/* 主体 */}
       <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         {tab === 'terminal' && (
           isFullscreenedHere ? (
@@ -341,7 +338,7 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
   );
 }
 
-// ─── Floor tab — roster, model, dispatch, dirs, assistant ────────────────────
+// ─── Floor 标签页 — 花名册、模型、分发、目录、助手 ────────────────────
 
 function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
   const { t } = useTranslation();
@@ -351,27 +348,27 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
   const select = useStore((s) => s.select);
   const updateAgent = useStore((s) => s.updateAgent);
   const toolCounts = useStore((s) => s.toolCounts);
-  // Live OpenTelemetry per agent — merged into each agent card below (the old
-  // standalone Fleet tab folded in here so the roster shows identity + controls
-  // AND live cost/usage in one place).
+  // 每个 agent 的实时 OpenTelemetry——合并到下面每个 agent 卡片中
+  // （旧的独立 Fleet 标签页并入此处，让花名册在一个地方同时展示
+  // 身份 + 控件 AND 实时成本/用量）。
   const { samples, spark, rate, lastTool, breakers } = useFleetTelemetry();
   const [repos, setRepos] = useState<string[]>([]);
-  // Floor-wide token budget (drives the breaker); also the token-meter denominator.
+  // 全大厅 token 预算（驱动熔断器）；也是 token 表的分母。
   const [tokenCap, setTokenCap] = useState<number | undefined>(undefined);
-  // Per-agent token limit (overrides the floor budget for that agent), keyed by id.
+  // 每个 agent 的 token 上限（覆盖该 agent 的大厅预算），按 id 键控。
   const [agentTokenCaps, setAgentTokenCaps] = useState<Record<string, number>>({});
   const [restarting, setRestarting] = useState<string | null>(null);
   const [engineProvider, setEngineProvider] = useState<AgentProvider>('claude');
   const [engineModel, setEngineModel] = useState<string | undefined>(undefined);
   const [restartErrors, setRestartErrors] = useState<Record<string, string>>({});
-  // The harness's own default model (Settings → default model). Michael and every
-  // new agent spawn on this, so the picker marks it — otherwise the only entry
-  // reading "default" was the CLI's, which is a different thing entirely.
+  // harness 自身的默认模型（设置 → 默认模型）。Michael 和每个新 agent
+  // 都用它 spawn，因此选择器要标记它——否则唯一显示"默认"的条目
+  // 是 CLI 的那个，而那完全是另一回事。
   const [defaultModel, setDefaultModel] = useState<string | undefined>(undefined);
-  const [dispatchTo, setDispatchTo] = useState<string>(''); // '' = Michael decides
+  const [dispatchTo, setDispatchTo] = useState<string>(''); // '' = 由 Michael 决定
   const [dispatchText, setDispatchText] = useState('');
   const [dispatchMsg, setDispatchMsg] = useState<string | null>(null);
-  // ── ISSUES section state ──
+  // ── ISSUES 区块状态 ──
   const [issueRepo, setIssueRepo] = useState<string>('');
   const [issues, setIssues] = useState<GHIssue[]>([]);
   const [issuesLoading, setIssuesLoading] = useState(false);
@@ -385,33 +382,32 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
       setEngineProvider(c.godProvider ?? 'claude');
       setEngineModel(c.godModel);
       setDefaultModel(c.defaultModel);
-    }).catch(() => { /* noop */ });
+    }).catch(() => { /* 空操作 */ });
   }, []);
 
-  // Seed the dispatch box from a task-card "assign" (keyed on seq so repeat
-  // assigns re-prefill). seq === 0 is the untouched initial state — skip it.
+  // 从任务卡片的"assign"播种分发框（按 seq 键控，重复 assign
+  // 会重新预填）。seq === 0 是未触碰的初始状态——跳过它。
   useEffect(() => {
     if (seed.seq > 0) setDispatchText(seed.text);
   }, [seed.seq, seed.text]);
 
-  // Restart an agent's PTY in place. `resume:true` reattaches its prior Claude
-  // conversation (`--resume <sessionId>`, resolved in the main process from the
-  // hive registry by agent id) — this is "Restart & Continue": a clean re-draw
-  // of the TUI in a fresh process WITHOUT losing the thread, which is the escape
-  // hatch for a corrupted/garbled terminal (e.g. xterm reflow after dragging the
-  // window between displays of different sizes). With `resume` unset it's the
-  // old behavior: a model change that starts a fresh session.
+  // 原地重启一个 agent 的 PTY。`resume:true` 会重新挂接它之前的 Claude
+  // 会话（`--resume <sessionId>`，由主进程从 hive registry 按 agent id
+  // 解析）——这就是"Restart & Continue"：在一个全新进程里干净地
+  // 重绘 TUI，且不丢失线索，这是损坏/花屏终端的逃生舱
+  // （例如把窗口拖到不同尺寸的显示器之间导致的 xterm 重排）。
+  // 当 `resume` 未设置时是旧行为：一次启动全新会话的模型变更。
   const restartWithModel = async (
     a: Agent,
     model: string | undefined,
     opts: {
       resume?: boolean;
       provider?: AgentProvider;
-      /** Resume if we can, start fresh if we can't, instead of refusing.
-       *  "Restart & Continue" wants the hard failure — continuing is the entire
-       *  point, so silently starting a blank session would be worse than an
-       *  error. A model change wants the soft one: the user asked to change
-       *  model, and an agent with no recorded session still has to get one. */
+      /** 能续则续，不能续就从新开始，而不是拒绝。
+       *  "Restart & Continue"要的是硬失败——续上才是全部意义所在，
+       *  默默开一个空白会话比报错更糟。模型变更要的是软失败：
+       *  用户要的是换模型，而没有记录会话的 agent 也仍然必须
+       *  得到一个会话。 */
       resumeOptional?: boolean;
     } = {}
   ) => {
@@ -420,20 +416,21 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
     setRestartErrors((errors) => ({ ...errors, [a.id]: '' }));
     try {
       const cfg = await window.cth.getConfig();
-      // Respawn on the same CLI this agent already runs on (inferred from its
-      // command if not explicitly tagged) so an Antigravity/Codex worker stays
-      // on its own binary. tokenizeCommand keeps quoted model labels one arg.
-      // opts.provider overrides the inferred provider — used when changing GOD's engine.
+      // 在这个 agent 已在运行的同一个 CLI 上重生（若未显式标记，
+      // 则从其 command 推断），这样 Antigravity/Codex worker 就
+      // 留在自己的二进制上。tokenizeCommand 让带引号的模型标签
+      // 保持为一个参数。opts.provider 覆盖推断出的 provider——
+      // 用于更换 GOD 的引擎。
       const previousProvider = inferAgentProvider(a.command, a.provider);
       const provider = opts.provider ?? previousProvider;
       let resume = opts.resume === true && provider === previousProvider;
       if (opts.resume && !resume && !opts.resumeOptional) {
-        throw new Error('Cannot resume a session through a different provider.');
+        throw new Error('无法通过不同的提供商续接会话。');
       }
       let resumeSessionId: string | undefined;
       if (resume) {
-        // A precondition miss is fatal for an explicit "continue", and merely
-        // means "start fresh" for an opportunistic one (see resumeOptional).
+        // 前置不满足对显式"continue"是致命的，对机会式的续接
+        // 则只意味着"重新开始"（见 resumeOptional）。
         const giveUpOnResume = (reason: string) => {
           if (!opts.resumeOptional) throw new Error(reason);
           resume = false;
@@ -442,14 +439,14 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
         const registry = await window.cth.hiveRegistry();
         resumeSessionId = registry.agents[a.id]?.sessionId;
         if (!resumeSessionId) {
-          giveUpOnResume('No recorded session ID; current process was left running.');
+          giveUpOnResume('没有记录的会话 ID；当前进程仍在运行。');
         } else if (provider === 'claude' && !(await window.cth.resolveSessionCwd(resumeSessionId))) {
-          giveUpOnResume('Session transcript not found; current process was left running.');
+          giveUpOnResume('找不到会话转录；当前进程仍在运行。');
         }
       }
-      // Capture the live grid before replacing anything. Restart & Continue
-      // recreates only this agent's xterm; model changes retain the old
-      // in-place reset behavior.
+      // 在替换任何东西之前捕获实时网格。Restart & Continue
+      // 只重建这个 agent 的 xterm；模型变更保留旧的
+      // 原地重置行为。
       const oldEntry = acquireTerminal(a.ptyId);
       let cols = oldEntry.term.cols || 100;
       let rows = oldEntry.term.rows || 30;
@@ -457,29 +454,29 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
         oldEntry.fit.fit();
         cols = oldEntry.term.cols;
         rows = oldEntry.term.rows;
-      } catch { /* host not sized yet */ }
+      } catch { /* 宿主尚未完成尺寸设置 */ }
 
       const killed = await window.cth.killPty(a.ptyId);
-      // A pty that is ALREADY gone is the state this kill was trying to reach, so
-      // it is not a failure. This is the single most common way to arrive at
-      // "Restart & Continue": the session died on its own — a crash, or Ctrl-C
-      // twice — main dropped it from the session map, and kill then answers
-      // `no pty: <id>`. Treating that as fatal aborted before the respawn and
-      // turned the one situation the button exists for into a dead end.
+      // 已经消失的 pty 正是这次 kill 想要达到的状态，
+      // 所以它不是失败。这是到达"Restart & Continue"最常见的方式：
+      // 会话自己死了——一次崩溃，或连按两次 Ctrl-C——主进程把它
+      // 从会话表中移除，kill 于是回答 `no pty: <id>`。
+      // 把它当作致命错误会在重生之前就中断，
+      // 把这个按钮存在的唯一情形变成死路。
       if (!killed.ok && !/^no pty:/.test(killed.error ?? '')) {
-        throw new Error(killed.error ?? 'Could not stop the current process.');
+        throw new Error(killed.error ?? '无法停止当前进程。');
       }
       if (resume) {
-        // A blank xterm can retain corrupt renderer/DOM/subscription state even
-        // after its PTY is healthy. Throw that one terminal away, acquire its
-        // replacement BEFORE spawning (so startup output has a listener), then
-        // bump the key so React remounts only this agent's terminal card.
+        // 空白的 xterm 即使在 PTY 健康之后也可能保留损坏的
+        // renderer/DOM/订阅状态。把这个终端扔掉，在 spawn 之前
+        // 获取它的替代品（这样启动输出就有监听者），然后
+        // 提升 key，让 React 只重新挂载这个 agent 的终端卡片。
         disposeTerminal(a.ptyId);
         acquireTerminal(a.ptyId);
         updateAgent(a.id, {
           terminalGeneration: (a.terminalGeneration ?? 0) + 1,
           status: 'idle',
-          action: 'recreating terminal…'
+          action: '正在重建终端…'
         });
       } else {
         resetTerminal(a.ptyId);
@@ -510,30 +507,29 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
       });
       if (!res.ok) throw new Error(res.error ?? 'Restart failed.');
       if (resume && res.resumed !== true) {
-        throw new Error('Resume was refused; no replacement session was accepted.');
+        throw new Error('恢复被拒绝；未接受任何替代会话。');
       }
       if (res.ok) {
-        // Record the model even on a resume. A same-provider model change now
-        // RESUMES the session (that is the point — you keep the conversation and
-        // just swap the model), so "resume ⇒ the model is unchanged" stopped
-        // being true. Skipping the patch left the live process on the new model
-        // while the selector and the persisted agent kept the old one, and the
-        // next restore relaunched the old command. `command` is rebuilt from the
-        // selected model above, so on a genuine no-change restart this is a no-op.
+        // 即使在续接时也记录模型。同 provider 的模型变更现在会
+        // 续接会话（这正是重点——你保留对话、只换模型），
+        // 所以"续接 ⇒ 模型不变"不再成立。跳过这个 patch 会让
+        // 实时进程用着新模型，而选择器与持久化 agent 还留着旧模型，
+        // 下一次恢复就会重新启动旧命令。`command` 在上面从所选
+        // 模型重建，因此在真正的无变化重启时这是一个无操作。
         const patch = resume
           ? {
               command: command.trim(),
               provider,
               model,
               status: 'idle' as const,
-              action: 'continuing…'
+              action: '继续中…'
             }
           : {
               command: command.trim(),
               provider,
               model,
               status: 'idle' as const,
-              action: provider === previousProvider ? 'restarting…' : `switching to ${providerPreset(provider).label}…`
+              action: provider === previousProvider ? '重启中…' : `正在切换到 ${providerPreset(provider).label}…`
             };
         updateAgent(a.id, patch);
       }
@@ -547,11 +543,11 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
     }
   };
 
-  // ALL human dispatch flows through the god — never directly into a worker's
-  // inbox. Direct dispatch bypassed the orchestrator's whole job: no 4-part
-  // contract, no card in tasks.json, no board awareness — and the old
-  // 'broadcast' DEFAULT sent the same task to every worker at once. A worker
-  // picked in the dropdown is forwarded as a SUGGESTION the god may follow.
+  // 所有人工分发都经 god 流转——从不直接进入 worker 的
+  // inbox。直接分发绕过了编排器的整个职责：没有 4 部分
+  // 契约、tasks.json 里没有卡片、看板无感知——而且旧的
+  // 'broadcast' 默认值会把同一条任务同时发给每个 worker。
+  // 在下拉框中选中的 worker 会作为 god 可以采纳的 SUGGESTION 转发。
   const dispatch = async () => {
     const body = dispatchText.trim();
     if (!body) return;
@@ -583,7 +579,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
         setIssues((res.issues ?? []).slice(0, 10));
       } else {
         setIssues([]);
-        setIssuesError(res.error ?? 'Failed to fetch issues.');
+        setIssuesError(res.error ?? '获取议题失败。');
       }
     } catch (e) {
       setIssues([]);
@@ -596,12 +592,12 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
   const assignIssue = (issue: GHIssue) => {
     const body = (issue.body ?? '').slice(0, 200);
     setDispatchText(`GitHub Issue #${issue.number}: ${issue.title}\n\n${body}\n\nURL: ${issue.url}`);
-    setDispatchTo(''); // Michael decomposes and assigns — no more broadcast blasts
+    setDispatchTo(''); // Michael 拆解并分配——不再有广播轰炸
   };
 
-  // Set/clear one agent's token limit atomically in main. Renderer config objects
-  // are snapshots, so persisting this whole map could clobber a cap added by the
-  // hire flow after this panel loaded.
+  // 在主进程中原子地设置/清除一个 agent 的 token 上限。renderer 的
+  // 配置对象是快照，所以持久化整张表可能会覆盖本面板加载之后
+  // 由雇佣流程新增的上限。
   const setAgentCap = (id: string, tokens: number | undefined) => {
     setAgentTokenCaps((current) => {
       const optimistic = { ...current };
@@ -612,18 +608,18 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
     void window.cth.setAgentTokenCap(id, tokens).then((updated) => {
       setAgentTokenCaps(updated.agentTokenCaps ?? {});
     }).catch(() => {
-      // Reconcile a failed optimistic edit with the persisted source of truth.
+      // 用持久化的真相来源调和失败的乐观编辑。
       void window.cth.getConfig().then((current) => {
         setAgentTokenCaps(current.agentTokenCaps ?? {});
-      }).catch(() => { /* noop */ });
+      }).catch(() => { /* 空操作 */ });
     });
   };
 
-  // The token meter is scaled to the agent's own limit when set, else the floor
-  // token budget — so each bar reads as "tokens used vs budget" with the remaining
-  // headroom visible, never pinned to a useless 100%.
+  // token 表在设置了 agent 自身上限时按其缩放，否则按大厅
+  // token 预算——这样每条都读作"已用 token vs 预算"，剩余
+  // 余量可见，绝不会钉死在无意义的 100%。
   const floorCap = tokenCap && tokenCap > 0 ? tokenCap : DEFAULT_TOKEN_CAP;
-  // Fleet totals across the roster (for the AGENTS summary band).
+  // 花名册上的舰队总量（用于 AGENTS 汇总带）。
   let sumTokens = 0, sumInput = 0, sumCacheRead = 0, sumRate = 0;
   for (const a of agents) {
     const s = samples[a.id];
@@ -674,12 +670,12 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
           const breaker = breakers[a.id];
           const armed = !!breaker && (breaker.level === 'constrained' || breaker.level === 'stopped');
           const tokens = sample ? sample.input + sample.output + sample.cacheRead + sample.cacheCreation : 0;
-          const agentCap = agentTokenCaps[a.id]; // per-agent limit, if set
+          const agentCap = agentTokenCaps[a.id]; // 每个 agent 的上限（若已设置）
           const denom = agentCap && agentCap > 0 ? agentCap : floorCap;
           const pct = Math.min(100, Math.round((tokens / denom) * 100));
           const meterColor = armed || pct >= 90 ? 'var(--cth-coral)' : pct >= 60 ? 'var(--cth-lemon)' : 'var(--cth-mint)';
-          // Sparkline only when the agent is actually burning tokens; otherwise the
-          // flat baseline is just a mystery line. Label it with the live rate.
+          // 只有当 agent 真的在烧 token 时才显示迷你图；否则
+          // 平坦的基线只是一条神秘线条。用实时速率标注它。
           const sparkSeries = spark[a.id] ?? [];
           const hasSpark = sparkSeries.some((v) => v > 0);
           const rateVal = Math.round(rate[a.id] ?? 0);
@@ -715,7 +711,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
               <TokenLimitEditor value={agentCap} onSet={(t) => setAgentCap(a.id, t)} />
             </div>
             <div style={{ fontSize: 11, color: 'var(--cth-ink-500)', wordBreak: 'break-all' }}>{a.cwd}</div>
-            {/* Live telemetry (folded in from the old Fleet tab) */}
+            {/* 实时遥测（自旧 Fleet 标签页并入） */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               {hasSpark ? (
                 <span style={{ flex: 1, minWidth: 0, display: 'inline-flex', alignItems: 'center', gap: 5 }}>
@@ -745,11 +741,10 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
               </div>
               <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-500)', width: 30, textAlign: 'right' }}>{pct}%</span>
             </div>
-            {/* Context window — the SAME exact statusLine-fed numbers as the
-                avatar-card gauge (tokens currently in the window vs the real
-                200k/1M size). Distinct from the cumulative budget meter above,
-                which keeps growing forever and pins at 100% — that one is
-                spend, this one is headroom before compaction. */}
+            {/* 上下文窗口——与头像卡片仪表完全相同的、由 statusLine 提供的
+                数字（当前窗口中的 token vs 真实的 200k/1M 大小）。
+                与上面的累计预算表不同：那个会永远增长并钉在 100%——
+                那是开销；这个是压缩前的剩余余量。 */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <span style={{ flex: 1 }} />
               <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 10, color: 'var(--cth-ink-300)', flexShrink: 0 }}>{t('commandCenter.ctx')}</span>
@@ -780,10 +775,10 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                 </span>
               )}
             </div>
-            {/* Non-god agents get the cross-provider model picker + restart controls
-                here. The GOD agent's model lives in the engine row below
-                (provider+model+apply), so we DON'T render this second selector for
-                it — one model picker, not two. */}
+            {/* 非 god agent 在这里获得跨 provider 的模型选择器和重启控件。
+                GOD agent 的模型在下面的引擎行（provider+model+apply）里，
+                所以我们不为它渲染这第二个选择器——一个模型选择器，
+                而不是两个。 */}
             {!a.isGod && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
               <Select
@@ -792,13 +787,12 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                 onChange={(value) => {
                   const choice = decodeProviderModel(value);
                   if (!choice) return;
-                  // Switching model within the SAME provider continues the
-                  // conversation — that's the whole point of switching mid-task
-                  // ("this got hard, go up a tier"), and starting fresh threw
-                  // away the context that made the switch necessary.
-                  // `resume` is best-effort: restartWithModel already refuses it
-                  // across providers, and falls back to a fresh session when no
-                  // session id or transcript is recorded.
+                  // 在同一 provider 内切换模型会续接对话——这正是
+                  // 任务中途切换的全部意义（"这变难了，升一档"），
+                  // 而重新开始会丢掉让切换变得必要的那份上下文。
+                  // `resume` 是尽力而为：restartWithModel 已经会在
+                  // 跨 provider 时拒绝它，并在没有记录会话 id 或
+                  // transcript 时回退到全新会话。
                   void restartWithModel(a, choice.model, {
                     provider: choice.provider,
                     resume: choice.provider === agentProvider,
@@ -814,8 +808,8 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                 {modelProvidersForAgent(a.isGod).map((preset) => (
                   <optgroup key={preset.id} label={preset.label}>
                     {modelsForProvider(preset.id).map((model) => {
-                      // `defaultModel` is a Claude model id, so it can only mark
-                      // an entry in the Claude group.
+                      // `defaultModel` 是 Claude 模型 id，所以它只能标记
+                      // Claude 组里的条目。
                       const isHarnessDefault = preset.id === 'claude'
                         && !!defaultModel && model.id === defaultModel;
                       return (
@@ -835,10 +829,10 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                   ? t('common.restarting')
                   : t('commandCenter.modelRestarts', { provider: agentPreset.label })}
               </span>
-              {/* Restart & Continue — kill + respawn keeping the SAME model and
-                  resuming the prior conversation (--resume). Use this to redraw a
-                  garbled TUI (e.g. after dragging the window across displays)
-                  without losing the thread. */}
+              {/* Restart & Continue —— 保持 SAME 模型杀掉并重生，
+                  并续接之前会话（--resume）。用它重绘一个花屏的
+                  TUI（例如把窗口拖过不同显示器之后）
+                  而不丢失线索。 */}
               {(agentProvider === 'claude' || agentPreset.resumeFlag || agentPreset.resumeSubcommand) && <>
                 <span style={{ flex: 1 }} />
                 <PixelButton
@@ -872,7 +866,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                     setEngineModel(preset?.recommendedOrchestratorModel);
                   }}
                 >
-                  {AGENT_PROVIDER_PRESETS.filter((p) => canReceiveInbox(p.id)).map((p) => (
+                  {AGENT_PROVIDER_PRESETS.filter((p) => canReceiveInbox(p.id) || p.id === 'kimi').map((p) => (
                     <option key={p.id} value={p.id}>
                       {p.label}{p.id === 'claude' ? ' ★' : ''}
                     </option>
@@ -902,8 +896,8 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
                 >
                   {restarting === a.id ? t('common.restarting') : t('commandCenter.apply')}
                 </PixelButton>
-                {/* Redraw a garbled terminal without losing the thread (resume the
-                    SAME engine+model). Kept here since the god has no per-agent row above. */}
+                {/* 重绘花屏终端而不丢失线索（续接 SAME engine+model）。
+                    放在这里是因为 god 在上方没有逐 agent 行。 */}
                 <PixelButton
                   variant="secondary"
                   size="sm"
@@ -919,7 +913,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
           </div>
           );
         })}
-        {/* Fleet summary band */}
+        {/* 舰队汇总带 */}
         <div style={{
           display: 'flex', gap: 14, marginTop: 2, padding: '6px 8px',
           background: 'var(--cth-cream-200)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
@@ -1010,7 +1004,7 @@ function FloorTab({ seed }: { seed: { text: string; seq: number } }) {
   );
 }
 
-// ─── Archived agents — retained + flagged, kept off the floor ────────────────
+// ─── 已归档 agents — 保留并标记，留在大厅之外 ────────────────
 
 function ArchivedSection() {
   const { t } = useTranslation();
@@ -1057,12 +1051,12 @@ function ArchivedSection() {
   );
 }
 
-// ─── Memory tab ──────────────────────────────────────────────────────────────
+// ─── 记忆标签页 ──────────────────────────────────────────────────────────────
 
 function MemoryTab({ godId, who: controlledWho, onWho }: { godId: string; who?: string; onWho?: (id: string) => void }) {
   const { t } = useTranslation();
   const agents = useStore((s) => s.agents);
-  // Selection is controllable from the graph tab; falls back to local state.
+  // 选择可由图形标签页控制；回退到本地状态。
   const [internalWho, setInternalWho] = useState<string>(godId);
   const who = controlledWho ?? internalWho;
   const setWho = onWho ?? setInternalWho;
@@ -1070,7 +1064,7 @@ function MemoryTab({ godId, who: controlledWho, onWho }: { godId: string; who?: 
   const [query, setQuery] = useState('');
   const [searchOut, setSearchOut] = useState('');
   const [busy, setBusy] = useState(false);
-  // Full-text search across hive files (board, tasks, memory) — additive.
+  // 跨 hive 文件（board、tasks、memory）的全文本搜索——纯增量。
   const [textQuery, setTextQuery] = useState('');
   const [textResults, setTextResults] = useState<Array<{ source: string; excerpt: string }>>([]);
   const [textSearched, setTextSearched] = useState(false);
@@ -1153,9 +1147,9 @@ function MemoryTab({ godId, who: controlledWho, onWho }: { godId: string; who?: 
   );
 }
 
-// ─── Fleet telemetry bits (folded into the Floor AGENTS cards) ───────────────
+// ─── 舰队遥测位（并入 Floor AGENTS 卡片） ───────────────────────
 
-/** Block-character sparkline of recent token deltas — neo-brutalist mono. */
+/** 近期 token 增量的方块字符迷你图——新粗野主义等宽风格。 */
 function Sparkline({ series }: { series: number[] }) {
   const blocks = '▁▂▃▄▅▆▇█';
   const max = Math.max(1, ...series);
@@ -1169,7 +1163,7 @@ function Sparkline({ series }: { series: number[] }) {
   );
 }
 
-/** Compact token count: 1K / 10K / 100K / 1M / 100M / 1B (trailing .0 trimmed). */
+/** 紧凑的 token 计数：1K / 10K / 100K / 1M / 100M / 1B（去掉尾部 .0）。 */
 function fmtTokens(n: number): string {
   if (n >= 1e9) return `${+(n / 1e9).toFixed(2)}B`;
   if (n >= 1e6) return `${+(n / 1e6).toFixed(1)}M`;
@@ -1177,9 +1171,9 @@ function fmtTokens(n: number): string {
   return String(Math.round(n));
 }
 
-/** Per-agent token-limit control (top-right of each agent card). Shows the
- *  current limit as a lemon chip, or "set limit"; click to edit a token number.
- *  Enter / ✓ / blur commit; Escape cancels. */
+/** 每个 agent 的 token 上限控件（每个 agent 卡片的右上角）。把当前
+ *  上限显示为柠檬色小片，或显示"set limit"；点击编辑 token 数字。
+ *  Enter / ✓ / blur 提交；Escape 取消。 */
 function TokenLimitEditor({ value, onSet }: { value?: number; onSet: (tokens: number | undefined) => void }) {
   const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
@@ -1233,7 +1227,7 @@ function TokenLimitEditor({ value, onSet }: { value?: number; onSet: (tokens: nu
   );
 }
 
-// ─── Activity tab — hive event log + board ───────────────────────────────────
+// ─── Activity 标签页 — hive 事件日志 + 看板 ───────────────────────
 
 interface LogEntry { ts?: number; kind?: string; [k: string]: unknown }
 
@@ -1284,12 +1278,12 @@ function ActivityTab() {
 }
 
 
-// ─── small shared bits ───────────────────────────────────────────────────────
+// ─── 小型共享组件 ───────────────────────────────────────────────────────
 
 function Scroll({ children }: { children: React.ReactNode }) {
-  // minWidth:0 + overflowX:hidden keep wide children (native selects, long paths,
-  // budget rows) from forcing a horizontal scrollbar in the narrow sidebar — they
-  // wrap/shrink instead. Vertical scroll stays.
+  // minWidth:0 + overflowX:hidden 防止宽子元素（原生 select、长路径、
+  // 预算行）在窄侧边栏里撑出横向滚动条——它们改为换行/收缩。
+  // 纵向滚动保留。
   return <div style={{ flex: 1, minWidth: 0, minHeight: 0, overflowY: 'auto', overflowX: 'hidden', padding: 10, background: 'var(--cth-paper-200)' }}>{children}</div>;
 }
 
@@ -1346,7 +1340,7 @@ function Select({ value, onChange, disabled, children }: {
         padding: '3px 6px', background: 'var(--cth-paper-100)',
         border: 'none', boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
         fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-ink-900)', cursor: 'pointer',
-        // Never let a long option name push the sidebar wider than it is.
+        // 绝不让长选项名把侧边栏撑得比它本身还宽。
         minWidth: 0, maxWidth: '100%'
       }}
     >{children}</select>

--- a/src/renderer/src/components/EditAgentModal.tsx
+++ b/src/renderer/src/components/EditAgentModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
 import { PixelPanel } from './PixelPanel';
 import { PixelButton } from './PixelButton';
 import { SpritePortrait } from './SpritePortrait';
@@ -25,11 +26,12 @@ export interface EditAgentModalProps {
 }
 
 /**
- * Compact post-hire editor for Identity / Engine / Briefing. Mirrors the Add
- * Agent fields that matter after spawn; save only patches the durable roster
- * via updateAgent (engine changes apply on the next restart).
+ * 聘用后的精简编辑器，用于身份 / 引擎 / 简报。镜像 Add Agent 中
+ * spawn 之后仍有意义的字段；保存时仅通过 updateAgent 修补持久化花名册
+ * （引擎改动在下次重启时生效）。
  */
 export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
+  const { t } = useTranslation();
   const updateAgent = useStore((s) => s.updateAgent);
   const [config, setConfig] = useState<HarnessConfig | null>(null);
 
@@ -47,7 +49,7 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
     void window.cth.getConfig().then(setConfig).catch(() => setConfig(null));
   }, []);
 
-  // Keep form in sync when the selected agent changes while the modal is open.
+  // 当模态框打开期间选中的 agent 变化时，保持表单同步。
   useEffect(() => {
     setName(agent.name);
     setCharacter(agent.character);
@@ -101,36 +103,35 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
         zIndex: 500
       }}
     >
-      {/* Same box as Add Agent (940 / 95vw / 86vh). They are the two halves of
-          one job — describe an agent — and a tall narrow dialog next to a wide
-          one reads as two unrelated screens. */}
+      {/* 与 Add Agent 相同的框（940 / 95vw / 86vh）。它们是同一份工作的
+          两半——描述一个 agent——如果一个是高窄对话框、另一个是宽对话框，
+          看起来就像两个互不相关的界面。 */}
       <div onClick={(e) => e.stopPropagation()} style={{ width: 940, maxWidth: '95vw' }}>
-        <PixelPanel variant="dialog" title="EDIT AGENT" style={{ padding: 16 }} noPadding>
+        <PixelPanel variant="dialog" title={t('editAgent.title')} style={{ padding: 16 }} noPadding>
           <div style={{
             display: 'flex', flexDirection: 'column', gap: 14,
             padding: 16, maxHeight: '86vh', overflowY: 'auto'
           }}>
-            {/* Two columns so the extra width is used rather than padded.
-                Identity and Engine are short field lists; Briefing is free
-                text and takes the taller side. minHeight keeps the dialog from
-                collapsing into a wide thin strip on a small form. */}
+            {/* 双列布局，让多余宽度被利用而不是留白。
+                身份和引擎是短字段列表；简报是自由文本，占据更高的一侧。
+                minHeight 防止对话框在小表单上塌缩成又宽又薄的条。 */}
             <div style={{
               display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
               gap: 16, alignItems: 'start', minHeight: 260
             }}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
-            <Section label="Identity" hint="name · character · color">
-              <Row label="Name">
+            <Section label={t('editAgent.identity')} hint={t('editAgent.identityHint')}>
+              <Row label={t('editAgent.name')}>
                 <input
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  placeholder="Stanley"
+                  placeholder={t('editAgent.namePlaceholder')}
                   style={inputStyle}
                   autoFocus
                 />
               </Row>
 
-              <Row label="Character">
+              <Row label={t('editAgent.character')}>
                 <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                   {OFFICE_CAST.map((c) => {
                     const active = character === c.name;
@@ -164,7 +165,7 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
                 </div>
               </Row>
 
-              <Row label="Color">
+              <Row label={t('editAgent.color')}>
                 <div style={{ display: 'flex', gap: 6 }}>
                   {ACCENTS.map((a) => (
                     <button
@@ -186,8 +187,8 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
               </Row>
             </Section>
 
-            <Section label="Engine" hint="provider · model · next restart">
-              <Row label="Provider">
+            <Section label={t('editAgent.engine')} hint={t('editAgent.engineHint')}>
+              <Row label={t('editAgent.provider')}>
                 <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                   {AGENT_PROVIDER_PRESETS.map((p) => {
                     const active = provider === p.id;
@@ -217,7 +218,7 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
               </Row>
 
               {preset.supportsModel && (
-                <Row label="Model">
+                <Row label={t('editAgent.model')}>
                   <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                     {(() => {
                       const known = modelsForProvider(provider);
@@ -257,12 +258,12 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
 
               </div>
               <div style={{ minWidth: 0 }}>
-            <Section label="Briefing" hint="description · goal">
-              <Row label="Description">
+            <Section label={t('editAgent.briefing')} hint={t('editAgent.briefingHint')}>
+              <Row label={t('editAgent.description')}>
                 <input
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  placeholder="what is this agent for"
+                  placeholder={t('editAgent.descriptionPlaceholder')}
                   style={inputStyle}
                 />
               </Row>
@@ -271,7 +272,7 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
                 <textarea
                   value={goal}
                   onChange={(e) => setGoal(e.target.value)}
-                  placeholder="long-running directive injected on every prompt"
+                  placeholder={t('editAgent.directivePlaceholder')}
                   rows={4}
                   style={{ ...inputStyle, fontFamily: 'var(--cth-font-ui)', resize: 'vertical', minHeight: 200 }}
                 />
@@ -281,9 +282,9 @@ export function EditAgentModal({ agent, onClose }: EditAgentModalProps) {
             </div>
 
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4 }}>
-              <PixelButton variant="ghost" size="md" onClick={onClose}>cancel</PixelButton>
+              <PixelButton variant="ghost" size="md" onClick={onClose}>{t('editAgent.cancel')}</PixelButton>
               <div style={{ flex: 1 }} />
-              <PixelButton variant="primary" size="md" onClick={save}>save changes</PixelButton>
+              <PixelButton variant="primary" size="md" onClick={save}>{t('editAgent.saveChanges')}</PixelButton>
             </div>
           </div>
         </PixelPanel>

--- a/src/renderer/src/components/FileTree.tsx
+++ b/src/renderer/src/components/FileTree.tsx
@@ -10,18 +10,18 @@ interface DirEntry {
 }
 
 interface NodeState {
-  rel: string;        // relative to root; '' for root
+  rel: string;        // 相对于 root 的路径；root 为 ''
   name: string;
   isDir: boolean;
   expanded: boolean;
-  children?: NodeState[]; // loaded lazily
+  children?: NodeState[]; // 懒加载
   loading?: boolean;
   error?: string;
 }
 
 export interface FileTreeProps {
   root: string;
-  /** Active file (relative path, no leading slash) */
+  /** 活动文件（相对路径，无前导斜杠） */
   activeRel?: string;
   onOpenFile: (rel: string) => void;
   onCopyPath: (rel: string) => void;
@@ -53,7 +53,7 @@ export function FileTree({ root, activeRel, onOpenFile, onCopyPath }: FileTreePr
     })) };
   }, [root]);
 
-  // Initial root load
+  // 初始根目录加载
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -64,7 +64,7 @@ export function FileTree({ root, activeRel, onOpenFile, onCopyPath }: FileTreePr
     return () => { cancelled = true; };
   }, [loadDir]);
 
-  /** Update a node deep in the tree by rel path. */
+  /** 按相对路径更新树中深层节点。 */
   const updateNode = useCallback((rel: string, patch: Partial<NodeState> | ((n: NodeState) => Partial<NodeState>)) => {
     setTree(prev => {
       const apply = (node: NodeState): NodeState => {
@@ -88,7 +88,7 @@ export function FileTree({ root, activeRel, onOpenFile, onCopyPath }: FileTreePr
       updateNode(node.rel, { expanded: false });
       return;
     }
-    // Expand: load if not already loaded
+    // 展开：未加载则先加载
     if (!node.children) {
       updateNode(node.rel, { expanded: true, loading: true });
       const res = await loadDir(node.rel);
@@ -104,7 +104,7 @@ export function FileTree({ root, activeRel, onOpenFile, onCopyPath }: FileTreePr
 
   const renderNode = (node: NodeState, depth: number): React.ReactNode => {
     if (node.rel === '' && depth === 0) {
-      // Render children of root only
+      // 仅渲染根节点的子节点
       return (
         <div>
           {node.children?.map(c => renderNode(c, 0))}

--- a/src/renderer/src/components/FilesTab.tsx
+++ b/src/renderer/src/components/FilesTab.tsx
@@ -17,7 +17,7 @@ export function FilesTab({ cwd }: FilesTabProps) {
   const [treeWidth, setTreeWidth] = useState<number>(200);
   const dragRef = useRef<{ x: number; w: number } | null>(null);
 
-  // Drag the inner splitter
+  // 拖动内侧分隔条
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
       if (!dragRef.current) return;
@@ -60,7 +60,7 @@ export function FilesTab({ cwd }: FilesTabProps) {
           onCopyPath={onCopyPath}
         />
       </div>
-      {/* Inner divider */}
+      {/* 内侧分隔条 */}
       <div
         onMouseDown={(e) => {
           dragRef.current = { x: e.clientX, w: treeWidth };

--- a/src/renderer/src/components/FullscreenTerminal.tsx
+++ b/src/renderer/src/components/FullscreenTerminal.tsx
@@ -23,28 +23,27 @@ import { useAppTheme, toggleAppTheme } from '@/design/theme';
 import type { HarnessConfig } from '@/store/config';
 import { useRtl } from '@/i18n/useDirection';
 
-/** Roster rail width. A fixed 232px is right on a 14" laptop but reads as a
- *  sliver on a 27" display, where names truncate for no reason — so it tracks
- *  the viewport between those two ends. */
+/** 花名册侧栏宽度。固定 232px 在 14 寸笔记本上刚好，但在 27 寸
+ *  显示器上就显得像一条细缝，名字毫无理由地被截断——所以它在
+ *  这两个端点之间跟随视口变化。 */
 const SIDEBAR_WIDTH = 'clamp(232px, 14vw, 340px)';
-/** Remembers the roster collapse across fullscreen sessions and app restarts. */
+/** 跨全屏会话和应用重启记住花名册的折叠状态。 */
 const ROSTER_COLLAPSED_KEY = 'cth.fullscreen.rosterCollapsed';
 
-/** Roster type scale, derived from the shared terminal zoom so Cmd +/- resizes
- *  the whole roster along with the terminal — one knob for the whole view
- *  instead of a size that only looked right on the display it was tuned on.
- *  Each is clamped: names are a pixel display face that turns to mush when it
- *  strays too far from its native size, and the bullets have to stay subordinate
- *  to the name however far the terminal is zoomed. */
+/** 花名册文字缩放，取自共享的终端缩放，这样 Cmd +/- 会随终端一起
+ *  调整整个花名册——整个视图只用一个旋钮，而不是一个只在其调校过的
+ *  显示器上才好看的大小。每一项都做了钳制：名字是像素显示字体，
+ *  离原生尺寸太远就会糊成一团；而圆点无论终端缩放多远，
+ *  都必须始终从属于名字。 */
 function rosterScale(zoom: number) {
   const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, Math.round(n)));
-  // The portrait is sized in SPRITE steps, not free pixels. The art is an 18×28
-  // pixel stamp: widening the tile alone just pads it (which is what the old
-  // `clamp(zoom * 1.2, 18, 40)` did past 18px — a bigger frame around the same
-  // small figure), and a scale like 1.37× renders some pixel rows one device
-  // pixel tall and others two. Half-steps double every other row cleanly, so
-  // that is the grid the size moves on. Floor is 1.5× — 1× was too small to
-  // tell two hires apart at a glance, which is the tile's whole job.
+  // 头像按 SPRITE 步进缩放，而不是自由像素。美术是一枚 18×28 的
+  // 像素印章：仅仅加宽贴图只会把它拉胖（这正是旧的
+  // `clamp(zoom * 1.2, 18, 40)` 在超过 18px 之后做的事——同一个
+  // 小人被放进了更大的框里），而像 1.37× 这样的缩放会让某些像素行
+  // 占一个设备像素高、另一些占两个。半步步进让每隔一行干净地翻倍，
+  // 这就是尺寸所在的网格。下限是 1.5×——1× 太小，无法一眼区分两个
+  // 高清晰度，而这正是贴图存在的全部意义。
   const portraitScale = Math.min(2.5, Math.max(1.5, Math.round(zoom * 0.11 * 2) / 2));
   return {
     name: clamp(zoom * 0.48, 7, 14),
@@ -56,33 +55,33 @@ function rosterScale(zoom: number) {
 }
 
 function basename(path: string): string {
-  // Split on BOTH separators: `git:mainRepo` hands back whatever the platform
-  // uses, and a Windows `C:\work\repo` contains no '/' at all — so a '/'-only
-  // split returned the whole absolute path as the group's "name".
+  // 同时按两种分隔符拆分：`git:mainRepo` 返回平台使用的任意形式，
+  // 而 Windows 的 `C:\work\repo` 根本不包含 '/'——所以只按 '/' 拆分
+  // 会把整个绝对路径当作该组的"名称"返回。
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
 }
 
-/** cwd → main-repo basename, resolved once per path and shared by every mount.
- *  An isolated agent's cwd is its own git worktree (`…/worktrees/<agent-id>`),
- *  so naming the group after that path buckets each such agent under its own id
- *  instead of the repository the user actually picked. `git:mainRepo` follows a
- *  linked worktree back to its main checkout. */
+/** cwd → 主仓库 basename，每个路径只解析一次，由所有挂载共享。
+ *  隔离 agent 的 cwd 是它自己的 git worktree（`…/worktrees/<agent-id>`），
+ *  因此按该路径命名分组会把每个这样的 agent 归到自己的 id 下，
+ *  而不是用户实际选择的仓库。`git:mainRepo` 会顺着链接的 worktree
+ *  回到它的主检出。 */
 const repoRootByCwd = new Map<string, string | null>();
-/** cwds with a lookup in flight, so a re-render can't start a second one. */
+/** 正在查询中的 cwd，这样一次重渲染不会启动第二次查询。 */
 const repoLookupsInFlight = new Set<string>();
 
-/** Which repository an agent belongs to — the ABSOLUTE root, so it is a real
- *  identity. Two unrelated checkouts can share a basename (`~/client-a/app` and
- *  `~/client-b/app`); keying groups on the name merged them into one section and
- *  let agents be dragged between two different repositories.
+/** agent 属于哪个仓库——取 ABSOLUTE 根，所以它是真正的身份标识。
+ *  两个无关的检出可能共享同一个 basename（`~/client-a/app` 和
+ *  `~/client-b/app`）；按名字给组键控会把它们合并成一个区块，
+ *  还允许 agent 在两个不同仓库之间被拖拽。
  *
- *  Falls back to the cwd itself until the async resolution lands, and for
- *  directories that aren't git repos at all. */
+ *  在异步解析落地之前，以及对于根本不是 git 仓库的目录，
+ *  回退到 cwd 本身。 */
 function repoKeyOf(agent: Agent): string {
   return repoRootByCwd.get(agent.cwd) || agent.cwd || 'unknown';
 }
 
-/** What that group is CALLED — the basename, or the project the user picked. */
+/** 该组叫什么——basename，或用户选择的项目名。 */
 function repoLabelOf(agent: Agent): string {
   const root = repoRootByCwd.get(agent.cwd);
   if (root) return basename(root);
@@ -91,20 +90,20 @@ function repoLabelOf(agent: Agent): string {
   return basename(agent.cwd) || 'unknown';
 }
 
-/** Resolve every distinct cwd's repository root, then re-render. Exactly one git
- *  call per distinct path, ever. */
+/** 解析每个不同 cwd 的仓库根，然后重新渲染。每个不同路径
+ *  恰好只调用一次 git。 */
 function useResolvedRepoNames(agents: Agent[]): number {
   const [version, setVersion] = useState(0);
   useEffect(() => {
     let cancelled = false;
     const pending = [...new Set(agents.map(a => a.cwd).filter(Boolean))]
-      // `has` (not a truthiness check) so a resolved-to-null path — a cwd that
-      // is not a git repo — counts as answered. Caching only successes meant
-      // every agent outside a repo re-asked on each pass, and this effect
-      // depends on `agents`, which the pty parser replaces on every chunk of
-      // terminal output: one such agent spawned `git rev-parse` continuously
-      // for as long as it was talking. In-flight paths are skipped too, so a
-      // re-render mid-lookup doesn't stack a second round of subprocesses.
+      // 用 `has`（而不是真值检查），这样解析结果为 null 的路径——
+      // 即不是 git 仓库的 cwd——也算作已回答。只缓存成功意味着
+      // 仓库外的每个 agent 每次都会重新询问，而这个 effect 依赖
+      // `agents`，pty 解析器会在每块终端输出到达时替换它：
+      // 曾经有一个这样的 agent 只要还在说话就持续地 spawn `git rev-parse`。
+      // 进行中的路径也会被跳过，因此查找中途的重渲染不会
+      // 叠加出第二轮子进程。
       .filter(cwd => !repoRootByCwd.has(cwd) && !repoLookupsInFlight.has(cwd));
     if (pending.length === 0) return;
     pending.forEach(cwd => repoLookupsInFlight.add(cwd));
@@ -112,8 +111,8 @@ function useResolvedRepoNames(agents: Agent[]): number {
       try {
         repoRootByCwd.set(cwd, (await window.cth.gitMainRepo(cwd)) || null);
       } catch {
-        // Record the failure as answered as well — retrying a path that throws
-        // is what the unbounded-subprocess bug was made of.
+        // 把失败也记为已回答——重试一个抛错的路径，
+        // 正是无界子进程 bug 的成因。
         repoRootByCwd.set(cwd, null);
       } finally {
         repoLookupsInFlight.delete(cwd);
@@ -124,13 +123,13 @@ function useResolvedRepoNames(agents: Agent[]): number {
   return version;
 }
 
-/** The roster section an agent lives in — god agents share one ungrouped
- *  section, everyone else groups by repository. */
+/** agent 所在的花名册区块——god agents 共享一个不分组区块，
+ *  其余按仓库分组。 */
 function groupKey(agent: Agent): string {
   return agent.isGod ? '__god__' : repoKeyOf(agent);
 }
 
-/** Drag-reorder wiring handed down to each row. */
+/** 传给每一行的拖拽重排接线。 */
 interface RowDrag {
   dragId: string | null;
   overId: string | null;
@@ -142,8 +141,8 @@ interface RowDrag {
 }
 
 export interface FullscreenTerminalProps {
-  /** Only needed to rebuild a spawn command for a restorable agent saved before
-   *  the `command` field existed — same role as in AgentStrip. */
+  /** 仅用于为早于 `command` 字段保存的可恢复 agent 重建 spawn 命令——
+   *  与 AgentStrip 中职责相同。 */
   config?: HarnessConfig | null;
 }
 
@@ -156,13 +155,13 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
   const select = useStore(s => s.select);
   const setAddAgentOpen = useStore(s => s.setAddAgentOpen);
   const addAgentOpen = useStore(s => s.addAgentOpen);
-  // Owned HERE, not in Header, purely so the Esc handler below can see it:
-  // Esc closing the dialog must not also throw you out of focus mode.
+  // 状态归属在这里而非 Header，纯粹是为了让下面的 Esc 处理器能看到它：
+  // Esc 关闭对话框时不能顺便把你扔出焦点模式。
   const [editAgentOpen, setEditAgentOpen] = useState(false);
   const setAgentNote = useStore(s => s.setAgentNote);
   const updateAgent = useStore(s => s.updateAgent);
-  // The floor strip (and with it the restore button) is hidden behind the
-  // overlay, so the roster carries restore too.
+  // 底层条带（连同其中的恢复按钮）被遮罩盖住了，
+  // 所以花名册也要承担恢复功能。
   const { restoring, autoRestoring, restoreTeam } = useRestoreTeam(config);
   const appThemeNow = useAppTheme();
 
@@ -172,24 +171,24 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
   const repoVersion = useResolvedRepoNames(agents);
   const scale = rosterScale(useTerminalFontSize());
 
-  // Drag-to-reorder, same as the floor strip (native HTML5 DnD, no dep). A plain
-  // click still selects — a drag only starts on movement. Drops are confined to
-  // the dragged agent's OWN group: the repo header comes from its cwd, so a
-  // cross-group drop would reorder the array and then snap the row straight back
-  // under its own header, which just reads as "reordering is broken".
+  // 拖拽重排，与底层条带相同（原生 HTML5 DnD，无依赖）。普通
+  // 点击仍会选择——只有移动才开始拖拽。放置被限制在
+  // 被拖 agent 自己的组内：仓库头部来自它的 cwd，因此跨组放置
+  // 会重排数组，然后行又立刻弹回自己的头部之下，
+  // 看起来就像"重排坏了"。
   const reorderAgents = useStore(s => s.reorderAgents);
   const [dragId, setDragId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
-  // Roster collapse. Persisted because it is a working preference, not a mode:
-  // someone who hides the rail to read wide terminal output wants it still hidden
-  // the next time they go fullscreen, not to re-hide it every single time.
+  // 花名册折叠。持久化是因为它是一种工作偏好，而非一种模式：
+  // 为了阅读宽终端输出而隐藏侧栏的人，希望下次进入全屏时它仍然
+  // 隐藏着，而不是每次都要重新隐藏一遍。
   const [rosterCollapsed, setRosterCollapsed] = useState<boolean>(() => {
     try { return localStorage.getItem(ROSTER_COLLAPSED_KEY) === '1'; } catch { return false; }
   });
   const toggleRoster = (): void => {
     setRosterCollapsed((v) => {
       const next = !v;
-      try { localStorage.setItem(ROSTER_COLLAPSED_KEY, next ? '1' : '0'); } catch { /* private mode */ }
+      try { localStorage.setItem(ROSTER_COLLAPSED_KEY, next ? '1' : '0'); } catch { /* 隐私模式 */ }
       return next;
     });
   };
@@ -211,14 +210,14 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
     end: () => { setDragId(null); setOverId(null); }
   };
 
-  // Roster: god agents first and ungrouped, everyone else bucketed by repo.
-  // Insertion order is preserved inside each bucket (it's the user's own
-  // drag-reorder from the floor strip) and buckets appear in first-seen order,
-  // so the list doesn't reshuffle as statuses change.
+  // 花名册：god agents 排在最前且不分组，其余按仓库分桶。
+  // 每个桶内保持插入顺序（这是用户自己在底层条带上
+  // 拖拽重排的结果），桶按首次出现顺序排列，
+  // 因此列表不会随状态变化而重新洗牌。
   const { gods, groups } = useMemo(() => {
     const godList: Agent[] = [];
-    // Keyed by absolute repo root (identity); the label is carried alongside so
-    // two same-named repos stay two groups but still read by name.
+    // 按绝对仓库根键控（身份）；标签随行携带，
+    // 让两个同名仓库仍是两个组，但仍可按名字阅读。
     const byRepo = new Map<string, { label: string; members: Agent[] }>();
     for (const a of agents) {
       if (a.isGod) { godList.push(a); continue; }
@@ -228,15 +227,16 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
       else byRepo.set(key, { label: repoLabelOf(a), members: [a] });
     }
     return { gods: godList, groups: [...byRepo.entries()] };
-    // repoVersion: rebucket once the async main-repo lookups land.
+    // repoVersion：异步主仓库查找落地后重新分桶。
   }, [agents, repoVersion]);
 
-  // Focus mode: adding (or removing) an agent changes the layout around the
-  // focused terminal, but nothing re-fits it, so the grid stays wrong until the
-  // user switches agent and back (a remount, hence a fresh fit). Re-fit on
-  // every roster change. reflowTerminal only pokes the pty when cols/rows
-  // actually moved and never scrolls, so a no-op roster change costs nothing.
-  // Two passes: one after layout settles, one after the roster row has painted.
+  // 焦点模式：添加（或移除）agent 会改变聚焦终端周围的布局，
+  // 但没有任何东西重新适配它，所以网格会一直错位，直到用户
+  // 切换 agent 再切回来（一次重新挂载，因此重新适配）。
+  // 每次花名册变化都重新适配。reflowTerminal 只在 cols/rows
+  // 真正变化时才去触碰 pty，且从不滚动，所以一次无操作的花名册
+  // 变化不花任何代价。跑两遍：一遍在布局稳定后，一遍在花名册
+  // 行绘制完成后。
   const rosterKey = agents.map(a => a.id).join('\n');
   const focusedPtyId = agent?.ptyId;
   useEffect(() => {
@@ -246,12 +246,12 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
     return () => { cancelAnimationFrame(raf); clearTimeout(late); };
   }, [rosterKey, focusedPtyId]);
 
-  // Esc exits fullscreen
+  // Esc 退出全屏
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        // A modal above fullscreen owns the interaction until it closes. Without
-        // this guard, Esc from the Add Agent form unexpectedly exits fullscreen.
+        // 全屏上方的模态框在其关闭前拥有交互权。没有这层
+        // 防护，Add Agent 表单中的 Esc 会意外退出全屏。
         if (addAgentOpen || editAgentOpen) return;
         e.preventDefault();
         setFullscreen(null);
@@ -261,15 +261,15 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
     return () => window.removeEventListener('keydown', onKey);
   }, [addAgentOpen, editAgentOpen, setFullscreen]);
 
-  // Focus mode is pointing at something we cannot render. Re-home to another live
-  // agent rather than dropping the user out; leave only when nothing is left.
-  // In an effect, not in render: setState during render is a React anti-pattern,
-  // and hard-nulling here defeated the store's re-homing the same way onKill did.
-  // `refocusFullscreen`, NOT `setFullscreen`: this is the app following the user,
-  // not the user telling the app what they want. Going through the explicit
-  // toggle here wrote `prefersFocusMode = false` every time an agent went away,
-  // which is the same "fix the store, then overwrite it from a call site" trap
-  // that broke closing an agent in focus mode.
+  // 焦点模式正指向某个我们无法渲染的东西。把它重新安置到另一个
+  // 在线 agent，而不是把用户直接踢出去；只有什么都不剩时才离开。
+  // 放在 effect 里而非 render 中：render 期间 setState 是 React 反模式，
+  // 而且在这里硬置 null 会和 onKill 一样破坏 store 的重新安置。
+  // 用 `refocusFullscreen` 而不是 `setFullscreen`：这是应用在跟随用户，
+  // 而不是用户告诉应用他们想要什么。走这里显式的 toggle 会在每次
+  // agent 离开时写入 `prefersFocusMode = false`，这正是那个
+  // "修好 store，再从调用处覆盖它"的陷阱，它曾弄坏过焦点模式下
+  // 关闭 agent 的功能。
   useEffect(() => {
     if (agent && agent.ptyId) return;
     const s = useStore.getState();
@@ -279,11 +279,11 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
 
   if (!agent || !agent.ptyId) return null;
 
-  // No kill button here on purpose. Killing an agent is a destructive action
-  // that belongs with the rest of its lifecycle controls in the docked panel;
-  // sitting inches from the tab you click to switch agents, it was only ever a
-  // mis-click waiting to happen. Exiting fullscreen is likewise already covered
-  // twice over (Esc, and the terminal toolbar's own fullscreen toggle).
+  // 这里刻意不放杀进程按钮。杀 agent 是破坏性操作，
+  // 应当与其余生命周期控件一起放在停靠面板中；
+  // 把它放在离你点击切换 agent 的标签页几英寸的地方，
+  // 它只会是迟早会发生的误点。退出全屏同样已被覆盖了两遍
+  // （Esc，以及终端工具栏自己的全屏开关）。
   return (
     <div style={{
       position: 'fixed', inset: 0,
@@ -291,9 +291,9 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
       zIndex: 250,
       display: 'flex',
       flexDirection: 'column',
-      paddingTop: 36  // leave room for macOS traffic lights / drag region
+      paddingTop: 36  // 为 macOS 红绿灯 / 拖拽区留出空间
     }}>
-      {/* Title bar drag region (so the user can still move the window) */}
+      {/* 标题栏拖拽区（让用户仍能移动窗口） */}
       <div
         className="cth-titlebar-drag"
         style={{
@@ -309,8 +309,8 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
           fontFamily: 'var(--cth-font-display)', fontSize: 12, lineHeight: '20px',
           color: 'var(--cth-ink-900)'
         }}>MUNDER DIFFLIN · FOCUS MODE</span>
-        {/* Same top-right controls as the main title bar — fullscreen covers
-            it, so theme / exit-fullscreen / IDE must live here too. */}
+        {/* 与主标题栏相同的右上角控件——全屏会盖住标题栏，
+            所以主题 / 退出全屏 / IDE 也必须在这里。 */}
         <div className="cth-titlebar-nodrag" style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 12 }}>
           <button
             onClick={toggleRoster}
@@ -320,8 +320,8 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
             style={{
               display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
               width: 28, height: 28, padding: 0,
-              // Pressed-in when collapsed, so the rail's absence reads as a state
-              // this button is holding rather than something that broke.
+              // 折叠时呈按下状，这样侧栏的消失读起来是这个按钮
+              // 保持的一种状态，而不是出了什么毛病。
               background: rosterCollapsed ? 'var(--cth-lemon)' : 'var(--cth-paper-100)',
               boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
               border: 'none', borderRadius: 2, cursor: 'pointer',
@@ -334,9 +334,9 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
             onClick={() => {
               const next = toggleAppTheme();
               void window.cth.updateConfig({ terminalTheme: next });
-              // Focus mode has its OWN theme button, so notifying only from the
-              // title-bar toggle meant a flip made from in here never reached a
-              // running TUI. Both entry points must tell them.
+              // 焦点模式有自己的主题按钮，所以只从标题栏开关通知的话，
+              // 从这里做出的切换永远到不了正在运行的 TUI。
+              // 两个入口都必须告诉它们。
               notifyThemeChangeAll(next === 'dark' ? 'dark' : 'light');
             }}
             title={appThemeNow === 'dark' ? t('fullscreenTerminal.lightTheme') : t('fullscreenTerminal.darkTheme')}
@@ -352,15 +352,15 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
           >
             {appThemeNow === 'dark' ? '☀' : '☾'}
           </button>
-          {/* Settings — the main title bar has it, so fullscreen must too:
-              anything reachable in one mode and not the other is a trap. Uses
-              App's existing `cth:open-settings` event rather than a new store
-              action, because this overlay is not a child of App. */}
+          {/* 设置——主标题栏有它，全屏也必须有：一种模式能访问而
+              另一种不能的东西都是陷阱。复用 App 现有的
+              `cth:open-settings` 事件而不是新增 store action，
+              因为这个遮罩层不是 App 的子元素。 */}
           <button
             className="cth-settings-btn"
             onClick={() => window.dispatchEvent(new CustomEvent('cth:open-settings'))}
-            title="Settings"
-            aria-label="Settings"
+            title={t('fullscreenTerminal.settingsTitle')}
+            aria-label={t('fullscreenTerminal.settingsTitle')}
             style={{
               display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
               width: 28, height: 28, padding: 0,
@@ -394,20 +394,19 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
           >
             <Icon name="minimize" size={1} style={{ width: 16, height: 16 }} />
           </button>
-          {/* v0.3.4: IDE moved to agent level — it lives in each agent's
-              header (see Header below), not in this global bar. */}
+          {/* v0.3.4: IDE 移到了 agent 层级——它住在每个 agent 的
+              头部（见下方 Header），不在这个全局栏里。 */}
         </div>
       </div>
 
-      {/* Body — roster on the left, the focused agent's terminal on the right.
-          A vertical list scales past the handful of agents a horizontal tab bar
-          could show, and grouping by repository is how the user actually thinks
-          about the fleet. */}
+      {/* 主体——左侧花名册，右侧聚焦 agent 的终端。
+          垂直列表能扩展到横向标签栏只能显示几个 agent 的数量之上，
+          而且按仓库分组正是用户思考整个团队的方式。 */}
       <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
-        {/* Unmounted rather than width:0 when collapsed — the roster renders a row
-            per agent with live status, and keeping a hidden copy mounted would go
-            on doing that work for a rail nobody can see. Remounting is cheap; the
-            terminals live in the pool and are untouched by this. */}
+        {/* 折叠时卸载而不是 width:0——花名册为每个 agent 渲染一行
+            实时状态，若保留一个隐藏副本挂载着，就会为一条没人看得见的
+            侧栏继续做那些工作。重新挂载代价很低；终端活在池子里，
+            不受此影响。 */}
         {!rosterCollapsed && (
         <aside style={{
           width: SIDEBAR_WIDTH, flexShrink: 0,
@@ -436,8 +435,8 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
           </div>
 
           <div className="cth-scroll-hidden" style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '6px 0' }}>
-            {/* The god agent runs the floor rather than a checkout, so it gets no
-                repository header — it sits alone at the top of the roster. */}
+            {/* god agent 运行整个大厅而不是某个检出，所以它没有
+                仓库头部——它独自坐在花名册顶部。 */}
             {gods.map(a => (
               <SidebarRow
                 key={a.id}
@@ -450,8 +449,8 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
               />
             ))}
             {groups.map(([repoKey, { label, members }]) => (
-              // Repos are the roster's real structure, so they get real
-              // separation — a hairline plus air above, not just a label.
+              // 仓库才是花名册真正的结构，所以它们需要真正的
+              // 分隔——上方一条发丝线加空隙，而不只是标签。
               <div key={repoKey} style={{ marginTop: 16, paddingTop: 10, borderTop: '1px solid var(--cth-ink-300)' }}>
                 <div
                   title={repoKey}
@@ -463,9 +462,9 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
                     color: 'var(--cth-ink-500)'
                   }}
                 >
-                  {/* Native 16px, never a fraction of it: this is pixel art on
-                      a 16-unit grid, so squeezing it to match a 7px label
-                      merged the outline into mush. Dimmed instead of shrunk. */}
+                  {/* 原生 16px，绝不用它的几分之一：这是绘制在 16 单位
+                      网格上的像素艺术，所以把它压到和 7px 标签一样大
+                      会把轮廓糊成一团。用变暗代替缩小。 */}
                   <span style={{ flexShrink: 0, display: 'inline-flex', opacity: 0.7 }}>
                     <Icon name="folder" size={scale.group >= 13 ? 2 : 1} />
                   </span>
@@ -489,16 +488,15 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
             ))}
           </div>
 
-          {/* Last session's team, same as the floor strip — pinned to the bottom
-              so it can't be scrolled out of reach behind a long roster. */}
+          {/* 上一会话的团队，与底层条带相同——固定在底部，
+              这样它不会被滚到一长条花名册后面够不着。 */}
           {(restorableAgents.length > 0 || autoRestoring) && (
             <div style={{
               flexShrink: 0, padding: 8, display: 'flex', flexDirection: 'column', gap: 6,
               borderTop: '1px solid var(--cth-ink-300)'
             }}>
               {autoRestoring && (
-                // Same banner as the floor strip: terminals that open by
-                // themselves need to say why.
+                // 与底层条带相同的横幅：自行打开的终端需要说明原因。
                 <div style={{
                   display: 'flex', alignItems: 'center', gap: 6,
                   padding: '4px 8px',
@@ -566,11 +564,11 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
           padding: 12, gap: 10
         }}>
           {agent.isGod ? (
-            // Michael runs the floor from the command center — its tabs (tasks,
-            // ask me, triggers, memory, graph…) are the whole point of selecting
-            // him, and fullscreen used to drop them for a bare terminal.
-            // Column so the panel's `height: 100%` resolves against a definite
-            // height and `align-items: stretch` gives it the full width.
+            // Michael 从指挥中心运行整个大厅——它的那些标签页（tasks、
+            // ask me、triggers、memory、graph…）正是选中他的全部意义所在，
+            // 而全屏模式以前会为了一台裸终端把它们全部丢掉。
+            // 用列布局，这样面板的 `height: 100%` 能解析出确定的高度，
+            // `align-items: stretch` 则给它完整宽度。
             <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
               <CommandCenterPanel agent={agent} fullscreen />
             </div>
@@ -581,8 +579,8 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
                 <EditAgentModal agent={agent} onClose={() => setEditAgentOpen(false)} />
               )}
 
-              {/* #7C — pause / halt / steer. These only existed in the docked
-                  sidebar, so going fullscreen took the operator controls away. */}
+              {/* #7C — pause / halt / steer。这些以前只存在于停靠的
+                  侧边栏中，所以进入全屏就把操作员控件拿走了。 */}
               <AgentControlStrip key={agent.id} agentId={agent.id} />
 
               <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
@@ -612,22 +610,22 @@ export function FullscreenTerminal({ config }: FullscreenTerminalProps) {
   );
 }
 
-/** Model ids are long and mostly boilerplate ("claude-opus-4-8[1m]",
- *  "anthropic/claude-sonnet-4-5"). The roster has ~120px, so show the part that
- *  distinguishes one agent from another and keep the full id in the tooltip. */
+/** 模型 id 很长且大多是样板文本（"claude-opus-4-8[1m]"、
+ *  "anthropic/claude-sonnet-4-5"）。花名册只有约 120px，
+ *  所以显示区分不同 agent 的那部分，完整 id 放在 tooltip 里。 */
 function shortModel(model?: string): string | null {
   if (!model || !model.trim()) return null;
   const tail = model.split('/').pop() ?? model;
   return tail
     .replace(/^claude-/i, '')
-    .replace(/-\d{8}$/, '')          // trailing date stamps
+    .replace(/-\d{8}$/, '')          // 末尾日期戳
     .replace(/\[(\d+)m\]/i, ' $1m') // [1m] → 1m
     .replace(/-/g, ' ')
     .trim();
 }
 
-/** Context fullness as a 3px rail. Colour tracks pressure rather than identity —
- *  an agent at 85% is about to compact, and that matters more than its accent. */
+/** 上下文饱满度，用一条 3px 轨道表示。颜色跟随压力而非身份——
+ *  处于 85% 的 agent 即将压缩，这比它的强调色更重要。 */
 function ContextBar({ tokens, limit, accent }: { tokens?: number; limit?: number; accent: string }) {
   const { t } = useTranslation();
   if (tokens === undefined || !limit) return null;
@@ -671,33 +669,31 @@ function SidebarRow({
   const noteRef = useRef<HTMLDivElement>(null);
   const [notePosition, setNotePosition] = useState<{ left: number; top: number } | null>(null);
 
-  // The editor rides the terminal's zoom, capped — it's a short note, not a
-  // reading pane, and following the terminal all the way up turned it into a
-  // banner wider than the roster itself.
+  // 编辑器跟随终端的缩放，但设了上限——它是短便条，不是阅读面板，
+  // 完全跟随终端缩放会把它变成比花名册还宽的横幅。
   const noteFontSize = Math.min(useTerminalFontSize(), 14);
   const noteLabelSize = Math.max(8, Math.round(noteFontSize * 0.6));
   const noteWidth = Math.min(300, Math.round(noteFontSize * 20));
   const noteHeight = Math.round(noteFontSize * 9);
-  // Total popover height, used only to keep it on screen near the bottom edge:
-  // the note textarea plus its label, the hint and the padding.
+  // 弹层总高度，仅用于让它贴着底部边缘保持在屏幕内：
+  // 便条文本框加上它的标签、提示和内边距。
   const popoverHeight = noteHeight + noteLabelSize * 2 + 40;
 
-  // One line of the note = one bullet on the row.
+  // 便条的一行 = 行上的一个圆点。
   const bullets = (agent.note ?? '').split('\n').map(s => s.trim()).filter(Boolean);
 
   const typing = useHasTerminalDraft(agent.ptyId);
 
-  /** The ✎ button opens the editor beside the row — the bullets on the row are
-   *  the summary, this is where you write them. EXPLICIT open only (v0.3.4):
-   *  hovering the roster no longer pops editors under the pointer. */
+  /** ✎ 按钮在行旁打开编辑器——行上的圆点是摘要，这里才是书写处。
+   *  仅显式打开（v0.3.4）：悬停花名册不再在指针下弹出编辑器。 */
   const toggleEditor = () => {
     if (notePosition) { setNotePosition(null); return; }
-    // An editor popping up mid-drag just gets in the way.
+    // 拖拽中途弹出一个编辑器只会碍事。
     if (drag.dragId) return;
     const rect = buttonRef.current?.getBoundingClientRect();
     if (!rect) return;
-    // The roster is a left rail, so the editor opens to the RIGHT of its row.
-    // Clamp so rows near an edge stay fully on screen.
+    // 花名册是左侧栏，所以编辑器在其行右侧打开。
+    // 钳制让靠近边缘的行也完整保持在屏幕内。
     setNotePosition({
       left: Math.min(rect.right + 6, window.innerWidth - noteWidth - 8),
       top: Math.max(8, Math.min(rect.top, window.innerHeight - popoverHeight - 8))
@@ -729,7 +725,7 @@ function SidebarRow({
           border: 'none',
           boxShadow: active
             ? 'inset 3px 0 0 var(--cth-ink-900), inset 0 0 0 1px var(--cth-ink-100)'
-            // Insertion cue on the hovered drop target.
+            // 悬停放置目标上的插入提示。
             : drag.overId === agent.id && drag.dragId && drag.dragId !== agent.id
             ? 'inset 0 2px 0 var(--cth-ink-900)'
             : 'none',
@@ -747,13 +743,13 @@ function SidebarRow({
           width: scale.portrait, height: Math.round(scale.portrait * 1.3), flexShrink: 0,
           background: `var(--cth-${agent.accent}-light)`,
           boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
-          // Anchor the sprite's TOP: the portrait is taller than this tile, and
-          // bottom-anchoring cropped the head — crop feet, not face (v0.3.4).
+          // 锚定精灵图的顶部：画像比这个贴图高，而底部锚定
+          // 会裁掉头部——裁脚不裁脸（v0.3.4）。
           display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
           overflow: 'hidden'
         }}>
-          {/* The sprite is drawn at exactly the tile's width, so the figure
-              grows with the tile instead of floating in it. */}
+          {/* 精灵图按恰好等于贴图宽度的尺寸绘制，因此形象
+              随贴图一起变大，而不是悬浮在其中。 */}
           <SpritePortrait character={agent.character} scale={scale.portraitScale} />
         </div>
         <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -764,12 +760,12 @@ function SidebarRow({
               fontFamily: 'var(--cth-font-display)',
               fontSize: scale.name, lineHeight: 1.5
             }}>{agent.name.toUpperCase()}</span>
-            {/* Your unsent text outranks the agent's own state here: an idle
-                agent with a draft on its prompt is not idle-and-free, it is
-                idle-and-held, and nothing else on screen said so. */}
+            {/* 你未发送的文本在这里优先于 agent 自身状态：一个在提示
+                框里拖着草稿的 idle agent 不是 idle-and-free，而是
+                idle-and-held，而屏幕上没有任何别处这么说。 */}
             <PixelBadge status={typing ? 'typing' : agent.status} />
-            {/* Explicit note edit — a real control instead of a hover surprise.
-                A span, not a <button>: we're inside the row's button element. */}
+            {/* 显式备注编辑——一个真正的控件，而不是悬停惊喜。
+                用 span 而非 <button>：我们位于该行的按钮元素内部。 */}
             <span
               role="button"
               tabIndex={0}
@@ -789,11 +785,11 @@ function SidebarRow({
               }}
             >✎</span>
           </div>
-          {/* WHAT this agent is, at a glance. The roster used to carry only a
-              name, a portrait and a status dot — enough to tell rows apart, not
-              enough to answer "which model is this on, where is it working, and
-              how full is its context", which is exactly what you need when the
-              terminal is the whole screen and the sidebar is your only index. */}
+          {/* 一眼看出这个 agent 是什么。花名册以前只带
+              名字、头像和一个状态点——足够区分行与行，却不足以回答
+              "这个跑在什么模型上、在哪工作、上下文有多满"，
+              而这正是当终端占满整个屏幕、侧边栏是你唯一索引时
+              你需要的信息。 */}
           <div style={{
             display: 'flex', alignItems: 'center', gap: 6, minWidth: 0,
             fontSize: Math.max(9, scale.name - 3), lineHeight: 1.4,
@@ -814,8 +810,8 @@ function SidebarRow({
             </span>
           </div>
           <ContextBar tokens={agent.contextTokens} limit={agent.contextLimit} accent={agent.accent} />
-          {/* Every line of every agent, always on screen — the roster's job is
-              to answer "who is on what" without a single interaction. */}
+          {/* 每个 agent 的每一行都常驻屏幕——花名册的职责就是
+              无需任何交互就回答"谁在做什么"。 */}
           <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             {bullets.map((line, i) => (
               <span
@@ -828,9 +824,9 @@ function SidebarRow({
                 }}
               >
                 <span style={{ flexShrink: 0, color: 'var(--cth-ink-300)' }}>•</span>
-                {/* Exactly one line per bullet — a wrapping row would make the
-                    roster's height jump around as notes are typed. The full
-                    text is on hover (title, and the editor beside it). */}
+                {/* 每个圆点恰好一行——折行会让花名册的高度
+                    在输入备注时来回跳动。全文放在悬停上
+                    （title 与旁边的编辑器）。 */}
                 <span style={{
                   whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
                 }}>{line}</span>
@@ -840,14 +836,14 @@ function SidebarRow({
               <span style={{
                 fontSize: scale.note, lineHeight: 1.35,
                 color: 'var(--cth-ink-300)', fontStyle: 'italic'
-              }}>no note</span>
+              }}>{t('fullscreenTerminal.noNote')}</span>
             )}
           </div>
         </div>
       </button>
       {notePosition && createPortal(
         <>
-        {/* click-away backdrop — the editor stays until dismissed on purpose */}
+        {/* 点击外部关闭的背景层——编辑器会一直保留，直到刻意关闭 */}
         <div
           onClick={() => setNotePosition(null)}
           style={{ position: 'fixed', inset: 0, zIndex: 449, background: 'transparent' }}
@@ -873,17 +869,17 @@ function SidebarRow({
             fontSize: noteLabelSize,
             lineHeight: `${Math.round(noteLabelSize * 1.5)}px`,
             color: 'var(--cth-ink-700)'
-          }}>PRIVATE NOTE</div>
-          {/* A textarea, not an input: the note is a bullet list, so Enter has
-              to make a new line rather than doing nothing. autoFocus is safe
-              now that opening is an explicit click, not a pointer fly-by. */}
+          }}>{t('fullscreenTerminal.privateNote')}</div>
+          {/* 用 textarea 而非 input：备注是项目符号列表，所以 Enter
+              必须新建一行而不是什么都不做。autoFocus 现在很安全，
+              因为打开是显式点击，不是指针飞掠。 */}
           <textarea
             dir={rtl ? 'auto' : undefined}
             autoFocus
             value={agent.note ?? ''}
             onChange={(e) => onNoteChange(e.target.value)}
             onKeyDown={(e) => {
-              e.stopPropagation(); // don't let Esc/typing reach the fullscreen handler
+              e.stopPropagation(); // 别让 Esc/输入触达全屏处理器
               if (e.key === 'Escape') {
                 setNotePosition(null);
                 buttonRef.current?.focus();
@@ -909,7 +905,7 @@ function SidebarRow({
           />
           <div style={{
             marginTop: 5, fontSize: 10, color: 'var(--cth-ink-500)'
-          }}>one line = one bullet · esc to close</div>
+          }}>{t('fullscreenTerminal.noteHint')}</div>
         </div>
         </>,
         document.body
@@ -924,9 +920,9 @@ function Header({ agent, onEdit }: { agent: Agent; onEdit: () => void }) {
   const archiveAgent = useStore((st) => st.archiveAgent);
   const [openState, setOpenState] = useState<'idle' | 'opening' | 'ok' | 'error'>('idle');
 
-  /** Same action as the docked panel: open the OS terminal in this agent's
-   *  working directory. Fullscreen had no way to do it, which is backwards —
-   *  this is the mode where you are most likely to want a shell beside it. */
+  /** 与停靠面板相同的动作：在这个 agent 的工作目录打开
+   *  OS 终端。全屏以前没有途径做到这一点，这很反常——
+   *  这正是你最可能想在其旁边开一个 shell 的模式。 */
   const openTerminal = async () => {
     setOpenState('opening');
     try {
@@ -936,18 +932,19 @@ function Header({ agent, onEdit }: { agent: Agent; onEdit: () => void }) {
     setTimeout(() => setOpenState('idle'), 1500);
   };
 
-  /** Kill + archive, mirroring AgentDetailPanel. Confirmed, because it ends a
-   *  running process. God is exempt: the floor respawns it immediately, so the
-   *  button would read as "restart Michael" while looking like "close". */
+  /** 杀掉并归档，与 AgentDetailPanel 一致。需要确认，
+   *  因为它会终止一个正在运行的进程。god 豁免：大厅会立即
+   *  把它重生，所以那个按钮会读作"重启 Michael"，
+   *  却长得像"关闭"。 */
   const onKill = async () => {
     if (!agent.ptyId) return;
     if (!confirm(t('agentDetail.killConfirm', { name: agent.name }))) return;
     await window.cth.killPty(agent.ptyId);
     disposeTerminal(agent.ptyId);
-    // archiveAgent re-homes focus mode to the next agent, and only leaves it when
-    // the last one is gone. Hard-nulling here threw that away, which is why
-    // closing an agent from inside focus mode still dropped you to the sidebar
-    // even after the store was fixed.
+    // archiveAgent 会把焦点模式重新安置到下一个 agent，并且只有当
+    // 最后一个也消失时才离开它。在这里硬置 null 会丢掉那一切，
+    // 这正是即使在 store 修复之后，从焦点模式内部关闭 agent
+    // 仍会把你丢回侧边栏的原因。
     archiveAgent(agent.id);
   };
 
@@ -962,11 +959,11 @@ function Header({ agent, onEdit }: { agent: Agent; onEdit: () => void }) {
         fontFamily: 'var(--cth-font-display)', fontSize: 10, lineHeight: '16px',
         color: 'var(--cth-ink-900)'
       }}>{agent.name.toUpperCase()}</span>
-      {/* Edit belongs with the NAME, not with the action cluster on the right:
-          it changes who this agent is, and the right-hand group is things you do
-          with the agent. Icon-only because it sits inside the identity line —
-          the word "edit" there would push the path off. God is excluded, as
-          everywhere else: his identity is the hive's, not the roster's. */}
+      {/* 编辑归属在名字旁，而不是右侧的操作簇：它改变的是这个
+          agent 是谁，而右侧那组是"对这个 agent 做什么"。仅图标，
+          因为它位于身份行内部——那里的 "edit" 一词会把路径挤掉。
+          god 被排除在外，与其他各处一致：他的身份属于整个 hive，
+          不属于花名册。 */}
       {!agent.isGod && (
         <PixelButton variant="secondary" size="sm" onClick={onEdit}>
           <span
@@ -989,11 +986,10 @@ function Header({ agent, onEdit }: { agent: Agent; onEdit: () => void }) {
         fontStyle: 'italic'
       }}>“{agent.description}”</span>
       <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
-        {/* v0.3.4: the IDE opens from agent level — full Monaco editor + git
-            diff over this agent's workspace. The id is passed EXPLICITLY:
-            fullscreen does not change the selection, so leaving the IDE to infer
-            its agent would open whichever agent happens to be selected in the
-            sidebar rather than the one filling the screen. */}
+        {/* v0.3.4: IDE 从 agent 层级打开——这个 agent 工作区上的
+            完整 Monaco 编辑器 + git diff。id 是显式传入的：
+            全屏不改变选择，所以让 IDE 自己推断 agent 会打开侧边栏里
+            恰好被选中的那个，而不是填满屏幕的这个。 */}
         <PixelButton variant="secondary" size="sm" onClick={() => useStore.getState().setIdeOpen(true, agent.id)}>
           <span
             className="cth-tip cth-tip-wrap"
@@ -1004,10 +1000,10 @@ function Header({ agent, onEdit }: { agent: Agent; onEdit: () => void }) {
             <Icon name="code" /> {t('commandCenter.ide')}
           </span>
         </PixelButton>
-        {/* Voice toggle is ALWAYS reachable in fullscreen — it controls Michael (the
-            god orchestrator) globally, not the agent in view, so users can start a
-            voice session even while a worker's terminal fills the screen. The cost
-            HUD stays Michael-only (it belongs to his card). */}
+        {/* 语音开关在全屏中始终可达——它全局控制 Michael（god
+            编排器），而不是当前视图里的 agent，因此即使用户在
+            worker 的终端占满屏幕时也能开始一次语音会话。成本
+            HUD 仍只属于 Michael（它属于他的卡片）。 */}
         <RealtimeMichaelToggle />
         {agent.isGod && <CostHud compact />}
         <PixelButton variant="secondary" size="sm" onClick={openTerminal} disabled={openState === 'opening'}>
@@ -1021,23 +1017,22 @@ function Header({ agent, onEdit }: { agent: Agent; onEdit: () => void }) {
             {openState === 'opening' ? t('agentDetail.opening') : openState === 'ok' ? t('agentDetail.ok') : openState === 'error' ? t('agentDetail.err') : t('agentDetail.open')}
           </span>
         </PixelButton>
-        {/* The badge is a STATUS, not a button, but it sits in a row of them.
-            Its own box is 20px (lineHeight 18 + 2px padding) against the 24px
-            every size="sm" PixelButton is fixed at, so the row read as ragged.
-            Sized through the badge's own style prop rather than a wrapper: a
-            wrapper only centres the 20px box inside 24px, it does not make the
-            visible border match. */}
+        {/* 徽章是一种 STATUS，不是按钮，但它和按钮排在一行。
+            它自身的盒高是 20px（lineHeight 18 + 2px 内边距），
+            而每个 size="sm" 的 PixelButton 都固定在 24px，
+            所以这一行读起来参差不齐。通过徽章自身的 style
+            属性来定尺寸，而不是用包装器：包装器只是把 20px 的盒
+            居中到 24px 里，并不会让可见边框对齐。 */}
         <PixelBadge
           status={typing ? 'typing' : agent.status}
           style={{ height: 24, padding: '0 8px', lineHeight: '24px' }}
         />
         {!agent.isGod && (
           <PixelButton variant="destructive" size="sm" onClick={onKill}>
-            {/* inline-flex + center: the other buttons hold TEXT, whose line box
-                the button centres for free. A bare <Icon> is replaced-content
-                sitting on the text baseline, so it rode low and overhung the
-                24px box — the button measured the same as its neighbours while
-                reading taller than them. */}
+            {/* inline-flex + center：其他按钮持有 TEXT，其行盒由按钮
+                免费居中。裸 <Icon> 是替换内容，落在文本基线上，
+                所以它会偏下并超出 24px 盒——按钮量起来和邻居一样，
+                看起来却比它们高。 */}
             <span
               title={t('fullscreenTerminal.closeAgent', { name: agent.name })}
               style={{ display: 'inline-flex', alignItems: 'center', lineHeight: 0 }}

--- a/src/renderer/src/components/GitTab.tsx
+++ b/src/renderer/src/components/GitTab.tsx
@@ -73,7 +73,7 @@ export function GitTab({ cwd }: GitTabProps) {
       if ('error' in s) setError(prev => prev ?? s.error); else setStatus(s);
       if (Array.isArray(l)) setLog(l); else if ('error' in l) setError(prev => prev ?? l.error);
       if ('error' in br) setError(prev => prev ?? br.error); else setBranches({ local: br.local, remote: br.remote });
-      if ('error' in ab) { /* keep defaults */ } else { setAhead(ab.ahead); setBehind(ab.behind); setUpstream(ab.upstream); }
+      if ('error' in ab) { /* 保留默认值 */ } else { setAhead(ab.ahead); setBehind(ab.behind); setUpstream(ab.upstream); }
     } finally {
       setLoading(false);
     }
@@ -81,7 +81,7 @@ export function GitTab({ cwd }: GitTabProps) {
 
   useEffect(() => {
     refresh();
-    // Poll the working-tree status every 4s so freshly-edited files show up.
+    // 每 4 秒轮询一次工作树状态，让刚编辑的文件及时出现。
     const id = window.setInterval(refresh, 4000);
     return () => window.clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -107,7 +107,7 @@ export function GitTab({ cwd }: GitTabProps) {
       display: 'flex', flexDirection: 'column',
       background: 'var(--cth-paper-100)'
     }}>
-      {/* Branch + ahead/behind header */}
+      {/* 分支 + ahead/behind 头部 */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 8,
         padding: '6px 10px',
@@ -145,9 +145,9 @@ export function GitTab({ cwd }: GitTabProps) {
         }}>{error}</div>
       )}
 
-      {/* Body — scrollable, contains status + branches + graph */}
+      {/* 主体 —— 可滚动，包含状态、分支与图形 */}
       <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-        {/* Status */}
+        {/* 状态 */}
         <Section title={t('gitTab.sectionStatus')}>
           {status && (
             <>
@@ -163,7 +163,7 @@ export function GitTab({ cwd }: GitTabProps) {
           )}
         </Section>
 
-        {/* Branches */}
+        {/* 分支 */}
         {branches && (branches.local.length > 0 || branches.remote.length > 0) && (
           <Section title={t('gitTab.sectionBranches')}>
             <div style={{ padding: '0 8px 8px', display: 'flex', flexWrap: 'wrap', gap: 4 }}>
@@ -191,7 +191,7 @@ export function GitTab({ cwd }: GitTabProps) {
           </Section>
         )}
 
-        {/* Graph */}
+        {/* 图形 */}
         <Section title={t('gitTab.sectionLog')}>
           {log.length > 0 ? <CommitGraph commits={log} currentBranch={branch} /> : (
             <div style={{ padding: 12, color: 'var(--cth-ink-500)', fontSize: 12 }}>{t('gitTab.noCommits')}</div>

--- a/src/renderer/src/components/HivePicker.tsx
+++ b/src/renderer/src/components/HivePicker.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
 import { PixelPanel } from './PixelPanel';
 import { PixelButton } from './PixelButton';
 import { Icon } from './Icon';
@@ -6,13 +7,13 @@ import type { HarnessConfig } from '@/store/config';
 
 export interface HivePickerProps {
   config: HarnessConfig;
-  /** Open the CURRENT harness home in-place (no relaunch). */
+  /** 原地打开当前 harness home（不重启）。 */
   onOpenCurrent: () => void;
 }
 
-// Set right before a hive SWITCH so App skips this picker once after the relaunch
-// changeHome triggers — otherwise the user would land back on the picker for the
-// hive they just chose. App.tsx reads + clears it on mount.
+// 在 hive 切换前设置此键，使 App 在 changeHome 触发的重启后
+// 只跳过此选择器一次——否则用户会再次落回刚刚选中的 hive 的选择器。
+// App.tsx 在挂载时读取并清除它。
 const SKIP_KEY = 'cth.skipHivePickerOnce';
 
 function folderName(path: string): string {
@@ -20,21 +21,22 @@ function folderName(path: string): string {
 }
 
 /**
- * HivePicker — the launch-time workspace selector. A "hive" is a harness home
- * folder: its own agents, memory, tasks, and history. On reopen the user can open
- * the hive they were in (fast, in-place), jump to a recent one, browse to an
- * existing folder, or start a new one. Switching to a DIFFERENT home goes through
- * changeHome('fresh'), which tears down services and relaunches against it — so
- * every switch is a clean process restart (cheap here, before any work is live).
+ * HivePicker —— 启动时的工作区选择器。"hive" 是一个 harness home
+ * 文件夹：拥有自己的 agents、memory、tasks 与 history。重新打开时，
+ * 用户可以进入上次所在的 hive（快速、原地），跳转到最近的某一个，
+ * 浏览一个已有文件夹，或新建一个。切换到"不同"的 home 会走
+ * changeHome('fresh')，它会拆除服务并针对新 home 重启——因此每次切换
+ * 都是一次干净的过程重启（在任何工作开始之前，代价很小）。
  */
 export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
+  const { t } = useTranslation();
   const current = config.harnessHome;
   const recents = (config.recentHives ?? []).filter((h) => h && h !== current);
   const [busy, setBusy] = useState<string | undefined>();
   const [error, setError] = useState<string | undefined>();
 
-  // Open a hive. Same folder as the current one → just enter it (no relaunch).
-  // A different folder → changeHome('fresh') re-points + relaunches the process.
+  // 打开一个 hive。与当前所在文件夹相同 → 直接进入（不重启）。
+  // 不同的文件夹 → changeHome('fresh') 重新指向并重启进程。
   const openHive = async (path: string) => {
     if (!path) return;
     if (current && path === current) { onOpenCurrent(); return; }
@@ -43,10 +45,10 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
     try {
       window.localStorage.setItem(SKIP_KEY, '1');
       const res = await window.cth.changeHome(path, 'fresh');
-      // Success never returns (the process relaunches). A return means an error.
+      // 成功从不返回（进程会重启）。有返回即意味着出错。
       if (!res.ok) {
         window.localStorage.removeItem(SKIP_KEY);
-        setError(res.error ?? 'Could not open that folder.');
+        setError(res.error ?? t('hivePicker.couldNotOpen'));
         setBusy(undefined);
       }
     } catch (e) {
@@ -74,20 +76,17 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
       padding: 32
     }}>
       <div style={{ width: 560, maxWidth: '94vw' }}>
-        <PixelPanel variant="dialog" title="SELECT A HARNESS CONFIG" noPadding>
+        <PixelPanel variant="dialog" title={t('hivePicker.title')} noPadding>
           <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 14 }}>
             <p style={{ margin: 0, fontSize: 12, lineHeight: '19px', color: 'var(--cth-ink-700)' }}>
-              A <strong>harness config</strong> is the folder where the app keeps everything for one
-              workspace — its settings, your agents and their memory, tasks, triggers, and history.
-              Each config is separate and self-contained, so you can run different setups side by side.
-              Open the one you were working in, switch to another, or start a new one.
+              <Trans i18nKey="hivePicker.desc" components={{ strong: <strong /> }} />
             </p>
 
-            {/* CURRENT — the last-used home, the one-click default. */}
+            {/* CURRENT —— 上次使用的 home，一键默认项。 */}
             {current && (
               <div>
                 <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 9, color: 'var(--cth-ink-500)', marginBottom: 4 }}>
-                  CURRENT
+                  {t('hivePicker.current')}
                 </div>
                 <div style={{
                   display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px',
@@ -104,17 +103,17 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
                     }}>{current}</div>
                   </div>
                   <PixelButton variant="primary" size="md" onClick={onOpenCurrent} disabled={!!busy}>
-                    open
+                    {t('hivePicker.open')}
                   </PixelButton>
                 </div>
               </div>
             )}
 
-            {/* RECENTS — other homes this install has opened before. */}
+            {/* RECENTS —— 此安装此前打开过的其他 home。 */}
             {recents.length > 0 && (
               <div>
                 <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 9, color: 'var(--cth-ink-500)', marginBottom: 4 }}>
-                  RECENT
+                  {t('hivePicker.recent')}
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 220, overflowY: 'auto' }}>
                   {recents.map((h) => (
@@ -122,7 +121,7 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
                       key={h}
                       onClick={() => openHive(h)}
                       disabled={!!busy}
-                      title={`Switch to ${h} (reloads the app)`}
+                      title={t('hivePicker.switchTo', { path: h })}
                       style={{
                         display: 'flex', alignItems: 'center', gap: 10, padding: '8px 12px',
                         background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
@@ -141,7 +140,7 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
                         }}>{h}</div>
                       </div>
                       <span style={{ fontSize: 11, color: 'var(--cth-ink-500)', flexShrink: 0 }}>
-                        {busy === h ? 'opening…' : 'switch →'}
+                        {busy === h ? t('hivePicker.openingEllipsis') : t('hivePicker.switchArrow')}
                       </span>
                     </button>
                   ))}
@@ -158,21 +157,21 @@ export function HivePicker({ config, onOpenCurrent }: HivePickerProps) {
 
             {busy && (
               <div style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>
-                Opening {folderName(busy)} — the app will reload…
+                {t('hivePicker.opening', { name: folderName(busy) })}
               </div>
             )}
 
-            {/* OPEN / CREATE — both browse to a folder; "fresh" mode re-points at it
-                (bootstrapping an empty one, or reusing existing hive data in place). */}
+            {/* OPEN / CREATE —— 两者都会浏览到文件夹；"fresh" 模式会重新指向它
+                （引导一个空文件夹，或就地复用已有的 hive 数据）。 */}
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
               <PixelButton variant="secondary" size="md" onClick={browse} disabled={!!busy}>
                 <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
-                  <Icon name="folder" /> open existing config…
+                  <Icon name="folder" /> {t('hivePicker.openExisting')}
                 </span>
               </PixelButton>
               <PixelButton variant="secondary" size="md" onClick={browse} disabled={!!busy}>
                 <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
-                  <Icon name="plus" /> create new config…
+                  <Icon name="plus" /> {t('hivePicker.createNew')}
                 </span>
               </PixelButton>
             </div>

--- a/src/renderer/src/components/Icon.tsx
+++ b/src/renderer/src/components/Icon.tsx
@@ -1,5 +1,5 @@
-// 16×16 pixel icons. 2 colors max. Integer paths only.
-// Add to library by extending `paths` below.
+// 16×16 像素图标。最多 2 种颜色。路径只使用整数坐标。
+// 要扩充图标库，请扩展下面的 `paths`。
 
 import { CSSProperties } from 'react';
 
@@ -10,15 +10,15 @@ export type IconName =
   | 'image' | 'edit' | 'git';
 
 interface IconDef {
-  ink: string;     // primary color path d
-  accent?: string; // optional accent color path d
-  accentColor: string; // CSS var name
+  ink: string;     // 主色路径 d
+  accent?: string; // 可选强调色路径 d
+  accentColor: string; // CSS 变量名
 }
 
 const paths: Record<IconName, IconDef> = {
-  // 16x16 each, designed on pixel grid
-  // Cog with four teeth (N/S/E/W) + a square hub hole. The hole is a second
-  // subpath cut out via fill-rule: evenodd (set on the <path> below).
+  // 每个均为 16x16，按像素网格设计
+  // 四齿齿轮（N/S/E/W）+ 方形中心孔。该孔是第二个子路径，
+  // 通过 fill-rule: evenodd（设置在下方的 <path> 上）镂空而成。
   gear: {
     accentColor: 'var(--cth-ink-300)',
     ink:   'M6 1h4v3h2v2h3v4h-3v2h-2v3h-4v-3h-2v-2h-3v-4h3v-2h2v-3zM6 6h4v4h-4z'
@@ -39,14 +39,13 @@ const paths: Record<IconName, IconDef> = {
     accentColor: 'var(--cth-sky)',
     ink:   'M8 3h2v2h2v2h2v2h-2v2h-2v2H8v-2h2V9H2V7h8V5H8V3z'
   },
-  // Notebook + pen. Two earlier tries were solid pixel-art pencils and both read
-  // as a blob at 16px; this sits next to `code` and `terminal` in the same row,
-  // so it is drawn the way they are — hairline outlines, one colour, two whole
-  // objects with a clear gap between them rather than one overlapping the other.
-  // Notepad with the pen laid ACROSS its top-right corner, not parked beside it.
-  // The pen breaks the pad's outline where it crosses, and that broken edge is
-  // the whole trick — two shapes sharing one ink colour only read as "over" if
-  // the lower one visibly stops. Same hairline weight as code/terminal/git.
+  // 记事本 + 笔。前两次尝试都是实心像素铅笔，在 16px 下都糊成一团；
+  // 它和 `code`、`terminal` 排在同一行，因此绘制风格与它们一致——
+  // 发丝级细轮廓、单色、两个完整对象之间留有清晰空隙，而不是彼此重叠。
+  // 记事本上的笔横跨其右上角摆放，而不是停在旁边。
+  // 笔在交叉处打断记事本的轮廓，这条断边正是关键所在——共享同一种墨色的
+  // 两个形状，只有当下方那个明显中断时，才会被读作"叠放在上"。
+  // 与 code/terminal/git 使用相同的发丝级粗细。
   edit: {
     accentColor: 'var(--cth-lilac)',
     ink:   'M13 1h2v1h-2zM1 2h10v1h-10zM12 2h2v1h-2zM1 3h1v1h-1zM11 3h2v1h-2zM1 4h1v1h-1zM10 4h2v1h-2zM1 5h1v1h-1zM9 5h2v1h-2zM1 6h1v1h-1zM3 6h5v1h-5zM9 6h1v1h-1zM1 7h1v1h-1zM10 7h1v1h-1zM1 8h1v1h-1zM10 8h1v1h-1zM1 9h1v1h-1zM3 9h5v1h-5zM10 9h1v1h-1zM1 10h1v1h-1zM10 10h1v1h-1zM1 11h1v1h-1zM10 11h1v1h-1zM1 12h1v1h-1zM3 12h5v1h-5zM10 12h1v1h-1zM1 13h1v1h-1zM10 13h1v1h-1zM1 14h1v1h-1zM10 14h1v1h-1zM1 15h10v1h-10z'
@@ -67,9 +66,9 @@ const paths: Record<IconName, IconDef> = {
     accentColor: 'var(--cth-lemon)',
     ink:   'M1 3h6v1h8v9H1V3zm1 1v8h12V5H6V4H2z'
   },
-  // Picture frame with a stepped mountain and a sun. The frame's two subpaths
-  // cut a hole via evenodd (same trick as `terminal`); the mountain rows sit
-  // inside that hole, so each adds a third crossing and fills again.
+  // 相框 + 层叠的山 + 太阳。相框的两个子路径用 evenodd 镂出孔洞
+  // （与 `terminal` 同款技巧）；山的几行像素位于孔内，
+  // 每行再增加一次交叉，于是又填充回来。
   image: {
     accentColor: 'var(--cth-lemon)',
     accent: 'M4 5h2v2H4V5z',
@@ -79,10 +78,10 @@ const paths: Record<IconName, IconDef> = {
     accentColor: 'var(--cth-mint)',
     ink:   'M1 2h14v12H1V2zm1 1v10h12V3H2zm1 2h1v1h1v1h1v1H5v1H4v1H3V9h1V8h1V7H4V6H3V5zm5 5h4v1H8v-1z'
   },
-  // The branch graph, which is what git's own mark is: a trunk with two commit
-  // nodes and one branch arcing off into a third. Drawn at the same hairline
-  // weight as `code` and `terminal` so a row of them reads as one set — a
-  // solid-filled mark next to those two looks like a different icon family.
+  // 分支图——这正是 git 自身的标识：一条主干、两个提交节点、
+  // 一条分叉出去的弧线通向第三个节点。与 `code`、`terminal` 采用相同的
+  // 发丝级粗细绘制，使同一行图标读起来像一套——若换成实心填充的标记，
+  // 放在这两个旁边会显得像是另一种图标家族。
   git: {
     accentColor: 'var(--cth-coral)',
     ink:   'M5 1h3v1h-3zM4 2h1v1h-1zM8 2h1v1h-1zM4 3h1v1h-1zM8 3h1v1h-1zM5 4h3v1h-3zM6 5h1v1h-1zM6 6h1v1h-1zM9 6h3v1h-3zM6 7h1v1h-1zM8 7h1v1h-1zM12 7h1v1h-1zM6 8h3v1h-3zM12 8h1v1h-1zM6 9h1v1h-1zM9 9h3v1h-3zM6 10h1v1h-1zM5 11h3v1h-3zM4 12h1v1h-1zM8 12h1v1h-1zM4 13h1v1h-1zM8 13h1v1h-1zM5 14h3v1h-3z'
@@ -111,37 +110,36 @@ const paths: Record<IconName, IconDef> = {
     accentColor: 'var(--cth-sky)',
     ink:   'M5 1h2v6H1V5h4V1zm4 0h2v4h4v2H9V1zM1 9h6v6H5v-4H1V9zm8 0h6v2h-4v4H9V9z'
   },
-  // Wall clock at five o'clock — closing time. Ring as an evenodd cutout,
-  // hands as a second subpath (minute hand up, hour hand toward 5).
+  // 五点整的挂钟——打烊时间。表盘用 evenodd 镂空成圆环，
+  // 指针作为第二个子路径（分针朝上，时针指向 5）。
   clock: {
     accentColor: 'var(--cth-lemon)',
     ink:   'M5 1h6v1h2v2h1v2h1v4h-1v2h-1v2h-2v1H5v-1H3v-2H2V8H1V6h1V4h1V2h2V1zm0 2H4v1H3v2H2v4h1v2h1v1h1v1h6v-1h1v-1h1v-2h1V6h-1V4h-1V3h-1V2H5v1zm2 1h2v4h2v1h1v1h-1v1h-1v-1H9v1H7V4z'
   },
-  // Ruled page — the trigger-history ledger. Frame as an evenodd cutout, three
-  // written lines inside it (the last one short, like a part-filled entry).
+  // 带横线的页面——触发器历史台账。边框用 evenodd 镂空，
+  // 内部画三条书写线（最后一条较短，像一条只填了一部分的记录）。
   ledger: {
     accentColor: 'var(--cth-lemon)',
     ink:   'M2 1h12v14H2V1zM3 2v12h10V2H3zM5 4h6v1H5zM5 7h6v1H5zM5 10h4v1H5z'
   },
-  // Microphone: a solid capsule head, an open cradle, a stem, and a base.
+  // 麦克风：实心胶囊头、开口的支架、杆和底座。
   mic: {
     accentColor: 'var(--cth-coral)',
     ink:   'M6 2h4v7H6V2z M4 9h1v2H4z M11 9h1v2h-1z M4 11h8v1H4z M7 12h2v2H7z M5 14h6v1H5z'
   },
-  // Filled disc with the 'i' knocked OUT of it — the dot and stem are separate
-  // subpaths cut by fill-rule: evenodd, same trick as the gear's hub hole. A
-  // knocked-out glyph stays legible at 16px where a 1px-stroked outline would
-  // shimmer against the pixel grid.
+  // 实心圆盘把 'i' 镂空出来——圆点和竖线是独立的子路径，
+  // 用 fill-rule: evenodd 切割，与齿轮中心孔同款技巧。
+  // 镂空出来的字形在 16px 下依然清晰，而 1px 描边轮廓反而
+  // 会在像素网格上产生抖动。
   info: {
     accentColor: 'var(--cth-sky)',
     ink:   'M5 1h6v1h2v1h1v2h1v6h-1v2h-1v1h-2v1H5v-1H3v-1H2v-2H1V5h1V3h1V2h2V1z M7 4h2v2H7z M7 7h2v5H7z'
   },
-  // Panel outline with the left column filled — the standard sidebar-toggle
-  // glyph. Three subpaths under fill-rule: evenodd — frame, hollow interior,
-  // then the left column, which lands on an ODD crossing count and so fills back
-  // in. Deliberately NOT `minimize`/`expand`: those sit in the same toolbar
-  // meaning "exit fullscreen", and two size-ish arrows side by side read as the
-  // same control twice.
+  // 面板轮廓 + 左侧栏填充——标准的侧边栏切换字形。fill-rule: evenodd
+  // 下的三个子路径——外框、镂空内部、然后是左侧栏，
+  // 左侧栏落在奇数次交叉上，因此重新填充回来。
+  // 刻意不用 `minimize`/`expand`：它们在同一工具栏里表示"退出全屏"，
+  // 两个尺寸类箭头并排摆放会被误读为同一个控件出现两次。
   sidebar: {
     accentColor: 'var(--cth-ink-300)',
     ink:   'M1 3h14v10H1z M2 4h12v8H2z M2 4h4v8H2z'
@@ -150,7 +148,7 @@ const paths: Record<IconName, IconDef> = {
 
 export interface IconProps {
   name: IconName;
-  size?: number; // integer scale: 1 = 16px, 2 = 32px, ...
+  size?: number; // 整数倍率：1 = 16px, 2 = 32px, ...
   style?: CSSProperties;
 }
 
@@ -167,13 +165,12 @@ export function Icon({ name, size = 1, style }: IconProps) {
       aria-hidden
     >
       {def.accent && <path d={def.accent} fill={def.accentColor} fillRule="evenodd" />}
-      {/* currentColor, not a hardcoded `--cth-ink-900`. `body` already sets that
-          same token as its color, so this is a no-op for every icon sitting on a
-          normal surface — but on an INVERTED surface it is the difference between
-          an icon and a blank space. A primary PixelButton fills itself with
-          `--cth-ink-900` and an icon painted the same token vanished into it (the
-          arrow on Send, in both themes). Inheriting means an icon is always the
-          colour of the text it sits beside, which is what every call site meant. */}
+      {/* 用 currentColor，而不是硬编码的 `--cth-ink-900`。`body` 已把同一 token
+          设为自身颜色，因此在普通表面上这对每个图标都是无操作——
+          但在反色表面上，它决定了一个图标是可见还是一块空白。
+          主色 PixelButton 用 `--cth-ink-900` 填充自身，而用同一 token
+          着色的图标会融进按钮里（两个主题下 Send 上的箭头都如此）。
+          继承意味着图标始终取旁边文本的颜色，这正是每个调用处的本意。 */}
       <path d={def.ink} fill="currentColor" fillRule="evenodd" />
     </svg>
   );

--- a/src/renderer/src/components/IntegrationsRegistry.tsx
+++ b/src/renderer/src/components/IntegrationsRegistry.tsx
@@ -13,18 +13,18 @@ import {
   type TestResult
 } from '@/integrations/registryClient';
 
-// Integrations configuration UI — Settings → Integrations. Conformed to Jim's
-// spec v1 (hive/docs/integrations-spec.md) and styled to Pam's mockup
-// (hive/docs/integrations-ui-mockup.html). Three views: the configured list, a
-// pick-a-template gallery, and a configure-&-test step.
+// Integrations 配置界面 —— 设置 → Integrations。遵循 Jim 的
+// spec v1（hive/docs/integrations-spec.md），并按 Pam 的线框稿
+// （hive/docs/integrations-ui-mockup.html）确定样式。包含三种视图：已配置列表、
+// 选模板的图库，以及配置并测试的步骤。
 //
-// All data flows through integrationsClient — never IPC directly.
+// 所有数据都通过 integrationsClient 流转 —— 从不直接走 IPC。
 //
-// v1 worker model (Jim §4): the broker grants EVERY enabled integration to ALL
-// workers; there is no per-integration worker scoping yet. So "which workers can
-// use it" is surfaced as the usability gate — usable === enabled && hasSecret —
-// rather than an editable per-integration picker. Per-worker scoping is a future
-// extension; this reflection updates when Jim confirms that model.
+// v1 worker 模型（Jim §4）：broker 把每个已启用的集成授予 ALL worker；
+// 目前还没有按集成划分 worker 的作用域。所以"哪些 worker 能用它"
+// 通过可用性门来表示 —— usable === enabled && hasSecret ——
+// 而不是提供一个可编辑的按集成选择器。按 worker 划作用域是未来的扩展；
+// 一旦 Jim 确认该模型，这里的描述就会更新。
 
 type View = 'list' | 'gallery' | 'configure';
 
@@ -37,9 +37,9 @@ interface Draft {
   authType: IntegrationAuthType;
   authHeader: string;
   enabled: boolean;
-  hasSecret: boolean; // an existing stored secret (edit)
+  hasSecret: boolean; // 已存在的已存储密钥（编辑时）
   createdAt: number;
-  secret: string;     // write-only input buffer
+  secret: string;     // 只写输入缓冲
 }
 
 const AUTH_LABEL: Record<IntegrationAuthType, string> = {
@@ -48,10 +48,10 @@ const AUTH_LABEL: Record<IntegrationAuthType, string> = {
   header: 'Custom header',
   github: 'GitHub'
 };
-// Auth types a user may pick for a custom-REST integration.
+// 用户可为自定义 REST 集成选择的认证类型。
 const CUSTOM_AUTH: IntegrationAuthType[] = ['none', 'bearer', 'header'];
 
-// UI-only brand glyphs (Jim's templates carry no glyph). Falls back to label initials.
+// 仅用于界面的品牌字形（Jim 的模板不带字形）。回退到标签首字母。
 const GLYPH: Record<string, { mono: string; bg: string }> = {
   github: { mono: 'Gh', bg: '#1A1320' },
   'custom-rest': { mono: '{}', bg: '#2E9E5B' }
@@ -74,7 +74,7 @@ function Glyph({ mono, bg, lg }: { mono: string; bg: string; lg?: boolean }) {
   );
 }
 
-/** Is an integration actually usable by workers? (Jim §6 gate.) */
+/** 集成对 worker 而言真的可用吗？（Jim §6 门。） */
 function usable(r: { enabled: boolean; authType: IntegrationAuthType; hasSecret: boolean }): boolean {
   return r.enabled && (!needsSecret(r.authType) || r.hasSecret);
 }
@@ -100,7 +100,7 @@ export function IntegrationsRegistry() {
   const [records, setRecords] = useState<IntegrationRecordView[]>([]);
 
   const [view, setView] = useState<View>('list');
-  const [picked, setPicked] = useState<string>(''); // selected template idSuggestion in gallery
+  const [picked, setPicked] = useState<string>(''); // 图库中选中的模板 idSuggestion
   const [draft, setDraft] = useState<Draft | null>(null);
   const [replacing, setReplacing] = useState(false);
   const [showSecret, setShowSecret] = useState(false);
@@ -205,7 +205,7 @@ export function IntegrationsRegistry() {
     finally { setTesting(false); }
   };
 
-  // ───────────────────────── GALLERY ─────────────────────────
+  // ───────────────────────── 图库 ─────────────────────────
   if (view === 'gallery') {
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -241,7 +241,7 @@ export function IntegrationsRegistry() {
     );
   }
 
-  // ───────────────────────── CONFIGURE ─────────────────────────
+  // ───────────────────────── 配置 ─────────────────────────
   if (view === 'configure' && draft) {
     const g = glyphFor(draft.kind, draft.label);
     const tpl = templates.find((t) => t.kind === draft.kind);
@@ -260,21 +260,21 @@ export function IntegrationsRegistry() {
           </div>
         </div>
 
-        {/* Label */}
+        {/* 标签 */}
         <label style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
           <span style={fieldLabel}>{tr('integrations.label')}</span>
           <input value={draft.label} onChange={(e) => patch({ label: e.target.value, ...(draft.isNew ? { id: slugify(e.target.value) } : {}) })} placeholder={`e.g. ${tpl?.label ?? 'My API'} (prod)`} style={inputStyle} />
           <span style={hint}>{tr('integrations.labelHint')}: <code style={{ fontFamily: 'var(--cth-font-mono)' }}>{slugify(draft.id || draft.label) || '—'}</code>{draft.isNew ? '' : ` (${tr('integrations.fixed')})`}</span>
         </label>
 
-        {/* Base URL — editable for custom-rest, fixed for presets */}
+        {/* Base URL —— 自定义 REST 可编辑，预设模板固定 */}
         <label style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
           <span style={fieldLabel}>{tr('integrations.baseUrl')}</span>
           <input value={draft.baseUrl} onChange={(e) => patch({ baseUrl: e.target.value })} placeholder="https://api.example.com" readOnly={draft.kind !== 'custom-rest'} style={{ ...inputStyle, fontFamily: 'var(--cth-font-mono)', opacity: draft.kind !== 'custom-rest' ? 0.7 : 1 }} />
           {draft.kind !== 'custom-rest' && <span style={hint}>{tr('integrations.baseUrlHint', { label: tpl?.label ?? tr('integrations.preset') })}</span>}
         </label>
 
-        {/* Auth type — selectable only for custom-rest */}
+        {/* 认证类型 —— 仅自定义 REST 可选择 */}
         {draft.kind === 'custom-rest' ? (
           <label style={{ display: 'flex', flexDirection: 'column', gap: 5, maxWidth: 260 }}>
             <span style={fieldLabel}>{tr('integrations.authentication')}</span>
@@ -289,7 +289,7 @@ export function IntegrationsRegistry() {
           </div>
         )}
 
-        {/* Custom header name (header auth only) */}
+        {/* 自定义 header 名（仅 header 认证） */}
         {draft.authType === 'header' && (
           <label style={{ display: 'flex', flexDirection: 'column', gap: 5, maxWidth: 320 }}>
             <span style={fieldLabel}>{tr('integrations.headerName')}</span>
@@ -298,7 +298,7 @@ export function IntegrationsRegistry() {
           </label>
         )}
 
-        {/* Secret — WRITE-ONLY (separate setSecret IPC) */}
+        {/* 密钥 —— 只写（独立 setSecret IPC） */}
         {needsSecret(draft.authType) && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
             <span style={fieldLabel}>{secretLabel}</span>
@@ -322,7 +322,7 @@ export function IntegrationsRegistry() {
           </div>
         )}
 
-        {/* Enabled gate + worker availability */}
+        {/* 启用开关 + worker 可用性 */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           <span style={fieldLabel}>{tr('integrations.availability')}</span>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -332,7 +332,7 @@ export function IntegrationsRegistry() {
           <span style={hint}>{tr('integrations.v1Note')}</span>
         </div>
 
-        {/* Test connection (saved integrations only — broker probes by id) */}
+        {/* 测试连接（仅已保存的集成 —— broker 按 id 探测） */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
           <span style={fieldLabel}>{tr('integrations.testConnection')}</span>
           <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
@@ -351,7 +351,7 @@ export function IntegrationsRegistry() {
     );
   }
 
-  // ───────────────────────── LIST (default) ─────────────────────────
+  // ───────────────────────── 列表（默认） ─────────────────────────
   const usableCount = records.filter(usable).length;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>

--- a/src/renderer/src/components/MemoryGraphPanel.tsx
+++ b/src/renderer/src/components/MemoryGraphPanel.tsx
@@ -14,12 +14,12 @@ import {
 } from './memoryGraph/buildGraph';
 import { forceLayout, type Positions } from './memoryGraph/forceLayout';
 
-/** The memory-graph tab: hive agents as nodes, messages as edges, an optional
- *  topic layer from each agent's memory file. SVG-rendered (DESIGN.md neo-pixel:
- *  square nodes, hard offset shadows, VT323/Pixelify). See MEMORY_GRAPH_SPEC.md.
+/** 记忆图标签页：hive agents 作为节点、消息作为边，还有一个可选的
+ *  来自每个 agent 记忆文件的主题层。SVG 渲染（DESIGN.md neo-pixel：
+ *  方形节点、硬偏移阴影、VT323/Pixelify）。参见 MEMORY_GRAPH_SPEC.md。
  *
- *  All data comes from the existing preload bridge: store.agents + hiveLog +
- *  hiveMemory. No new IPC. Click an agent to jump to its memory; hover to peek. */
+ *  所有数据都来自现有的 preload bridge：store.agents + hiveLog +
+ *  hiveMemory。不新增 IPC。点击 agent 跳到它的记忆；悬停可预览。 */
 export function MemoryGraphPanel({
   godId,
   onJumpToMemory
@@ -35,7 +35,7 @@ export function MemoryGraphPanel({
   const [memories, setMemories] = useState<Record<string, string>>({});
   const [loadingTopics, setLoadingTopics] = useState(false);
 
-  // ── poll the message log (same cadence as the Activity tab) ──────────────────
+  // ── 轮询消息日志（与 Activity 标签页相同的节奏）──────────────────
   const refresh = useCallback(async () => {
     try { setLog((await window.cth.hiveLog(200)) as MessageLogEntry[]); } catch { /* noop */ }
   }, []);
@@ -45,7 +45,7 @@ export function MemoryGraphPanel({
     return () => clearInterval(t);
   }, [refresh]);
 
-  // ── lazy memory loads: one on hover, all when the topic layer turns on ───────
+  // ── 懒加载记忆：悬停时加载一个，主题层开启时加载全部 ───────
   const fetchMemory = useCallback(async (id: string) => {
     try {
       const text = await window.cth.hiveMemory(id);
@@ -67,13 +67,13 @@ export function MemoryGraphPanel({
     });
   }, [showTopics, agents, memories]);
 
-  // ── graph model ──────────────────────────────────────────────────────────────
+  // ── 图模型 ──────────────────────────────────────────────────────────────
   const graph: GraphData = useMemo(
     () => buildGraph(agents, log, { showTopics, memories }),
     [agents, log, showTopics, memories]
   );
 
-  // ── canvas sizing ─────────────────────────────────────────────────────────────
+  // ── 画布尺寸 ─────────────────────────────────────────────────────────────
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [dims, setDims] = useState({ w: 640, h: 440 });
   useEffect(() => {
@@ -87,10 +87,10 @@ export function MemoryGraphPanel({
     return () => ro.disconnect();
   }, []);
 
-  // ── pinned (dragged) node positions ──────────────────────────────────────────
+  // ── 固定的（拖拽过的）节点位置 ──────────────────────────────────────────
   const [pinned, setPinned] = useState<Record<string, { x: number; y: number }>>({});
 
-  // recompute layout only when structure / size / pins change (not on every poll)
+  // 仅在结构 / 尺寸 / 固定点变化时重算布局（而不是每次轮询）
   const structKey = useMemo(
     () => graph.nodes.map((n) => n.id).join(',') + '|' + graph.edges.map((e) => e.id).join(','),
     [graph]
@@ -107,11 +107,11 @@ export function MemoryGraphPanel({
       strength: e.kind === 'topic' ? 0.35 : 0.7 + Math.min(e.weight, 5) * 0.06
     }));
     return forceLayout(lnodes, ledges, { width: dims.w, height: dims.h, pinned });
-    // structKey/pinnedKey capture the relevant graph identity; intentional.
+    // structKey/pinnedKey 捕获了相关的图身份；这是有意为之。
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [structKey, pinnedKey, dims.w, dims.h, godId]);
 
-  // ── drag ──────────────────────────────────────────────────────────────────────
+  // ── 拖拽 ──────────────────────────────────────────────────────────────────────
   const [live, setLive] = useState<{ id: string; x: number; y: number } | null>(null);
   const dragOffset = useRef({ x: 0, y: 0 });
   const moved = useRef(false);
@@ -159,7 +159,7 @@ export function MemoryGraphPanel({
     };
   }, [live, toSvg, dims.w, dims.h]);
 
-  // ── hover / tooltip ─────────────────────────────────────────────────────────
+  // ── 悬停 / 工具提示 ─────────────────────────────────────────────────────────
   const [hover, setHover] = useState<
     | { kind: 'node'; node: GraphNode }
     | { kind: 'edge'; edge: GraphEdge }
@@ -184,7 +184,7 @@ export function MemoryGraphPanel({
 
   return (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--cth-paper-200)' }}>
-      {/* toolbar */}
+      {/* 工具栏 */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', flexShrink: 0,
         borderBottom: '1px solid var(--cth-ink-300)', background: 'var(--cth-cream-100)', flexWrap: 'wrap'
@@ -201,7 +201,7 @@ export function MemoryGraphPanel({
         )}
       </div>
 
-      {/* canvas */}
+      {/* 画布 */}
       <div ref={wrapRef} style={{ position: 'relative', flex: 1, minHeight: 0, overflow: 'hidden' }}>
         <svg
           width={dims.w}
@@ -230,7 +230,7 @@ export function MemoryGraphPanel({
           <rect x={0} y={0} width={dims.w} height={dims.h} fill="var(--cth-paper-100)" />
           <rect x={0} y={0} width={dims.w} height={dims.h} fill="url(#mg-grid)" />
 
-          {/* edges */}
+          {/* 边 */}
           <g>
             {graph.edges.map((e) => {
               const sp = posOf(e.source);
@@ -273,7 +273,7 @@ export function MemoryGraphPanel({
             })}
           </g>
 
-          {/* nodes */}
+          {/* 节点 */}
           <g>
             {graph.nodes.map((n) => {
               const p = posOf(n.id);
@@ -293,21 +293,21 @@ export function MemoryGraphPanel({
                   onClick={() => { if (navigable && !moved.current) onJumpToMemory(n.id); }}
                   style={{ cursor: navigable ? 'pointer' : 'grab' }}
                 >
-                  {/* hard offset shadow */}
+                  {/* 硬偏移阴影 */}
                   <rect x={-half + 2} y={-half + 2} width={s} height={s} fill="var(--cth-ink-900)" />
-                  {/* body */}
+                  {/* 主体 */}
                   <rect
                     x={-half} y={-half} width={s} height={s}
                     fill={nodeFill(n)}
                     stroke="var(--cth-ink-900)"
                     strokeWidth={n.kind === 'agent' && n.isGod ? 2 : 1.5}
                   />
-                  {/* double border for god + human */}
+                  {/* god + human 的双重边框 */}
                   {((n.kind === 'agent' && n.isGod) || (n.kind === 'pseudo' && n.id === 'human')) && (
                     <rect x={-half + 3} y={-half + 3} width={s - 6} height={s - 6}
                       fill="none" stroke="var(--cth-ink-900)" strokeWidth={1} />
                   )}
-                  {/* status ring for agents */}
+                  {/* agents 的状态环 */}
                   {n.kind === 'agent' && (
                     <rect x={-half - 2} y={-half - 2} width={s + 4} height={s + 4}
                       fill="none" stroke={`var(--cth-status-${n.status})`} strokeWidth={1.5} />
@@ -317,7 +317,7 @@ export function MemoryGraphPanel({
             })}
           </g>
 
-          {/* labels */}
+          {/* 标签 */}
           <g pointerEvents="none">
             {graph.nodes.map((n) => {
               const p = posOf(n.id);
@@ -342,7 +342,7 @@ export function MemoryGraphPanel({
           </g>
         </svg>
 
-        {/* empty hint */}
+        {/* 空状态提示 */}
         {messageEdgeCount === 0 && !showTopics && (
           <div style={{
             position: 'absolute', top: 10, left: 0, right: 0, textAlign: 'center',
@@ -350,7 +350,7 @@ export function MemoryGraphPanel({
           }}>No messages logged yet — the hive is quiet. Agents shown as roster.</div>
         )}
 
-        {/* tooltip */}
+        {/* 工具提示 */}
         {hover && (
           <Tooltip x={cursor.x} y={cursor.y} wrap={dims}>
             {hover.kind === 'node'
@@ -359,14 +359,14 @@ export function MemoryGraphPanel({
           </Tooltip>
         )}
 
-        {/* legend */}
+        {/* 图例 */}
         <Legend />
       </div>
     </div>
   );
 }
 
-// ─── tooltip bodies ──────────────────────────────────────────────────────────
+// ─── 工具提示主体 ──────────────────────────────────────────────────────────
 
 function NodeTip({ node, memories }: { node: GraphNode; memories: Record<string, string> }) {
   const { t } = useTranslation();
@@ -474,12 +474,12 @@ function Toggle({ on, onClick, label }: { on: boolean; onClick: () => void; labe
   );
 }
 
-// ─── helpers ─────────────────────────────────────────────────────────────────
+// ─── 辅助函数 ─────────────────────────────────────────────────────────────────
 
 const MARKER_ACTS: MessageAct[] = ['request', 'inform', 'propose', 'query', 'agree', 'refuse', 'done'];
 
-/** Speech-act → colour. Mirrors ACT_COLOR in MessageEnvelope.ts so the graph
- *  speaks the same visual language as the floor's flying envelopes. */
+/** 言语行为 → 颜色。镜像 MessageEnvelope.ts 中的 ACT_COLOR，
+ *  让图形与大厅里飞行的信封讲同一种视觉语言。 */
 function actColor(act?: MessageAct): string {
   switch (act) {
     case 'request': return 'var(--cth-sky)';
@@ -496,7 +496,7 @@ function actColor(act?: MessageAct): string {
 function nodeSize(n: GraphNode): number {
   if (n.kind === 'agent') return (n.isGod ? 30 : 22) + Math.min(n.degree, 10) * 1.0;
   if (n.kind === 'topic') return 12 + Math.min(n.weight, 6) * 1.4;
-  return 17; // pseudo
+  return 17; // 伪节点
 }
 function nodeRadius(n: GraphNode): number { return nodeSize(n) / 2; }
 
@@ -517,7 +517,7 @@ function truncate(s: string, n: number): string {
   return s.length > n ? s.slice(0, n - 1) + '…' : s;
 }
 
-/** First meaningful line(s) of a memory file, for the hover preview. */
+/** 记忆文件中有意义的前几行，用于悬停预览。 */
 function memorySnippet(text: string, t: TFunction): string {
   if (!text.trim()) return t('memoryGraph.noMemory');
   const lines = text

--- a/src/renderer/src/components/MemoryPanel.tsx
+++ b/src/renderer/src/components/MemoryPanel.tsx
@@ -17,17 +17,16 @@ interface MemoryStatus {
 
 type ModelId = 'minilm' | 'embeddinggemma';
 
-// Plain-language framing of each model — lead with the benefit the user actually
-// chooses between, not the model's codename. Labels are i18n keys.
+// 每个模型的平实语言定位——先讲用户真正在选择的收益，
+// 而不是模型的代号。标签是 i18n key。
 const MODELS: { id: ModelId; titleKey: string; detailKey: string }[] = [
   { id: 'minilm',         titleKey: 'memoryPanel.modelFast',         detailKey: 'memoryPanel.modelFastDetail' },
   { id: 'embeddinggemma', titleKey: 'memoryPanel.modelMultilingual', detailKey: 'memoryPanel.modelMultilingualDetail' },
 ];
 
 /**
- * Lets the human search the shared memory agents build up across sessions, turn
- * it on/off, and pick how it searches. Agents read/write it directly; this is
- * the human-facing window into the same memory.
+ * 让人可以搜索 agent 跨会话构建的共享记忆、开关它，
+ * 并选择它的搜索方式。agent 直接读写它；这是同一份记忆面向人的窗口。
  */
 export function MemoryPanel() {
   const { t } = useTranslation();
@@ -39,7 +38,7 @@ export function MemoryPanel() {
   const [busy, setBusy] = useState(false);
 
   const refreshStatus = async () => {
-    try { setStatus(await window.cth.memoryStatus()); } catch { /* ignore */ }
+    try { setStatus(await window.cth.memoryStatus()); } catch { /* 忽略 */ }
   };
   useEffect(() => { refreshStatus(); }, []);
 
@@ -67,7 +66,7 @@ export function MemoryPanel() {
   const active = status?.active;
   const pill = active ? `${t('memoryPanel.pillActive')} · ${status?.model}` : t('memoryPanel.pill');
 
-  // One clear state line: is memory working, off, or not set up?
+  // 一行清晰的状态：记忆在运行、关闭，还是没配置？
   const state: { dot: string; label: string } = !status?.available
     ? { dot: 'var(--cth-coral)', label: t('memoryPanel.notSetUp') }
     : !status.enabled
@@ -101,12 +100,12 @@ export function MemoryPanel() {
         <PixelPanel variant="dialog" title={t('memoryPanel.title')} noPadding>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 14 }}>
 
-            {/* What this is — one plain line. */}
+            {/* 这是什么——一行平实说明。 */}
             <div style={{ fontSize: 12, color: 'var(--cth-ink-700)', lineHeight: 1.5 }}>
               {t('memoryPanel.intro')}
             </div>
 
-            {/* Status + on/off — the two things the user controls at a glance. */}
+            {/* 状态 + 开/关——用户一眼就能控制的两样东西。 */}
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 12, color: 'var(--cth-ink-900)', fontFamily: 'var(--cth-font-ui)' }}>
                 <span style={{ width: 9, height: 9, background: state.dot, boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)' }} />
@@ -123,27 +122,26 @@ export function MemoryPanel() {
               )}
             </div>
 
-            {/* Not installed: show full self-sufficient setup so any machine can follow it. */}
+            {/* 未安装：显示完整自足的安装指引，让任何机器都能照着做。 */}
             {!status?.available && (
               <div style={{
                 fontSize: 12, color: 'var(--cth-ink-700)', lineHeight: 1.6,
                 background: 'var(--cth-cream-100)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)', padding: 10
               }}>
                 {t('memoryPanel.notInstalled')}
-                {/* The commands used to be inlined here, hardcoded for macOS
-                    (`curl … | sh`, `source ~/.zshrc`) — dead text under cmd.exe or
-                    PowerShell, on the platform most likely to be missing the tool.
-                    Setup owns the platform-correct commands now, plus the uv
-                    dependency, the live detected state, and the delegate-to-Michael
-                    path. One source of truth beats two that disagree by OS. */}
+                {/* 命令过去内联写死在这里，硬编码为 macOS（`curl … | sh`、
+                    `source ~/.zshrc`）——在最可能缺这个工具的平台上，
+                    它们在 cmd.exe 或 PowerShell 下是死文本。现在 Setup 拥有
+                    平台正确的命令，外加 uv 依赖、实时检测到的状态，
+                    以及委托给 Michael 的路径。一个真相来源好过两个
+                    按 OS 打架的来源。 */}
                 <div style={{ marginTop: 8 }}>
                   <PixelButton
                     variant="primary"
                     size="sm"
                     onClick={() => {
-                      // Prerequisites moved from a Command Center tab into
-                      // Settings; requesting the old tab key is now a no-op that
-                      // silently does nothing on click.
+                      // Prerequisites 从 Command Center 标签页移进了 Settings；
+                      // 请求旧标签页 key 现在是空操作，点击时静默地什么都不做。
                       window.dispatchEvent(new CustomEvent('cth:open-settings', {
                         detail: { section: 'Prerequisites' }
                       }));
@@ -159,7 +157,7 @@ export function MemoryPanel() {
               </div>
             )}
 
-            {/* Model: a benefit-framed choice, not a codename dump. */}
+            {/* 模型：以收益为框架的选择，而不是代号倾倒。 */}
             {status?.available && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
                 <span style={{ fontSize: 11, color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-display)', textTransform: 'uppercase', letterSpacing: 0.5 }}>
@@ -196,7 +194,7 @@ export function MemoryPanel() {
               </div>
             )}
 
-            {/* Search the memory. */}
+            {/* 搜索记忆。 */}
             {canSearch && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 <div style={{ display: 'flex', gap: 6 }}>

--- a/src/renderer/src/components/MessageQueueComposer.tsx
+++ b/src/renderer/src/components/MessageQueueComposer.tsx
@@ -13,22 +13,22 @@ import { useRtl } from '@/i18n/useDirection';
 
 const EMPTY_QUEUE: QueuedMessage[] = [];
 
-/** A file/image attached to the draft. Travels to the agent as a PATH it Reads. */
+/** 附加到草稿的文件/图片。作为一条 PATH 传给 agent 去 Read。 */
 interface Attachment {
   path: string;
   name: string;
 }
 
-// Prepended (only to the enqueued value, never the visible draft) when the
+// 前置的内容（只加到入队值，从不加到可见草稿）当
 
 export interface MessageQueueComposerProps {
   agent: Agent;
 }
 
 /**
- * Lets the user keep messaging an agent whose terminal is mid-run. Typed
- * messages park in a per-agent queue and are submitted to the agent's Claude
- * TUI one-by-one as soon as it goes idle (see useHive's flush loop).
+ * 让用户在 agent 终端运行中途也能继续给它发消息。输入的消息停在
+ * 每个 agent 自己的队列里，等它的 Claude TUI 一空闲就逐条提交
+ *（见 useHive 的 flush 循环）。
  */
 export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   const { t } = useTranslation();
@@ -39,17 +39,16 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   const releaseQueuedMessage = useStore((s) => s.releaseQueuedMessage);
   const clearQueue = useStore((s) => s.clearQueue);
 
-  // Draft lives in the store, keyed by agent — switching agents remounts this
-  // component, and component-local state would silently eat the typed text.
+  // 草稿存在 store 里，按 agent 分键——切换 agent 会重挂这个
+  // 组件，组件本地状态会悄悄吃掉已输入的文本。
   const text = useStore((s) => s.drafts[agent.id] ?? '');
   const setDraft = useStore((s) => s.setDraft);
   const setText = (t: string) => setDraft(agent.id, t);
 
-  // Free Flow voice dictation (entry point A). The mic button shows only when the
-  // feature is enabled in Settings; a transcript is appended to this draft for
-  // review before sending (never auto-sent). When enabled but no Groq key is set,
-  // the button stays VISIBLE but DISABLED with a tooltip pointing to Settings
-  // (hasGroqKey is boolean presence only — the key value never reaches the store).
+  // Free Flow 语音听写（入口 A）。麦克风按钮只在 Settings 里启用该功能时
+  // 出现；转录文本追加到这个草稿里供发送前审阅（绝不自动发送）。启用但
+  // 未配置 Groq key 时，按钮保持 VISIBLE 但 DISABLED，带指向 Settings 的
+  // tooltip（hasGroqKey 只表示布尔存在——key 值从不进入 store）。
   const freeflowEnabled = useStore((s) => s.freeflowEnabled);
   const hasGroqKey = useStore((s) => s.hasGroqKey);
   const ff = useFreeflow();
@@ -64,18 +63,18 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
     ? `${t('queueComposer.voice')}: ${ff.error}`
     : null;
 
-  // The draft box is the terminal's twin — it should read at the same size the
-  // agent's output does, at every zoom level.
+  // 草稿框是终端的孪生——它应该在任何缩放级别下都与 agent 输出
+  // 同字号阅读。
   const composerFontSize = useTerminalFontSize();
   const composerLineHeight = Math.round(composerFontSize * 1.4);
 
   const idle = agent.status === 'idle';
 
-  // Only the god/Michael agent gets the delegation toggle. Default OFF.
+  // 只有 god/Michael agent 有委托开关。默认关。
 
-  // Files/images staged for the next message. Component-local: switching agents
-  // remounts this component, so attachments are cleared on tab switch (drafts
-  // persist in the store, attachments deliberately don't carry over).
+  // 为下一条消息暂存的文件/图片。组件本地状态：切换 agent 会重挂
+  // 这个组件，所以附件在切换标签页时被清掉（草稿保存在 store 里，
+  // 附件刻意不跨标签页保留）。
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [dragOver, setDragOver] = useState(false);
 
@@ -89,13 +88,13 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   const removeAttachment = (path: string) =>
     setAttachments((prev) => prev.filter((a) => a.path !== path));
 
-  // '+' button → OS picker (images group + all files).
+  // '+' 按钮 → OS 选择器（图片组 + 所有文件）。
   const pickFiles = async () => {
     const res = await window.cth.attachFiles();
     if (res.ok) addAttachments(res.files);
   };
 
-  // Drop files onto the composer → resolve each to its absolute path.
+  // 把文件拖到 composer 上 → 把每个都解析成绝对路径。
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     setDragOver(false);
@@ -107,8 +106,8 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
     if (atts.length) addAttachments(atts);
   };
 
-  // Paste a screenshot (no path → persist the native clipboard image to a temp
-  // file) or paste files copied from the OS file manager (carry a real path).
+  // 粘贴截图（无路径 → 把原生剪贴板图片持久化到临时文件）
+  // 或粘贴从 OS 文件管理器复制的文件（带真实路径）。
   const onPaste = async (e: ClipboardEvent<HTMLTextAreaElement>) => {
     const items = Array.from(e.clipboardData?.items ?? []);
     const hasImage = items.some((it) => it.kind === 'file' && it.type.startsWith('image/'));
@@ -134,19 +133,19 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
 
   const queueIt = () => {
     if (!canSend) return;
-    // Prepend an "Attached files:" block using the same path-based convention as
-    // the Slack inbound path (useHive.ts) so agents Read the files directly.
+    // 用与 Slack 入站路径（useHive.ts）相同的基于路径的约定，
+    // 前置一个 "Attached files:" 块，让 agent 直接 Read 这些文件。
     const body = attachments.length
       ? (text.trim()
           ? `${text}\n\nAttached files:\n`
           : 'Attached files:\n') + attachments.map((a) => `- ${a.path} (${a.name})`).join('\n')
       : text;
     enqueueMessage(agent.id, body);
-    // Counted HERE, at the composer's submit, and NOT inside enqueueMessage:
-    // that store action is also how work orders, Slack inbound, nudges and
-    // compact commands reach an agent, and none of those is a person sending a
-    // message. Past the isComposingKey guard in onKey, so an IME candidate
-    // Enter never counts. (TELEMETRY.md → message_sent)
+    // 在 HERE（composer 的提交处）计数，而不是 enqueueMessage 内部：
+    // 那个 store action 也是工单、Slack 入站、提醒和 compact 命令到达
+    // agent 的途径，而它们没有一个是真人发消息。在 onKey 的
+    // isComposingKey 守卫之后，所以 IME 候选字的 Enter 绝不会被计数。
+    // (TELEMETRY.md → message_sent)
     void window.cth.trackMessageSent('composer');
     setText('');
     setAttachments([]);
@@ -160,14 +159,14 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
     }
   };
 
-  // Delivery can be held back by the agent's own terminal (a half-typed draft or
-  // an open slash-command picker owns the prompt). That used to be invisible —
-  // the hint claimed it was sending while nothing moved — so poll it and say so.
+  // 投递可能被 agent 自己的终端拖住（打到一半的草稿或打开的斜杠命令
+  // 选择器占着 prompt）。过去这不可见——提示声称正在发送而什么都没动——
+  // 所以轮询它并说出来。
   const block = useTerminalBlock(agent.ptyId, queue.length > 0 && idle);
 
-  // Floor-wide auto-delivery pause (Command Center switch) also holds the queue.
-  // Without saying so — and without the per-row "send now" override — messages
-  // look permanently stuck with no explanation and no escape hatch.
+  // 全地板的自动投递暂停（Command Center 开关）也会拖住队列。
+  // 不说清楚这一点、也没有逐行"立即发送"覆盖的话，消息看起来就像
+  // 永远卡住，既无解释也无逃生口。
   const deliveryPaused = useDeliveryPaused(agent.id, queue.length > 0);
 
   const statusHint = queue.length === 0
@@ -188,7 +187,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
     <div
       onDragOver={(e) => { e.preventDefault(); if (!dragOver) setDragOver(true); }}
       onDragLeave={(e) => {
-        // Only clear when the cursor actually leaves the composer, not on child enter.
+        // 只在光标真正离开 composer 时才清除，而不是进入子元素时。
         if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
         setDragOver(false);
       }}
@@ -209,7 +208,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
           color: 'var(--cth-ink-700)', textAlign: 'center'
         }}>{t('queueComposer.dropToAttach')}</span>
       )}
-      {/* Header: label, count, status, clear-all */}
+      {/* 头部：标签、计数、状态、全部清除 */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <span style={{
           fontFamily: 'var(--cth-font-display)',
@@ -239,20 +238,19 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
         {(block === 'draft' || block === 'picker') && agent.ptyId && (
           <button
             onClick={() => {
-              // A picker and a draft are unblocked by different keys: Escape
-              // closes the picker, Ctrl-U kills the input line. Sending Ctrl-U
-              // at a picker leaves it open while telling automation the prompt
-              // is free, which is how a queued message ends up typed into a
-              // menu and marked delivered.
+              // 选择器和草稿由不同的键解锁：Escape 关掉选择器，Ctrl-U
+              // 杀掉输入行。在打开的选择器上发 Ctrl-U 会让它继续开着，
+              // 却告诉自动化 prompt 已空——于是排队的消息被打进一个
+              // 菜单里并被标记为已投递。
               if (block === 'picker') { dismissTerminalPicker(agent.ptyId!); return; }
-              // Keep whatever was on the prompt — it lands in this composer so
-              // the user can send it properly instead of losing it to Ctrl-U.
+              // 保留 prompt 上的内容——它落到这个 composer 里，让用户
+              // 能正式发送，而不是被 Ctrl-U 丢掉。
               const discarded = clearTerminalDraft(agent.ptyId!);
               if (discarded.trim()) setText(text ? `${text}\n${discarded}` : discarded);
             }}
             title={block === 'picker'
-              ? "Close the picker this agent has open so queued messages can be delivered"
-              : "Move the leftover text on this agent's prompt into this box so queued messages can be delivered"}
+              ? "关闭该 agent 已打开的选择器，以便投递排队中的消息"
+              : "把该 agent 的 prompt 中遗留的文本移入此框，以便投递排队中的消息"}
             style={{
               border: 'none', background: 'transparent', cursor: 'pointer', padding: 0,
               fontFamily: 'var(--cth-font-ui)', fontSize: 12,
@@ -274,7 +272,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
         )}
       </div>
 
-      {/* Pending list */}
+      {/* 待处理列表 */}
       {queue.length > 0 && (
         <div style={{
           display: 'flex', flexDirection: 'column', gap: 4,
@@ -293,7 +291,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
         </div>
       )}
 
-      {/* Free Flow recording / transcription status (entry point A) */}
+      {/* Free Flow 录音/转录状态（入口 A） */}
       {ffHint && (
         <span style={{
           fontSize: 12, lineHeight: '16px',
@@ -302,7 +300,7 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
         }}>{ffHint}</span>
       )}
 
-      {/* Attached files/images — chips with a remove 'x', above the textarea. */}
+      {/* 附加的文件/图片——带移除 'x' 的 chips，位于 textarea 上方。 */}
       {attachments.length > 0 && (
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
           {attachments.map((a) => (
@@ -339,8 +337,8 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
         </div>
       )}
 
-      {/* Composer — full-width input above a single tidy control bar (cc-ui-polish),
-          with file/image attachment chips + paste-to-attach (rich-composer). */}
+      {/* Composer——全宽输入，下面一条整洁的控制栏（cc-ui-polish），
+          带文件/图片附件 chips + 粘贴即附加（rich-composer）。 */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
         <textarea
           dir={rtl ? 'auto' : undefined}
@@ -354,18 +352,16 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
           style={{
             width: '100%',
             resize: 'vertical',
-            // Track the terminal's zoom (Cmd +/- or the terminal's own zoom
-            // buttons) instead of a hardcoded 13px. On a large display the
-            // terminal text scaled up while this box stayed tiny; box height is
-            // derived from the same size so the visible line count is stable.
+            // 跟随终端的缩放（Cmd +/- 或终端自己的缩放按钮），而不是
+            // 写死的 13px。在大屏幕上，终端文本放大了而这个框还那么小；
+            // 框高从同一个尺寸推导，可见行数才稳定。
             minHeight: composerLineHeight * 5 + 14,
             maxHeight: composerLineHeight * 18,
             padding: '6px 8px',
             background: 'var(--cth-paper-100)',
             border: 'none',
-            // Border lives in .cth-input so :focus can change it — an inline
-            // boxShadow here would outrank the stylesheet and the focus state
-            // would silently never apply.
+            // 边框放在 .cth-input 里，这样 :focus 能改它——内联的
+            // boxShadow 在这里会压过样式表，focus 状态就永远不生效了。
             fontFamily: 'var(--cth-font-mono)',
             fontSize: composerFontSize, lineHeight: `${composerLineHeight}px`,
             color: 'var(--cth-ink-900)',
@@ -373,9 +369,8 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
             boxSizing: 'border-box'
           }}
         />
-        {/* Control bar: Attach + voice + Send aligned right. flexWrap so a
-            narrow sidebar wraps the buttons onto a second row instead of
-            pushing Send off-screen. */}
+        {/* 控制栏：Attach + 语音 + Send 右对齐。flexWrap 让窄侧边栏
+            把按钮换行到第二行，而不是把 Send 推出屏幕。 */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, rowGap: 6, flexWrap: 'wrap', minWidth: 0 }}>
           <span style={{ flex: 1 }} />
           <PixelButton variant="secondary" size="sm" onClick={pickFiles}>
@@ -395,9 +390,9 @@ export function MessageQueueComposer({ agent }: MessageQueueComposerProps) {
   );
 }
 
-/** Poll the pty's automation block while there is something waiting on it. The
- * flag lives in the terminal pool (a plain module map, not the store), so there
- * is nothing to subscribe to — a 1s tick while the queue is pending is enough. */
+/** 当有东西在等它时，轮询 pty 的自动化阻塞状态。该标志活在终端池里
+ * （一个普通模块 map，不是 store），所以没有可订阅的东西——
+ * 队列待处理时 1s 轮询一次就足够了。 */
 function useTerminalBlock(ptyId: string | undefined, active: boolean): TerminalAutomationBlock {
   const [block, setBlock] = useState<TerminalAutomationBlock>(null);
   useEffect(() => {
@@ -407,13 +402,13 @@ function useTerminalBlock(ptyId: string | undefined, active: boolean): TerminalA
     const iv = setInterval(read, 1000);
     return () => clearInterval(iv);
   }, [ptyId, active]);
-  // 'settling' is a sub-second gap between writes — not worth telling anyone.
+  // 'settling' 是写入之间的亚秒级空隙——不值得告诉任何人。
   return block === 'settling' ? null : block;
 }
 
-/** Poll the floor-wide auto-delivery pause (main-process control state) while
- * this agent has messages waiting. 2s is plenty — the pause flips on human
- * timescales, and the drain re-reads the live snapshot before every send. */
+/** 当这个 agent 有待处理消息时，轮询全地板自动投递暂停（主进程控制
+ * 状态）。2s 足够——暂停以人类时间尺度翻转，而 drain 在每次发送前都会
+ * 重读实时快照。 */
 function useDeliveryPaused(agentId: string, active: boolean): boolean {
   const [paused, setPaused] = useState(false);
   useEffect(() => {
@@ -422,7 +417,7 @@ function useDeliveryPaused(agentId: string, active: boolean): boolean {
     const read = () => {
       window.cth.controlSnapshot(agentId)
         .then((s) => { if (alive) setPaused(!!s?.autoDeliveryPaused); })
-        .catch(() => { /* main not ready — assume not paused */ });
+        .catch(() => { /* 主进程未就绪——假定未暂停 */ });
     };
     read();
     const iv = setInterval(read, 2000);
@@ -432,15 +427,15 @@ function useDeliveryPaused(agentId: string, active: boolean): boolean {
 }
 
 /**
- * One pending queue row. Collapsed it clamps to 2 lines; "see more" expands it
- * in place so a long message can be read without hovering for the tooltip. The
- * toggle only renders when the text actually clips, so short messages stay tidy.
+ * 一条待处理队列行。折叠时钳制到 2 行；"see more"就地展开，
+ * 让长消息不用悬停等 tooltip 也能读全。开关只在文本确实被裁剪时
+ * 渲染，所以短消息保持整洁。
  */
 function QueuedMessageRow(
   { index, message, paused, onSendNow, onRemove }: {
     index: number;
     message: QueuedMessage;
-    /** Floor-wide auto-delivery is paused — offer the per-message override. */
+    /** 全地板自动投递已暂停——提供逐消息覆盖。 */
     paused: boolean;
     onSendNow: () => void;
     onRemove: () => void;
@@ -452,8 +447,8 @@ function QueuedMessageRow(
   const [clipped, setClipped] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
 
-  // Measure against the CLAMPED box, so the toggle survives being expanded (the
-  // expanded box never overflows and would otherwise report clipped = false).
+  // 针对 CLAMPED 盒子测量，让开关在展开后依然成立（展开的盒子
+  // 永不溢出，否则会报 clipped = false）。
   useLayoutEffect(() => {
     const el = bodyRef.current;
     if (!el) return;
@@ -462,7 +457,7 @@ function QueuedMessageRow(
       setClipped(el.scrollHeight > el.clientHeight + 1);
     };
     measure();
-    // The panel is resizable — re-measure on width changes, not just text ones.
+    // 面板可调整大小——宽度变化时重测，而不只是文本变化。
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
@@ -489,8 +484,8 @@ function QueuedMessageRow(
             color: 'var(--cth-ink-900)',
             whiteSpace: 'pre-wrap', wordBreak: 'break-word',
             ...(expanded
-              // Cap the expanded body so one long message can't push the rest of
-              // the queue out of the list's own 280px scroll area.
+              // 限制展开的正文，让一条长消息不会把队列其余部分
+              // 挤出列表自己的 280px 滚动区。
               ? { maxHeight: 220, overflowY: 'auto' as const }
               : {
                   display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
@@ -548,15 +543,15 @@ function QueuedMessageRow(
 
 
 /**
- * Push-to-talk button for the queue composer. Click to start recording, click
- * again to stop → transcribe → the text is appended to this agent's draft. While
- * another agent is mid-dictation it's disabled (one shared recorder). The actual
- * capture + Groq call live in the freeflow recorder singleton.
+ * 队列 composer 的按住说话按钮。点击开始录音，再点一次停止 →
+ * 转录 → 文本追加到这个 agent 的草稿。另一个 agent 正在听写时
+ * 它被禁用（共用一个录音器）。实际的采集 + Groq 调用活在
+ * freeflow 录音器单例里。
  *
- * When no Groq key is configured the button stays visible but disabled, with a
- * tooltip pointing to Settings — it never starts a recording, so getUserMedia and
- * the Groq STT call are never reached (preserving the zero-call-when-unavailable
- * guarantee). `hasGroqKey` is boolean presence only; the key value never gets here.
+ * 未配置 Groq key 时按钮保持可见但禁用，带指向 Settings 的
+ * tooltip——它绝不会开始录音，所以 getUserMedia 和 Groq STT 调用
+ * 永不被触达（保持"不可用时零调用"的保证）。`hasGroqKey` 只表示
+ * 布尔存在；key 值绝不落到这里。
  */
 function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: boolean }) {
   const { t } = useTranslation();
@@ -564,7 +559,7 @@ function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: 
   const mine = ff.targetAgentId === agentId;
   const recording = ff.status === 'recording' && mine;
   const transcribing = ff.status === 'transcribing' && mine;
-  // Block while another agent's clip is recording/uploading (single recorder).
+  // 另一个 agent 的片段正在录音/上传时阻塞（单个录音器）。
   const busyElsewhere = ff.status !== 'idle' && !mine;
   const noKey = !hasGroqKey;
 
@@ -584,9 +579,9 @@ function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: 
     : transcribing ? t('queueComposer.transcribing')
     : t('queueComposer.ffTitle');
 
-  /** Same placement rule as RealtimeMichaelToggle's hint: prefer above (the
-   *  composer sits low in the panel), flip below only when there is no room, and
-   *  clamp both axes so it can never hang off an edge. */
+  /** 与 RealtimeMichaelToggle 提示的同一放置规则：优先上方（composer
+   *  在面板里位置偏下），只有没空间时才翻到下方，并把两个轴都夹住，
+   *  让它绝不会伸出边缘。 */
   const toggleHint = (e: ReactMouseEvent): void => {
     e.stopPropagation();
     if (hint) { setHint(null); return; }
@@ -602,7 +597,7 @@ function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: 
     if (!hintOpen) return;
     const onDown = (ev: globalThis.MouseEvent): void => {
       const t = ev.target as Node;
-      // Portalled, so an inside-click has to be tested against BOTH nodes.
+      // Portalled，所以"内部点击"必须同时对两个节点做测试。
       if (hintRef.current?.contains(t) || panelRef.current?.contains(t)) return;
       setHint(null);
     };
@@ -628,9 +623,8 @@ function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: 
 
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: noKey ? 4 : 0, minWidth: 0 }}>
-      {/* Wrap in a (non-disabled) span so the native tooltip still shows on hover
-          even when the inner button is disabled — Chromium suppresses tooltips on
-          a disabled <button> itself. */}
+      {/* 包在一个（非禁用）span 里，让原生 tooltip 在内层按钮被禁用时
+         仍能在悬停时显示——Chromium 会抑制禁用 <button> 自身的 tooltip。 */}
       <span title={title} style={{ display: 'inline-flex' }}>
         <PixelButton
           variant={recording ? 'destructive' : 'secondary'}
@@ -645,10 +639,9 @@ function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: 
         </PixelButton>
       </span>
 
-      {/* A missing key is a SETUP STATE, not a failure — the same treatment Talk
-          already gets. Without this the button is simply dead on click, and the
-          two facts that would make someone act (it is FREE, and there is a
-          hold-to-talk shortcut) were written down nowhere in the UI. */}
+      {/* 缺 key 是 SETUP STATE，不是失败——与 Talk 得到的处理一致。
+         没有它按钮点击就是死的，而且能让用户行动的两个事实（它是 FREE 的、
+         有个按住说话的快捷键）在 UI 里没有任何地方写明。 */}
       {noKey && (
         <span ref={hintRef} style={{ display: 'inline-flex', flexShrink: 0 }}>
           <button
@@ -687,8 +680,8 @@ function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: 
                 textTransform: 'uppercase', color: 'var(--cth-ink-500)'
               }}>{t('queueComposer.ffSetupTitle')}</span>
 
-              {/* Lead with the cost, because "add an API key" reads as "this will
-                  bill me" and that assumption is what stops people here. */}
+              {/* 先讲代价，因为"add an API key"读起来像"这会扣我钱"，
+                 而正是这个假设挡住了人。 */}
               <span>
                 {t('queueComposer.ffSetupIntro')}
               </span>
@@ -700,7 +693,7 @@ function FreeFlowButton({ agentId, hasGroqKey }: { agentId: string; hasGroqKey: 
                     href="https://console.groq.com/keys"
                     onClick={(e) => { e.preventDefault(); void window.cth.openExternal('https://console.groq.com/keys'); }}
                     style={{ color: 'var(--cth-ink-900)' }}
-                  >console.groq.com/keys</a>
+                  >{t('queueComposer.groqKeysLink')}</a>
                 </li>
                 <li>{t('queueComposer.ffPasteKey')}</li>
                 <li>{t('queueComposer.ffClickOrHold')}</li>

--- a/src/renderer/src/components/MichaelBooting.tsx
+++ b/src/renderer/src/components/MichaelBooting.tsx
@@ -1,18 +1,19 @@
 import { PixelPanel } from '@/components/PixelPanel';
+import { useTranslation } from 'react-i18next';
 import { useResolvedGodName } from '@/hooks/useResolvedGodName';
 
 /**
- * Loader shown on the empty floor while the god agent is clocking in on
- * launch. Replaces the "add agent" prompt so a returning user doesn't see the
- * empty-floor call-to-action before god has booted.
+ * 空办公室上、god agent 启动打卡时显示的 loader。它取代"add agent"
+ * 提示，让回访用户不会在 god 启动完成前看到空办公室的呼唤行动。
  *
- * Rendered while `agentCount === 0` — before the store has god's live agent
- * object (and so before `agent.name` exists anywhere to read) — so this reads
- * the persisted name directly, the same way useHive.ts's spawn effect does,
- * rather than assuming the default.
+ * 在 `agentCount === 0` 期间渲染——此时 store 还没有 god 的活 agent
+ * 对象（所以 `agent.name` 也还不存在于任何可读之处）——因此这里直接读
+ * 持久化的名字，与 useHive.ts 的 spawn effect 相同的方式，而不是
+ * 假定默认值。
  */
 export function MichaelBooting() {
   const godName = useResolvedGodName();
+  const { t } = useTranslation();
   return (
     <div style={{
       position: 'absolute', inset: 0,
@@ -20,12 +21,12 @@ export function MichaelBooting() {
       pointerEvents: 'none'
     }}>
       <div style={{ pointerEvents: 'auto', width: 360 }}>
-        <PixelPanel variant="dialog" title="CLOCKING IN" noPadding>
+        <PixelPanel variant="dialog" title={t('michaelBooting.clockingIn')} noPadding>
           <div style={{
             padding: 20,
             display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 14
           }}>
-            {/* Stepped pixel blocks — staggered blink, no easing (matches aesthetic) */}
+            {/* 阶梯式像素块——错开闪烁、无缓动（契合美学） */}
             <div style={{ display: 'flex', gap: 6 }}>
               {[0, 1, 2, 3].map((i) => (
                 <span

--- a/src/renderer/src/components/OfficeThemePicker.tsx
+++ b/src/renderer/src/components/OfficeThemePicker.tsx
@@ -8,11 +8,11 @@ import { PixelButton } from './PixelButton';
 import { Icon } from './Icon';
 import type { ThemeId } from '@/scene/office/themeRegistry';
 
-// TV-show office themes (Phase 1 = the switch flow infra). Only `office` has a
-// real map+cast today; the five shows render via the loader's office fallback
-// until their content lands (Phase 2). `built: false` shows a "soon" tag and a
-// fallback note on switch, but the destructive switch flow still runs so the
-// whole pipeline (modal → delete cast → persist → re-seat) is exercisable now.
+// 电视剧办公室主题（Phase 1 = 切换流程的基础设施）。目前只有 `office`
+// 有真实的地图+演员表；其余五部剧在内容落地（Phase 2）前，都经 loader 的
+// office 回退渲染。`built: false` 在切换时显示"soon"标签和回退说明，
+// 但破坏性切换流程仍然会跑，所以整条管线（modal → 删除 cast → 持久化 →
+// 重新安置）现在就可演练。
 interface ThemeMeta { id: ThemeId; label: string; blurb: string; built: boolean; swatch: string; }
 const THEME_META: ThemeMeta[] = [
   { id: 'office',        label: 'The Office',         blurb: 'Dunder Mifflin — the original floor', built: true,  swatch: '#6b5a4a' },
@@ -23,9 +23,8 @@ const THEME_META: ThemeMeta[] = [
   { id: 'hogwarts',      label: 'Harry Potter',       blurb: 'Hogwarts great hall',                 built: false, swatch: '#39305a' },
 ];
 
-/** Settings "Office Theme" section: an experimental flag toggle + a 6-card
- *  theme picker with the destructive switch flow (report §E). Self-contained so
- *  it stays out of SettingsModal's bulk. */
+/** Settings 的 "Office Theme" 区块：一个实验性开关 + 带破坏性切换流程
+ *  （报告 §E）的 6 卡片主题选择器。自包含，以免塞进 SettingsModal 的主干。 */
 export function OfficeThemePicker({ config }: { config: HarnessConfig }) {
   const { t } = useTranslation();
   const [enabled, setEnabled] = useState(!!config.tvShowOffices);
@@ -43,11 +42,11 @@ export function OfficeThemePicker({ config }: { config: HarnessConfig }) {
     setNote('');
     try {
       await window.cth.updateConfig({ tvShowOffices: next });
-      // Flag off → the office renders regardless of the saved theme; flag on →
-      // restore the persisted theme.
+      // 关闭标志 → 办公室无论保存的主题是什么都按默认渲染；开启标志 →
+      // 恢复持久化的主题。
       setOfficeTheme(next ? current : 'office');
     } catch {
-      setEnabled(!next); // revert optimistic toggle on failure
+      setEnabled(!next); // 失败时回滚乐观开关
     }
   };
 
@@ -56,18 +55,18 @@ export function OfficeThemePicker({ config }: { config: HarnessConfig }) {
 
   const onSelect = (id: ThemeId) => {
     setNote('');
-    if (busy || id === current) return;                 // no-op on the current theme
-    if (nonGodAgents().length === 0) { void applyTheme(id); return; } // god-only → instant
-    setPending(id);                                     // workers exist → confirm modal
+    if (busy || id === current) return;                 // 当前主题上无操作
+    if (nonGodAgents().length === 0) { void applyTheme(id); return; } // 只有 god → 立即应用
+    setPending(id);                                     // 有 worker → 确认 modal
   };
 
   const applyTheme = async (id: ThemeId) => {
     setBusy(true);
     try {
-      // Tear down every non-god agent through the EXISTING lifecycle (kill PTY →
-      // dispose terminal → archive). god + the prep assistant carry over; god's
-      // PTY is never touched. If a PTY won't die, abort the switch (surface the
-      // error, don't persist the new theme) rather than leave a half-switched floor.
+      // 通过 EXISTING 生命周期拆掉每个非 god agent（kill PTY →
+      // dispose terminal → archive）。god + 预备 assistant 保留；god 的
+      // PTY 绝不触碰。如果某个 PTY 不肯死，就中止切换（把错误亮出来，
+      // 不持久化新主题），而不是留一个切了一半的办公室。
       const victims = nonGodAgents();
       for (const a of victims) {
         if (a.ptyId) {
@@ -78,7 +77,7 @@ export function OfficeThemePicker({ config }: { config: HarnessConfig }) {
       for (const a of victims) archiveAgent(a.id);
       await window.cth.updateConfig({ officeTheme: id });
       setCurrent(id);
-      setOfficeTheme(id); // → OfficeFloor rebuilds the scene on the new map/cast
+      setOfficeTheme(id); // → OfficeFloor 在新地图/演员表上重建场景
       const meta = THEME_META.find((t) => t.id === id);
       if (meta && !meta.built) setNote(t('officeTheme.notBuiltYet', { label: meta.label }));
     } catch (e) {
@@ -100,7 +99,7 @@ export function OfficeThemePicker({ config }: { config: HarnessConfig }) {
         {t('officeTheme.title')}
       </div>
 
-      {/* Experimental feature flag */}
+      {/* 实验性功能开关 */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           <span style={{ fontSize: 13, lineHeight: '20px', color: 'var(--cth-ink-900)' }}>
@@ -115,7 +114,7 @@ export function OfficeThemePicker({ config }: { config: HarnessConfig }) {
         </PixelButton>
       </div>
 
-      {/* Theme picker grid (only when the flag is on) */}
+      {/* 主题选择网格（仅当开关开启时） */}
       {enabled && (
         <div style={{ marginTop: 12, display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 8 }}>
           {THEME_META.map((theme) => {
@@ -184,7 +183,7 @@ export function OfficeThemePicker({ config }: { config: HarnessConfig }) {
 
 interface VictimAgent { id: string; status?: string; }
 
-/** Destructive confirm for a theme switch with live workers (report §E copy). */
+/** 有活跃 worker 时主题切换的破坏性确认（报告 §E 文案）。 */
 function ThemeSwitchConfirmModal({
   label, agents, busy, onCancel, onConfirm,
 }: {

--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -20,16 +20,16 @@ export interface OnboardingWizardProps {
 type Audience = 'technical' | 'non-technical';
 type Step = 'persona' | 'welcome' | 'home' | 'orchestrator' | 'repos' | 'permissions' | 'done';
 
-// First-run showcase "— the highest-value features a brand-new user should grasp
-// before any setup. Labels and copy live in i18n (two registers: `desc` for the
-// technical audience, `descPlain` for the plain-language one "— item 1).
+// 首次运行的展示——一个全新用户在任何设置前就该掌握的最高价值功能。
+// 标签和文案放在 i18n 里（两个语域：`desc` 面向技术受众，`descPlain`
+// 面向平实语言受众——第 1 项）。
 interface Feature {
   icon: IconName;
   labelKey: string;
-  descKey: string;       // technical register
-  descPlainKey: string;  // non-technical register
-  tint: string;          // tile background token
-  edge: string;          // tile border token
+  descKey: string;       // 技术语域
+  descPlainKey: string;  // 非技术语域
+  tint: string;          // 磁贴背景 token
+  edge: string;          // 磁贴边框 token
 }
 const FEATURES: Feature[] = [
   {
@@ -76,32 +76,29 @@ const FEATURES: Feature[] = [
   }
 ];
 
-// One-liner of what each engine is, shown under its row on the orchestrator step
-// so a non-technical user knows what they're picking (item 3).
+// 每个引擎的一句话简介，显示在 orchestrator 步骤对应行下方，
+// 让非技术用户知道自己在选什么（第 3 项）。
 const PROVIDER_BLURB_KEYS: Partial<Record<AgentProvider, string>> = {
-  gemini: 'onboarding.providerBlurb.gemini',
   claude: 'onboarding.providerBlurb.claude',
   codex: 'onboarding.providerBlurb.codex',
-  antigravity: 'onboarding.providerBlurb.antigravity',
-  qwen: 'onboarding.providerBlurb.qwen',
-  cursor: 'onboarding.providerBlurb.cursor'
+  qwen: 'onboarding.providerBlurb.qwen'
 };
 
 export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const { t } = useTranslation();
-  // Onboarding runs before god exists in the store, so read the persisted name.
+  // Onboarding 运行时 god 尚未在 store 里，所以读取持久化的名字。
   const godName = useResolvedGodName();
   const [step, setStep] = useState<Step>('persona');
-  // Self-identified audience (item 1). Undefined until chosen on the first screen;
-  // the rest of the wizard reads `plain` to swap copy registers.
+  // 自我识别的受众（第 1 项）。在第一屏做出选择前保持 undefined；
+  // 向导其余部分读 `plain` 来切换文案语域。
   const [audience, setAudience] = useState<Audience | undefined>();
   const plain = audience === 'non-technical';
 
   const [home, setHome] = useState<string>('');
   const [repos, setRepos] = useState<string[]>([]);
   const [autoMode, setAutoMode] = useState<boolean>(true);
-  // Anonymous usage stats (TELEMETRY.md). Default ON (opt-out); persisted by
-  // finish() so unchecking before finishing means nothing is ever sent.
+  // 匿名使用统计（TELEMETRY.md）。默认开启（opt-out）；由 finish()
+  // 持久化，所以只要在完成前取消勾选，就什么都不会发送。
   const [shareStats, setShareStats] = useState<boolean>(true);
   const [godProvider, setGodProvider] = useState<AgentProvider>('claude');
   const [godModel, setGodModel] = useState<string | undefined>(
@@ -110,61 +107,59 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const [error, setError] = useState<string | undefined>();
   const [busy, setBusy] = useState(false);
 
-  // Which engine CLIs are actually on this machine. The picker used to record the
-  // choice blind; the first check happened when Michael spawned, and for a
-  // provider with no installer that meant a first run where nothing ever booted.
-  // `undefined` = probe not back yet (or failed): rows show no badge and nothing
-  // is blocked, because a broken probe must not lock a new user out.
+  // 这台机器上实际装有哪些引擎 CLI。选择器过去是盲记选择；第一次检查
+  // 发生在 Michael spawn 时，对一个没有安装器的 provider 来说，那意味着
+  // 首次运行什么都不曾启动。`undefined` = 探测还没回来（或失败）：
+  // 行不显示徽章、什么都不被阻塞，因为一个坏掉的探测绝不能把新用户锁在外面。
   const [engines, setEngines] = useState<ToolStatus[] | undefined>();
   const [probing, setProbing] = useState(false);
   const probeEngines = async () => {
     setProbing(true);
     try { setEngines(await window.cth.toolsStatus()); }
-    catch { /* leave undefined: unknown, never blocking */ }
+    catch { /* 保持 undefined：未知，绝不阻塞 */ }
     finally { setProbing(false); }
   };
   useEffect(() => { void probeEngines(); }, []);
   const selectedEngine = classifyEngineAvailability(engines, godProvider);
   const engineBlocked = engineBlocksOnboarding(selectedEngine);
 
-  // Permissions & reliability toggles. These apply IMMEDIATELY on change (their
-  // own IPC / OS state) "— they are NOT part of finish()'s config write. First-run
-  // defaults: notifications off (config default), login-item off (fresh install);
-  // each reconciles to the real state the IPC returns.
+  // 权限与可靠性开关。这些在变更时 IMMEDIATELY 生效（它们各自的
+  // IPC / OS 状态）——它们不属于 finish() 的 config 写入。首次运行默认值：
+  // 通知关（config 默认）、登录项关（全新安装）；每一项都会与 IPC
+  // 返回的真实状态对齐。
   const [strongKeepalive, setStrongKeepalive] = useState(false);
   const [notifications, setNotifications] = useState(false);
   const [openAtLogin, setOpenAtLogin] = useState(false);
 
   const toggleStrongKeepalive = async (v: boolean) => {
-    setStrongKeepalive(v); // optimistic
+    setStrongKeepalive(v); // 乐观更新
     try { setStrongKeepalive((await window.cth.updateConfig({ strongKeepalive: v })).strongKeepalive === true); }
     catch { setStrongKeepalive(!v); }
   };
   const toggleNotifications = async (v: boolean) => {
-    setNotifications(v); // optimistic
+    setNotifications(v); // 乐观更新
     try { await window.cth.setNotifications(v); }
-    catch { setNotifications(!v); } // revert on failure
+    catch { setNotifications(!v); } // 失败时回滚
   };
   const toggleOpenAtLogin = async (v: boolean) => {
-    setOpenAtLogin(v); // optimistic
-    try { setOpenAtLogin(await window.cth.setLoginItem(v)); } // reconcile to OS truth
+    setOpenAtLogin(v); // 乐观更新
+    try { setOpenAtLogin(await window.cth.setLoginItem(v)); } // 与 OS 真实状态对齐
     catch { setOpenAtLogin(!v); }
   };
   const openSettings = (url: string) => { void window.cth.openExternal(url); };
 
-  // Default-suggest a sensible harness home on first render.
+  // 首次渲染时默认建议一个合理的 harness home。
   //
-  // This used to read `window.process.env.HOME`, which is ALWAYS undefined here:
-  // the window runs with `contextIsolation: true` / `nodeIntegration: false` and
-  // the preload bridges exactly one object (`cth`), so the renderer's main world
-  // has no `process`. The suggestion therefore always collapsed to '' and the
-  // field rendered empty "— leaving the copy above promising a default the user
-  // could not accept, and Finish failing with "Pick a harness home folder first."
+  // 这里以前读 `window.process.env.HOME`，它在渲染器里 ALWAYS 是 undefined：
+  // 窗口以 `contextIsolation: true` / `nodeIntegration: false` 运行，preload
+  // 只桥接一个对象（`cth`），所以渲染器的主世界没有 `process`。因此这个
+  // 建议总是塌缩成 ''，字段渲染为空——上方的文案承诺着一个用户无法接受的
+  // 默认值，Finish 也以 "Pick a harness home folder first." 失败。
   //
-  // Suggest the literal `~/HarnessAgents` instead. That is exactly the string
-  // #140's normalizeHiveHome()/expandTilde() were built to absorb: it is expanded
-  // at the config-write boundary AND at ensureHarnessHome's mkdir, so every
-  // downstream reader still sees one absolute path. No new IPC surface.
+  // 改为建议字面量 `~/HarnessAgents`。那正是 #140 的
+  // normalizeHiveHome()/expandTilde() 生来就要吸收的字符串：它既在
+  // config 写入边界展开、也在 ensureHarnessHome 的 mkdir 处展开，
+  // 所以每个下游读者看到的仍是一个绝对路径。没有新增 IPC 表面。
   useEffect(() => {
     if (!home) setHome('~/HarnessAgents');
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -189,11 +184,10 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const finish = async () => {
     setBusy(true);
     setError(undefined);
-    const harnessHome = home.trim(); // whitespace-only is not a folder
+    const harnessHome = home.trim(); // 纯空白不算文件夹
     if (!harnessHome) { setError(t('onboarding.errPickHome')); setBusy(false); setStep('home'); return; }
-    // The orchestrator step already refuses to advance on this, but a late probe
-    // result can change the answer after the user has moved on. Never write a
-    // godProvider that is known to be unable to boot.
+    // orchestrator 步骤已经拒绝在此继续，但迟到的探测结果可以在用户
+    // 前进之后改变答案。绝不写入一个已知无法启动的 godProvider。
     if (engineBlocked) {
       setError(t('onboarding.errEngineNotInstalled', { label: providerPreset(godProvider).label }));
       setBusy(false); setStep('orchestrator'); return;
@@ -207,7 +201,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     const next = await window.cth.updateConfig({
       onboardingComplete: true,
       audience: audience ?? 'technical',
-      harnessHome, // the same trimmed value we just mkdir'd, not the raw field
+      harnessHome, // 就是我们刚 mkdir 过的同一修剪值，而非原始字段
       registeredRepos: repos,
       autoMode,
       godProvider,
@@ -224,19 +218,17 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
       background: 'var(--cth-cream-200)',
       backgroundImage:
         `repeating-linear-gradient(45deg, rgba(232, 217, 160, 0.4) 0 1px, transparent 1px 8px)`,
-      // Scroll the overlay rather than clip the wizard. Step 2 lists every
-      // installed CLI engine (8 rows + a model select), which is taller than a
-      // 1080p-class window once the OS chrome is subtracted "— the panel was
-      // being cut off at BOTH edges with no way to reach the buttons.
+      // 滚动 overlay 而不是裁剪向导。第 2 步列出每个已安装的 CLI 引擎
+      //（8 行 + 一个模型选择），减去 OS chrome 后比 1080p 级窗口还高——
+      // 面板过去在 BOTH 边缘都被截断，按钮完全够不到。
       display: 'flex',
       overflowY: 'auto',
       zIndex: 200,
       padding: 32
     }}>
-      {/* `margin: auto` centers, NOT `align-items: center`. A centered flex item
-          that overflows its container is clipped at the TOP and unreachable by
-          scrolling (the overflow spills past the scroll origin); auto margins
-          center while it fits and collapse to a normal scroll once it doesn't. */}
+      {/* `margin: auto` 居中，不是 `align-items: center`。一个居中的 flex
+          元素溢出容器时会在 TOP 被裁剪，而且滚动够不到它（溢出越过滚动
+          原点溢出）；auto margin 在放得下时居中，放不下时塌缩成普通滚动。 */}
       <div style={{ width: 640, maxWidth: '94vw', margin: 'auto' }}>
         <PixelPanel
           variant="dialog"
@@ -339,8 +331,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                         <div style={{
                           fontFamily: 'var(--cth-font-display)',
                           fontSize: 10, lineHeight: '14px', marginBottom: 3
-                          // These labels are literal caps to match their siblings, so
-                          // the orchestrator's name has to arrive upper-cased too.
+                          // 这些标签是字面大写，以与兄弟标签一致，所以
+                          // orchestrator 的名字也必须以大写形式到达。
                         }}>{t(f.labelKey, { godName: godName.toUpperCase() })}</div>
                         <div style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-700)' }}>
                           {plain ? t(f.descPlainKey) : t(f.descKey)}
@@ -382,7 +374,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   {plain ? t('onboarding.orchestrator.descPlain') : t('onboarding.orchestrator.desc')}
                 </p>
 
-                {/* What is a CLI agent / your clone "— item 3 */}
+                {/* 什么是 CLI agent / 你的克隆——第 3 项 */}
                 <div style={{
                   display: 'flex', gap: 8, alignItems: 'flex-start', padding: 10,
                   background: 'var(--cth-lemon-light)', boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
@@ -413,7 +405,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                 </div>
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                  {AGENT_PROVIDER_PRESETS.filter((p) => canReceiveInbox(p.id)).map((p) => {
+                  {AGENT_PROVIDER_PRESETS.filter((p) => canReceiveInbox(p.id) || p.id === 'kimi').map((p) => {
                     const sel = godProvider === p.id;
                     return (
                       <label key={p.id} style={{
@@ -430,8 +422,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                           checked={sel}
                           onChange={() => {
                             setGodProvider(p.id);
-                            // Reset the model to the new provider's recommended pick so the
-                            // dropdown below always shows a valid model for the chosen engine.
+                            // 把模型重置为新 provider 的推荐选择，让下面的
+                            // 下拉框始终为所选引擎显示一个有效模型。
                             setGodModel(p.recommendedOrchestratorModel);
                           }}
                           style={{ width: 16, height: 16, flexShrink: 0 }}
@@ -454,7 +446,9 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                         </span>
                         {(() => {
                           const a = classifyEngineAvailability(engines, p.id);
-                          const badge = engineAvailabilityBadge(a);
+                          const badge = a.state === 'installed' ? t('onboarding.orchestrator.badgeInstalled')
+                            : a.state === 'installs-on-first-run' ? t('onboarding.orchestrator.badgeInstallsFirstRun')
+                            : a.state === 'not-installable' ? t('onboarding.orchestrator.badgeNotInstalled') : null;
                           if (!badge) return null;
                           const bad = a.state === 'not-installable';
                           return (
@@ -485,14 +479,14 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                     background: 'var(--cth-paper-100)', boxShadow: 'inset 0 0 0 2px var(--cth-ink-900)',
                     fontSize: 12, lineHeight: '17px', color: 'var(--cth-ink-900)'
                   }}>
-                    <span>{engineAvailabilityMessage(selectedEngine, providerPreset(godProvider).label)}</span>
+                    <span>{t('onboarding.orchestrator.blockedMessage', { label: providerPreset(godProvider).label, godName: godName })}</span>
                     <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                       <PixelButton variant="secondary" size="sm" onClick={() => { void probeEngines(); }} disabled={probing}>
-                        {probing ? 'checking...' : 'check again'}
+                        {probing ? t('onboarding.orchestrator.checking') : t('onboarding.orchestrator.checkAgain')}
                       </PixelButton>
                       {selectedEngine.docsUrl && (
                         <PixelButton variant="ghost" size="sm" onClick={() => { void window.cth.openExternal(selectedEngine.docsUrl!); }}>
-                          install instructions
+                          {t('onboarding.orchestrator.installInstructions')}
                         </PixelButton>
                       )}
                     </div>
@@ -565,10 +559,10 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 
             {step === 'permissions' && (
               <>
-                {/* AUTONOMY — merged from the old "auto mode" step (item 5). One choice
-                    that maps to each engine's flag (item 6): autoMode → claude
-                    bypassPermissions / codex -a never -s workspace-write (sandbox kept),
-                    etc.; off → each engine's ask-first default. */}
+                {/* AUTONOMY——由旧的"auto mode"步骤合并而来（第 5 项）。一个选择
+                    映射到每个引擎的标志（第 6 项）：autoMode → claude
+                    bypassPermissions / codex -a never -s danger-full-access（保留 sandbox），
+                    等等；关 → 每个引擎的"先询问"默认值。 */}
                 <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 10, color: 'var(--cth-ink-700)' }}>
                   {t('onboarding.permissions.autonomyHead')}
                 </div>
@@ -602,7 +596,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 
                 <div style={{ height: 1, background: 'var(--cth-ink-300)', margin: '2px 0' }} />
 
-                {/* RELIABILITY "— keeping work firing while you're away. */}
+                {/* RELIABILITY——让你离开时工作仍在持续。 */}
                 <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 10, color: 'var(--cth-ink-700)' }}>
                   {t('onboarding.permissions.reliabilityHead')}
                 </div>
@@ -650,7 +644,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   onChange={() => setShareStats(!shareStats)}
                 />
 
-                {/* LEVER 4 "— instruction-only: macOS won't let the app flip Energy, so we deep-link the pane. */}
+                {/* LEVER 4——仅指示：macOS 不让应用翻转 Energy，所以我们深链到该面板。 */}
                 <div style={{
                   display: 'flex', gap: 10, alignItems: 'flex-start', padding: 10,
                   background: 'var(--cth-lemon-light)',
@@ -694,7 +688,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
               }}>{error}</div>
             )}
 
-            {/* Footer / nav */}
+            {/* 页脚 / 导航 */}
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 4 }}>
               <Dots step={step} />
               <div style={{ display: 'flex', gap: 8 }}>
@@ -713,18 +707,16 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                     variant="primary"
                     size="md"
                     onClick={() => {
-                      // Validate the home step HERE. Without this the only check
-                      // lives in finish(), so an empty field walks you through all
-                      // four steps and then bounces you back to step 1 to be told.
+                      // 在这里校验 home 步骤。没有它，唯一的检查在 finish() 里，
+                      // 于是空的字段会带你走完四步，然后把你弹回第 1 步才告诉你。
                       if (step === 'home' && !home.trim()) {
                         setError(t('onboarding.errPickHome'));
                         return;
                       }
-                      // Same idea for the engine: refuse here, with the reason on
-                      // screen, instead of letting a pick that cannot boot through
-                      // to a Michael that never starts.
+                      // 引擎同理：在这里拒绝并显示理由，
+                      // 而不是让一个无法启动的选择一路走到一个永不启动的 Michael。
                       if (step === 'orchestrator' && engineBlocked) {
-                        setError(`${providerPreset(godProvider).label} is not installed. Install it and press "check again", or pick another engine.`);
+                        setError(`${providerPreset(godProvider).label} 未安装。请安装它并按"重新检查"，或选择其它引擎。`);
                         return;
                       }
                       setError(undefined);
@@ -787,8 +779,8 @@ function ToggleRow({ icon, label, desc, on, tint, edge, onChange }: {
   label: string;
   desc: string;
   on: boolean;
-  tint: string; // background token when on
-  edge: string; // border token when on
+  tint: string; // 开启时的背景 token
+  edge: string; // 开启时的边框 token
   onChange: (v: boolean) => void;
 }) {
   return (

--- a/src/renderer/src/components/PixelBadge.tsx
+++ b/src/renderer/src/components/PixelBadge.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 
 export type StatusKind =
   | 'idle' | 'thinking' | 'working' | 'waiting' | 'blocked' | 'success' | 'ghost'
-  // #5C — richer states driven by real events: PreCompact/PostCompact hooks and
-  // the Lane A circuit breaker (#6) respectively.
+  // #5C —— 由真实事件驱动的更丰富状态：PreCompact/PostCompact hooks
+  // 和 Lane A 熔断器（#6）各自对应一个。
   | 'compacting' | 'looping'
-  // Not an agent state at all — the USER has unsubmitted text on that agent's
-  // prompt, which holds its queue. Never stored on the agent (the pty parser
-  // would overwrite it); derived at render, see `hasTerminalDraft`. Without it
-  // a held queue looked identical to an idle agent doing nothing.
+  // 根本不是 agent 状态——是 USER 在该 agent 的 prompt 上有未提交的
+  // 文本，它拖住了队列。永不存储在 agent 上（pty parser 会覆盖它）；
+  // 渲染时派生，见 `hasTerminalDraft`。没有它，被拖住的队列看起来和
+  // 无所事事的 idle agent 毫无区别。
   | 'typing';
 
 export interface PixelBadgeProps {
@@ -31,9 +31,9 @@ const colorByStatus: Record<StatusKind, string> = {
   typing:     'var(--cth-status-typing)'
 };
 
-// i18n key per status. "blocked" is reserved for the god agent waiting on YOU,
-// so it reads as "needs you"; sub-agents waiting on god/another agent are
-// "waiting", which is honest about who they're actually stalled on.
+// 每种状态的 i18n key。"blocked" 预留给等 YOU 的 god agent，
+// 所以它读作"需要你"；等 god/另一个 agent 的子 agent 用
+// "waiting"，这如实反映了他们实际卡在谁身上。
 const labelKeyByStatus: Record<StatusKind, string> = {
   idle:     'badge.idle',
   thinking: 'badge.thinking',
@@ -44,8 +44,8 @@ const labelKeyByStatus: Record<StatusKind, string> = {
   ghost:    'badge.ghost',
   compacting: 'badge.compacting',
   looping:    'badge.looping',
-  // Reads as "you are typing", not "the agent is typing" — it is your text
-  // sitting on the prompt, and it is why nothing is being delivered.
+  // 读作"你在输入"，不是"agent 在输入"——是你的文本坐在 prompt 上，
+  // 也正是为什么没有任何东西被送出。
   typing:     'badge.typing'
 };
 
@@ -58,8 +58,8 @@ export function PixelBadge({ status, label, style }: PixelBadgeProps) {
       style={{
         display: 'inline-flex',
         alignItems: 'center',
-        // Same reason as PixelButton: a status chip that shrinks spills its text
-        // under the controls beside it instead of holding its own width.
+        // 与 PixelButton 同样的原因：会缩小的状态 chip 会把文本溢到
+        // 旁边的控件底下，而不是守住自己的宽度。
         flexShrink: 0,
         gap: 6,
         padding: '2px 8px 0',

--- a/src/renderer/src/components/PixelButton.tsx
+++ b/src/renderer/src/components/PixelButton.tsx
@@ -30,19 +30,18 @@ export function PixelButton({
   const [pressed, setPressed] = useState(false);
   const [hover, setHover] = useState(false);
 
-  // DISABLED TEXT IS ITS OWN COLOR, not the variant's.
+  // 禁用文本是它自己的颜色，不是变体的颜色。
   //
-  // Every variant swaps its FILL to `--cth-cream-300` when disabled, but the
-  // variants used to keep their enabled text token — and `primary`'s is
-  // `--cth-cream-50`, the INVERSE foreground picked to sit on an ink-900 button.
-  // On the cream-300 disabled fill that pairing collapses: in dark mode it is
-  // #1A191E text on #37363E (~1.4:1, effectively invisible), and in light mode a
-  // near-white #FFFDF5 on tan, which is barely better. That is why a disabled
-  // Send or Dispatch reads as an empty box.
+  // 每个变体在禁用时把 FILL 换成 `--cth-cream-300`，但变体过去保留
+  // 自己启用时的文本 token——而 `primary` 的是 `--cth-cream-50`，这个
+  // INVERSE（反相）前景是特意选来坐在 ink-900 按钮上的。在 cream-300
+  // 禁用填充上这对组合就崩了：深色模式下是 #1A191E 文本配 #37363E 底
+  //（约 1.4:1，几乎看不见），浅色模式下近白 #FFFDF5 配棕黄，也好不到
+  // 哪里去。这就是为什么禁用的 Send 或 Dispatch 读起来像一个空盒子。
   //
-  // `--cth-ink-500` is the one foreground that works against cream-300 in BOTH
-  // themes, because both tokens flip together — and a muted label is what a
-  // disabled control should look like anyway.
+  // `--cth-ink-500` 是唯一一个在 BOTH 主题下都能在 cream-300 上成立
+  // 的前景，因为两个 token 是一起翻转的——而且被压暗的标签本来就是一个
+  // 禁用控件应有的样子。
   const disabledText = 'var(--cth-ink-500)';
 
   const palette = (() => {
@@ -88,36 +87,34 @@ export function PixelButton({
       onMouseEnter={() => setHover(true)}
       disabled={disabled}
       style={{
-        // Centre content HERE rather than trusting each call site.
+        // 在这里居中内容，而不是信任每个调用点。
         //
-        // A <button> with a fixed height centres bare text on its own, but a
-        // child that is itself `inline-flex` (which every icon+label call site
-        // uses, to sit the glyph beside the word) aligns on ITS baseline
-        // instead. So a row of buttons where some labels were wrapped and some
-        // were bare text — `edit` beside `IDE` and `terminal` — sat at visibly
-        // different heights. Fixing it per call site fixes today's row and not
-        // the next one someone writes.
+        // 固定高度的 <button> 会自己居中裸文本，但子元素本身是
+        // `inline-flex` 时（每个 icon+label 调用点都这么用，为了让字形
+        // 挨着词）它会按自己的基线对齐。于是一排按钮里有些 label 包了层、
+        // 有些是裸文本——比如 `edit` 挨着 `IDE` 和 `terminal`——
+        // 坐在明显不同的高度上。在调用点逐个修只修得了今天这一行，
+        // 修不了别人以后写的下一行。
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        // Matches the gap the wrapped call sites already use, so an icon can be
-        // dropped in beside a label with no wrapper at all.
+        // 与已包层调用点用的 gap 一致，这样 icon 不用任何包裹层
+        // 就能直接放进 label 旁边。
         gap: 4,
-        // Kill descender-driven drift: with the height fixed above, an inherited
-        // line-height only moves the text off centre.
+        // 干掉 descender 带来的漂移：上面高度已固定，继承的 line-height
+        // 只会把文本推离正中。
         lineHeight: 1,
-        // A button never shrinks below its own label. The default flex-shrink is
-        // 1, and with `whiteSpace: nowrap` below, a squeezed button keeps drawing
-        // its full-width text out of a narrowed box — so in a tight row the
-        // labels paint straight over whatever sits to their left. That is not a
-        // clipped button, it is two controls on top of each other.
+        // 按钮永不缩得比自己的 label 还小。默认 flex-shrink 是 1，
+        // 而配合下面的 `whiteSpace: nowrap`，被挤压的按钮会把全宽文本
+        // 画出变窄的盒子——所以在紧凑的一行里，标签会直接画到左边
+        // 邻居身上。那不是被裁剪的按钮，而是两个控件叠在一起。
         flexShrink: 0,
         height: heightBySize[size],
         padding: padBySize[size],
         background: palette.fill,
         color: palette.text,
         border: 'none',
-        // v0.3.4: 1px hairline + 1px lift — the 2px chrome read as heavy boxes
+        // v0.3.4: 1px 发丝线 + 1px 抬升——2px 的 chrome 读起来像厚重的盒子
         boxShadow: pressed && !disabled
           ? `inset 0 0 0 1px ${palette.border}`
           : `inset 0 0 0 1px ${palette.border}, 0 1px 0 ${palette.shadow}`,
@@ -127,12 +124,11 @@ export function PixelButton({
         cursor: disabled ? 'not-allowed' : 'pointer',
         width: fullWidth ? '100%' : 'auto',
         userSelect: 'none',
-        // Height is fixed by the size variant above, so a label that wraps does
-        // not make the button taller — the extra line simply prints through the
-        // bottom border. Every label here is a short phrase ("Check for updates",
-        // "reset & start over"), so wrapping is always a layout bug rather than a
-        // wanted behaviour. Callers that genuinely want a multi-line button can
-        // still override, since `style` spreads after this.
+        // 高度由上面的尺寸变体固定，所以换行的 label 不会让按钮变高——
+        // 多出的一行只是从底部边框打印出去。这里的每个 label 都是短短语
+        //（"Check for updates"、"reset & start over"），所以换行永远是布局
+        // bug 而不是想要的行为。真正想要多行按钮的调用方仍可覆盖，
+        // 因为 `style` 在这个后面展开。
         whiteSpace: 'nowrap',
         ...style
       }}

--- a/src/renderer/src/components/PixelPanel.tsx
+++ b/src/renderer/src/components/PixelPanel.tsx
@@ -16,7 +16,7 @@ export interface PixelPanelProps {
 const borderByVariant: Record<Variant, string> = {
   default:  'var(--cth-panel-border)',
   inset:    'var(--cth-panel-border-inset)',
-  active:   'var(--cth-panel-border)',  // accent overlay added separately
+  active:   'var(--cth-panel-border)',  // 强调色另行叠加
   terminal: 'var(--cth-panel-border-terminal)',
   dialog:   'var(--cth-panel-border-dialog)'
 };
@@ -46,7 +46,7 @@ export function PixelPanel({
     ...style
   };
 
-  // Active variant: paint accent over the middle border slot (3px ring at 1px inset)
+  // Active 变体：把强调色画在中间边框槽上（1px inset 处的 3px 环）
   if (variant === 'active' && accent) {
     baseStyle.boxShadow = `
       inset 0 0 0 1px var(--cth-ink-100),

--- a/src/renderer/src/components/ProviderLogo.tsx
+++ b/src/renderer/src/components/ProviderLogo.tsx
@@ -1,40 +1,33 @@
 import type { AgentProvider } from '@/store/config';
 
 /**
- * ProviderLogo — the official brand mark for each CLI-agent provider, rendered
- * inline as a single-path SVG so it stays crisp at any size and inherits the
- * surrounding ink color (monochrome, to sit cleanly inside the neo-brutalist UI).
+ * ProviderLogo —— 每个 CLI-agent provider 的官方品牌标识，内联渲染成
+ * 单路径 SVG，任何尺寸都保持锐利，并继承周围的墨色（单色，才能干净地
+ * 坐在新粗野主义 UI 里）。
  *
- * Brand marks (Anthropic / OpenAI / Google Gemini / Qwen) are the canonical
- * single-color glyphs from the Simple Icons set. `custom` is a bring-your-own
- * engine with no brand, so it gets a hand-drawn terminal-prompt stroke glyph in
- * the same weight.
+ * 品牌标识（Anthropic / OpenAI / Google Gemini / Qwen）来自 Simple Icons
+ * 集的规范单色字形。`custom` 是没有品牌的自带引擎，所以它使用同等粗细的
+ * 手绘终端提示符描边字形。
  */
 
-// Single-path fills (24×24 viewBox), official brand marks.
+// 单路径填充（24×24 viewBox），官方品牌标识。
 const BRAND_PATHS: Partial<Record<AgentProvider, string>> = {
-  // Google Gemini CLI.
-  gemini:
-    'M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81',
-  // Anthropic — powers Claude Code.
+  // Anthropic —— 驱动 Claude Code。
   claude:
     'M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z',
-  // OpenAI — powers the Codex CLI.
+  // OpenAI —— 驱动 Codex CLI。
   codex:
     'M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z',
-  // Google Gemini — Antigravity runs Gemini models.
-  antigravity:
-    'M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81',
-  // Qwen (Alibaba) — the local qwen-code CLI.
+  // Qwen（阿里巴巴）——本地 qwen-code CLI。
   qwen:
     'M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z'
 };
 
 export interface ProviderLogoProps {
   provider: AgentProvider;
-  /** Edge length in px (square). Default 18. */
+  /** 边长（px，正方形）。默认 18。 */
   size?: number;
-  /** Overrides the fill/stroke color; defaults to currentColor (inherits ink). */
+  /** 覆盖填充/描边颜色；默认 currentColor（继承墨色）。 */
   color?: string;
 }
 
@@ -55,7 +48,7 @@ export function ProviderLogo({ provider, size = 18, color = 'currentColor' }: Pr
     );
   }
 
-  // custom / fallback — bring-your-own CLI: a terminal prompt glyph (">_").
+  // custom / fallback —— 自带 CLI：一个终端提示符字形（">_"）。
   return (
     <svg
       width={size}

--- a/src/renderer/src/components/PtyTerminalView.tsx
+++ b/src/renderer/src/components/PtyTerminalView.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { CSSProperties } from 'react';
 import '@xterm/xterm/css/xterm.css';
 import { Icon } from './Icon';
-import { acquireTerminal, attachTerminal, detachTerminal, reflowTerminal } from './terminalPool';
+import { acquireTerminal, attachTerminal, debouncedResizePty, detachTerminal, reflowTerminal } from './terminalPool';
 import {
   DEFAULT_TERMINAL_FONT_SIZE,
   MAX_TERMINAL_FONT_SIZE,
@@ -13,15 +14,15 @@ import {
 } from './terminalFontSize';
 import { useAppTheme } from '@/design/theme';
 
-// Zoom lives in ./terminalFontSize so anything outside the terminal (the message
-// composer) can scale with it too; these aliases keep the call sites below short.
+// 缩放放在 ./terminalFontSize 里，让终端之外的任何东西（消息
+// composer）也能一起缩放；这些别名让下面的调用点保持简短。
 const DEFAULT_FONT_SIZE = DEFAULT_TERMINAL_FONT_SIZE;
 const MIN_FONT_SIZE = MIN_TERMINAL_FONT_SIZE;
 const MAX_FONT_SIZE = MAX_TERMINAL_FONT_SIZE;
 
-// v0.3.4: the terminal follows the APP-WIDE theme (design/theme.ts, toggled in
-// the title bar) instead of keeping its own light/dark switch — one theme for
-// chrome, terminal, and (via config.terminalTheme) each agent's TUI palette.
+// v0.3.4: 终端跟随 APP-WIDE 主题（design/theme.ts，在标题栏切换），
+// 而不再保留自己的明/暗开关——chrome、终端，以及（经 config.terminalTheme）
+// 每个 agent 的 TUI 配色，统一一套主题。
 type PtyTheme = 'light' | 'dark';
 
 const zoomBtnStyle: CSSProperties = {
@@ -40,16 +41,13 @@ const zoomBtnStyle: CSSProperties = {
   padding: 0
 };
 
-// Light theme — cream paper. The ANSI "white" / "yellow" / bright slots are
-// remapped to readable dark inks: programs that print white or pale-yellow text
-// (expecting a dark terminal) were previously invisible on the cream background.
-// A single ANSI slot has to serve both roles — coloured *foreground* on cream and
-// a coloured *background* under the dark default ink — which no fixed luminance
-// can satisfy at once. The terminal's `minimumContrastRatio` (see terminalPool.ts)
-// dynamically adjusts the per-cell foreground to keep both roles legible; these
-// values are tuned so the colours stay recognisable and read well natively. The
-// green/yellow are kept deep enough to read as text on cream (the brighter
-// variants are the lighter shades, per terminal convention).
+// 浅色主题——奶油底纸。ANSI "white" / "yellow" / bright 槽被重映射成
+// 可读的深色墨：预期深色终端的程序打印白色或浅黄文本时，在奶油背景上
+// 之前是看不见的。单个 ANSI 槽必须同时扮演两种角色——奶油底上的彩色
+// *前景* 和深色默认墨下的彩色 *背景*——任何固定亮度都无法同时满足。
+// 终端的 `minimumContrastRatio`（见 terminalPool.ts）会动态调整每个单元格的
+// 前景来让两种角色都可读；这里的取值按"原生读起来就清晰可辨"调校。绿色/黄色
+// 保持足够深，能在奶油上读作文本（更亮的变体属于更浅的色阶，符合终端惯例）。
 const lightTheme = {
   background: '#FCFAF0',
   foreground: '#1A1320',
@@ -59,12 +57,12 @@ const lightTheme = {
   selectionForeground: '#1A1320',
   black:        '#1A1320',
   red:          '#D1453B',
-  green:        '#20904B',    // deep green → readable as text on cream
-  yellow:       '#9C6B00',    // deep amber → readable as text on cream
+  green:        '#20904B',    // 深绿 → 在奶油底上读作文本
+  yellow:       '#9C6B00',    // 深琥珀 → 在奶油底上读作文本
   blue:         '#2B6CB0',
   magenta:      '#8A5CF0',
   cyan:         '#1F9C94',
-  white:        '#3A2F44',   // default "white" text → dark, so it's visible
+  white:        '#3A2F44',   // 默认 "white" 文本 → 用深色，才能看见
   brightBlack:  '#6B5878',
   brightRed:    '#E0584E',
   brightGreen:  '#2E9E54',
@@ -75,14 +73,12 @@ const lightTheme = {
   brightWhite:  '#1A1320'
 };
 
-// Dark theme — mirrors the app's dark surface ramp (tokens.css
-// data-cth-theme='dark'). xterm takes literal colours and cannot read CSS
-// custom properties, so these values are RE-STATED rather than referenced, and
-// drift the moment the tokens move: this set was still on the pre-readability
-// ramp (background #1D1C21, the old paper-100) after tokens.css dropped to
-// a softer ground, which would have left every terminal sitting a visible step
-// apart from the panel holding it. Muted-professional ANSI: recognizable hues, no
-// fluorescing on the dark ground; brights are one legible step up, not pastels.
+// 深色主题——镜像应用的深色表面阶梯（tokens.css data-cth-theme='dark'）。
+// xterm 接受字面颜色，读不了 CSS custom property，所以这些值是 RE-STATED
+// 而非引用，token 一动就漂移：这一套在 tokens.css 降到更柔和的底色后，
+// 仍停留在可读性改进前的阶梯上（background #1D1C21，旧的 paper-100），
+// 会让每个终端与托着它的面板之间都明显差出一阶。Muted-professional ANSI：
+// 可辨识的色相，在深色地面上不荧光；bright 是清晰可见的一级提升，不是粉彩。
 const darkTheme = {
   background: '#1A1A1F',        // = --cth-paper-100
   foreground: '#DEDBD6',        // = --cth-ink-900
@@ -112,19 +108,20 @@ const THEMES: Record<PtyTheme, typeof lightTheme> = { light: lightTheme, dark: d
 
 export interface PtyTerminalViewProps {
   ptyId: string;
-  /** Forwarded to the renderer-side onData hook so the parent can also tap
-   *  the stream for regex parsing (avatar state inference). */
+  /** 转发给 renderer 侧的 onData hook，让父组件也能截获
+   *  这个流做正则解析（avatar 状态推断）。 */
   onStreamData?: (chunk: string) => void;
-  /** Fires with the trimmed text whenever the user submits a line (Enter). */
+  /** 用户提交一行（Enter）时，用去 trim 后的文本触发。 */
   onUserPrompt?: (text: string) => void;
-  /** When provided, render an expand/minimize button in the header. */
+  /** 提供时，在头部渲染一个展开/最小化按钮。 */
   onToggleFullscreen?: () => void;
   fullscreen?: boolean;
-  /** Edge-to-edge mode for the sidebar tab: no outer chrome/border. */
+  /** 侧边栏标签页的边到边模式：无外框/无边框。 */
   embedded?: boolean;
 }
 
 export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFullscreen, fullscreen, embedded }: PtyTerminalViewProps) {
+  const { t } = useTranslation();
   const hostRef = useRef<HTMLDivElement | null>(null);
   const onStreamDataRef = useRef(onStreamData);
   onStreamDataRef.current = onStreamData;
@@ -136,10 +133,9 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
   const ptyThemeRef = useRef(ptyTheme);
   ptyThemeRef.current = ptyTheme;
 
-  // Attach this view to the pty's persistent terminal. The terminal and its
-  // buffer live in the pool across mounts, so re-parenting its host element
-  // here shows the already-rendered content immediately — no blank pane while
-  // switching agents or toggling fullscreen.
+  // 把这个视图挂到 pty 的持久终端上。终端和它的 buffer 跨挂载
+  // 存在 pool 里，所以在这里重新挂宿主元素会立即显示已渲染的内容——
+  // 切换 agent 或切换全屏时不会出现空白窗格。
   useEffect(() => {
     const container = hostRef.current;
     if (!container) return;
@@ -150,105 +146,97 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
     entry.onData = (chunk) => onStreamDataRef.current?.(chunk);
     entry.onPrompt = (text) => onUserPromptRef.current?.(text);
 
-    // Snap to bottom immediately on re-attach before fit settles
-    try { entry.term.scrollToBottom(); } catch { /* not yet open */ }
+    // 重新挂载后、fit 落定前立即贴到底部
+    try { entry.term.scrollToBottom(); } catch { /* 尚未打开 */ }
 
-    // `scrollToEnd` is true only for the initial attach (switching agents /
-    // toggling fullscreen) so we land on the most recent output. Re-parenting
-    // the pooled terminal resets its viewport to the top otherwise. Later
-    // resize-driven fits pass false so they don't yank a user who has scrolled
-    // up to read history back down to the bottom.
-    // Tracks the first fit that actually ran against a real (non-zero) host, so
-    // the ResizeObserver below can snap to the bottom on the FIRST effective fit
-    // even when the initial rAF/timeout fits no-op (terminal mounted under an
-    // inactive tab whose host has no size yet).
+    // `scrollToEnd` 只在初始挂载时为 true（切换 agent / 切换全屏），
+    // 这样我们落在最近的输出上。否则重新挂父的 pooled terminal 会把
+    // 视口重置到顶部。之后由 resize 驱动的 fit 传 false，
+    // 不会把已经向上滚去读历史的人拽回底部。
+    // 跟踪第一次真正跑在真实（非零）宿主上的 fit，让下面的 ResizeObserver
+    // 能在首次有效 fit 时贴到底部——哪怕初始的 rAF/timeout fit 是空操作
+    // （终端挂在不活跃标签页下，宿主还没有尺寸）。
     let initialFitDone = false;
     const tryFit = (scrollToEnd = false) => {
-      // Never fit while the host has no real size. Fitting a 0×0 host makes
-      // xterm propose a tiny grid and resize the pty to it, so the boot banner
-      // renders oversized/clipped and only "fixes" on a later manual resize.
-      // Wait for real dimensions — the ResizeObserver drives the first fit.
+      // 宿主没有真实尺寸时绝不 fit。对 0×0 的宿主做 fit 会让 xterm
+      // 提出一个极小的网格并把 pty 缩成它，于是启动横幅渲染得过大/被裁剪，
+      // 只有等之后的手动 resize 才"修好"。等真实尺寸——由
+      // ResizeObserver 驱动首次 fit。
       if (!container.clientWidth || !container.clientHeight) return;
       try {
         const before = { cols: entry.term.cols, rows: entry.term.rows };
         entry.fit.fit();
-        // Only poke the pty when the grid ACTUALLY changed: every resize makes
-        // the Claude TUI repaint its whole screen, and each repaint pushes the
-        // previous frame into scrollback — the attach-time refit cascade (rAF,
-        // 60ms, 240ms, font-load) used to stack the boot banner three times
-        // before the user ever typed anything.
+        // 只在网格 ACTUALLY 变化时才去戳 pty：每次 resize 都会让
+        // Claude TUI 重绘整屏，而每次重绘都把上一帧推进 scrollback——
+        // 挂载时的重 fit 级联（rAF、60ms、240ms、字体加载）过去会在用户
+        // 键入任何东西之前把启动横幅叠三次。经防抖合并后，整个级联只发
+        // 一次 SIGWINCH（最终网格），qwen 的 alternate-screen 全量重绘
+        // 不再把同一横幅推进 scrollback 多份。
         if (entry.term.cols !== before.cols || entry.term.rows !== before.rows) {
-          window.cth.resizePty(ptyId, entry.term.cols, entry.term.rows);
+          debouncedResizePty(ptyId, entry.term.cols, entry.term.rows);
         }
         entry.term.refresh(0, Math.max(0, entry.term.rows - 1));
         initialFitDone = true;
-      } catch { /* host may not be sized yet */ }
+      } catch { /* 宿主可能还没有尺寸 */ }
       if (scrollToEnd) {
         try {
-          // Re-parenting the pooled terminal resets the DOM viewport's
-          // scrollTop to 0 while xterm's internal scroll state stays at the
-          // bottom — the screen still LOOKS right, but the user's first wheel
-          // reads the stale scrollTop≈0 and yanks the view to the top of
-          // history. A bare scrollToBottom() can't repair this (the buffer is
-          // already at the bottom internally → no state change → no viewport
-          // re-sync). Writing the DOM scrollTop from out here is no good
-          // either: it races with xterm's ignore-next-scroll-event flag
-          // (scroll events coalesce), which can leave the scrollbar pinned at
-          // max while the buffer sits ABOVE the bottom — then wheeling down is
-          // dead (scrollTop can't exceed max → no event → no re-sync).
-          // Instead force a REAL position change through xterm's own state
-          // machine: one line up, then back to the bottom. Its Viewport then
-          // re-syncs the DOM scrollTop itself, atomically with its flag.
+          // 重新挂父 pooled terminal 会把 DOM 视口的 scrollTop 重置为 0，
+          // 而 xterm 的内部滚动状态仍停在底部——屏幕看起来还是对的，
+          // 但用户第一次滚轮会读到陈旧的 scrollTop≈0，把视图拽到历史顶部。
+          // 裸的 scrollToBottom() 修不了这个（buffer 内部已经在底部 →
+          // 无状态变化 → 视口不同步）。从外面写 DOM scrollTop 也不行：
+          // 它会和 xterm 的 ignore-next-scroll-event 标志竞速（滚动事件会
+          // 合并），可能留下滚动条钉在 max 而 buffer 却在底部之上——
+          // 然后向下滚就死了（scrollTop 无法超过 max → 无事件 → 无重同步）。
+          // 改为通过 xterm 自己的状态机强制一次 REAL 位置变化：
+          // 先上一行，再回到底部。它的 Viewport 随即自己重新同步
+          // DOM scrollTop，与自己的标志原子地完成。
           entry.term.scrollLines(-1);
           entry.term.scrollToBottom();
-        } catch { /* noop */ }
+        } catch { /* 空操作 */ }
       }
     };
-    // Fit once layout has settled and again once the web font has loaded —
-    // these are the initial-attach fits, so snap to the bottom. They no-op
-    // until the host has a real size, so a terminal mounted under an inactive
-    // tab simply waits for the ResizeObserver below to fire the first fit.
+    // 布局落定后 fit 一次，等网络字体加载后再 fit 一次——
+    // 这些是初始挂载的 fit，所以贴到底部。它们在宿主有真实尺寸前
+    // 都是空操作，所以挂在不活跃标签页下的终端就等下面的
+    // ResizeObserver 触发第一次 fit。
     requestAnimationFrame(() => requestAnimationFrame(() => tryFit(true)));
     const retries = [setTimeout(() => tryFit(true), 60), setTimeout(() => tryFit(true), 240)];
     if (typeof document !== 'undefined' && document.fonts?.ready) {
       document.fonts.ready
         .then(() => {
-          // xterm measures the character cell ONCE at open(); if VT323 hadn't
-          // loaded yet, that cached cell is the fallback font's size, so every
-          // fit() proposes the wrong column count and the WebGL glyph atlas is
-          // rastered at the wrong metrics — the banner renders oversized until a
-          // manual resize. Re-applying the font + clearing the texture atlas
-          // forces a re-measure / re-raster with the real font, then we refit.
+          // xterm 在 open() 时只量一次字符单元；如果那时 VT323 还没加载，
+          // 缓存的单元就是回退字体的尺寸，于是每次 fit() 都提出错误的
+          // 列数，WebGL 字形图集也按错误的度量栅格化——横幅渲染得过大，
+          // 直到手动 resize。重新应用字体 + 清空纹理图集会强制用真实字体
+          // 重新度量 / 重新栅格化，然后我们重 fit。
           try {
             const fam = entry.term.options.fontFamily;
             entry.term.options.fontFamily = fam;
             entry.term.options.fontSize = fontSizeRef.current;
             entry.term.clearTextureAtlas?.();
-          } catch { /* noop */ }
+          } catch { /* 空操作 */ }
           tryFit(true);
         })
-        .catch(() => { /* noop */ });
+        .catch(() => { /* 空操作 */ });
     }
 
-    // The ResizeObserver is the authoritative trigger: it fires when the host
-    // first gets a real size (e.g. its tab becomes visible) and on every later
-    // resize. Snap to the bottom on the first effective fit, then never again
-    // (so a user who scrolled up to read history isn't yanked back down).
+    // ResizeObserver 是权威触发器：宿主第一次拿到真实尺寸（比如它的
+    // 标签页变为可见）以及之后每次 resize 时它都会触发。首次有效 fit
+    // 时贴到底部，之后再也不贴（这样向上滚去读历史的人不会被拽回底部）。
     const ro = new ResizeObserver(() => tryFit(!initialFitDone));
     ro.observe(container);
     const onWinResize = () => tryFit(false);
     window.addEventListener('resize', onWinResize);
 
-    // Self-heal after a display wake. Closing the laptop lid sleeps the GPU,
-    // which loses the WebGL context and leaves xterm's cached cell-height (and
-    // the viewport scroll-area derived from it) stale — the full buffer is still
-    // there but only part is scrollable until a re-measure (the user otherwise
-    // has to zoom to force a fit). The ResizeObserver/resize listeners DON'T fire
-    // on lid-open because the window's pixel size is unchanged, so we re-fit
-    // explicitly when the page becomes visible / regains focus. reflowTerminal
-    // re-measures + refits WITHOUT scrolling, so a user reading history isn't
-    // yanked to the bottom. rAF lets the waking layout settle first; if the host
-    // is still unsized the reflow no-ops and the next focus/visibility catches it.
+    // 显示器唤醒后自愈。合上笔记本盖子会让 GPU 休眠，从而丢失 WebGL
+    // context，并使 xterm 缓存的单元高度（以及由它派生的视口滚动区）过期——
+    // 完整 buffer 还在，但只有一部分可滚动，直到重新度量（否则用户只能
+    // 靠缩放来强制 fit）。ResizeObserver/resize 监听在开盖时不会触发，
+    // 因为窗口像素尺寸没变，所以页面变为可见 / 重新聚焦时我们显式重 fit。
+    // reflowTerminal 重新度量 + 重 fit 但不去滚动，所以正在读历史的人
+    // 不会被拽到底部。rAF 让唤醒后的布局先落定；如果宿主仍未定尺寸，
+    // reflow 是空操作，下一次 focus/visibility 会接住它。
     const onWake = () => {
       if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
       requestAnimationFrame(() => reflowTerminal(ptyId));
@@ -262,40 +250,40 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
       window.removeEventListener('resize', onWinResize);
       document.removeEventListener('visibilitychange', onWake);
       window.removeEventListener('focus', onWake);
-      // Detach (but DON'T dispose) the terminal — it keeps running in the pool.
-      // detachTerminal also releases the WebGL lease, so a terminal nobody is
-      // looking at stops holding a GPU context that an on-screen one needs.
+      // Detach（但 DON'T dispose）终端——它继续在 pool 里运行。
+      // detachTerminal 也会释放 WebGL 租约，所以没人看的终端不再
+      // 占着一个屏幕上其他终端需要的 GPU context。
       entry.onData = undefined;
       entry.onPrompt = undefined;
       detachTerminal(entry, container);
     };
   }, [ptyId]);
 
-  // Apply app-theme changes to the pooled terminal (persistence lives in
-  // design/theme.ts — the title-bar toggle owns it).
+  // 把应用主题的变更应用到 pooled terminal（持久化在 design/theme.ts ——
+  // 由标题栏开关掌管）。
   useEffect(() => {
     acquireTerminal(ptyId, THEMES[ptyTheme], fontSizeRef.current).term.options.theme = THEMES[ptyTheme];
   }, [ptyTheme, ptyId]);
 
-  // Apply font-size (zoom) changes to the pooled terminal and re-fit cols/rows.
+  // 把字号（缩放）变更应用到 pooled terminal，并重 fit 列/行。
   useEffect(() => {
     fontSizeRef.current = fontSize;
     const entry = acquireTerminal(ptyId, THEMES[ptyThemeRef.current], fontSize);
     entry.term.options.fontSize = fontSize;
     try {
       entry.fit.fit();
-      window.cth.resizePty(ptyId, entry.term.cols, entry.term.rows);
-    } catch { /* host may not be sized yet */ }
+      debouncedResizePty(ptyId, entry.term.cols, entry.term.rows);
+    } catch { /* 宿主可能还没有尺寸 */ }
   }, [fontSize, ptyId]);
 
-  // Drag-and-drop a file (image, etc.) onto the terminal → inject its absolute
-  // path into the pty, exactly like a native terminal's drag-drop. Claude Code
-  // detects an image path in the prompt and attaches it. Without this, Electron
-  // would treat the drop as navigation and load the file:// URL over the app.
+  // 把文件（图片等）拖放到终端上 → 把它的绝对路径注入 pty，
+  // 与原生终端的拖放完全一致。Claude Code 会在提示里检测到图片路径
+  // 并附上它。没有这个，Electron 会把拖放当作导航，把 file:// URL
+  // 加载到应用上。
   const onDragOver = (e: React.DragEvent) => {
-    // Must preventDefault on dragover too — otherwise `drop` never fires and the
-    // window navigates to the dropped file. Only claim it when files are present
-    // so text/selection drags fall through to xterm's own handling.
+    // dragover 上也必须 preventDefault——否则 `drop` 永远不会触发，
+    // 窗口会导航到被拖放的文件。只在确实带着文件时认领它，
+    // 让文本/选区拖放落到 xterm 自己的处理上。
     if (e.dataTransfer?.types?.includes('Files')) {
       e.preventDefault();
       e.dataTransfer.dropEffect = 'copy';
@@ -303,25 +291,25 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
   };
   const onDrop = (e: React.DragEvent) => {
     const files = Array.from(e.dataTransfer?.files ?? []);
-    if (files.length === 0) return; // not a file drop — let xterm handle it
+    if (files.length === 0) return; // 不是文件拖放——让 xterm 处理
     e.preventDefault();
     const paths = files
       .map((f) => window.cth.pathForFile(f))
       .filter(Boolean)
-      // SECURITY: a dropped filename is attacker-controllable; inject it as an
-      // INERT single shell token in the NATIVE backslash-escaped style (what macOS
-      // Terminal/iTerm emit on drag-drop, and the format Claude Code recognizes to
-      // attach a dropped file). (1) Strip ALL control chars first - newline/CR
-      // would be delivered as Enter by writePty and AUTO-SUBMIT the line; ESC would
-      // inject raw terminal escape sequences. (2) Backslash-escape the backslash
-      // itself and every shell metacharacter that could act on Enter (space $ ` " '
-      // ; | & < > ( ) { } [ ] * ? ! ~ #) so the path stays one literal token.
-      // (String.fromCharCode keeps backslashes/control chars out of this source.)
+// SECURITY: 被拖放的文件名是攻击者可控的；把它当作一个
+      // INERT（惰性）的单 shell token 注入，用 NATIVE 反斜杠转义风格
+      //（即 macOS Terminal/iTerm 拖放时发出的格式，也是 Claude Code
+      // 识别以附加被拖文件所用的格式）。(1) 先剥掉所有控制字符——
+      // 换行/回车会被 writePty 当作 Enter 送达并 AUTO-SUBMIT 那一行；
+      // ESC 会注入裸的终端转义序列。(2) 反斜杠转义反斜杠本身以及
+      // 每一个可能作用于 Enter 的 shell 元字符（space $ ` " ' ; | & < > ( ) { } [ ] * ? ! ~ #），
+      // 让路径保持为一个字面 token。（String.fromCharCode 让反斜杠/控制
+      // 字符不进入本源码。）
       .map((p) => {
         const BS = String.fromCharCode(92);
         const CTRL = new RegExp('[' + String.fromCharCode(0) + '-' + String.fromCharCode(31) + String.fromCharCode(127) + ']', 'g');
-        // Backslash is FIRST in the set so escaping each ORIGINAL char exactly once
-        // turns a literal backslash into a pair (never forming a new escape).
+        // 反斜杠放在集合第一个，这样对每个 ORIGINAL 字符恰好转义一次，
+        // 会把一个字面反斜杠变成一对（绝不会形成新的转义）。
         const SPECIAL = new Set(
           (BS + ' $' + String.fromCharCode(96) + String.fromCharCode(34) + String.fromCharCode(39) + ';|&<>(){}[]*?!~#')
             .split('').map((c) => c.charCodeAt(0))
@@ -330,14 +318,14 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
           .map((ch) => (SPECIAL.has(ch.charCodeAt(0)) ? BS + ch : ch)).join('');
       });
     if (paths.length === 0) return;
-    // Trailing space separates consecutive drops and lets the user keep typing.
+    // 结尾空格分隔连续两次拖放，也让用户能继续输入。
     void window.cth.writePty(ptyId, paths.join(' ') + ' ');
   };
 
   const zoom = (delta: number) => setTerminalFontSize(getTerminalFontSize() + delta);
   const resetZoom = () => setTerminalFontSize(DEFAULT_FONT_SIZE);
 
-  // Keyboard zoom: Cmd/Ctrl + '=' / '-' / '0'
+  // 键盘缩放：Cmd/Ctrl + '=' / '-' / '0'
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
@@ -379,30 +367,30 @@ export function PtyTerminalView({ ptyId, onStreamData, onUserPrompt, onToggleFul
         }} />
         live · pty {ptyId}
         <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 2 }}>
-          {/* v0.3.4: the theme + enter-fullscreen buttons moved to the TITLE BAR
-              (top right) — more accessible, and the theme now darkens the whole
-              app. Only the EXIT affordance stays here, in fullscreen. */}
+          {/* v0.3.4: 主题 + 进入全屏的按钮移到了 TITLE BAR（右上角）——
+              更容易够到，而且主题现在会让整个应用变暗。
+              只有 EXIT 这个退出口留在这里（全屏时）。 */}
           <button
             onClick={() => zoom(-1)}
             disabled={fontSize <= MIN_FONT_SIZE}
-            title="Zoom out (Cmd -)"
+            title={t('ptyTerminalView.zoomOut')}
             style={zoomBtnStyle}
           >−</button>
           <button
             onClick={resetZoom}
-            title="Reset zoom (Cmd 0)"
+            title={t('ptyTerminalView.resetZoom')}
             style={{ ...zoomBtnStyle, width: 'auto', padding: '0 4px', minWidth: 28 }}
           >{fontSize}px</button>
           <button
             onClick={() => zoom(1)}
             disabled={fontSize >= MAX_FONT_SIZE}
-            title="Zoom in (Cmd +)"
+            title={t('ptyTerminalView.zoomIn')}
             style={zoomBtnStyle}
           >+</button>
           {fullscreen && onToggleFullscreen && (
             <button
               onClick={onToggleFullscreen}
-              title="Exit focus mode (Esc)"
+              title={t('ptyTerminalView.exitFocusMode')}
               style={{ ...zoomBtnStyle, width: 22, height: 22, marginLeft: 4 }}
             >
               <Icon name="minimize" />

--- a/src/renderer/src/components/QuitWarningModal.tsx
+++ b/src/renderer/src/components/QuitWarningModal.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
 import { PixelPanel } from './PixelPanel';
 import { PixelButton } from './PixelButton';
 import { Icon } from './Icon';
 
-/** Renderer-side closing-time view state. Mirrors the main process's
- *  ClosingTimeEvent phases, plus a local 'error' for a failed start. */
+/** Renderer 侧收尾阶段的视图状态。镜像主进程 ClosingTimeEvent
+ *  的各个阶段，外加一个表示启动失败的本地 'error'。 */
 export interface ClosingTimeState {
   phase: 'started' | 'progress' | 'complete' | 'timeout' | 'error';
   acked: number;
@@ -14,22 +15,22 @@ export interface ClosingTimeState {
 
 export interface QuitWarningModalProps {
   ptyCount: number;
-  /** Non-null while the closing-time protocol runs — switches the dialog into
-   *  the "wrapping up the floor" progress view. */
+  /** 收尾协议运行期间非 null——把对话框切进"收拾现场"的进度视图。 */
   closing?: ClosingTimeState | null;
   onCancel: () => void;
   onConfirm: () => void;
-  /** Start the graceful shutdown (the third button). */
+  /** 启动优雅关闭（第三个按钮）。 */
   onClosingTime?: () => void;
 }
 
 export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClosingTime }: QuitWarningModalProps) {
+  const { t } = useTranslation();
   const [busy, setBusy] = useState(false);
 
   const confirm = async () => {
     setBusy(true);
     await onConfirm();
-    // No need to clear busy — the app is quitting.
+    // 无需清除 busy——应用正在退出。
   };
 
   const inClosingTime = !!closing && closing.phase !== 'error';
@@ -41,12 +42,11 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
         position: 'fixed', inset: 0,
         background: 'rgba(26, 19, 32, 0.7)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
-        // Above EVERY modal, not just most of them. Modals in this app sit at
-        // 500 (add agent, edit agent, the release drop) and overlays below that.
-        // At 300 this dialog opened BEHIND the release drop, so clicking quit
-        // with a drop on screen looked like quit did nothing — while a hidden
-        // dialog held the app open. This is the last thing the user is asked
-        // before the process dies; it outranks whatever it interrupts.
+        // 在 EVERY modal 之上，不只是大多数。本应用中的 modal 位于 500
+        //（add agent、edit agent、release drop），其下还有各种 overlay。
+        // 之前在 300 时，这个对话框会打开在 release drop 后面——于是屏幕上
+        // 有 drop 时点 quit 看起来毫无反应，而一个隐藏的对话框却一直拽着应用
+        // 不放。这是进程消亡前问用户的最后一件事；它理应压过所打断的任何东西。
         zIndex: 1000
       }}
     >
@@ -54,11 +54,11 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
         onClick={(e) => e.stopPropagation()}
         style={{ width: 480, maxWidth: '92vw' }}
       >
-        <PixelPanel variant="dialog" title={inClosingTime ? 'CLOSING TIME' : 'QUITTING NOW?'} noPadding>
+        <PixelPanel variant="dialog" title={inClosingTime ? t('quitWarning.closingTitle') : t('quitWarning.quittingTitle')} noPadding>
           <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
             {inClosingTime ? (
               <>
-                {/* ── Graceful shutdown in progress ──────────────────────── */}
+                {/* ── 优雅关闭进行中 ──────────────────────────────── */}
                 <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
                   <div style={{
                     width: 32, height: 32,
@@ -77,25 +77,22 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
                       marginBottom: 4
                     }}>
                       {closing!.phase === 'complete'
-                        ? 'FLOOR SAVED — SEE YOU TOMORROW'
+                        ? t('quitWarning.savedTitle')
                         : closing!.phase === 'timeout'
-                          ? 'STILL WRAPPING UP…'
-                          : 'WRAPPING UP THE FLOOR'}
+                          ? t('quitWarning.wrappingStill')
+                          : t('quitWarning.wrappingTitle')}
                     </div>
                     <div style={{ fontSize: 15, lineHeight: '22px', color: 'var(--cth-ink-700)' }}>
                       {closing!.phase === 'complete' ? (
-                        <>Every agent saved its memory and the orchestrator confirmed the
-                        shutdown. The harness closes itself in a moment.</>
+                        <>{t('quitWarning.savedBody')}</>
                       ) : (
-                        <>The orchestrator broadcast closing time. Every worker parks its
-                        work, saves its memory, and reports back — the app closes only
-                        after the orchestrator confirms nothing will be lost.</>
+                        <>{t('quitWarning.wrappingBody')}</>
                       )}
                     </div>
                   </div>
                 </div>
 
-                {/* ACK progress */}
+                {/* ACK 进度 */}
                 <div style={{
                   padding: 8,
                   background: 'var(--cth-cream-200)',
@@ -105,12 +102,13 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
                   fontFamily: 'var(--cth-font-display)'
                 }}>
                   {closing!.total > 0
-                    ? `${closing!.acked} / ${closing!.total} WORKERS CONFIRMED${closing!.acked >= closing!.total ? ' — WAITING FOR THE ORCHESTRATOR' : ''}`
-                    : 'NO WORKERS ON THE FLOOR — WAITING FOR THE ORCHESTRATOR'}
+                    ? (closing!.acked >= closing!.total
+                        ? t('quitWarning.workersConfirmedWaiting', { acked: closing!.acked, total: closing!.total })
+                        : t('quitWarning.workersConfirmed', { acked: closing!.acked, total: closing!.total }))
+                    : t('quitWarning.noWorkersWaiting')}
                   {closing!.phase === 'timeout' && (
                     <div style={{ marginTop: 6, fontFamily: 'var(--cth-font-body, inherit)' }}>
-                      This is taking a while (an agent may be mid-compaction or deep in a
-                      tool call). Keep waiting, or force quit and accept the data loss.
+                      {t('quitWarning.timeoutNote')}
                     </div>
                   )}
                 </div>
@@ -119,10 +117,10 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
                   {closing!.phase !== 'complete' && (
                     <>
                       <PixelButton variant="secondary" size="md" onClick={onCancel} disabled={busy}>
-                        cancel — back to work
+                        {t('quitWarning.cancelBack')}
                       </PixelButton>
                       <PixelButton variant="destructive" size="md" onClick={confirm} disabled={busy}>
-                        {busy ? 'killing...' : 'force quit now'}
+                        {busy ? t('quitWarning.killing') : t('quitWarning.forceQuit')}
                       </PixelButton>
                     </>
                   )}
@@ -130,7 +128,7 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
               </>
             ) : (
               <>
-                {/* ── The classic quit warning ────────────────────────────── */}
+                {/* ── 经典退出警告 ──────────────────────────────── */}
                 <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
                   <div style={{
                     width: 32, height: 32,
@@ -148,13 +146,14 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
                       color: 'var(--cth-ink-900)',
                       marginBottom: 4
                     }}>
-                      {ptyCount} {ptyCount === 1 ? 'AGENT' : 'AGENTS'} STILL RUNNING
+                      {ptyCount === 1
+                        ? t('quitWarning.runningTitle', { count: ptyCount })
+                        : t('quitWarning.runningTitlePlural', { count: ptyCount })}
                     </div>
                     <div style={{ fontSize: 15, lineHeight: '22px', color: 'var(--cth-ink-700)' }}>
-                      Closing the harness will terminate{' '}
-                      {ptyCount === 1 ? 'the running claude session' : `all ${ptyCount} running claude sessions`}{' '}
-                      and discard any unsaved progress they were holding in memory. The conversation
-                      history inside each session is lost when the PTY exits.
+                      {ptyCount === 1
+                        ? t('quitWarning.terminateOne')
+                        : t('quitWarning.terminateMany', { count: ptyCount })}
                     </div>
                   </div>
                 </div>
@@ -166,9 +165,7 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
                   fontSize: 12, lineHeight: '18px',
                   color: 'var(--cth-ink-700)'
                 }}>
-                  Tip: <strong>closing time</strong> is the safe way out — the orchestrator has
-                  every agent commit its work and save its memory, and the app closes itself
-                  once the whole floor has confirmed. No data loss.
+                  <Trans i18nKey="quitWarning.tip" components={{ strong: <strong /> }} />
                 </div>
 
                 {closing?.phase === 'error' && (
@@ -179,23 +176,23 @@ export function QuitWarningModal({ ptyCount, closing, onCancel, onConfirm, onClo
                     fontSize: 12, lineHeight: '18px',
                     color: 'var(--cth-ink-900)'
                   }}>
-                    {closing.error ?? 'Closing time could not start.'}
+                    {closing.error ?? t('quitWarning.closeStartFail')}
                   </div>
                 )}
 
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap' }}>
                   <PixelButton variant="secondary" size="md" onClick={onCancel} disabled={busy}>
-                    keep them running
+                    {t('quitWarning.keepRunning')}
                   </PixelButton>
                   {onClosingTime && (
                     <PixelButton variant="primary" size="md" onClick={onClosingTime} disabled={busy}>
                       <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
-                        <Icon name="clock" /> closing time
+                        <Icon name="clock" /> {t('quitWarning.closingTime')}
                       </span>
                     </PixelButton>
                   )}
                   <PixelButton variant="destructive" size="md" onClick={confirm} disabled={busy}>
-                    {busy ? 'killing...' : `kill ${ptyCount === 1 ? 'it' : 'all'} & quit`}
+                    {busy ? t('quitWarning.killing') : (ptyCount === 1 ? t('quitWarning.killItQuit') : t('quitWarning.killAllQuit'))}
                   </PixelButton>
                 </div>
               </>

--- a/src/renderer/src/components/RealtimeMichaelToggle.tsx
+++ b/src/renderer/src/components/RealtimeMichaelToggle.tsx
@@ -1,20 +1,19 @@
 /**
- * Realtime Michael — voice toggle + live state indicator (card rt-3, Phase 1).
+ * Realtime Michael —— 语音开关 + 实时状态指示（卡片 rt-3，Phase 1）。
  *
- * A reusable mic button for the god/orchestrator agent ("Michael"). It consumes the
- * already-built `useRealtimeMichael()` voice-loop hook (a shared module-level singleton —
- * see realtime/session.ts) and exposes a single start/stop control plus a live indicator
- * of the loop's status.
+ * 面向 god/编排 agent（"Michael"）的可复用麦克风按钮。它消费已经
+ * 构建好的 `useRealtimeMichael()` 语音循环 hook（一个共享的模块级单例——
+ * 见 realtime/session.ts），并暴露一个启动/停止控件加上循环状态的实时指示。
  *
- * Gating mirrors the established Free Flow / Groq precedent (FreeFlowButton in
- * MessageQueueComposer): the button stays VISIBLE but DISABLED when no BYOK OpenAI key is
- * present (`hasOpenAiKey === false`), with a tooltip pointing at Settings — so connect() /
- * getUserMedia are never reached without a key (the zero-call-when-unavailable guarantee).
+ * 门控复刻既有的 Free Flow / Groq 先例（MessageQueueComposer 里的 FreeFlowButton）：
+ * 当没有 BYOK OpenAI key 时按钮保持 VISIBLE 但 DISABLED
+ * （`hasOpenAiKey === false`），带指向 Settings 的 tooltip——所以没有 key 时
+ * connect() / getUserMedia 永不被触达（不可用时零调用的保证）。
  *
- * Click behaviour: status==='off' → connect(); anything else → disconnect().
+ * 点击行为：status==='off' → connect()；其他任何状态 → disconnect()。
  *
- * Rendered in two places (AgentCard for the god card, FullscreenTerminal header when
- * Michael is fullscreen). It is intentionally state-only / hook-only so both can mount it.
+ * 在两个地方渲染（god 卡片的 AgentCard、Michael 全屏时的 FullscreenTerminal
+ * 头部）。它刻意只依赖 state / hook，所以两者都能挂载它。
  */
 import { useEffect, useRef, useState, type MouseEvent } from 'react';
 import { createPortal } from 'react-dom';
@@ -24,10 +23,10 @@ import { Icon } from './Icon';
 import { useStore } from '@/store/store';
 import { useRealtimeMichael, type RealtimeStatus } from '@/realtime/session';
 
-/** Per-status presentation: button variant, SHORT label, dot color, and (optional)
- *  animation for the live-state indicator dot. Maps hook.status → visuals.
- *  Labels are i18n keys (`realtimeToggle.*`); the long help/title text is
- *  resolved per-render via t() since it can interpolate the error. */
+/** 各状态的外观：按钮变体、SHORT 标签、圆点颜色，以及（可选的）
+ *  实时状态指示圆点的动画。把 hook.status 映射到视觉。
+ *  标签是 i18n key（`realtimeToggle.*`）；长帮助/标题文本因为要插值错误
+ *  信息，所以每次渲染经 t() 解析。 */
 const STATE_VIEW: Record<
   RealtimeStatus,
   {
@@ -36,9 +35,9 @@ const STATE_VIEW: Record<
     dot: string;
     anim?: string;
     helpKey: string;
-    /** When live, the button fill — a distinct accent so the active mic never
-     *  reads as a flat black 'primary' button. (working uses the destructive
-     *  coral variant, already non-black, so it needs no override.) */
+    /** 活跃时的按钮填充——一个不同的强调色，让活动的麦克风绝不被读作
+     *  扁平的黑色 'primary' 按钮。（working 用破坏性的珊瑚变体，
+     *  已经非黑，所以无需覆盖。） */
     activeBg?: string;
   }
 > = {
@@ -81,7 +80,7 @@ const STATE_VIEW: Record<
 };
 
 export interface RealtimeMichaelToggleProps {
-  /** Compact form for the fullscreen header / tight rows — hides the text label. */
+  /** 全屏头部 / 紧凑行的紧凑形态——隐藏文本标签。 */
   compact?: boolean;
 }
 
@@ -89,10 +88,9 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
   const { t } = useTranslation();
   const hasOpenAiKey = useStore((s) => s.hasOpenAiKey);
   const { status, error, connect, disconnect } = useRealtimeMichael();
-  // Measured viewport coords, not a CSS offset. The agent dock clips its
-  // children, so a popover positioned inside the card gets sliced at the card's
-  // edge no matter how it is anchored — which is exactly what happened. A portal
-  // to <body> with fixed coordinates leaves that clipping context entirely.
+  // 实测的视口坐标，不是 CSS 偏移。agent dock 会裁剪它的子元素，所以
+  // 定位在卡片内部的 popover 无论怎么锚定都会被卡片的边缘切掉——这正是
+  // 之前发生的情况。portalling 到 <body> 用固定坐标，就彻底离开了那个裁剪上下文。
   const [hint, setHint] = useState<{ left: number; top: number } | null>(null);
   const hintRef = useRef<HTMLSpanElement | null>(null);
   const iconRef = useRef<HTMLButtonElement | null>(null);
@@ -102,11 +100,11 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
   const view = STATE_VIEW[status];
   const noKey = !hasOpenAiKey;
 
-  // Without a BYOK OpenAI key: stay visible but disabled (matches FreeFlowButton).
-  // Talk mints an ephemeral token from the OpenAI key (apikey:openai) — the SAME
-  // OpenAI provider key set under Agents & Models, used for the Realtime voice API.
-  // The tooltip carries the full WHY; the quiet info affordance below gives a
-  // discoverable cue so the user never just hits a silently-dead button.
+  // 没有 BYOK OpenAI key：保持可见但禁用（与 FreeFlowButton 一致）。
+  // Talk 用 OpenAI key（apikey:openai）铸造一个临时 token——就是 Agents & Models
+  // 下设置的那个 SAME OpenAI provider key，用于 Realtime voice API。
+  // tooltip 承载完整的 WHY；下面安静的 info 提示提供一个可发现的线索，
+  // 让用户绝不会遇到一个悄悄死掉的按钮。
   const title = noKey
     ? t('realtimeToggle.noKeyTitle')
     : error
@@ -119,11 +117,11 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
     else disconnect();
   };
 
-  // Jump straight to the tab that holds the key. App owns the Settings modal's
-  // open state, so this goes through the `cth:` window-event convention rather
-  // than threading a callback down through AgentCard/FullscreenTerminal.
-  // Target is VOICE, not Agents & Models: the key is settable in both, but only
-  // one of them explains what it is for.
+  // 直接跳到持有该 key 的标签页。App 拥有 Settings modal 的打开状态，
+  // 所以这里走 `cth:` 窗口事件约定，而不是把回调一路穿过
+  // AgentCard/FullscreenTerminal 传下来。
+  // 目标是 VOICE，不是 Agents & Models：key 两处都能设置，
+  // 但只有其中一处解释它是干什么用的。
   const openKeySettings = (e: MouseEvent): void => {
     e.stopPropagation();
     setHint(null);
@@ -135,17 +133,16 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
   const HINT_W = 210;
   const HINT_GAP = 8;
 
-  /** Place the popover against the icon in VIEWPORT space, preferring above and
-   *  flipping below only when there is genuinely no room — the agent dock sits on
-   *  the bottom edge, so "above" is almost always right. Both axes are clamped to
-   *  the viewport so it can never hang off an edge. */
+  /** 把 popover 放在 VIEWPORT 空间里贴着图标，优先在上方，只有确实
+   *  没有空间时才翻到下方——agent dock 位于底边，所以"上方"几乎总是
+   *  对的。两个轴都夹在视口内，绝不会伸出边缘。 */
   const toggleHint = (e: MouseEvent): void => {
     e.stopPropagation();
     if (hint) { setHint(null); return; }
     const r = iconRef.current?.getBoundingClientRect();
     if (!r) return;
-    // Height is content-dependent; this is the two-line + link case, and the
-    // clamp below absorbs the error if it wraps to three.
+    // 高度取决于内容；这是两行 + 链接的情况，如果它折成三行，
+    // 下面的 clamp 会吸收这个误差。
     const estH = 78;
     const above = r.top - HINT_GAP - estH;
     const top = above >= 8 ? above : Math.min(r.bottom + HINT_GAP, window.innerHeight - estH - 8);
@@ -153,21 +150,20 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
     setHint({ left, top: Math.max(8, top) });
   };
 
-  // Click-to-open explanation. A hover title would do for a mouse, but this sits
-  // on a disabled control — the one thing people click when nothing happens — so
-  // the answer belongs behind that click.
+  // 点击打开的说明。悬停 title 对鼠标够用，但它位于一个禁用控件上——
+  // 正是人们没反应时会去点的东西——所以答案应该藏在这次点击后面。
   useEffect(() => {
     if (!hintOpen) return;
     const onDown = (ev: globalThis.MouseEvent): void => {
       const t = ev.target as Node;
-      // The popover is portalled out of this subtree, so an inside-click has to
-      // be tested against BOTH the anchor and the floating panel.
+      // popover 被 portalled 到这个子树之外，所以"内部点击"必须同时
+      // 对锚点和浮动面板两者做测试。
       if (hintRef.current?.contains(t) || panelRef.current?.contains(t)) return;
       setHint(null);
     };
     const onKey = (ev: KeyboardEvent): void => { if (ev.key === 'Escape') setHint(null); };
-    // A dock that scrolls or a window that resizes leaves fixed coords stale, and
-    // a popover stranded away from its icon is worse than one that closed.
+    // dock 滚动或窗口缩放会让固定坐标失效，
+    // 一个漂离图标的 popover 比关掉的更糟。
     const onReflow = (): void => setHint(null);
     document.addEventListener('mousedown', onDown);
     document.addEventListener('keydown', onKey);
@@ -181,17 +177,16 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
     };
   }, [hintOpen]);
 
-  // Wrap in a (non-disabled) span so the native title tooltip still shows on hover even
-  // when the inner button is disabled — Chromium suppresses tooltips on a disabled button.
+  // 包在一个（非禁用）span 里，让原生的 title tooltip 在内层按钮被禁用时
+  // 仍能在悬停时显示——Chromium 会抑制禁用按钮上的 tooltip。
   return (
     <span
       title={title}
       className="cth-titlebar-nodrag"
-      // minWidth:0 is what actually stops the overflow: without it this inline-flex
-      // keeps its max-content width and pushes past the card's edge no matter what
-      // the label inside does.
+      // minWidth:0 才是真正阻止溢出的东西：没有它，这个 inline-flex
+      // 会保持它的 max-content 宽度，无论内部标签做什么都顶出卡片边缘。
       style={{ display: 'inline-flex', alignItems: 'center', gap: noKey ? 4 : 0, minWidth: 0 }}
-      // Stop the click bubbling to a parent card's onClick (selecting the agent).
+      // 阻止点击冒泡到父卡片的 onClick（选择 agent）。
       onClick={(e) => e.stopPropagation()}
     >
       <PixelButton
@@ -199,13 +194,13 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
         size="sm"
         onClick={onClick}
         disabled={noKey}
-        // Live mic → a clear accent fill (mint listening / sky speaking) so the
-        // active button never reads as a flat black primary. Skipped when disabled
-        // (no key) and when off/connecting, so those states are untouched.
+        // 活动麦克风 → 清晰的强调色填充（mint 聆听 / sky 说话），让
+        // 活跃按钮绝不被读作扁平的黑色 primary。禁用（无 key）和
+        // off/connecting 状态跳过，所以那些状态不被触碰。
         style={!noKey && view.activeBg ? { background: view.activeBg, color: 'var(--cth-ink-900)' } : undefined}
       >
         <span style={{ display: 'inline-flex', gap: 5, alignItems: 'center' }}>
-          {/* Live-state indicator dot — color + animation reflect the loop status. */}
+          {/* 实时状态指示圆点——颜色与动画反映循环的状态。 */}
           <span
             aria-hidden
             style={{
@@ -225,15 +220,15 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
           )}
         </span>
       </PixelButton>
-      {/* Missing key is a SETUP STATE, not a failure — so this is a quiet info mark
-          and a way to fix it, never a warning chip. The old lemon chip spelled the
-          whole problem out inline ("needs OpenAI key · Settings") and, being
-          nowrap + flex-shrink:0, pushed itself past the agent card's edge instead
-          of wrapping. The explanation now lives in the hover tooltip; what stays on
-          screen is one 16px glyph plus a two-word action.
+      {/* 缺 key 是 SETUP STATE（配置态），不是失败——所以这是一个安静的
+          info 标记和一条修复途径，绝不是警告 chip。旧版柠檬色 chip 把整个
+          问题内联写出来（"needs OpenAI key · Settings"），而且因为是
+          nowrap + flex-shrink:0，把自己顶出了 agent 卡片的边缘而不是换行。
+          现在解释放在悬停 tooltip 里；屏幕上留下的只是一个 16px 字形
+          加一个两词的行动。
 
-          In compact mode (fullscreen toolbar) the icon alone carries it — the
-          tooltip still explains, and Settings is a click away in the same header. */}
+          在紧凑模式（全屏工具栏）下，只有图标在承载它——tooltip 依然解释，
+          而且 Settings 就在同一头部的点击范围里。 */}
       {noKey && (
         <span ref={hintRef} style={{ display: 'inline-flex', flexShrink: 0 }}>
           <button
@@ -268,9 +263,8 @@ export function RealtimeMichaelToggle({ compact = false }: RealtimeMichaelToggle
                 gap: 5,
                 boxSizing: 'border-box',
                 background: 'var(--cth-paper-100)',
-                // Matches the note editor's portalled popover: hairline + a hard
-                // drop shadow, so it reads as floating above the dock rather than
-                // as part of whichever card it happens to cover.
+                // 与笔记编辑器的 portalled popover 一致：发丝线 + 硬投影，
+                // 让它读作浮在 dock 之上，而不是所覆盖的某张卡片的一部分。
                 boxShadow: 'inset 0 0 0 1.5px var(--cth-ink-500), 4px 4px 0 rgba(26,19,32,0.25)',
                 fontFamily: 'var(--cth-font-ui)',
                 fontSize: 11,

--- a/src/renderer/src/components/RecentText.tsx
+++ b/src/renderer/src/components/RecentText.tsx
@@ -1,4 +1,5 @@
 import { useTypewriter } from '@/hooks/useTypewriter';
+import { useTranslation } from 'react-i18next';
 import type { AccentColorName } from '@/design/tokens';
 
 export interface RecentTextProps {
@@ -8,11 +9,12 @@ export interface RecentTextProps {
 }
 
 /**
- * Shows the agent's most recent assistant message with a streaming typewriter.
- * The cursor blink persists after the stream completes — same shape Claude Code
- * uses while it's still composing — and disappears only when text is empty.
+ * 以流式打字机显示 agent 最近一条助手消息。
+ * 流结束后光标闪烁仍然持续——与 Claude Code 还在撰写时相同的形态——
+ * 且只在文本为空时消失。
  */
 export function RecentText({ accent, text, seed }: RecentTextProps) {
+  const { t } = useTranslation();
   const { shown, done } = useTypewriter(text, seed);
   if (!text) return null;
   return (
@@ -31,7 +33,7 @@ export function RecentText({ accent, text, seed }: RecentTextProps) {
         color: 'var(--cth-ink-700)',
         textTransform: 'uppercase'
       }}>
-        <span>recent</span>
+        <span>{t('recentText.recent')}</span>
         <span style={{
           display: 'inline-flex', alignItems: 'center', gap: 4,
           color: done ? 'var(--cth-ink-500)' : `var(--cth-${accent})`

--- a/src/renderer/src/components/ReleaseDrop.tsx
+++ b/src/renderer/src/components/ReleaseDrop.tsx
@@ -1,51 +1,45 @@
 /**
- * The release drop: a centered, full-bleed "what's new" moment.
+ * 发布 drop：一个居中、全幅的"有什么新东西"时刻。
  *
- * A corner toast with three clipped bullets is a changelog notification. This is
- * the other thing: a page the release author designs, shown once, at the size the
- * work deserves.
+ * 角落 toast 带三条裁剪的要点是 changelog 通知。这是另一回事：一个由发布作者
+ * 设计的页面，只显示一次，以作品配得上的尺寸呈现。
  *
- * The chrome follows the landing site (docs/DESIGN.md), not the app's pixel
- * idiom and not a generic rounded sheet: warm paper, square corners, a thick
- * ink border, a hard offset shadow with no blur, and a dark mono title bar with
- * three square dots. It is the `.win` window from munderdiffl.in, so the moment
- * a user opens the drop it reads as the same product they downloaded from.
+ * 它的外观跟随落地页（docs/DESIGN.md），而非应用自己的像素风格、也不是通用的
+ * 圆角卡片：暖色纸、方角、粗墨色边框、无模糊的硬偏移阴影，以及一条带三个方点的
+ * 深色等宽标题栏。它就是 munderdiffl.in 上的 `.win` 窗口，用户一打开 drop 就
+ * 读作他们下载的那个同一款产品。
  *
- * There is NO chrome button here, on purpose. The app frames the drop and gets
- * out of the way; every action the release wants to offer (read the notes, star
- * the repo, join the Discord) is authored INSIDE the HTML as an ordinary link,
- * where the person writing the release controls the wording and the placement.
+ * 这里刻意没有浏览器按钮。应用给 drop 装框然后退到一边；发布想提供的每个动作
+ * （读说明、star 仓库、加入 Discord）都由作者在 HTML 内部写成普通链接，
+ * 由写发布的人控制措辞和位置。
  *
- * The authored HTML runs in an iframe with a `default-src 'none'` CSP and a
- * sandbox that grants exactly one capability: `allow-popups` (see
- * shared/releaseDrop.ts for why everything else stays shut). That is what makes
- * an authored `<a target="_blank">` work: the frame cannot navigate anything
- * itself, it can only ASK for a window, and main's setWindowOpenHandler denies
- * the window and hands the URL to the OS browser if and only if it is http(s).
- * No scripts, no same-origin, no forms, no top-level navigation.
+ * 编写的 HTML 运行在带 `default-src 'none'` CSP 和只授予一项能力的 sandbox 的
+ * iframe 里：`allow-popups`（为什么其他一切都保持关闭见 shared/releaseDrop.ts）。
+ * 这就是让作者写的 `<a target="_blank">` 生效的原因：frame 自己不能导航任何东西，
+ * 它只能 ASK 一个窗口，而 main 的 setWindowOpenHandler 会拒绝窗口并只在 URL 是
+ * http(s) 时把它交给操作系统浏览器。没有脚本、没有同源、没有表单、没有顶层导航。
  *
- * One consequence still shapes the layout: the frame's height cannot be measured
- * (that needs a postMessage bridge, which needs allow-scripts). So the modal is a
- * fixed viewport-relative box and the drop pages itself inside it, rather than
- * the box growing to fit.
+ * 有一个后果仍塑造着布局：frame 的高度无法测量（那需要 postMessage 桥，
+ * 又需要 allow-scripts）。所以 modal 是一个固定的视口相对盒子，drop 在它内部
+ * 分页，而不是让盒子随内容长高。
  *
- * Dismissal is Esc, the title bar's close, or a click on the backdrop. A modal
- * this large with no visible way out is a trap, so the close is a real control
- * out here even though the drop itself holds none.
+ * 关闭方式是 Esc、标题栏的关闭按钮，或点击背景。一个没有可见退出的这么大的
+ * modal 是陷阱，所以关闭是一个真实控件，即使 drop 本身一个都不带。
  */
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { buildDropSrcDoc } from '../../../shared/releaseDrop';
 
 export interface ReleaseDropProps {
   version: string;
-  /** Authored HTML, already extracted from the release body. */
+  /** 已从发布正文提取出来的 Authored HTML。 */
   html: string;
   onDismiss: () => void;
 }
 
-// Landing site palette (docs/DESIGN.md §2). Restated here because the modal is
-// app chrome and cannot reach the site's stylesheet; kept in one place so the
-// frame's tokens in shared/releaseDrop.ts and this chrome never drift apart.
+// 落地页配色（docs/DESIGN.md §2）。在此复述是因为 modal 是应用外壳，够不到
+// 站点的样式表；集中放在一处，让 shared/releaseDrop.ts 里 frame 的 token 和这
+// 套外壳永不失步。
 const PAPER = '#FFFDF7';
 const INK = '#1B1B1B';
 const INK_FAINT = '#8A867A';
@@ -54,36 +48,35 @@ const SKY = '#72C2DF';
 const MAROON = '#B23A4E';
 const MONO = '"JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace';
 
-// How long the loader may cover the frame before it is revealed regardless.
+// loader 最长可遮挡 frame 多久，然后无论结果如何都揭开。
 //
-// The reveal signal is the iframe ELEMENT's own `onLoad` (it fires on the
-// parent, needs no script rights in the sandboxed child) — but `load` WAITS for
-// subresources, so a drop with slow remote images would hold the loader for the
-// whole fetch. With the render-blocking font @import gone (shared/releaseDrop.ts),
-// first paint is immediate and onLoad is normally well under this; the cap only
-// governs the pathological case, where revealing a paper page whose images are
-// still arriving beats a spinner that never ends. 2.5s is long enough not to cut
-// off a normal onLoad and short enough not to read as a hang.
+// 揭开的信号是 iframe ELEMENT 自身的 `onLoad`（它触发在父级，不需要沙箱子级
+// 里的脚本权限）——但 `load` 会等子资源，所以带慢速远程图片的 drop 会为整次
+// 获取一直撑着 loader。随着 render-blocking 的字体 @import 被移除（shared/releaseDrop.ts），
+// 首绘是即时的，onLoad 通常远低于这个上限；该上限只约束病态情况——揭出一张
+// 图片仍在陆续到达的纸面页面，好过永无止境的 spinner。2.5s 足够不切断正常的
+// onLoad，又足够短到不会读作卡死。
 const REVEAL_TIMEOUT_MS = 2500;
 
 export function ReleaseDrop({ version, html, onDismiss }: ReleaseDropProps) {
+  const { t } = useTranslation();
   const srcDoc = useMemo(() => buildDropSrcDoc(html), [html]);
 
-  // The loader covers the frame until it is ready to be seen. `revealed` latches
-  // true on the FIRST of two signals — the iframe's onLoad or the timeout cap —
-  // and never flips back, so the reveal is monotonic and cannot flicker.
+  // loader 覆盖 frame 直到它准备好被看到。`revealed` 在两个信号中
+  // 先到的一个上锁存为 true——iframe 的 onLoad 或超时上限——
+  // 并且从不翻回，所以揭开是单调的、不可能闪烁。
   const [revealed, setReveal] = useState(false);
   const reveal = () => setReveal(true);
 
-  // The timeout cap. Cleared on unmount so a dismissed-early drop schedules
-  // nothing, and it races onLoad rather than replacing it: whichever fires first
-  // reveals, the other is a harmless no-op against the latched state.
+  // 超时上限。卸载时清除，让提前关闭的 drop 不再排程任何东西，
+  // 并且它与 onLoad 竞争而非取代它：谁先触发谁揭开，另一个对着已锁存的状态
+  // 是无害的空操作。
   useEffect(() => {
     const t = setTimeout(reveal, REVEAL_TIMEOUT_MS);
     return () => clearTimeout(t);
   }, []);
 
-  // Esc dismisses. "Later" is always a legitimate answer to an update.
+  // Esc 关闭。"稍后"对一次更新来说永远是合理的回答。
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onDismiss(); };
     window.addEventListener('keydown', onKey);
@@ -92,9 +85,8 @@ export function ReleaseDrop({ version, html, onDismiss }: ReleaseDropProps) {
 
   return (
     <div
-      // Backdrop. Clicking it dismisses, same meaning as "later". Warm ink over
-      // the app with the site's dotted paper grid, so the window sits on paper
-      // rather than floating in a grey void.
+      // 背景。点击关闭，与"稍后"同义。应用之上是暖色墨，带站点点状纸网格，
+      // 让窗口落在纸上而不是漂浮在灰色虚空里。
       onClick={onDismiss}
       style={{
         position: 'fixed', inset: 0, zIndex: 600,
@@ -102,28 +94,27 @@ export function ReleaseDrop({ version, html, onDismiss }: ReleaseDropProps) {
           'radial-gradient(rgba(255,253,247,0.16) 1px, transparent 1px) 0 0 / 22px 22px, rgba(27,27,27,0.72)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
         padding: 28,
-        // Center with auto margins on the child and let the overlay scroll, so a
-        // tall dialog is never clipped at the top where it cannot be scrolled
-        // back to.
+        // 用子元素上的 auto margin 居中并让遮罩层滚动，这样很高的对话框
+        // 不会被从顶部剪掉、滚不回去。
         overflowY: 'auto'
       }}
     >
       <div
         role="dialog"
-        aria-label={`What's new in Munder Difflin ${version}`}
+        aria-label={t('releaseDrop.whatsNew', { version })}
         onClick={(e) => e.stopPropagation()}
         style={{
           margin: 'auto',
-          // A landscape window, like the site's hero frame, not a square card.
-          // Width is derived from height so the shape holds as the window
-          // resizes; `min(…, 92vw)` is the escape hatch for a narrow window.
+          // 一个横版窗口，像站点的 hero 框一样，而不是方卡片。
+          // 宽度由高度推导，这样窗口缩放时形状保持不变；`min(…, 92vw)`
+          // 是窄窗口的逃生口。
           height: 'min(82vh, 720px)',
           width: 'min(calc(82vh * 1.28), 92vw, 920px)',
           minHeight: 420,
           display: 'flex', flexDirection: 'column',
           background: PAPER,
-          // The neo-brutalist window: square, 3px ink border, hard 10px offset
-          // shadow with no blur. Depth comes from the offset, not elevation.
+          // 新粗野主义窗口：方形、3px 墨色边框、无模糊的硬 10px 偏移
+          // 阴影。纵深来自偏移，而非抬升。
           border: `3px solid ${INK}`,
           borderRadius: 0,
           boxShadow: `12px 12px 0 ${INK}`,
@@ -131,8 +122,8 @@ export function ReleaseDrop({ version, html, onDismiss }: ReleaseDropProps) {
           fontFamily: MONO
         }}
       >
-        {/* Title bar: the site's `.win` header. Dark band, three square dots,
-            white mono title, and the only control the chrome owns: close. */}
+        {/* 标题栏：站点的 `.win` 头部。深色带、三个方点、
+            白色等宽标题，以及外壳唯一拥有的控件：关闭。 */}
         <div style={{
           flexShrink: 0, display: 'flex', alignItems: 'center', gap: 12,
           padding: '10px 14px', background: INK, color: PAPER,
@@ -150,19 +141,19 @@ export function ReleaseDrop({ version, html, onDismiss }: ReleaseDropProps) {
           }}>
             Munder Difflin <span style={{ color: YELLOW }}>v{version.replace(/^v/, '')}</span>
             <span style={{ color: INK_FAINT, fontWeight: 500, marginLeft: 10, letterSpacing: '.12em' }}>
-              / release notes
+              {t('releaseDrop.releaseNotes')}
             </span>
           </span>
           <span aria-hidden style={{
             flexShrink: 0, fontSize: 11, fontWeight: 500, letterSpacing: '.12em',
             color: INK_FAINT, textTransform: 'uppercase'
           }}>
-            esc
+            {t('releaseDrop.esc')}
           </span>
           <button
             onClick={onDismiss}
-            aria-label="Close release notes"
-            title="Close (Esc)"
+            aria-label={t('releaseDrop.closeReleaseNotes')}
+            title={t('releaseDrop.closeEsc')}
             style={{
               flexShrink: 0, width: 26, height: 26, padding: 0,
               background: PAPER, color: INK, border: `2px solid ${PAPER}`,
@@ -173,23 +164,22 @@ export function ReleaseDrop({ version, html, onDismiss }: ReleaseDropProps) {
           >✕</button>
         </div>
 
-        {/* The frame area. Relative so the loader can sit exactly over the drop,
-            not the title bar. The iframe is always mounted at full opacity — the
-            loader is a separate overlay that is REMOVED on reveal, so the failure
-            mode of a broken reveal is a brief extra spinner, never a permanently
-            hidden frame. */}
+        {/* 框架区域。Relative 让 loader 能正好盖在 drop 上、
+            而不盖住标题栏。iframe 始终以全不透明挂载——loader 是一个单独的
+            覆盖层，在揭开时被移除，所以揭开失败的模式是短暂多转一圈 spinner，
+            绝不是永远藏起的框架。 */}
         <div style={{ position: 'relative', flex: 1, minHeight: 0, background: PAPER }}>
-          {/* The drop itself. `allow-popups` is the ONLY grant: it is what lets an
-              authored <a target="_blank"> reach the OS browser, and it carries no
-              script, same-origin, form or navigation rights with it. */}
+          {/* drop 本身。`allow-popups` 是唯一的授权：它让作者写的
+              <a target="_blank"> 能到达操作系统浏览器，且它不带任何脚本、
+              同源、表单或导航权限。 */}
           <iframe
             title={`What's new in ${version}`}
             srcDoc={srcDoc}
             sandbox="allow-popups"
             referrerPolicy="no-referrer"
-            // onLoad fires on the PARENT and needs no script rights in the child;
-            // it is the honest "the frame is ready" signal. The timeout cap in the
-            // effect above covers the case where it is delayed by slow subresources.
+            // onLoad 触发在 PARENT，不需要子级里的脚本权限；
+            // 它是诚实的"框架已就绪"信号。上面 effect 里的超时上限
+            // 覆盖它被慢速子资源推迟的情况。
             onLoad={reveal}
             style={{
               position: 'absolute', inset: 0, width: '100%', height: '100%',
@@ -203,17 +193,17 @@ export function ReleaseDrop({ version, html, onDismiss }: ReleaseDropProps) {
   );
 }
 
-/** The window before the frame paints. Warm paper (never a white flash) with the
- *  title bar's three square dots marching, in the landing-site palette. Pure
- *  chrome — it carries no control; dismissal stays Esc / close / backdrop. It is
- *  removed the instant the frame is revealed, so it is only ever seen briefly. */
+/** 框架绘制前的窗口。暖色纸（从不是白色闪屏），标题栏的三个方点
+ *  按落地页配色行进。纯外壳——它不带任何控件；关闭仍是 Esc / 关闭 / 背景。
+ *  框架一揭开它就被移除，所以它只被短暂看到。 */
 function DropLoader() {
+  const { t } = useTranslation();
   return (
     <div
-      // aria-hidden: the dialog's own label already announces the drop, and a
-      // transient loader should not be read out. It sits ABOVE the frame and
-      // lets no interaction through, but the frame under it is inert until loaded
-      // anyway, so blocking pointer events here changes nothing a user could do.
+      // aria-hidden：对话框自身的 label 已经宣告了 drop，一个转瞬即逝的
+      // loader 不应被读出来。它位于 frame 之上且不放过任何交互，但下面的
+      // frame 在加载完成前本来就是惰性的，所以拦截指针事件在这里不会改变
+      // 用户可做的任何事情。
       aria-hidden
       style={{
         position: 'absolute', inset: 0, zIndex: 1,
@@ -247,7 +237,7 @@ function DropLoader() {
         fontFamily: MONO, fontSize: 11, fontWeight: 500, letterSpacing: '.18em',
         textTransform: 'uppercase', color: INK_FAINT
       }}>
-        Loading
+        {t('releaseDrop.loading')}
       </span>
     </div>
   );

--- a/src/renderer/src/components/SettingsHeroCard.tsx
+++ b/src/renderer/src/components/SettingsHeroCard.tsx
@@ -1,26 +1,21 @@
 /**
- * The hero card at the top of Settings → General.
+ * Settings → General 顶部的 hero 卡片。
  *
- * One card that answers "what is this install, and what can I do about it" —
- * the running version, the plan it is on, and the handful of actions that do not
- * belong to any individual setting below (re-read the release notes, star, back
- * the project).
+ * 一张卡片回答"这是什么安装，我能拿它做什么"——
+ * 正在运行的版本、所在的方案，以及少数几个不属于下方任何具体设置的
+ * 操作（重读发布说明、star、支持项目）。
  *
- * Its contents come from docs/hero.json IN THIS REPO, fetched at runtime and
- * cached — so plan copy, a sponsor, or a one-line notice can change without
- * shipping a build. That payload is DATA, never markup: every field below is a
- * React text node, so it is escaped, and shared/heroPayload.ts validates types,
- * caps lengths and requires https before any of it reaches here.
+ * 其内容来自本仓库内的 docs/hero.json，运行时获取并缓存——因此方案文案、
+ * 赞助商或一行公告都可以不改动构建就变更。该载荷是 DATA，绝不是 markup：
+ * 下面的每个字段都是 React 文本节点，所以会被转义，shared/heroPayload.ts 在任何
+ * 内容到达这里之前会校验类型、截断长度并要求 https。
  *
- * It renders instantly from the app's built-in defaults and upgrades in place
- * when the fetch lands, so the dialog never waits on the network and reads the
- * same offline. A sponsor slot with nothing in it renders NOTHING rather than a
- * "your logo here" placeholder.
+ * 它先以应用内置默认值即时渲染，获取落地后再就地升级，所以对话框从不等网络，
+ * 离线读起来也一样。空着的赞助商槽位渲染为 NOTHING，而不是"此处放你的 logo"占位。
  *
- * Since 0.4.5 it borrows the release drop's idiom (ink borders, a lilac
- * announcement block, a dark offer band) and carries the v0.5.0 Pro announcement and the
- * Founders' Wall offer, so the one card people see in Settings says the same
- * thing the release modal does. Plan label and blurb still come from hero.json.
+ * 自 0.4.5 起它借用发布 drop 的表达方式（墨色边框、淡紫公告块、深色优惠带），
+ * 并承载 v0.5.0 Pro 公告和 Founders' Wall 优惠，让人在 Settings 看到的那张卡片
+ * 与发布 modal 说的是同一件事。方案标签和简介仍来自 hero.json。
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,17 +31,16 @@ const DISCORD_URL = 'https://discord.gg/SEDzP5ZPk5';
 export function SettingsHeroCard() {
   const { t } = useTranslation();
   const [version, setVersion] = useState<string | null>(null);
-  // Starts on the compiled-in defaults, so there is no empty frame or spinner
-  // while the fetch is in flight — it just fills in if anything changed.
+  // 以编译内置的默认值起步，所以请求在途时没有空框或 spinner——
+  // 只在有变化的时候填上内容。
   const [hero, setHero] = useState<HeroPayload>(DEFAULT_HERO);
-  /** Whatever release the updater knows about, so the card can offer the
-   *  manual download right where the version is shown. */
+  /** updater 所知道的任何发布版本，让卡片能在版本号旁边直接提供手动下载。 */
   const [status, setStatus] = useState<UpdateStatus | null>(null);
   useEffect(() => {
     const off = window.cth.onUpdateStatus?.((next) => setStatus((prev) => reduceStatus(prev, next)));
     void window.cth.updateCurrent?.().then((cur) => {
       if (cur) setStatus((prev) => reduceStatus(prev, cur));
-    }).catch(() => { /* push channel still works */ });
+    }).catch(() => { /* push 通道仍可用 */ });
     return off;
   }, []);
   const pending = version ? pendingVersion(status, version) : null;
@@ -60,19 +54,18 @@ export function SettingsHeroCard() {
     let alive = true;
     window.cth.appInfo()
       .then((i) => { if (alive) setVersion(i.version); })
-      .catch(() => { /* the card is still useful without it */ });
+      .catch(() => { /* 没有它卡片也仍然有用 */ });
     window.cth.heroPayload()
       .then((r) => { if (alive) setHero(r.hero); })
-      .catch(() => { /* defaults already rendered */ });
+      .catch(() => { /* 默认值已渲染 */ });
     return () => { alive = false; };
   }, []);
 
   const PLAN = hero.plan;
   const SPONSOR = hero.sponsor;
 
-  /** Re-show the release notes. UpdateToast owns that surface — it holds the
-   *  last status and the drop renderer — so this asks rather than duplicating
-   *  it, via the same CustomEvent convention App uses for opening Settings. */
+  /** 重新显示发布说明。UpdateToast 拥有那个界面——它持有最近的状态和 drop 渲染器——
+   *  所以这里是请求而非复制，通过与 App 打开 Settings 相同的 CustomEvent 约定。 */
   const showReleaseNotes = () => {
     window.dispatchEvent(new CustomEvent('cth:show-release-notes'));
   };
@@ -87,12 +80,12 @@ export function SettingsHeroCard() {
       border: `2px solid ${INK}`
     }}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 14 }}>
-        {/* Identity: name, the running version in plain sight, the plan. */}
+        {/* 身份：名称、一目了然的运行中版本、方案。 */}
         <div>
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
             <span style={{
               fontFamily: 'var(--cth-font-display)', fontSize: 13, lineHeight: '20px', color: INK
-            }}>MUNDER DIFFLIN</span>
+            }}>{t('settingsHero.brandName')}</span>
             {version && (
               <span style={{
                 fontFamily: MONO, fontSize: 15, fontWeight: 700, color: INK
@@ -107,11 +100,11 @@ export function SettingsHeroCard() {
               <>
                 <span style={{ flex: 1 }} />
                 <span style={{ fontFamily: MONO, fontSize: 11, color: 'var(--cth-ink-700)' }}>
-                  v{pending} is out
+                  {t('settingsHero.versionOut', { version: pending })}
                 </span>
                 <PixelButton variant="primary" size="sm" onClick={downloadManually}
-                  title="Download the installer and replace the app yourself. Auto-update is in Updates below.">
-                  download v{pending}
+                  title={t('settingsHero.downloadManualTitle')}>
+                  {t('settingsHero.downloadVersion', { version: pending })}
                 </PixelButton>
               </>
             )}
@@ -121,7 +114,7 @@ export function SettingsHeroCard() {
           </div>
         </div>
 
-        {/* A one-line notice (an incident, a migration heads-up), when set. */}
+        {/* 一行公告（事故、迁移提醒），当设置时显示。 */}
         {hero.notice && (
           <div style={{
             padding: '8px 10px', fontSize: 12, lineHeight: 1.5, color: INK,
@@ -129,7 +122,7 @@ export function SettingsHeroCard() {
           }}>{hero.notice}</div>
         )}
 
-        {/* Pro announcement. Same block the release drop carries. */}
+        {/* Pro 公告。与发布 drop 携带的同一块内容。 */}
         <div style={{
           padding: '12px 14px',
           background: 'var(--cth-lilac-light)',
@@ -149,7 +142,7 @@ export function SettingsHeroCard() {
           </div>
         </div>
 
-        {/* Founders' Wall offer. */}
+        {/* Founders' Wall 优惠。 */}
         <div style={{
           display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
           padding: '12px 14px',
@@ -181,7 +174,7 @@ export function SettingsHeroCard() {
           )}
         </div>
 
-        {/* Sponsor — only when there is one. */}
+        {/* 赞助商——仅当存在时。 */}
         {SPONSOR && (
           <div style={{
             display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap',
@@ -201,7 +194,7 @@ export function SettingsHeroCard() {
           </div>
         )}
 
-        {/* Actions that belong to the app rather than to any setting below. */}
+        {/* 属于应用本身、而非下方任何设置的行动。 */}
         <div style={{
           display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center',
           paddingTop: 12, borderTop: `2px solid ${INK}`

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -36,18 +36,17 @@ import { LANGUAGES, setLanguage } from '@/i18n';
 export interface SettingsModalProps {
   config: HarnessConfig;
   onClose: () => void;
-  /** Open straight to a section instead of General. Used by deep links from
-   *  elsewhere in the UI — "set it now" beside a disabled Talk button lands on
-   *  the tab that actually holds the field, rather than making the user hunt. */
+  /** 直接打开到某个 section 而不是 General。供 UI 其他地方的深链使用——
+   *  禁用态 Talk 按钮旁的"立即设置"会落到真正持有该字段的标签页上，
+   *  而不是让用户自己去找。 */
   initialSection?: Section;
 }
 
 /**
- * The triggers IPC surface. `src/preload/index.ts` is owned by another lane and
- * these methods are landing there in parallel, so `CthApi` doesn't declare them
- * yet — read them off a narrow local view instead of widening the preload
- * contract from the renderer. Every call site wraps them in try/catch, which also
- * covers the window in which a method is still missing at runtime.
+ * triggers 的 IPC 接口。`src/preload/index.ts` 由另一条 lane 负责，
+ * 这些方法正在并行落地，所以 `CthApi` 暂时还不声明它们——从窄化的本地视图读取，
+ * 而不是从 renderer 侧扩大 preload 契约。每个调用点都用 try/catch 包裹，这也
+ * 覆盖了某个方法在运行时仍缺失的窗口期。
  */
 interface TriggersApi {
   listWebhooks: () => Promise<WebhookTrigger[]>;
@@ -60,13 +59,13 @@ interface TriggersApi {
 }
 const triggersApi = (): TriggersApi => window.cth as unknown as TriggersApi;
 
-/** Process-unique id for a new webhook — it is the path segment callers POST to,
- *  so it must be stable and collision-free across renames. */
+/** 新 webhook 的进程内唯一 id——它是调用方 POST 的路径段，
+ *  因此在重命名时也必须稳定且不冲突。 */
 function newWebhookId(): string {
   return `wh-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-/** Pixel-aesthetic text input, mirroring AddAgentModal's inputStyle. */
+/** 像素风文本输入，与 AddAgentModal 的 inputStyle 保持一致。 */
 const slackInputStyle: CSSProperties = {
   width: '100%',
   padding: '6px 8px 4px',
@@ -87,40 +86,38 @@ const slackLabelStyle: CSSProperties = {
   textTransform: 'uppercase'
 };
 
-/** The exact connect walkthrough shown behind the i icon. Steps 6 & 7 spell out
- *  the both-lists requirement: subscribe to message.channels / message.groups in
- *  BOTH "Subscribe to bot events" AND "Subscribe to events on behalf of users". */
-const SLACK_CONNECT_STEPS = `Connect Munder Difflin to Slack
+/** i 图标后面显示的精确连接教程。第 6、7 步讲明了两个列表都订阅的要求：
+ *  在 BOTH "Subscribe to bot events" 和 "Subscribe to events on behalf of users"
+ *  中订阅 message.channels / message.groups。 */
+const SLACK_CONNECT_STEPS = `将 Munder Difflin 连接到 Slack
 
-1. api.slack.com/apps -> Create New App -> From scratch. Name it
-   "Munder Difflin" and pick your workspace.
-2. Basic Information -> Signing Secret -> copy it into the
-   "Signing secret" field here.
-3. OAuth & Permissions -> Bot Token Scopes: add
-     chat:write          (office replies in-thread)
-     channels:history    (read public-channel messages)
-     groups:history      (read private-channel messages)
-   Install to workspace, then copy the Bot User OAuth Token
-   (xoxb-...) into the "Bot token" field here.
-4. Press Start (below) to launch the webhook and get your
-   Request URL.
-5. Event Subscriptions -> Enable Events -> Request URL: paste the
-   Request URL from here and wait for Slack's green check (Verified).
-6. Event Subscriptions -> "Subscribe to bot events": add
+1. 打开 api.slack.com/apps -> Create New App -> From scratch。把它命名为
+   "Munder Difflin" 并选择你的工作区。
+2. 在 Basic Information -> Signing Secret 处把签名密钥复制到这里的
+   "Signing secret" 字段。
+3. 在 OAuth & Permissions -> Bot Token Scopes 处添加：
+     chat:write          （办公室在帖内回复）
+     channels:history    （读取公共频道消息）
+     groups:history      （读取私有频道消息）
+   然后安装到工作区，并把 Bot User OAuth Token
+   (xoxb-...) 复制到这里的 "Bot token" 字段。
+4. 按下方的 Start 启动 webhook，获取你的
+   Request URL。
+5. 在 Event Subscriptions -> Enable Events 的 Request URL 处粘贴
+   这里得到的 Request URL，等待 Slack 出现绿色对勾（Verified）。
+6. 在 Event Subscriptions -> "Subscribe to bot events" 处添加：
      message.channels
      message.groups
-7. Event Subscriptions -> "Subscribe to events on behalf of users"
-   (add the matching User Token Scope channels:history / groups:history
-   first if Slack asks): add
+7. 在 Event Subscriptions -> "Subscribe to events on behalf of users"
+   （若 Slack 要求，先添加对应的 User Token Scope channels:history / groups:history）：添加
      message.channels
      message.groups
-8. Save Changes, reinstall if Slack prompts, then invite the bot
-   to your channel:  /invite @MunderDifflin`;
+8. 保存更改（Save Changes），若 Slack 提示则重新安装，然后把机器人邀请到
+   你的频道：/invite @MunderDifflin`;
 
-/** The request/response contract shown behind the webhook i icon. Every webhook
- *  shares one server and one tunnel and is told apart by its id in the path, so
- *  `<tunnel>` is the public base URL and `<webhookId>` picks the endpoint. The
- *  secret/token go in headers so they stay out of URLs and access logs. */
+/** webhook i 图标后面显示的请求/响应契约。每个 webhook 共享一个服务器和一个隧道，
+ *  靠路径里的 id 区分，所以 `<tunnel>` 是公共基址，`<webhookId>` 选定端点。secret/token
+ *  放在 header 里，从而不进入 URL 和访问日志。 */
 const webhookApiDoc = (godName: string): string => `Webhook API
 
 Every webhook has its own URL, its own secret and its own mode. They share one
@@ -150,7 +147,7 @@ authorizes new work, the token only reads one task's status. Keep both private.
 Each webhook checks bodies against its own JSON schema — edit that in the
 Triggers tab of ${godName}'s Command Center.`;
 
-/** Clear every renderer-side persisted key so a relaunch starts truly empty. */
+/** 清除 renderer 侧所有持久化的 key，让重新启动真正从零开始。 */
 function clearLocalState(): void {
   try {
     const keys: string[] = [];
@@ -159,30 +156,29 @@ function clearLocalState(): void {
       if (k && k.startsWith('cth.')) keys.push(k);
     }
     for (const k of keys) window.localStorage.removeItem(k);
-  } catch { /* noop */ }
+  } catch { /* 空操作 */ }
 }
 
-// v0.3.4 redesign: six tabs, one topic each. 'AI Engines' folded into
-// Agents & Models; MCP + Slack + webhook + REST live together in Connections;
-// voice gets its own tab; Danger Zone became a red row at the bottom of General.
-/* The small-caps section heading, defined once. It was written out inline
-   seventeen times, in three slightly different forms, which is how a tab ends
-   up looking subtly unlike its neighbours. */
+// v0.3.4 重新设计：六个标签页，每个一个主题。'AI Engines' 并入
+// Agents & Models；MCP + Slack + webhook + REST 一起放在 Connections；
+// voice 拥有独立标签页；Danger Zone 变成 General 底部的一行红色区域。
+/* 小型大写 section 标题，只定义一次。以前它被内联写了十七遍、
+   三种略不同的形式——这就是为什么某个标签页看起来会和它的邻居微妙地不一致。 */
 const sectionHead = {
   fontFamily: 'var(--cth-font-display)', fontSize: 8, lineHeight: '12px',
   color: 'var(--cth-ink-500)', textTransform: 'uppercase', marginBottom: 10
 } as const;
-/** Same heading, tight under a section that supplies its own spacing. */
+/** 同样的标题，紧贴自带间距的 section 下方。 */
 const sectionHeadTight = { ...sectionHead, marginBottom: 2 } as const;
-/** Same heading with no bottom margin at all. */
+/** 完全不带底部间距的标题变体。 */
 const sectionHeadFlush = { ...sectionHead, marginBottom: 0 } as const;
-/** The 2px rule between Settings sections. */
+/** Settings 各 section 之间的 2px 分隔线。 */
 const sectionRule = { height: 2, background: 'var(--cth-ink-300)' } as const;
 
 export type Section = 'General' | 'Prerequisites' | 'Agents & Models' | 'Autonomy & Budgets' | 'Connections' | 'Voice' | 'Memory & Knowledge';
 const NAV_SECTIONS: Section[] = ['General', 'Prerequisites', 'Agents & Models', 'Autonomy & Budgets', 'Connections', 'Voice', 'Memory & Knowledge'];
-/** i18n key for each nav section's label — the Section values themselves stay
- *  as stable identifiers (tab state, deep links). */
+/** 每个导航 section 标签的 i18n key——Section 值本身保持不变，
+ *  作为稳定标识符（标签页状态、深链）。 */
 const NAV_SECTION_KEYS: Record<Section, string> = {
   'General': 'settings.nav.general',
   'Prerequisites': 'settings.nav.prerequisites',
@@ -200,58 +196,56 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
   const [busy, setBusy] = useState(false);
   const [activeSection, setActiveSection] = useState<Section>(initialSection ?? 'General');
 
-  // Change-home flow: null until the user picks a new folder, then the sub-modal
-  // confirms move-vs-fresh. Pre-selects 'move' (recommended - keeps the data).
+  // 更换主目录流程：在用户选定新文件夹前为 null，随后子模态框
+  // 确认是迁移（move）还是全新（fresh）。默认预选 'move'（推荐——保留数据）。
   const [changeHome, setChangeHome] = useState<string | null>(null);
   const [changeMode, setChangeMode] = useState<'move' | 'fresh'>('move');
   const [changeBusy, setChangeBusy] = useState(false);
   const [changeErr, setChangeErr] = useState('');
 
-  // `notifications` is an optional field on the main-process config; the renderer
-  // mirror type may not declare it yet, so read it defensively.
+  // `notifications` 是主进程配置里的可选字段；renderer 侧的镜像类型可能尚未声明它，
+  // 所以防御性读取。
   const [notifications, setNotifications] = useState<boolean>(
     (config as HarnessConfig & { notifications?: boolean }).notifications === true
   );
 
   const toggleNotifications = async () => {
     const next = !notifications;
-    setNotifications(next); // optimistic
+    setNotifications(next); // 乐观更新
     try { await window.cth.setNotifications(next); }
-    catch { setNotifications(!next); /* revert on failure */ }
+    catch { setNotifications(!next); /* 失败则回滚 */ }
   };
 
-  // ─── v0.3.4 redesign: settings that were onboarding-trapped or UI-less ────
+  // ─── v0.3.4 重新设计：曾被 onboarding 困住或没有 UI 的设置 ────
   const cfgX = config as HarnessConfig & {
     strongKeepalive?: boolean; audience?: string; autoMode?: boolean;
     defaultModel?: string; maxTurns?: number; semanticMemory?: boolean;
   };
   /**
-   * ONE SAVE BUTTON.
+   * 只有一个保存按钮。
    *
-   * Settings used to persist three different ways: toggles wrote to disk the
-   * instant you clicked them, some sections had their own Save, and a couple of
-   * fields saved on blur. Nothing told you which kind you were looking at, so
-   * "did that stick?" had no answer you could learn once and reuse.
+   * 以前设置用三种不同的方式持久化：开关在点击瞬间写入磁盘，部分 section 有各自的
+   * Save，还有几个字段在失焦时保存。没有任何提示告诉你现在面对的是哪一种，所以
+   * "刚才那个改了吗？"这个问题没有一个可以学会一次就复用的答案。
    *
-   * Now every setting that goes through `updateConfig` is STAGED here and
-   * written by the footer Save, in a single call.
+   * 现在，所有经过 `updateConfig` 的设置都先在这里 STAGE（暂存），
+   * 再由底部 Save 一次性写入。
    *
-   * Two things stay immediate, on purpose, and they are not settings:
-   *   - API keys, which go to the write-only secret broker. Nothing can read
-   *     one back to diff it, so there is no staged value to hold.
-   *   - Free Flow, which arms a global hotkey in main. Staging that would leave
-   *     the hotkey and the checkbox disagreeing until you pressed Save.
-   * Slack and webhooks keep their own controls too: those connect and
-   * disconnect live rather than storing a preference.
+   * 有两样东西刻意保持即时生效，而且它们不是设置：
+   *   - API key，它们进入只写的 secret broker。没有任何方式读回 key 来做 diff，
+   *     所以没有可暂存的值。
+   *   - Free Flow，它会在 main 里挂一个全局热键。暂存它会导致热键和复选框
+   *     在你按下 Save 之前一直不一致。
+   * Slack 和 webhook 也保留各自的控件：它们直接连接/断开，而不是存储偏好。
    */
   const [pending, setPending] = useState<Partial<HarnessConfig>>({});
-  /** Auto-compact lives inside the missions array, so it is resolved at save
-   *  time against the config on disk rather than staged as a whole array. */
+  /** Auto-compact 位于 missions 数组内部，所以保存时对照磁盘上的配置解析，
+   *  而不是把整个数组暂存起来。 */
   const [autoCompactPending, setAutoCompactPending] = useState<boolean | null>(null);
   const [saveBusy, setSaveBusy] = useState(false);
   const [saveNote, setSaveNote] = useState('');
-  /** True once a control that USED to persist on click has been changed. Only
-   *  those need the close guard: the text fields always needed a Save. */
+  /** 一旦某个曾经"点击即持久化"的控件被改动即为 true。只有这些需要关闭守卫：
+   *  文本框本来就必须点 Save。 */
   const dirty = Object.keys(pending).length > 0 || autoCompactPending !== null;
   const stage = (patch: Partial<HarnessConfig>): void =>
     setPending((prev) => ({ ...prev, ...patch }));
@@ -263,13 +257,12 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     stage({ strongKeepalive: next } as Partial<HarnessConfig>);
   };
   const [simpleMode, setSimpleMode] = useState<boolean>(cfgX.audience === 'non-technical');
-  // Renderer-local, not part of HarnessConfig — it only changes how this window
-  // paints pty output. Read once; the setter keeps localStorage in step.
+  // Renderer 本地状态，不属于 HarnessConfig——它只影响本窗口如何渲染 pty 输出。
+  // 启动时读取一次；setter 会让 localStorage 同步跟进。
   const [arabicTerminal, setArabicTerminal] = useState(isArabicTerminalEnabled);
-  // Whether that value is the language's default or a choice the user made.
-  // Shown as a note rather than a second control: the toggle already IS the
-  // override, so the only thing missing is telling them which one they are
-  // looking at. Re-read on every language change, because the default moves.
+  // 该值是否只是语言的默认值，还是用户做过的选择。
+  // 以注释提示而非第二个控件呈现：开关本身就是覆盖，唯一缺的是告诉用户
+  // 自己正看着哪一个。每次语言变化都要重读，因为默认值会移动。
   const [arabicFollowsLanguage, setArabicFollowsLanguage] = useState(isArabicTerminalFollowingLanguage);
   useEffect(() => {
     setArabicTerminal(isArabicTerminalEnabled());
@@ -286,9 +279,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     setAutoModeOn(next);
     stage({ autoMode: next } as Partial<HarnessConfig>);
   };
-  // Default OFF, so an absent value must read as off. Note this is `=== true`,
-  // the mirror image of autoMode's `!== false` above, because the two defaults
-  // are opposite.
+  // 默认 OFF，所以缺省值必须读作 off。注意这是 `=== true`，
+  // 与上面 autoMode 的 `!== false` 互为镜像，因为两者的默认值正好相反。
   const [orchSpawnOn, setOrchSpawnOn] = useState<boolean>(cfgX.orchestratorMaySpawn === true);
   const toggleOrchSpawn = async () => {
     const next = !orchSpawnOn;
@@ -312,10 +304,10 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     stage({ semanticMemory: next } as Partial<HarnessConfig>);
   };
 
-  // --- circuit-breaker config (Lane A #6 canonical fields, widened view) ---
-  // Drives Jim's real breaker: floor-wide TOKEN budget (costCapTokens) + output-
-  // token velocity ceiling (circuitBreaker.tokenVelocityPerMin). The token cap
-  // replaced the old dollar cap as the user-facing budget.
+  // --- 熔断器配置（Lane A #6 规范字段，加宽视图）---
+  // 驱动 Jim 的真实熔断器：全局 TOKEN 预算（costCapTokens）+ 输出
+  // token 速率上限（circuitBreaker.tokenVelocityPerMin）。token 上限
+  // 取代了旧的美元上限作为面向用户的预算。
   type BreakerCfgView = HarnessConfig & {
     costCapTokens?: number;
     circuitBreaker?: { tokenVelocityPerMin?: number; enabled?: boolean; hardStop?: boolean; repeatedToolLimit?: number; errorStormLimit?: number };
@@ -323,7 +315,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
   const breakerCfg = config as BreakerCfgView;
   const [agentBudget, setAgentBudget] = useState(breakerCfg.costCapTokens != null ? String(breakerCfg.costCapTokens) : '');
   const [velocityCeiling, setVelocityCeiling] = useState(breakerCfg.circuitBreaker?.tokenVelocityPerMin != null ? String(breakerCfg.circuitBreaker.tokenVelocityPerMin) : '');
-  // v0.3.4: the four previously UI-less breaker fields get controls.
+  // v0.3.4: 之前四个没有 UI 的熔断字段现在有控件了。
   const [brkEnabled, setBrkEnabled] = useState<boolean>(breakerCfg.circuitBreaker?.enabled !== false);
   const [brkHardStop, setBrkHardStop] = useState<boolean>(breakerCfg.circuitBreaker?.hardStop === true);
   const [brkRepeated, setBrkRepeated] = useState(breakerCfg.circuitBreaker?.repeatedToolLimit != null ? String(breakerCfg.circuitBreaker.repeatedToolLimit) : '');
@@ -345,8 +337,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
       }
     } as Partial<HarnessConfig>;
   };
-  /** The one writer. Commits what the form currently shows, in a single
-   *  updateConfig, so a half-applied save is not a state the app can reach. */
+  /** 唯一的写入方。在单次 updateConfig 中一次性提交表单当前显示的内容，
+   *  让"保存了一半"不会成为应用可达的状态。 */
   const saveAll = async (): Promise<void> => {
     setSaveBusy(true); setSaveNote('');
     try {
@@ -356,8 +348,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
         ...pending
       };
       if (autoCompactPending !== null) {
-        // Read-modify-write against disk, not against a stale copy: another
-        // window (or main) may have edited a different mission meanwhile.
+        // 对磁盘做读-改-写，而不是对一个过期的副本：另一个窗口（或 main）
+        // 可能与此同时编辑了不同的 mission。
         const cfg = await window.cth.getConfig();
         patch.missions = (cfg.missions ?? []).map((m) =>
           m.id === 'compact-maintenance' ? { ...m, enabled: autoCompactPending } : m
@@ -373,8 +365,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     } finally { setSaveBusy(false); }
   };
 
-  /** Closing with staged changes used to be impossible, because everything wrote
-   *  on click. Now it is, so say so rather than dropping the edit silently. */
+  /** 以前带暂存变更关闭是不可能的，因为一切都在点击时写入。现在可以了，
+   *  所以要明说，而不是静默丢弃编辑。 */
   const requestClose = (): void => {
     if (dirty && !window.confirm(t('settings.unsavedWarning'))) return;
     onClose();
@@ -389,49 +381,48 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     return String(n);
   };
 
-  // --- Slack integration ---
+  // --- Slack 集成 ---
   const [slackEnabled, setSlackEnabled] = useState(config.slackEnabled ?? false);
   const [slackSecret, setSlackSecret] = useState(config.slackSigningSecret ?? '');
   const [slackBotToken, setSlackBotToken] = useState(config.slackBotToken ?? '');
   const [slackChannel, setSlackChannel] = useState(config.slackChannelId ?? '');
   const [slackPort, setSlackPort] = useState(String(config.slackPort ?? 3847));
-  // App/voice-initiated proactive posting (the "queued" ack). Default OFF —
-  // the Slack-origin done-reply round-trip is unaffected by this toggle.
+  // 应用/语音发起的主动推送（"queued" 确认）。默认 OFF ——
+  // 由 Slack 来源的完成回执往返不受此开关影响。
   const [slackProactivePosting, setSlackProactivePosting] = useState(config.slackProactivePosting ?? false);
   const [tunnelUrl, setTunnelUrl] = useState('');
   const [slackBusy, setSlackBusy] = useState(false);
   const [slackNote, setSlackNote] = useState('');
-  // Whether the webhook server is currently live. Hydrated from main on open so
-  // reopening Settings shows the true connection state + the persisted Request URL.
+  // webhook 服务器当前是否存活。打开时从 main 灌入，
+  // 让重新打开 Settings 能显示真实的连接状态和持久化的 Request URL。
   const [running, setRunning] = useState(false);
-  // Whether the connect-steps help panel is expanded.
+  // 连接步骤帮助面板是否展开。
   const [showSlackHelp, setShowSlackHelp] = useState(false);
 
-  // --- Webhook triggers (a LIST; src/shared/triggers.ts owns the type) ---------
-  // The list itself lives in the store, not in local state: the Triggers tab
-  // edits the same webhooks, and one of the two surfaces holding a private copy
-  // is exactly the drift this feature exists to prevent.
+  // --- Webhook 触发器（一个 LIST；类型归 src/shared/triggers.ts 所有）---------
+  // 列表本身存在 store 里，而不是本地 state：Triggers 标签页编辑的是同一批
+  // webhook，两个界面各持一份私有副本，正是这个功能要防止的漂移。
   const webhookTriggers = useStore((s) => s.webhookTriggers);
   const setWebhookTriggersStore = useStore((s) => s.setWebhookTriggers);
-  /** Public base URL of the shared tunnel; each webhook's endpoint is `<base>/<id>`. */
+  /** 共享隧道的公共基址；每个 webhook 的端点是 `<base>/<id>`。 */
   const [webhookUrl, setWebhookUrl] = useState('');
   const [webhookRunning, setWebhookRunning] = useState(false);
   const [webhookBusy, setWebhookBusy] = useState(false);
   const [webhookNote, setWebhookNote] = useState('');
-  /** Which secrets the user has unmasked, by webhook id. Reset on every reopen. */
+  /** 用户已取消掩码的 secret，按 webhook id 记录。每次重新打开时重置。 */
   const [shownSecrets, setShownSecrets] = useState<Record<string, boolean>>({});
-  /** Webhook awaiting a second delete click — deleting one revokes a live caller. */
+  /** 等待第二次点击删除的 webhook——删除会吊销一个在线调用方。 */
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const [showWebhookHelp, setShowWebhookHelp] = useState(false);
 
-  // --- Organisation trigger (peer messaging; configuration only for now) ------
+  // --- 组织触发器（对等消息；目前只有配置）------
   const orgTrigger = useStore((s) => s.orgTrigger);
   const setOrgTriggerStore = useStore((s) => s.setOrgTrigger);
   const [showOrgKey, setShowOrgKey] = useState(false);
   const [orgBusy, setOrgBusy] = useState(false);
   const [orgNote, setOrgNote] = useState('');
 
-  // ─── Knowledge Graph (enterprise multimodal context for agents) ───────────
+  // ─── Knowledge Graph（面向 agent 的企业级多模态上下文）───────────
   const [kgEnabled, setKgEnabled] = useState<boolean>(
     (config as HarnessConfig & { knowledgeGraph?: { enabled?: boolean } }).knowledgeGraph?.enabled === true
   );
@@ -441,7 +432,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
   const refreshKgStatus = async () => {
     try { const s = await window.cth.kgStatus(); setKgDocCount(s.docCount); }
-    catch { /* status unavailable */ }
+    catch { /* 状态不可用 */ }
   };
 
   const toggleKg = async () => {
@@ -466,9 +457,9 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     finally { setKgBusy(false); }
   };
 
-  // ─── Scheduled auto-compact — the compact-maintenance mission's enabled flag.
-  // The mission itself stays the single source of truth (the Triggers tab edits
-  // the same field); this is just a General-section shortcut. Default OFF (v0.3.4).
+  // ─── 定时自动压缩——compact-maintenance mission 的 enabled 标志。
+  // mission 本身仍是唯一事实来源（Triggers 标签页编辑同一字段）；这只是
+  // General 区块的快捷方式。默认 OFF（v0.3.4）。
   const [autoCompactOn, setAutoCompactOn] = useState<boolean>(
     (config.missions ?? []).some((m) => m.id === 'compact-maintenance' && m.enabled)
   );
@@ -478,7 +469,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     setAutoCompactPending(next);
   };
 
-  // ─── Auto-update (default ON; gates main's updater checks entirely) ────────
+  // ─── 自动更新（默认 ON；完全控制 main 的 updater 检查）───────
   const [autoUpdateOn, setAutoUpdateOn] = useState<boolean>(config.autoUpdate !== false);
   const toggleAutoUpdate = async () => {
     const next = !autoUpdateOn;
@@ -487,7 +478,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     catch { setAutoUpdateOn(!next); }
   };
 
-  // ─── Anonymous usage stats (default ON = opt-out; contract in TELEMETRY.md) ─
+  // ─── 匿名使用统计（默认 ON = 可选择退出；契约见 TELEMETRY.md）─
   const [telemetryOn, setTelemetryOn] = useState<boolean>(config.telemetryEnabled !== false);
   const toggleTelemetry = async () => {
     const next = !telemetryOn;
@@ -496,15 +487,14 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     catch { setTelemetryOn(!next); }
   };
 
-  // --- Free Flow (voice dictation → message queue) ---
+  // --- Free Flow（语音听写 → 消息队列）---
   const setFreeflowEnabledStore = useStore((s) => s.setFreeflowEnabled);
   const setHasGroqKeyStore = useStore((s) => s.setHasGroqKey);
-  // Talk (Realtime Michael) is gated on the OpenAI key — read the live presence
-  // boolean so the Realtime Michael section can show its enabled/disabled status.
+  // Talk（Realtime Michael）由 OpenAI key 把关——读取实时存在性
+  // 布尔值，让 Realtime Michael 区块能显示自己的启用/禁用状态。
   const hasOpenAiKey = useStore((s) => s.hasOpenAiKey);
-  // Voice-tab entry for the SAME broker slot Agents & Models writes (apikey:openai).
-  // Mirroring presence into the store on save is what makes the Talk button light up
-  // immediately instead of on next launch.
+  // Voice 标签页对同一个 broker 槽位的入口（apikey:openai），与 Agents & Models 写入一致。
+  // 保存时把存在性镜像进 store，正是让 Talk 按钮立刻亮起、而不是等下次启动的原因。
   const setHasOpenAiKey = useStore((s) => s.setHasOpenAiKey);
   const [openAiVoiceKey, setOpenAiVoiceKey] = useState('');
   const [openAiVoiceNote, setOpenAiVoiceNote] = useState('');
@@ -522,22 +512,22 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
       setOpenAiVoiceNote(e instanceof Error ? e.message : String(e));
     }
   };
-  // v0.3.4 fix: the config default is ON ('now on by default', 0.2.7) — seeding
-  // with `?? false` displayed OFF while the feature was actually running.
+  // v0.3.4 修复：配置默认值是 ON（0.2.7 起"默认开启"）——以前用
+  // `?? false` 做种子会在功能实际运行时显示成 OFF。
   const [freeflowEnabled, setFreeflowEnabled] = useState(config.freeflowEnabled !== false);
   const [groqKey, setGroqKey] = useState(config.groqApiKey ?? '');
   const [freeflowModel, setFreeflowModel] = useState(config.freeflowModel ?? 'whisper-large-v3-turbo');
   const [showGroqKey, setShowGroqKey] = useState(false);
   const [freeflowBusy, setFreeflowBusy] = useState(false);
   const [freeflowNote, setFreeflowNote] = useState('');
-  // rt-9 idle-tunable: realtime voice idle auto-disconnect window (ms); 0 = never.
+  // rt-9 空闲可调项：实时语音空闲自动断开窗口（毫秒）；0 = 永不断开。
   const [idleDisconnectMs, setIdleDisconnectMs] = useState<number>(
     (config as HarnessConfig).realtimeIdleDisconnectMs ?? 180_000
   );
 
-  // Re-seed every editable field from the on-disk config when the modal opens.
-  // App's `config` prop is loaded once and never refreshed after a save, so
-  // without this the saved budget / velocity / slack values show blank on reopen.
+  // 每次 modal 打开时，从磁盘配置重新为所有可编辑字段做种子。
+  // App 的 `config` prop 只加载一次，保存后从不刷新，所以没有这一步，
+  // 重新打开时保存过的预算 / velocity / slack 值会显示为空白。
   useEffect(() => {
     let alive = true;
     window.cth.getConfig().then((c) => {
@@ -558,40 +548,40 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
       setGroqKey(cc.groqApiKey ?? '');
       setFreeflowModel(cc.freeflowModel ?? 'whisper-large-v3-turbo');
       setIdleDisconnectMs((c as HarnessConfig).realtimeIdleDisconnectMs ?? 180_000);
-    }).catch(() => { /* keep prop-seeded values */ });
+    }).catch(() => { /* 保留 prop 种子值 */ });
     window.cth.kgStatus().then((s) => { if (alive) setKgDocCount(s.docCount); })
-      .catch(() => { /* status unavailable */ });
-    // Hydrate live connection state + the persisted Request URL: the
-    // tunnel URL lives in main, so reopening Settings while connected re-shows it.
+      .catch(() => { /* 状态不可用 */ });
+    // 灌入实时连接状态 + 持久化的 Request URL：tunnel URL 存在 main 里，
+  // 所以保持连接时重新打开 Settings 会重新显示它。
     window.cth.slackStatus().then((s) => {
       if (!alive) return;
       setRunning(s.running);
       if (s.url) setTunnelUrl(s.url);
-    }).catch(() => { /* status unavailable - assume not running */ });
-    // Triggers: re-read main and push the result into the shared mirror. App
-    // already seeded it at launch; this catches anything the Triggers tab (or
-    // another window) changed since, and is the ONLY place Settings reads them —
-    // every render below comes off the store.
+    }).catch(() => { /* 状态不可用——假定未运行 */ });
+    // Triggers：重新读取 main 并把结果推进共享镜像。App
+    // 已在启动时做过种子；这一步能捕获 Triggers 标签页（或
+    // 另一个窗口）自那以后做的修改，也是 Settings 读取它们的唯一位置——
+    // 下方所有渲染都来自 store。
     void (async () => {
       try {
         const list = await triggersApi().listWebhooks();
         if (alive && Array.isArray(list)) useStore.getState().setWebhookTriggers(list);
-      } catch { /* keep the mirror App seeded from getConfig() */ }
+      } catch { /* 保持 App 从 getConfig() 种下的镜像 */ }
       try {
         const org = await triggersApi().getOrgTrigger();
         if (alive && org) useStore.getState().setOrgTrigger(org);
-      } catch { /* ditto */ }
+      } catch { /* 同上 */ }
       try {
         const s = await triggersApi().webhooksStatus();
         if (!alive) return;
         setWebhookRunning(s.running);
         if (s.url) setWebhookUrl(s.url);
-      } catch { /* status unavailable - assume not listening */ }
+      } catch { /* 状态不可用——假定未在监听 */ }
     })();
     return () => { alive = false; };
   }, []);
 
-  /** Persist the current Slack inputs. Returns the resolved config patch. */
+  /** 持久化当前 Slack 输入。返回解析后的配置补丁。 */
   const slackPatch = (enabled: boolean) => ({
     signingSecret: slackSecret,
     botToken: slackBotToken,
@@ -614,13 +604,13 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
   const startSlack = async () => {
     setSlackBusy(true); setSlackNote('');
     try {
-      // Persist first so the server starts with the latest secret/port/channel.
+      // 先持久化，让服务器以最新的 secret/port/channel 启动。
       await window.cth.slackSetConfig(slackPatch(true));
       setSlackEnabled(true);
       const res = await window.cth.slackStart();
       if (res.ok) {
         setRunning(true);
-        // Keep the last URL if this start returned none (tunnel hiccup) - don't blank it.
+        // 若本次启动没返回 URL（tunnel 小故障），保留最后一个——不要清空。
         if (res.url) setTunnelUrl(res.url);
         setSlackNote(res.url ? 'listening' : (res.error ?? 'started, but tunnel unavailable'));
       } else {
@@ -633,36 +623,35 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
   const stopSlack = async () => {
     setSlackBusy(true); setSlackNote('');
-    // Keep the last Request URL visible (greyed) after Stop.
+    // Stop 之后保留最后一个 Request URL（置灰）可见。
     try { await window.cth.slackStop(); setRunning(false); setSlackNote('stopped'); }
     catch (e) { setSlackNote(e instanceof Error ? e.message : String(e)); }
     finally { setSlackBusy(false); }
   };
 
-  // --- Webhook trigger handlers ---
-  /** The one write path. Updates the shared mirror FIRST so the Triggers tab
-   *  repaints immediately, then persists. Pass `persist: false` for keystroke
-   *  edits (a rename) — the blur commits them. */
+  // --- Webhook 触发器处理器 ---
+  /** 唯一的写入路径。先更新共享镜像，让 Triggers 标签页立即重绘，再持久化。
+   *  按键级编辑（如重命名）传 `persist: false`——由 blur 提交。 */
   const applyWebhooks = async (list: WebhookTrigger[], persist = true) => {
     setWebhookTriggersStore(list);
     if (!persist) return;
     setWebhookBusy(true); setWebhookNote('');
     try {
       const res = await triggersApi().saveWebhooks(list);
-      if (res && res.ok === false) { setWebhookNote(res.error ?? 'could not save'); return; }
-      setWebhookNote('saved');
+      if (res && res.ok === false) { setWebhookNote(res.error ?? '保存失败'); return; }
+      setWebhookNote('已保存');
       setTimeout(() => setWebhookNote(''), 1500);
     } catch (e) {
       setWebhookNote(e instanceof Error ? e.message : String(e));
     } finally { setWebhookBusy(false); }
   };
 
-  /** Replace one entry by id (the shape every per-row control uses). */
+  /** 按 id 替换一条（每个行内控件都用这个形状）。 */
   const patchWebhook = (id: string, patch: Partial<WebhookTrigger>, persist = true) =>
     applyWebhooks(webhookTriggers.map((w) => (w.id === id ? { ...w, ...patch } : w)), persist);
 
-  /** New endpoint: main mints the secret (256-bit), and it ships DISABLED —
-   *  turning on a public surface is always an explicit second click. */
+  /** 新端点：main 铸造 secret（256 位），并且它以 DISABLED 状态发货——
+   *  开启一个公网面始终是一次明确的二次点击。 */
   const addWebhook = async () => {
     setWebhookBusy(true); setWebhookNote('');
     let secret = '';
@@ -672,7 +661,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     } catch (e) {
       setWebhookNote(e instanceof Error ? e.message : String(e));
     } finally { setWebhookBusy(false); }
-    if (!secret) { setWebhookNote('could not generate a secret'); return; }
+    if (!secret) { setWebhookNote('无法生成密钥'); return; }
     const entry: WebhookTrigger = {
       id: newWebhookId(),
       name: `Webhook ${webhookTriggers.length + 1}`,
@@ -682,12 +671,11 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
       schema: DEFAULT_WEBHOOK_SCHEMA,
       createdAt: Date.now()
     };
-    setShownSecrets((s) => ({ ...s, [entry.id]: true })); // show it once, to copy
+    setShownSecrets((s) => ({ ...s, [entry.id]: true })); // 显示一次，便于复制
     await applyWebhooks([...webhookTriggers, entry]);
   };
 
-  /** Mint a fresh secret for ONE endpoint. The old one stops working at once —
-   *  that is the point, and it never disturbs the other webhooks. */
+  /** 为单个端点铸造新 secret。旧的立刻失效——这正是目的，而且从不影响其他 webhook。 */
   const rotateWebhookSecret = async (id: string) => {
     setWebhookBusy(true); setWebhookNote('');
     let secret = '';
@@ -697,7 +685,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     } catch (e) {
       setWebhookNote(e instanceof Error ? e.message : String(e));
     } finally { setWebhookBusy(false); }
-    if (!secret) { setWebhookNote('could not generate a secret'); return; }
+    if (!secret) { setWebhookNote('无法生成密钥'); return; }
     setShownSecrets((s) => ({ ...s, [id]: true }));
     await patchWebhook(id, { secret });
     setWebhookNote('new secret — copy it now');
@@ -713,34 +701,34 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     } catch (e) {
       setWebhookNote(e instanceof Error ? e.message : String(e));
     } finally { setWebhookBusy(false); }
-    // Mirror the removal either way: if main rejected it, the next open re-reads.
+    // 无论成败都镜像删除：若 main 拒绝了它，下次打开会重新读取。
     setWebhookTriggersStore(webhookTriggers.filter((w) => w.id !== id));
   };
 
-  /** Endpoint URL for one webhook: every entry shares the tunnel, the id picks it. */
+  /** 单个 webhook 的端点 URL：每个条目共享隧道，由 id 选中。 */
   const webhookEndpoint = (id: string) => (webhookUrl ? `${webhookUrl.replace(/\/$/, '')}/${id}` : '');
   const copyTunnel = () => { void window.cth.copyToClipboard(tunnelUrl); };
 
-  // --- Organisation trigger handlers ---
-  /** Same contract as webhooks: mirror first (so the Triggers tab is live), then
-   *  persist. Keystroke edits pass `persist: false` and commit on blur. */
+  // --- 组织触发器处理器 ---
+  /** 与 webhooks 相同的契约：先镜像（让 Triggers 标签页实时生效），再
+   *  持久化。按键级编辑传 `persist: false`，在 blur 时提交。 */
   const applyOrg = async (next: OrgTriggerConfig, persist = true) => {
     setOrgTriggerStore(next);
     if (!persist) return;
     setOrgBusy(true); setOrgNote('');
     try {
       const res = await triggersApi().setOrgTrigger(next);
-      if (res && res.ok === false) { setOrgNote(res.error ?? 'could not save'); return; }
-      setOrgNote('saved');
+      if (res && res.ok === false) { setOrgNote(res.error ?? '保存失败'); return; }
+      setOrgNote('已保存');
       setTimeout(() => setOrgNote(''), 1500);
     } catch (e) {
       setOrgNote(e instanceof Error ? e.message : String(e));
     } finally { setOrgBusy(false); }
   };
 
-  // --- Free Flow handlers ---
-  /** Persist Free Flow settings; main re-arms the global hotkey. Also mirror the
-   *  flag into the store so the composer mic button appears/disappears live. */
+  // --- Free Flow 处理器 ---
+  /** 持久化 Free Flow 设置；main 重新挂载全局热键。同时也把该标志
+   *  镜像进 store，让 composer 的麦克风按钮实时出现/消失。 */
   const saveFreeflow = async (enabledOverride?: boolean) => {
     const enabled = enabledOverride ?? freeflowEnabled;
     setFreeflowBusy(true); setFreeflowNote('');
@@ -751,8 +739,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
         model: freeflowModel.trim() || 'whisper-large-v3-turbo'
       });
       setFreeflowEnabledStore(enabled);
-      // Mirror boolean key-presence so the voice button enables/disables live
-      // without an app restart (presence only — never the key value).
+      // 镜像布尔 key 存在性，让语音按钮无需重启应用即可实时启用/禁用
+      // （只镜像存在性——绝不传 key 值）。
       setHasGroqKeyStore(!!groqKey.trim());
       setFreeflowNote('saved');
     } catch (e) {
@@ -760,8 +748,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
     } finally { setFreeflowBusy(false); }
   };
 
-  /** Toggle on/off and persist immediately so the change takes effect (and the
-   *  global hotkey arms/disarms) without a separate Save click. */
+  /** 开/关并立即持久化，让变更（以及全局热键的挂载/卸下）无需
+   *  单独点一次 Save 就生效。 */
   const toggleFreeflow = () => {
     const next = !freeflowEnabled;
     setFreeflowEnabled(next);
@@ -771,34 +759,34 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
   const reset = async () => {
     setBusy(true);
     clearLocalState();
-    // Wipes hive + palace, resets config, and relaunches into onboarding.
-    // The app exits, so this never resolves - no need to clear `busy`.
+    // 清空 hive + palace、重置配置，并重新启动进入 onboarding。
+    // 应用会退出，所以这个过程永不 resolve——无需清 `busy`。
     await window.cth.resetAll();
   };
 
-  // --- Change home folder ---
-  /** Pick a new folder, then open the move-vs-fresh sub-modal. */
+  // --- 更换主目录 ---
+  /** 选定新文件夹，然后打开 move-vs-fresh 子模态框。 */
   const pickNewHome = async () => {
     setChangeErr('');
     const res = await window.cth.chooseFolder();
-    if (!res.ok) return; // cancelled - no-op
-    setChangeMode('move'); // recommended default
+    if (!res.ok) return; // 取消——无操作
+    setChangeMode('move'); // 推荐默认值
     setChangeHome(res.path);
   };
 
-  /** Apply the home-folder change. On success the app relaunches (never resolves);
-   *  on failure we surface the error and the existing home keeps running. */
+  /** 应用主目录变更。成功时应用会重新启动（永不 resolve）；
+   *  失败时我们呈现错误，现有主目录继续运行。 */
   const applyChangeHome = async () => {
     if (!changeHome) return;
     setChangeBusy(true); setChangeErr('');
-    // Moving copies the hive (incl. its .git) + palace, so the new home owns the
-    // same renderer-side roster - keep localStorage. A 'fresh' home starts empty,
-    // so clear the renderer cache to match.
+    // 迁移会复制 hive（含其 .git）+ palace，所以新主目录拥有
+    // 相同的 renderer 侧名册——保留 localStorage。'fresh' 主目录从零开始，
+    // 所以清空 renderer 缓存以保持一致。
     if (changeMode === 'fresh') clearLocalState();
     try {
       const res = await window.cth.changeHome(changeHome, changeMode);
-      if (!res.ok) { setChangeErr(res.error ?? 'Could not change the home folder.'); setChangeBusy(false); }
-      // ok === true never returns (the process relaunches).
+      if (!res.ok) { setChangeErr(res.error ?? '无法更改主文件夹。'); setChangeBusy(false); }
+      // ok === true 时永不返回（进程会重新启动）。
     } catch (e) {
       setChangeErr(e instanceof Error ? e.message : String(e));
       setChangeBusy(false);
@@ -835,7 +823,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
           noPadding
           style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', maxHeight: '88vh' }}
         >
-          {/* === Change home sub-modal === */}
+          {/* === 更换主目录子模态框 === */}
           {changeHome ? (
             <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 16, overflowY: 'auto' }}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
@@ -846,7 +834,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                 }}>{changeHome}</code>
               </div>
 
-              {/* Move vs. fresh - two selectable option rows; move is preselected. */}
+              {/* 迁移 vs. 全新 —— 两个可选的选项行；move 预设选中。 */}
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 {([
                   ['move', t('settings.changeHome.moveTitle'), t('settings.changeHome.moveDesc')],
@@ -892,7 +880,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
               </div>
             </div>
 
-          /* === Reset confirmation screen === */
+          /* === 重置确认画面 === */
           ) : confirming ? (
             <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
               <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
@@ -920,12 +908,12 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
               </div>
             </div>
 
-          /* === Main two-pane settings layout === */
+          /* === 主双栏设置布局 === */
           ) : (
             <>
               <div style={{ display: 'flex', flex: 1, overflow: 'hidden', minHeight: 0 }}>
 
-                {/* Left nav */}
+                {/* 左侧导航 */}
                 <div style={{
                   width: 160, flexShrink: 0,
                   display: 'flex', flexDirection: 'column',
@@ -960,35 +948,30 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                   })}
                 </div>
 
-                {/* Right scrollable content pane. minWidth:0 lets this flex child
-                    shrink to the row's width instead of growing to its content's
-                    min-content (which would push a horizontal scrollbar). */}
+                {/* 右侧可滚动内容面板。minWidth:0 让这个 flex 子元素可以收缩到行的宽度，
+                    而不是撑到其内容的 min-content（那会把横向滚动条挤出来）。 */}
                 <div style={{
                   flex: 1, minWidth: 0, overflowY: 'auto', overflowX: 'hidden',
                   padding: '20px 24px',
                   display: 'flex', flexDirection: 'column', gap: 20
                 }}>
 
-                  {/* GENERAL */}
+                  {/* 常规 */}
                   {activeSection === 'General' && (
                     <>
-                      {/* Who you are and what this install is — version, plan,
-                          sponsor, and the app-level actions that belong to none
-                          of the settings below. Slots for a future subscription
-                          and a sponsor live here; both render nothing until set. */}
+                      {/* 你是谁、这是什么安装——版本、计划、赞助商，以及不属于下方任何设置的应用级
+                          操作。未来的订阅槽位和赞助商槽位在这里；两者在设置之前都不渲染任何东西。 */}
                       <SettingsHeroCard />
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Updates — first among the settings proper, because "am I
-                          on the latest?" is the question people open Settings to
-                          answer, and the toolbar chip says nothing at all when
-                          the answer is yes. */}
+                      {/* 更新——在正式设置里排第一，因为"我是不是最新版？"是人们打开 Settings
+                          想问的问题，而当答案是"是"时，工具栏的 chip 什么都不说。 */}
                       <UpdatesSection />
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Home folder */}
+                      {/* 主目录 */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.general.homeFolder')}
@@ -1004,7 +987,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Environment — settings that used to be trapped in onboarding */}
+                      {/* 环境——曾被困在 onboarding 里的设置 */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.general.environment')}
@@ -1054,8 +1037,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                                 setArabicTerminalEnabled(next);
                                 setArabicTerminal(next);
                                 setArabicFollowsLanguage(false);
-                                // Reach the terminals that are already open, the
-                                // same way a language switch does.
+                                // 让已经打开的终端同步更新，和语言切换时的做法相同。
                                 notifyArabicTerminalChangeAll();
                               }}
                             >
@@ -1067,7 +1049,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Language — app UI language (i18n) */}
+                      {/* 语言——应用 UI 语言（i18n） */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.general.language')}
@@ -1094,7 +1076,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Desktop notifications toggle */}
+                      {/* 桌面通知开关 */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.general.notifications')}
@@ -1120,7 +1102,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Scheduled auto-compact (compact-maintenance mission) */}
+                      {/* 定时自动压缩（compact-maintenance mission） */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.general.maintenance')}
@@ -1180,16 +1162,15 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                         </div>
                       </div>
 
-                      {/* Office Theme — TV-show office maps (experimental; flag tvShowOffices, default off) */}
+                      {/* Office Theme —— 电视节目办公室地图（实验性；flag tvShowOffices，默认关闭） */}
                       <OfficeThemePicker config={config} />
                     </>
                   )}
 
-                  {/* AGENTS & MODELS — what powers the office */}
-                  {/* PREREQUISITES — the external tools the app leans on and
-                      whether this machine has them. It was a Command Center tab,
-                      which was the wrong home: it is machine-wide state, not
-                      something about the agent whose terminal you are reading. */}
+                  {/* AGENTS & MODELS —— 办公室的驱动力 */}
+                  {/* PREREQUISITES —— 应用依赖的外部工具，以及这台机器是否具备。
+                      它曾是 Command Center 标签页，那是个错误的家：这是机器级状态，
+                      而不是你正读其终端的那个 agent 的事。 */}
                   {activeSection === 'Prerequisites' && <SetupPanel onDone={onClose} />}
 
                   {activeSection === 'Agents & Models' && (
@@ -1225,7 +1206,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Advanced */}
+                      {/* 高级 */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.agentsModels.advanced')}
@@ -1244,7 +1225,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                     </>
                   )}
 
-                  {/* AUTONOMY & BUDGETS — the safety tab */}
+                  {/* AUTONOMY & BUDGETS —— 安全标签页 */}
                   {activeSection === 'Autonomy & Budgets' && (
                     <>
                       <div>
@@ -1272,23 +1253,23 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                             <span style={{ fontSize: 13, lineHeight: '20px', color: 'var(--cth-ink-900)' }}>
-                              Who can add agents
+                              {t('settings.autonomy.whoCanAdd')}
                             </span>
                             <span style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-500)' }}>
                               {orchSpawnOn
-                                ? `${godName} can hire on his own. Every agent he starts spends tokens you did not approve.`
-                                : `Only you. ${godName} can still ask, and his request waits in the queue instead of failing.`}
+                                ? t('settings.autonomy.orchSpawnDesc', { godName })
+                                : t('settings.autonomy.onlyYouDesc', { godName })}
                             </span>
                           </div>
                           <PixelButton variant={orchSpawnOn ? 'primary' : 'secondary'} size="sm" onClick={toggleOrchSpawn}>
-                            {orchSpawnOn ? `me and ${godName}` : 'only me'}
+                            {orchSpawnOn ? t('settings.autonomy.meAndGod', { godName }) : t('settings.autonomy.onlyMe')}
                           </PixelButton>
                         </div>
                       </div>
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Circuit breaker — the FULL unit (v0.3.4: all fields have UI) */}
+                      {/* 熔断器 —— 完整单元（v0.3.4：所有字段都有 UI） */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.autonomy.breaker')}
@@ -1361,7 +1342,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                     </>
                   )}
 
-                  {/* MEMORY & KNOWLEDGE */}
+                  {/* MEMORY & KNOWLEDGE（记忆与知识） */}
                   {activeSection === 'Memory & Knowledge' && (
                     <>
                       <div>
@@ -1383,7 +1364,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={{ height: 1, background: 'var(--cth-ink-300)' }} />
 
-                      {/* Knowledge Graph — enterprise multimodal context for agents */}
+                      {/* Knowledge Graph —— 面向 agent 的企业级多模态上下文 */}
                       <div>
                         <div style={sectionHead}>
                           {t('settings.memory.kg')}
@@ -1422,7 +1403,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                     </>
                   )}
 
-                  {/* CONNECTIONS — everything external (MCP + Slack + webhook + REST) */}
+                  {/* CONNECTIONS —— 一切外部连接（MCP + Slack + webhook + REST） */}
                   {activeSection === 'Connections' && (
                     <>
                       <McpDefaultsSettings config={config} />
@@ -1432,14 +1413,14 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                   {activeSection === 'Connections' && (
                     <>
-                      {/* Connected-services registry (generic, registry-driven).
-                          Leads the section; the hardcoded Slack/Webhook/Free Flow
-                          blocks below stay as-is. */}
+                      {/* 已连接服务注册表（通用、由 registry 驱动）。
+                          放在区块开头；下面硬编码的 Slack/Webhook/Free Flow
+                          块保持原样。 */}
                       <IntegrationsRegistry />
 
                       <div style={sectionRule} />
 
-                      {/* Slack integration */}
+                      {/* Slack 集成 */}
                       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                         <div style={sectionHeadTight}>
                           {t('settings.connections.slack')}
@@ -1448,7 +1429,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                             <span style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, lineHeight: '20px', color: 'var(--cth-ink-900)' }}>
                               {t('settings.connections.slackIntegration')}
-                              {/* i - toggles the step-by-step connect guide. */}
+                              {/* i —— 切换分步连接指南的显隐。 */}
                               <button
                                 type="button"
                                 aria-label={t('settings.connections.showSlackHelp')}
@@ -1469,7 +1450,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                             </span>
                           </div>
                           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                            {/* Connection status: clear, always-visible. */}
+                            {/* 连接状态：清晰、始终可见。 */}
                             <span style={{
                               fontSize: 12, lineHeight: '16px',
                               color: running ? 'var(--cth-mint-700, #1f7a4d)' : 'var(--cth-ink-500)'
@@ -1486,8 +1467,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                           </div>
                         </div>
 
-                        {/* Step-by-step connect guide. Includes the both-lists
-                            bot-event subscription requirement (steps 6 & 7). */}
+                        {/* 分步连接指南。包含两个列表都订阅 bot 事件的要求（第 6、7 步）。 */}
                         {showSlackHelp && (
                           <pre style={{
                             margin: 0, padding: 10, whiteSpace: 'pre-wrap',
@@ -1500,7 +1480,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                         {slackEnabled && (
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                            {/* Signing secret + bot token side-by-side in the wider layout */}
+                            {/* 宽版布局中并排的 Signing secret + bot token */}
                             <div style={{ display: 'flex', gap: 16 }}>
                               <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}>
                                 <span style={slackLabelStyle}>{t('settings.connections.signingSecret')}</span>
@@ -1512,7 +1492,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                                   style={{ ...slackInputStyle, fontFamily: 'var(--cth-font-mono)' }}
                                 />
                               </label>
-                              {/* Bot token: stays in main; never leaves the main process. */}
+                              {/* Bot token：留在 main 中；永不离开主进程。 */}
                               <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}>
                                 <span style={slackLabelStyle}>{t('settings.connections.botToken')}</span>
                                 <input
@@ -1547,10 +1527,10 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                               </label>
                             </div>
 
-                            {/* App/voice-INITIATED proactive posting — OFF by
-                                default ("stop posting into Slack by default").
-                                Gates ONLY the renderer's "queued" ack; the
-                                Slack-ORIGIN done-reply round-trip is never gated. */}
+                            {/* 应用/语音发起的主动推送 —— 默认 OFF
+                                （"默认不要往 Slack 里发帖"）。
+                                只约束 renderer 的"queued"确认；由 Slack
+                                来源的完成回执往返永不受约束。 */}
                             <div style={{ display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'space-between' }}>
                               <span style={slackLabelStyle}>
                                 {t('settings.connections.proactivePosting')}
@@ -1565,7 +1545,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                             </div>
 
                             <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                              {/* Start disabled once connected; Stop only when running. */}
+                              {/* 已连接时禁用 Start；仅在运行时才可 Stop。 */}
                               <PixelButton variant="primary" size="sm" onClick={startSlack} disabled={slackBusy || !slackSecret.trim() || running}>
                                 {slackBusy ? '...' : running ? t('settings.connections.connectedBtn') : t('settings.connections.start')}
                               </PixelButton>
@@ -1580,9 +1560,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                               )}
                             </div>
 
-                            {/* Keep the Request URL visible while connected even after a
-                                modal reopen; when stopped, show the last URL greyed
-                                since Slack reuses it until the next Start. */}
+                            {/* 连接期间即使模态框重新打开也要让 Request URL 可见；停止时显示
+                                最后一个 URL（置灰），因为 Slack 在下次 Start 前会复用它。 */}
                             {(running || tunnelUrl) && (
                               <div style={{ display: 'flex', flexDirection: 'column', gap: 4, opacity: running ? 1 : 0.55 }}>
                                 <span style={slackLabelStyle}>
@@ -1611,10 +1590,9 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={sectionRule} />
 
-                      {/* Webhook triggers — a LIST of endpoints, one per caller.
-                          Everything renders off the store mirror, so a change made
-                          in the Triggers tab lands here without a refetch (and the
-                          other way round). */}
+                      {/* Webhook 触发器 —— 端点列表，一个调用方一个。
+                          所有渲染都来自 store 镜像，所以 Triggers 标签页里的改动
+                          无需重新拉取就能落到这里（反之亦然）。 */}
                       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                         <div style={sectionHeadTight}>
                           {t('settings.connections.webhooks')}
@@ -1665,7 +1643,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                           }}>{webhookApiDoc(godName)}</pre>
                         )}
 
-                        {/* Public surface warning. Loud, not buried. */}
+                        {/* 公网面警告。醒目，而不是藏在角落。 */}
                         <span style={{ fontSize: 12, lineHeight: '16px', color: '#6E1423' }}>
                           {t('settings.connections.webhookWarning')}
                         </span>
@@ -1690,8 +1668,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                                     boxShadow: `inset 0 0 0 ${w.enabled ? 1.5 : 1}px ${w.enabled ? 'var(--cth-ink-500)' : 'var(--cth-ink-100)'}`
                                   }}
                                 >
-                                  {/* Name, on/off, delete. Renaming is live in the
-                                      mirror on every keystroke and persists on blur. */}
+                                  {/* 名称、开关、删除。重命名在镜像里每次按键实时生效，并在 blur 时持久化。 */}
                                   <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
                                     <input
                                       value={w.name}
@@ -1708,7 +1685,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                                     >
                                       {w.enabled ? t('common.on') : t('common.off')}
                                     </PixelButton>
-                                    {/* Two clicks: deleting revokes a caller's access for good. */}
+                                    {/* 两次点击：删除会永久吊销调用方的访问。 */}
                                     <PixelButton
                                       variant={pendingDelete === w.id ? 'destructive' : 'ghost'}
                                       size="sm"
@@ -1743,7 +1720,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                                     </PixelButton>
                                   </div>
 
-                                  {/* Masked by default; never in a title attribute. */}
+                                  {/* 默认掩码；绝不放进 title 属性。 */}
                                   <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
                                     <span style={{ ...slackLabelStyle, width: 56, flexShrink: 0 }}>{t('settings.connections.secret')}</span>
                                     <input
@@ -1809,8 +1786,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={sectionRule} />
 
-                      {/* Organisation trigger — teammates messaging this clone node.
-                          Persisted + mirrored; no transport reads the key yet. */}
+                      {/* 组织触发器 —— 队友给这个克隆节点发消息。
+                          持久化 + 镜像；目前还没有传输层读取该 key。 */}
                       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                         <div style={sectionHeadTight}>
                           {t('settings.connections.organisation')}
@@ -1893,10 +1870,10 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                     </>
                   )}
 
-                  {/* VOICE — Free Flow dictation + Realtime Michael (v0.3.4: its own tab) */}
+                  {/* VOICE —— Free Flow 听写 + Realtime Michael（v0.3.4：独立标签页） */}
                   {activeSection === 'Voice' && (
                     <>
-                      {/* Free Flow (voice dictation) */}
+                      {/* Free Flow（语音听写） */}
                       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                         <div style={sectionHeadTight}>
                           {t('settings.voice.freeFlow')}
@@ -1922,7 +1899,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                         {freeflowEnabled && (
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                            {/* Groq API key — stored in main config, used only there. */}
+                            {/* Groq API key —— 存于 main 配置，只在那里使用。 */}
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                               <span style={slackLabelStyle}>{t('settings.voice.groqKey')}</span>
                               <div style={{ display: 'flex', gap: 6 }}>
@@ -1939,7 +1916,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                               </div>
                             </label>
 
-                            {/* Model picker */}
+                            {/* 模型选择器 */}
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 4, width: 280 }}>
                               <span style={slackLabelStyle}>{t('settings.voice.model')}</span>
                               <select
@@ -1970,7 +1947,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                       <div style={sectionRule} />
 
-                      {/* Realtime Michael — voice device selection (rt-8) */}
+                      {/* Realtime Michael —— 语音设备选择（rt-8） */}
                       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                         <div style={sectionHeadTight}>
                           {t('settings.voice.realtime')}
@@ -1984,13 +1961,13 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                           </span>
                         </div>
 
-                        {/* OpenAI Realtime key — settable HERE, not just described here.
-                            This is where someone looking for voice actually lands (the Talk
-                            button deep-links to it), so sending them to another tab to type
-                            the key was a dead end dressed up as documentation. Same broker
-                            slot as Agents & Models (apikey:openai) — one key, two doorways,
-                            and saving in either flips the same gate. The value never leaves
-                            main; only the presence boolean comes back. */}
+                        {/* OpenAI Realtime key —— 在这里可设置，而不只是被描述。
+                            找语音功能的人实际会落在这里（Talk 按钮深链到此），
+                            所以把他们打发到另一个标签页去输入 key，等于把死路
+                            包装成文档。与 Agents & Models 是同一个 broker
+                            槽位（apikey:openai）——一个 key、两个入口，
+                            在任一侧保存都会翻转同一个闸门。该值从不离开
+                            main；只有存在性布尔值会回来。 */}
                         <div style={{
                           display: 'flex', flexDirection: 'column', gap: 8,
                           padding: 10,
@@ -2042,8 +2019,8 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
 
                         <RealtimeDevicePicker />
                         <CostHud />
-                        {/* rt-9 idle-tunable: how long an idle voice session stays open before
-                            it auto-closes. The spend cap remains the real runaway guard. */}
+                        {/* rt-9 空闲可调项：空闲语音会话在自动关闭前保持多久。
+                            支出上限仍是真正的失控护栏。 */}
                         <label style={{ display: 'flex', flexDirection: 'column', gap: 4, width: 280 }}>
                           <span style={slackLabelStyle}>{t('settings.voice.idleDisconnect')}</span>
                           <select
@@ -2071,7 +2048,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                     </>
                   )}
 
-                  {/* Danger — a red row at the bottom of General (was its own tab) */}
+                  {/* Danger —— General 底部的一行红色区域（曾是独立标签页） */}
                   {activeSection === 'General' && (
                     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
                       <div style={{
@@ -2092,7 +2069,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                 </div>
               </div>
 
-              {/* Footer */}
+              {/* 页脚 */}
               <div style={{
                 borderTop: '2px solid var(--cth-ink-300)',
                 padding: '10px 16px',

--- a/src/renderer/src/components/SetupPanel.tsx
+++ b/src/renderer/src/components/SetupPanel.tsx
@@ -1,19 +1,16 @@
 /**
- * PREREQUISITES — the external tools this app needs, and whether you have them.
+ * 前置依赖（PREREQUISITES）——本应用需要的外部工具，以及你是否已经拥有它们。
  *
- * Several of the harness's best features are thin wrappers over tools that live
- * OUTSIDE the app bundle: mempalace for semantic memory, uv to install it, git
- * for worktrees, one CLI per agent engine. Every one of them degrades silently
- * when missing — which is the right runtime behaviour and a terrible diagnostic
- * one, because "off" and "broken" look identical from the floor. This page is the
- * single place that distinguishes them, and the only place that says what each
- * tool actually buys you.
+ * 本 harness 的几项最佳功能，其实是对应用包之外工具的薄封装：mempalace 提供语义记忆，
+ * uv 负责安装它，git 用于 worktree，每个 agent 引擎各有一个 CLI。它们任何一个缺失时
+ * 都会静默降级——这是正确的运行时行为，却也是糟糕的排查体验，因为从 floor 上看，
+ * "关闭"和"损坏"长得一模一样。本页是唯一能区分两者的地方，也是唯一说明每个工具
+ * 到底能给你带来什么的地方。
  *
- * The primary action delegates rather than executes: installing software touches
- * the user's machine and can need a password, so the button SEEDS Michael's
- * dispatch box with an exact, verified-by-him contract instead of shelling out
- * from the renderer. The user still presses dispatch. That keeps a real
- * confirmation step in front of anything that writes outside the app.
+ * 主操作是委托而非直接执行：安装软件会动到用户的机器，可能需要密码，所以按钮是把
+ * 一条精确、经 Michael 验证过的契约 SEED（预填）进他的 dispatch 框，而不是从 renderer
+ * 直接 shell 出去。用户仍然要自己按下 dispatch。这样，任何写入应用之外的操作前面
+ * 都保留了一道真实的确认步骤。
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -50,7 +47,7 @@ function ToolRow({ tool }: { tool: ToolStatus }) {
   const copy = () => {
     void navigator.clipboard.writeText(tool.installCommand).then(
       () => { setCopied(true); setTimeout(() => setCopied(false), 1200); },
-      () => { /* clipboard denied — the text is on screen to select by hand */ }
+      () => { /* 剪贴板被拒绝——文本就在屏幕上，可手动选择 */ }
     );
   };
   return (
@@ -70,7 +67,7 @@ function ToolRow({ tool }: { tool: ToolStatus }) {
 
       <div style={{ fontSize: 12, color: 'var(--cth-ink-700)', lineHeight: 1.5 }}>{tool.why}</div>
 
-      {/* Found: show WHERE, so a "ready" claim is verifiable rather than trusted. */}
+      {/* 已找到：展示位置，让"就绪"的结论可验证而非凭空信任。 */}
       {tool.found && tool.path && (
         <div style={{
           fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-500)',
@@ -80,7 +77,7 @@ function ToolRow({ tool }: { tool: ToolStatus }) {
         </div>
       )}
 
-      {/* Missing WITH a scripted install: the exact command, one click to copy. */}
+      {/* 缺失但有脚本化安装：给出确切命令，一键复制。 */}
       {!tool.found && tool.installCommand && (
         <div style={{ display: 'flex', gap: 6, alignItems: 'stretch' }}>
           <code style={{
@@ -131,8 +128,8 @@ export function SetupPanel({ onDone }: { onDone?: () => void } = {}) {
   }, []);
   useEffect(() => { void refresh(); }, [refresh]);
 
-  // Only ESSENTIALS are handed to Michael. Installing all eight engine CLIs
-  // because they happen to be listed would be a wild overreach of one click.
+  // 只把 ESSENTIALS（必需项）交给 Michael。只因为它们碰巧被列出就把全部八个引擎 CLI
+  // 都装上，对一次点击来说越界得离谱。
   const missingEssential = useMemo(
     () => (tools ?? []).filter((t) => !t.found && t.essential),
     [tools]
@@ -142,9 +139,8 @@ export function SetupPanel({ onDone }: { onDone?: () => void } = {}) {
   const askMichael = () => {
     if (missingEssential.length === 0) return;
     requestDispatchSeed(setupPrompt(missingEssential));
-    requestCommandCenterTab('floor'); // the dispatch box lives on the monitor tab
-    // This panel lives in a modal now — leaving it open would hide the very box
-    // we just filled in.
+    requestCommandCenterTab('floor'); // dispatch 输入框在 monitor 标签页上
+    // 这个面板现在位于 modal 中——保持打开会遮住我们刚填好的那个输入框。
     onDone?.();
   };
 
@@ -164,8 +160,7 @@ export function SetupPanel({ onDone }: { onDone?: () => void } = {}) {
         </PixelButton>
       </div>
 
-      {/* The headline action. Present but disabled when nothing is missing, so the
-          page reads the same either way rather than the button vanishing. */}
+      {/* 主操作。没有缺失时以禁用态呈现，让页面两种情况下观感一致，而不是让按钮消失。 */}
       <div style={{
         padding: 10, display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap',
         background: missingEssential.length ? 'var(--cth-lemon-light)' : 'var(--cth-cream-100)',

--- a/src/renderer/src/components/SidebarSplitter.tsx
+++ b/src/renderer/src/components/SidebarSplitter.tsx
@@ -1,30 +1,32 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface SidebarSplitterProps {
-  /** Current sidebar width in px. */
+  /** 当前侧边栏宽度（px）。 */
   width: number;
-  /** Called with the new width (already clamped externally). */
+  /** 以新宽度回调（已在外部钳制到合理范围）。 */
   onChange: (px: number) => void;
-  /** Containing viewport width — used to clamp delta to a sane max. */
+  /** 容器视口宽度——用于把增量钳制到合理上限。 */
   viewportWidth: number;
   min?: number;
   max?: number;
 }
 
 /**
- * Vertical drag handle. Sits between the floor canvas (left) and the sidebar
- * (right). Drag left → wider sidebar. Cursor + pixel-stripe affordance.
+ * 垂直拖拽手柄。位于 floor 画布（左）与侧边栏（右）之间。
+ * 向左拖 → 侧边栏更宽。光标 + 像素条纹的视觉提示。
  */
 export function SidebarSplitter({
   width, onChange, viewportWidth, min = 320, max = 1200
 }: SidebarSplitterProps) {
+  const { t } = useTranslation();
   const startRef = useRef<{ clientX: number; width: number } | null>(null);
   const [active, setActive] = useState(false);
 
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
       if (!startRef.current) return;
-      const delta = startRef.current.clientX - e.clientX; // left drag = positive delta → grow sidebar
+      const delta = startRef.current.clientX - e.clientX; // 向左拖 = 正增量 → 侧边栏变宽
       const clampMax = Math.min(max, Math.max(min, viewportWidth - 360));
       const next = Math.min(clampMax, Math.max(min, startRef.current.width + delta));
       onChange(next);
@@ -55,7 +57,7 @@ export function SidebarSplitter({
         e.preventDefault();
       }}
       onDoubleClick={() => onChange(420)}
-      title="Drag to resize · double-click to reset"
+      title={t('sidebarSplitter.dragToResize')}
       style={{
         width: 10,
         cursor: 'ew-resize',
@@ -64,7 +66,7 @@ export function SidebarSplitter({
         background: active ? 'var(--cth-cream-300)' : 'transparent'
       }}
     >
-      {/* The visible 2px stripe with hash marks in the middle */}
+      {/* 中间带井字刻度的可见 2px 竖条 */}
       <div style={{
         position: 'absolute',
         top: 0, bottom: 0, left: 4,

--- a/src/renderer/src/components/SidebarTabs.tsx
+++ b/src/renderer/src/components/SidebarTabs.tsx
@@ -3,8 +3,8 @@ import { type SidebarTab } from '@/store/store';
 import { type AccentColorName } from '@/design/tokens';
 import { Icon, type IconName } from './Icon';
 
-// v0.3.4: the files tab is gone — the per-agent IDE button (header) opens the
-// full Monaco editor + file tree, which superseded the read-only browser.
+// v0.3.4: files 标签页已移除——每个 agent 的 IDE 按钮（header）会打开完整的
+// Monaco 编辑器 + 文件树，取代了原来的只读浏览器。
 const TABS: { key: SidebarTab; labelKey: string; icon: IconName }[] = [
   { key: 'terminal', labelKey: 'sidebar.terminal', icon: 'terminal' },
   { key: 'git',      labelKey: 'sidebar.git',      icon: 'code' },

--- a/src/renderer/src/components/SkillsTab.tsx
+++ b/src/renderer/src/components/SkillsTab.tsx
@@ -1,13 +1,12 @@
 /**
- * SKILLS — what the coding agents here can already do, and 1,200 more they could.
+ * SKILLS——这里的编码 agent 已经会什么，以及它们还能会的 1,200 多个。
  *
- * Two modes behind one toggle rather than two tabs: "installed" answers "why did
- * my agent just do that?", "browse" answers "what else is out there?", and they
- * share the same search box because the user's question is usually just a word.
+ * 一个开关后面有两种模式，而不是两个标签页：“installed”回答“我的 agent 刚才
+ * 为什么那样做？”，"browse" 回答“外面还有什么？”，它们共享同一个搜索框，因为
+ * 用户的问题通常只是一个词。
  *
- * Nothing here installs anything. A skill is instructions that run inside an
- * agent holding the user's tools and keys, so adding one is a decision, not a
- * click — the catalog links out and the user chooses.
+ * 这里不安装任何东西。一个 skill 是在持有用户工具和密钥的 agent 内部运行的
+ * 指令，所以添加一个是一次决定，不是一次点击——目录链接出去，由用户选择。
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,7 +17,6 @@ type Mode = 'installed' | 'browse';
 
 const PROVIDER_LABEL: Record<LocalSkill['provider'], string> = {
   claude: 'Claude Code',
-  opencode: 'OpenCode',
   codex: 'Codex'
 };
 
@@ -44,11 +42,11 @@ export function SkillsTab({ agentCwd }: { agentCwd?: string }) {
   const [owner, setOwner] = useState<string>('all');
   const [category, setCategory] = useState<string>('all');
   const [busy, setBusy] = useState(false);
-  /** Per-row action state, keyed by catalog url / local path. Keeps one row's
-   *  spinner or error from being mistaken for the whole tab failing. */
+  /** 逐行动作状态，以目录 url / 本地路径为键。避免把某一行的 spinner 或错误
+   *  误当成整个标签页失败。 */
   const [action, setAction] = useState<Record<string, { busy?: boolean; error?: string; done?: string }>>({});
-  /** Uninstall is destructive, so it is two clicks: the first arms this, the
-   *  second does it. No modal — the row itself becomes the confirmation. */
+  /** 卸载是破坏性的，所以要两次点击：第一次武装这个，第二次才执行。不用弹窗——
+   *  行本身成为确认。 */
   const [confirming, setConfirming] = useState<string | null>(null);
 
   const loadLocal = useCallback(async () => {
@@ -68,8 +66,7 @@ export function SkillsTab({ agentCwd }: { agentCwd?: string }) {
   }, [t]);
 
   useEffect(() => { void loadLocal(); }, [loadLocal]);
-  // The catalog is fetched only when the user actually opens Browse — no network
-  // call for someone who just wanted to see what is installed.
+  // 只有用户真正打开 Browse 时才获取目录——只想看已装了什么的人不做网络调用。
   useEffect(() => { if (mode === 'browse' && catalog === null) void loadCatalog(); }, [mode, catalog, loadCatalog]);
 
   const q = query.trim().toLowerCase();
@@ -101,8 +98,8 @@ export function SkillsTab({ agentCwd }: { agentCwd?: string }) {
       list = list.filter((s) =>
         s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q));
     }
-    // Bounded render: 1,200 rows in a DOM list makes the panel janky, and nobody
-    // scrolls past a few hundred. The count below always states the real total.
+    // 限制渲染：DOM 列表里放 1,200 行会让面板卡顿，而且没人会滚过几百行。
+    // 下面的数字始终说明真实总数。
     return list.slice(0, 300);
   }, [catalog, owner, category, q]);
 
@@ -121,7 +118,7 @@ export function SkillsTab({ agentCwd }: { agentCwd?: string }) {
       const res = await window.cth.skillsInstall(c.url, c.name);
       if (res.ok) {
         setAction((a) => ({ ...a, [c.url]: { done: t('skillsTab.installed') } }));
-        void loadLocal(); // the installed pane must reflect it immediately
+        void loadLocal(); // 已安装面板必须立刻反映它
       } else {
         setAction((a) => ({ ...a, [c.url]: { error: res.error } }));
       }
@@ -165,7 +162,7 @@ export function SkillsTab({ agentCwd }: { agentCwd?: string }) {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, height: '100%' }}>
-      {/* Controls */}
+      {/* 控件 */}
       <div style={{
         flexShrink: 0, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap',
         padding: 10, borderBottom: '1px solid var(--cth-ink-300)'
@@ -226,7 +223,7 @@ export function SkillsTab({ agentCwd }: { agentCwd?: string }) {
         >{busy ? t('skillsTab.loading') : t('skillsTab.refresh')}</PixelButton>
       </div>
 
-      {/* Body */}
+      {/* 主体 */}
       <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 10 }}>
         {mode === 'installed' ? (
           local === null ? <Muted>{t('skillsTab.scanning')}</Muted>
@@ -261,9 +258,9 @@ export function SkillsTab({ agentCwd }: { agentCwd?: string }) {
                       {t('skillsTab.openFolder')}
                     </button>
                     {s.scope === 'bundled' ? (
-                      // Bundled skills ship inside the app and are re-copied into
-                      // every agent on spawn, so "removing" one would silently come
-                      // back. Say that instead of offering a button that lies.
+                      // Bundled skills 随应用一起分发，每次 spawn 都会被重新复制到
+                      // 每个 agent，所以“移除”一个会在稍后悄悄复活。说明这一点，
+                      // 而不是提供一个撒谎的按钮。
                       <span style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>
                         {t('skillsTab.shipsWithApp')}
                       </span>

--- a/src/renderer/src/components/SpritePortrait.tsx
+++ b/src/renderer/src/components/SpritePortrait.tsx
@@ -7,14 +7,13 @@ const FRAME_H = PORTRAIT_H;
 
 export interface SpritePortraitProps {
   character: OfficeCharacterName;
-  /** Pixels per source pixel. Whole numbers are exact; half-steps (1.5, 2.5)
-   *  double every other row, which pixel art survives. The blit runs with
-   *  smoothing off, so nothing here is ever interpolated. */
+  /** 每源像素的像素数。整数是精确的；半步（1.5、2.5）会让每隔一行翻倍，
+   *  像素画能承受这种。blit 关闭平滑运行，所以这里永远不会被插值。 */
   scale?: number;
   background?: string;
 }
 
-/** Static standing portrait of an Office cast member (recolored LimeZu sprite). */
+/** Office 剧组角色（重着色的 LimeZu sprite）的静态站立肖像。 */
 export function SpritePortrait({
   character,
   scale = 2,
@@ -34,14 +33,12 @@ export function SpritePortrait({
       ctx.fillStyle = background;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
     }
-    paintCastPortrait(ctx, character, scale).catch(() => { /* asset load race */ });
+    paintCastPortrait(ctx, character, scale).catch(() => { /* 资源加载竞态 */ });
     return () => { cancelled = true; void cancelled; };
   }, [character, scale, background]);
 
-  // A fractional scale can land on a fractional pixel count; the canvas
-  // attributes are integers either way, so round once and use the same number
-  // for the backing store and the CSS box (a mismatch is what makes pixel art
-  // blurry).
+  // 分数缩放可能落在分数的像素数上；画布属性反正都是整数，所以只取一次整，
+  // 后端存储和 CSS 盒都用同一个数（不一致正是像素画发糊的原因）。
   const w = Math.round(FRAME_W * scale);
   const h = Math.round(FRAME_H * scale);
 

--- a/src/renderer/src/components/TaskDetailOverlay.tsx
+++ b/src/renderer/src/components/TaskDetailOverlay.tsx
@@ -3,10 +3,9 @@ import { useStore } from '@/store/store';
 import { TaskDetail, parseTasks, type HiveTask } from './TasksKanban';
 
 /**
- * App-wide host for the task detail: whoever calls store.openTaskDetail(id) —
- * a kanban card, the sticky note on an agent's strip card, a floor prop —
- * gets the SAME big overlay rendered over the office floor. Keeps its own
- * 5s ledger poll so an open detail stays fresh while the god edits cards.
+ * 任务详情的全应用范围宿主：无论谁调用 store.openTaskDetail(id)——一张看板
+ * 卡片、agent 条状卡上的便签、地板道具——都会在办公室地板上渲染出同一个大的
+ * 覆盖层。它自己维护 5 秒账本轮询，让打开中的详情在 god 编辑卡片时保持新鲜。
  */
 
 const POLL_MS = 5000;
@@ -20,10 +19,10 @@ export function TaskDetailOverlay() {
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
-    // parseTasks NORMALIZES (the ledger is a hand-written file; cards may lack
-    // dependsOn/priority/etc.) — a raw card without dependsOn crashed the
-    // detail once. Never feed TaskDetail unparsed ledger entries.
-    try { setTasks(parseTasks(await window.cth.hiveTasks())); } catch { /* keep last good */ }
+    // parseTasks 会 NORMALIZE（账本是人手写的文件；卡片可能缺少
+    // dependsOn/priority 等）——一张没有 dependsOn 的原始卡片曾让详情崩溃。
+    // 绝不要把未解析的账本条目喂给 TaskDetail。
+    try { setTasks(parseTasks(await window.cth.hiveTasks())); } catch { /* 保留最后的好数据 */ }
   }, []);
 
   useEffect(() => {
@@ -40,15 +39,14 @@ export function TaskDetailOverlay() {
   const nameFor = (id?: string): string | undefined =>
     id ? (agents.find((a) => a.id === id)?.name ?? restorable.find((a) => a.id === id)?.name ?? id) : undefined;
 
-  // Moving a card writes ONE field. Operate on the RAW ledger (the same pattern
-  // as TasksKanban.dismissTask), never on the display-parsed state: parseTasks
-  // NORMALIZES, so re-serializing it turns a hand-written `priority: "high"`
-  // into the number 3 and grafts `dependsOn: []` onto a card that spells the key
-  // `deps`. Those are real values, so they survive the merge in hive.writeTasks
-  // and land on disk — a status change quietly rewriting the god's cards.
+  // 移动卡片只写一个字段。在原始账本上操作（与 TasksKanban.dismissTask 相同的
+  // 模式），绝不要用显示解析后的状态：parseTasks 会 NORMALIZE，所以重新序列化
+  // 它会把手写的 `priority: "high"` 变成数字 3，并把 `dependsOn: []` 嫁接到
+  // 一个拼写 `deps` 键的卡片上。那些是真实值，所以它们在 hive.writeTasks 的
+  // 合并中存活并落盘——一次状态变更悄悄改写 god 的卡片。
   const move = async (status: HiveTask['status']) => {
     const next = tasks.map((t) => (t.id === task.id ? { ...t, status } : t));
-    setTasks(next); // optimistic
+    setTasks(next); // 乐观
     try {
       const result = await window.cth.hivePatchTask(task.id, { status });
       if (!result.ok) void refresh();
@@ -56,8 +54,8 @@ export function TaskDetailOverlay() {
   };
 
   const assign = () => {
-    // Route through the Command Center's dispatch box (which mails the god —
-    // the human never writes into a worker's inbox directly).
+    // 经命令中心的分发框走（它会给 god 发信——人类从不直接写进 worker 的
+    // 收件箱）。
     const st = useStore.getState();
     const god = st.agents.find((a) => a.isGod);
     if (god) st.select(god.id);

--- a/src/renderer/src/components/TasksKanban.tsx
+++ b/src/renderer/src/components/TasksKanban.tsx
@@ -8,17 +8,16 @@ import { useStore } from '@/store/store';
 import { MarkdownPreview } from '@/markdown/MarkdownPreview';
 import { useRtl } from '@/i18n/useDirection';
 
-/** A card on the task kanban. Mirrors HiveTask in the main/preload process —
- *  re-declared locally so the renderer doesn't reach into the preload package
- *  (same convention as store/config.ts). */
+/** 任务看板上的一张卡片。镜像 main/preload 进程里的 HiveTask——
+ *  在本地重新声明，这样渲染器不会伸进 preload 包
+ *  （与 store/config.ts 相同的约定）。 */
 export interface HumanQA {
   q: string;
   a?: string;
   askedAt?: string;
   answeredAt?: string;
-  /** Set when the human dismisses the ask from the ASK ME board WITHOUT
-   *  answering — the question stays on the card (history is preserved) but
-   *  openQuestion() stops returning it, so the card leaves ASK ME. */
+  /** 当人类不回答就从 ASK ME 看板撤掉这个 ask 时设置——问题仍留在卡片上
+   *  （历史被保留），但 openQuestion() 不再返回它，所以卡片离开 ASK ME。 */
   dismissedAt?: string;
 }
 
@@ -31,13 +30,13 @@ export interface HiveTask {
   dependsOn: string[];
   priority: number;
   createdAt: string;
-  /** First-class human feedback: the god appends {q} when a card needs the
-   *  human; the ASK ME view fills in {a}. Full history stays on the card. */
+  /** 一等公民的人类反馈：卡片需要人类时 god 追加 {q}；ASK ME 视图填 {a}。
+   *  完整历史留在卡片上。 */
   humanQA?: HumanQA[];
 }
 
-/** The card's currently open question for the human, if any. An entry the human
- *  dismissed (dismissedAt) counts as resolved, same as an answered one. */
+/** 卡片当前向人类打开的问题（如果有）。人类已撤掉（dismissedAt）的条目
+ *  和已回答的一样视为已解决。 */
 export function openQuestion(t: HiveTask): HumanQA | undefined {
   if (!Array.isArray(t.humanQA)) return undefined;
   for (let i = t.humanQA.length - 1; i >= 0; i--) {
@@ -47,7 +46,7 @@ export function openQuestion(t: HiveTask): HumanQA | undefined {
   return undefined;
 }
 
-/** Waiting on the human = blocked with an unanswered question on the card. */
+/** 等人类 = 卡上有未回答的问题且处于 blocked。 */
 export function waitsOnHuman(t: HiveTask): boolean {
   return t.status === 'blocked' && !!openQuestion(t);
 }
@@ -63,24 +62,27 @@ const COLUMNS: { key: Status; labelKey: string; accent: string }[] = [
 
 const POLL_MS = 5000;
 
-/** Deterministic fallback id derived from a task's content (djb2 → base36).
- *  Used for tasks lacking a valid string id so re-parsing tasks.json on every
- *  5s poll yields the SAME id — no React key churn / card remount. Unlike
- *  shortId() (random, for brand-new tasks), this never changes across polls. */
+/** 由任务内容派生的确定性回退 id（djb2 → base36）。
+ *  用于缺少合法字符串 id 的任务，这样每次 5 秒轮询重新解析 tasks.json 都会得到
+ *  同一个 id——没有 React key 抖动 / 卡片重挂载。与 shortId()（随机，用于全新
+ *  任务）不同，它在各轮轮询之间永不变。 */
 function stableId(seed: string): string {
   let h = 5381;
   for (let i = 0; i < seed.length; i++) h = (((h << 5) + h) ^ seed.charCodeAt(i)) | 0;
   return `t-${(h >>> 0).toString(36)}`;
 }
 
-/** Normalize whatever hive:tasks returns into a typed task array. The god
- *  writes this file by hand — every field except the shape itself is optional
- *  in practice, so EVERY consumer must go through this (exported for the
- *  detail overlay; a raw card without dependsOn once crashed it). */
+/** 把 hive:tasks 返回的任何东西规范成类型化的任务数组。god 手工写这个
+ *  文件——除形状本身外，每个字段实际上都是可选的，所以每个消费者都必须走
+ *  这个函数（导出给详情覆盖层用；一张没有 dependsOn 的原始卡片曾让它崩溃）。 */
 export function parseTasks(raw: unknown): HiveTask[] {
-  const list = (raw && typeof raw === 'object' && Array.isArray((raw as { tasks?: unknown }).tasks))
-    ? (raw as { tasks: unknown[] }).tasks
-    : [];
+  // 兜底裸数组形状（历史上 god 手写 tasks.json 时曾写成顶层数组）：
+  // 即使 readJson 返回裸数组，看板也照常显示，绝不静默空白。
+  const list = Array.isArray(raw)
+    ? raw
+    : (raw && typeof raw === 'object' && !Array.isArray(raw) && 'tasks' in raw && Array.isArray(raw.tasks)
+      ? raw.tasks
+      : []);
   return list
     .filter((t): t is Record<string, unknown> => !!t && typeof t === 'object')
     .map((t, i) => ({
@@ -103,8 +105,8 @@ export function parseTasks(raw: unknown): HiveTask[] {
             a: typeof e.a === 'string' ? e.a : undefined,
             askedAt: typeof e.askedAt === 'string' ? e.askedAt : undefined,
             answeredAt: typeof e.answeredAt === 'string' ? e.answeredAt : undefined,
-            // Preserve a dismissal across the 5s re-parse, else the card would
-            // resurface on the next poll (openQuestion would see it as open).
+            // 在 5 秒重新解析间保留一次撤掉，否则卡片会在下一次轮询时重新浮出
+            // （openQuestion 会把它当作打开的）。
             dismissedAt: typeof e.dismissedAt === 'string' ? e.dismissedAt : undefined
           }))
         : undefined
@@ -112,36 +114,33 @@ export function parseTasks(raw: unknown): HiveTask[] {
 }
 
 /**
- * Task kanban over hive/tasks.json — a READ surface. Polls every 5s; cards
- * carry just the title and open the app-wide detail overlay on click. The god
- * is the ledger's writer: new work enters via the dispatch box (mailed to the
- * god), never by the human inserting cards the orchestrator never heard about.
+ * 基于 hive/tasks.json 的任务看板——一个 READ 界面。每 5 秒轮询一次；卡片只
+ * 带标题，点击打开全应用范围的详情覆盖层。god 是这个账本的写者：新工作经
+ * 分发框（发给 god）进入，绝不由人类插入编排器从没听说过的工作。
  */
 export function TasksKanban() {
   const { t } = useTranslation();
   const agents = useStore((s) => s.agents);
   const [tasks, setTasks] = useState<HiveTask[]>([]);
-  // Detail view: cards show just the title — clicking one opens the full
-  // breakdown as an APP-WIDE overlay over the office floor (see
-  // TaskDetailOverlay) — the content grows (contracts, deps, human Q&A), so it
-  // gets the big stage instead of the narrow side panel.
+  // 详情视图：卡片只显示标题——点击一张会把它完整拆解成一个覆盖在办公室地板上
+  // 的全应用范围覆盖层（见 TaskDetailOverlay）——内容会增长（契约、依赖、人类
+  // 问答），所以它要的是大舞台，而不是窄侧面板。
   const openTaskDetail = useStore((s) => s.openTaskDetail);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
-    try { setTasks(parseTasks(await window.cth.hiveTasks())); } catch { /* keep last good */ }
+    try { setTasks(parseTasks(await window.cth.hiveTasks())); } catch { /* 保留最后的好数据 */ }
   }, []);
 
-  // Dismiss a card off the board (human-initiated). The kanban is otherwise the
-  // god's to write, but a person can clear a card they no longer want tracked.
-  // Main removes the named id from its latest on-disk ledger, so a webhook or
-  // god card added since this renderer's last poll cannot be lost.
+  // 把一张卡片撤下看板（人类发起）。除此之外看板是 god 写的，但人可以清掉一张
+  // 他们不再想追踪的卡片。main 从它最新的磁盘账本里移除该命名 id，所以自这次
+  // 渲染器上次轮询以来由 webhook 或 god 新增的卡片不会丢。
   const dismissTask = useCallback(async (id: string) => {
-    setTasks((prev) => prev.filter((t) => t.id !== id)); // optimistic
+    setTasks((prev) => prev.filter((t) => t.id !== id)); // 乐观
     try {
       const result = await window.cth.hiveDeleteTask(id);
       if (!result.ok) void refresh();
-    } catch { /* keep last good; the next poll re-syncs from disk */ }
+    } catch { /* 保留最后的好数据；下一次轮询会从磁盘重新同步 */ }
   }, [refresh]);
 
   useEffect(() => {
@@ -151,9 +150,8 @@ export function TasksKanban() {
   }, [refresh]);
 
   const restorableAgents = useStore((s) => s.restorableAgents);
-  /** Resolve an assignee id to a display name — falls back to the restorable
-   *  roster so a done card keeps its author's name even after that worker's
-   *  terminal is gone, then to the raw id. */
+  /** 把 assignee id 解析成显示名——回退到可恢复名单，这样一张 done 卡片即使在
+   *  那个 worker 的终端消失后也保留作者的名字，再回退到原始 id。 */
   const nameFor = (id?: string): string | undefined =>
     id
       ? (agents.find((a) => a.id === id)?.name
@@ -163,9 +161,8 @@ export function TasksKanban() {
 
   return (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--cth-paper-200)', position: 'relative' }}>
-      {/* Toolbar — read-only: the god is the ledger's writer. New work enters
-          through the dispatch box (which mails the god), not by the human
-          inserting cards the orchestrator never heard about. */}
+      {/* 工具栏——只读：god 是账本的写者。新工作经分发框（发给 god）进入，
+          而不是由人类插入编排器从没听说过的工作。 */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', flexShrink: 0,
         borderBottom: '1px solid var(--cth-ink-300)'
@@ -178,7 +175,7 @@ export function TasksKanban() {
         </span>
       </div>
 
-      {/* Columns */}
+      {/* 列 */}
       <div style={{
         flex: 1, minHeight: 0, display: 'flex', gap: 8, padding: 10, overflowX: 'auto'
       }}>
@@ -220,10 +217,9 @@ export function TasksKanban() {
   );
 }
 
-// ─── Card ────────────────────────────────────────────────────────────────────
-// Deliberately minimal — a colored status edge, the title, a whisper of an
-// assignee. Everything else (the full contract, deps, controls) lives in the
-// detail view a click away: a kanban card can carry a title at most.
+// ─── 卡片 ────────────────────────────────────────────────────────────────────
+// 刻意极简——一条彩色状态边、标题、一丝负责人信息。其它一切（完整契约、依赖、
+// 控件）都在点击可及的详情视图里：一张看板卡片最多只能承载标题。
 
 function TaskCard({ task, accent, assigneeName, onOpen, onDismiss }: {
   task: HiveTask;
@@ -268,7 +264,7 @@ function TaskCard({ task, accent, assigneeName, onOpen, onDismiss }: {
           }}>?</span>
         )}
       </button>
-      {/* Dismiss — sibling button (not nested) so it never triggers onOpen. */}
+      {/* 撤掉——兄弟按钮（不是嵌套），所以它绝不会触发 onOpen。 */}
       <button
         onClick={(e) => { e.stopPropagation(); onDismiss(); }}
         title={t('kanban.dismissTitle')}
@@ -286,14 +282,12 @@ function TaskCard({ task, accent, assigneeName, onOpen, onDismiss }: {
   );
 }
 
-// ─── Detail view ─────────────────────────────────────────────────────────────
-// The full breakdown of one task: status, assignee, priority, the complete
-// description (the god writes 4-part dispatch contracts in there — preserved
-// line by line), dependencies resolved to their titles, the human Q&A trail,
-// and the move/assign controls that used to crowd every card. Rendered as an
-// APP-WIDE overlay (over the office floor) — this content grows, so it gets
-// the big stage instead of the narrow side panel. Exported for App's
-// TaskDetailOverlay; opened via the store's openTaskDetail from anywhere.
+// ─── 详情视图 ────────────────────────────────────────────────────────────────
+// 单个任务的完整拆解：状态、负责人、优先级、完整描述（god 在那里写 4 部分的
+// 分发契约——逐行保留）、解析成标题的依赖、人类问答记录，以及过去挤在每张
+// 卡上的移动/分配控件。渲染成覆盖在办公室地板上的全应用范围覆盖层——这个
+// 内容会增长，所以它要的是大舞台，而不是窄侧面板。导出给 App 的
+// TaskDetailOverlay；从任何地方经 store 的 openTaskDetail 打开。
 
 export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose }: {
   task: HiveTask;
@@ -306,8 +300,8 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
   const { t } = useTranslation();
   const rtl = useRtl();
   const col = COLUMNS.find((c) => c.key === task.status) ?? COLUMNS[0];
-  // Belt + suspenders: parseTasks normalizes these, but the ledger is a
-  // hand-written file — never trust a card's shape at the point of use.
+  // 双保险：parseTasks 会规范这些，但账本是人手写的文件——绝不要在使用的
+  // 地方相信卡片的形状。
   const deps = (task.dependsOn ?? [])
     .map((id) => all.find((t) => t.id === id))
     .filter((t): t is HiveTask => !!t);
@@ -324,14 +318,14 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
       <div onClick={(e) => e.stopPropagation()} style={{ width: 720, maxWidth: '94vw', maxHeight: '90vh', display: 'flex' }}>
         <PixelPanel variant="dialog" title={t('kanban.taskTitle')} noPadding style={{ display: 'flex', flexDirection: 'column', width: '100%', minHeight: 0 }}>
           <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10, minHeight: 0, overflowY: 'auto' }}>
-            {/* Title under a status-colored bar */}
+            {/* 状态色条下方的标题 */}
             <div style={{ borderLeft: `4px solid ${col.accent}`, paddingLeft: 8 }}>
               <div style={{ fontFamily: 'var(--cth-font-ui)', fontSize: 15, lineHeight: '20px', color: 'var(--cth-ink-900)' }}>
                 {task.title}
               </div>
             </div>
 
-            {/* Fact row */}
+            {/* 信息行 */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
               <span style={{
                 fontFamily: 'var(--cth-font-display)', fontSize: 8, padding: '2px 6px 1px',
@@ -346,7 +340,7 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
               </span>
             </div>
 
-            {/* The contract — preserved line by line */}
+            {/* 契约——逐行保留 */}
             <div style={{
               padding: 10, background: 'var(--cth-paper-100)',
               boxShadow: 'inset 0 0 0 1px var(--cth-ink-300)',
@@ -356,9 +350,9 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
               {task.description?.trim() || <span style={{ color: 'var(--cth-ink-300)' }}>{t('kanban.noDescription')}</span>}
             </div>
 
-            {/* The human Q&A trail — every decision documented on the card.
-                Rendered as markdown (card variant), matching the ASK ME tab the
-                "view earlier answers" link arrives from. */}
+            {/* 人类问答记录——每个决定都记录在卡片上。
+                渲染成 markdown（卡片变体），与“查看更早回答”链接来自的 ASK ME
+                标签页一致。 */}
             {(task.humanQA?.length ?? 0) > 0 && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                 <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 8, color: 'var(--cth-ink-500)' }}>
@@ -399,7 +393,7 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
               </div>
             )}
 
-            {/* Dependencies, resolved to titles */}
+            {/* 依赖，解析为标题 */}
             {deps.length > 0 && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                 <div style={{ fontFamily: 'var(--cth-font-display)', fontSize: 8, color: 'var(--cth-ink-500)' }}>
@@ -421,7 +415,7 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
               </div>
             )}
 
-            {/* Controls */}
+            {/* 控件 */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <select
                 value={task.status}
@@ -450,7 +444,7 @@ export function TaskDetail({ task, all, assigneeName, onMove, onAssign, onClose 
 
 function PriorityDots({ level }: { level: number }) {
   const { t } = useTranslation();
-  // 1 = lowest, 5 = highest. Warmer fill as priority climbs.
+  // 1 = 最低，5 = 最高。优先级越高填充越暖。
   const color = level >= 4 ? 'var(--cth-coral)' : level === 3 ? 'var(--cth-lemon)' : 'var(--cth-mint)';
   return (
     <span title={t('kanban.priority', { level })} style={{ display: 'inline-flex', gap: 1, flexShrink: 0, marginTop: 2 }}>

--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -3,11 +3,10 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 
-// Cream-paper light theme — kept in sync with the tuned light palette in
-// PtyTerminalView.tsx. The old palette here used the dark-theme neon colours
-// (e.g. green #6BCF7F, yellow #FFD93D) which are near-invisible as foreground on
-// the cream background; these dark/deep inks read on cream, and the terminal's
-// `minimumContrastRatio` (below) keeps coloured backgrounds legible too.
+// 奶油纸亮色主题——与 PtyTerminalView.tsx 里调好的亮色盘保持一致。旧的
+// 调色板用了暗色主题的霓虹色（例如绿色 #6BCF7F、黄色 #FFD93D），在奶油背景上
+// 作为前景几乎不可见；这些深/浓墨色在奶油纸上可读，而终端的 `minimumContrastRatio`
+// （见下）也让彩色背景保持可读。
 const theme = {
   background: '#FCFAF0',
   foreground: '#1A1320',
@@ -35,7 +34,7 @@ const theme = {
 
 export interface TerminalViewProps {
   initialLines?: string[];
-  feed?: string[]; // appended lines (replaced each render — we diff naively)
+  feed?: string[]; // 追加的行（每次渲染都替换——我们做朴素 diff）
 }
 
 export function TerminalView({ initialLines = [], feed = [] }: TerminalViewProps) {
@@ -48,15 +47,15 @@ export function TerminalView({ initialLines = [], feed = [] }: TerminalViewProps
     if (!hostRef.current) return;
     const term = new Terminal({
       theme,
-      fontFamily: '"JetBrains Mono", "SF Mono", Menlo, monospace',
+      fontFamily: '"JetBrains Mono", "Sarasa Mono SC", ui-monospace, "SF Mono", Menlo, "PingFang SC", "Microsoft YaHei", "Noto Sans Mono CJK SC", "Noto Sans CJK SC", monospace',
       fontSize: 13,
       lineHeight: 1.0,
       cursorBlink: true,
       cursorStyle: 'block',
       scrollback: 5000,
       convertEol: true,
-      // Keep text legible on any program-set background colour (WCAG AA).
-      // See terminalPool.ts for the full rationale.
+      // 保持文字在程序设置的任何背景色上都可读（WCAG AA）。
+      // 完整理由见 terminalPool.ts。
       minimumContrastRatio: 4.5,
       allowProposedApi: true
     });
@@ -83,7 +82,7 @@ export function TerminalView({ initialLines = [], feed = [] }: TerminalViewProps
   useEffect(() => {
     const term = termRef.current;
     if (!term) return;
-    // Write only new lines beyond `writtenCount` to avoid duplicating
+    // 只写 `writtenCount` 之后的新行，避免重复写入
     const base = initialLines.length;
     const total = base + feed.length;
     if (writtenCount.current < total) {

--- a/src/renderer/src/components/ThreadsPanel.tsx
+++ b/src/renderer/src/components/ThreadsPanel.tsx
@@ -4,14 +4,14 @@ import { PixelPanel } from './PixelPanel';
 import { PixelButton } from './PixelButton';
 import { useRtl } from '@/i18n/useDirection';
 
-// Derive the message shape from the preload-exposed API so the renderer never
-// reaches across project boundaries for a type (window.cth is globally typed).
+// 从 preload 暴露的 API 推导消息形状，这样渲染器绝不会为了一个类型跨界去拿
+// （window.cth 是全局类型化的）。
 type HiveMessage = Awaited<ReturnType<Window['cth']['hiveInbox']>>[number];
 
 /**
- * Human-readable threaded view of an agent's hive inbox. Groups messages by
- * `conversation`, renders each as a collapsible thread, and lets the human reply
- * inline (sent as the "human" sender via window.cth.hiveSend).
+ * agent 的 hive 收件箱的人类可读线程视图。按 `conversation` 分组消息，把每组
+ * 渲染成一个可折叠的线程，并让人可以内联回复（通过 window.cth.hiveSend 以
+ * "human" 发送者身份发送）。
  */
 export interface ThreadsPanelProps {
   agentId: string;
@@ -43,7 +43,7 @@ function groupThreads(msgs: HiveMessage[], noSubject: string): Thread[] {
     .sort((a, b) => {
       const la = a.messages[a.messages.length - 1].created_at;
       const lb = b.messages[b.messages.length - 1].created_at;
-      return la < lb ? 1 : -1; // newest activity first
+      return la < lb ? 1 : -1; // 最新活动在前
     });
 }
 
@@ -61,7 +61,7 @@ export function ThreadsPanel({ agentId }: ThreadsPanelProps) {
       try {
         const inbox = await window.cth.hiveInbox(agentId);
         if (alive) setMessages(inbox);
-      } catch { /* keep last good state */ }
+      } catch { /* 保留最后的好状态 */ }
     };
     load();
     const timer = setInterval(load, 3000);

--- a/src/renderer/src/components/ToolWaterfall.tsx
+++ b/src/renderer/src/components/ToolWaterfall.tsx
@@ -2,11 +2,10 @@ import { useTranslation } from 'react-i18next';
 import { useAgentSpans, useFleetTelemetry, totalTokens, cacheFraction } from '@/hooks/useTelemetry';
 
 /**
- * Per-agent tool-call timeline (#7B.2) — a horizontal waterfall of tool spans
- * from live `tool_result` telemetry. Each bar is one tool call, width ∝ its
- * duration, mint=success / coral=failure. A header band shows cumulative cost
- * with the cache-vs-fresh split made visible (fixes cost bug #1.1.3). This is
- * the headline upgrade over the old bare tool-count proxy.
+ * 每个 agent 的工具调用时间线（#7B.2）——来自实时 `tool_result` 遥测的工具
+ * span 横向瀑布。每个条是一次工具调用，宽度 ∝ 其耗时，mint=成功 / coral=失败。
+ * 头部色带显示累计成本，并把缓存对比新算的拆分显式展示出来（修复成本 bug
+ * #1.1.3）。这是对旧的裸工具计数代理的一次重磅升级。
  */
 export function ToolWaterfall({ agentId }: { agentId: string }) {
   const { t } = useTranslation();
@@ -15,11 +14,11 @@ export function ToolWaterfall({ agentId }: { agentId: string }) {
   const sample = samples[agentId];
 
   const maxDur = Math.max(1, ...spans.map((s) => s.durationMs));
-  const recent = spans.slice(-60); // keep the view legible
+  const recent = spans.slice(-60); // 保持视图可读
 
   return (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--cth-paper-200)', overflow: 'hidden' }}>
-      {/* Header band: cumulative cost + cache-vs-fresh split */}
+      {/* 头部色带：累计成本 + 缓存对比新算的拆分 */}
       <div style={{
         flexShrink: 0, padding: '8px 10px', background: 'var(--cth-cream-200)',
         boxShadow: 'inset 0 -2px 0 var(--cth-ink-900)',
@@ -43,7 +42,7 @@ export function ToolWaterfall({ agentId }: { agentId: string }) {
         )}
       </div>
 
-      {/* Waterfall */}
+      {/* 瀑布 */}
       <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 10 }}>
         {recent.length === 0 && (
           <div style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>

--- a/src/renderer/src/components/UpdateBadge.tsx
+++ b/src/renderer/src/components/UpdateBadge.tsx
@@ -1,55 +1,84 @@
 /**
- * Toolbar version + update control — top-left, right next to the logo.
+ * 工具栏版本 + 更新控件——左上角，紧挨着 logo。
  *
- * Always shows the running version. When main's updater reports anything
- * interesting it grows a chip that IS the button: "v0.3.7 ready to install"
- * (click → download), "downloading 42%", "restart to update to v0.3.7"
- * (click → quitAndInstall). With nothing pending, clicking the version itself
- * runs a manual check — the old build only ever checked 30s after boot and then
- * every 6h, so there was no way to ask.
+ * 总是显示当前运行的版本。当 main 的更新器报告任何有意思的事时，它会长出一个
+ * 本身就是按钮的胶囊：“v0.3.7 可安装”（点击 → 下载）、“正在下载 42%”、
+ * “重启以更新到 v0.3.7”（点击 → quitAndInstall）。没有待办时，点击版本号本身
+ * 会跑一次手动检查——旧构建只在启动 30 秒后检查一次，然后每 6 小时一次，
+ * 所以之前没有问的途径。
  *
- * All of the "what does this state say and do" logic lives in
- * src/shared/updateState.ts so it can be unit-tested without Electron; this file
- * is wiring and pixels.
+ * 所有“这个状态说什么、做什么”的逻辑都放在 src/shared/updateState.ts，
+ * 以便在没有 Electron 的情况下做单元测试；这个文件只是接线和像素。
  */
 import { useCallback, useEffect, useState } from 'react';
-import { describeUpdate, manualDownloadUrl, manualInstallSteps, pendingVersion, reduceStatus, type UpdateStatus } from '@shared/updateState';
+import { useTranslation } from 'react-i18next';
+import { describeUpdate, manualDownloadUrl, manualInstallSteps, pendingVersion, reduceStatus, clampPercent as clampPct, type UpdateStatus } from '@shared/updateState';
 import { PixelButton } from './PixelButton';
 
 declare const __APP_VERSION__: string;
 
 export function UpdateBadge() {
+  const { t } = useTranslation();
   const [status, setStatus] = useState<UpdateStatus | null>(null);
   const [busy, setBusy] = useState(false);
   const [hover, setHover] = useState(false);
-  /** The version whose download was just started, for the "now replace the
-   *  app" notice. Local state: it is a one-off explanation, not an update state. */
+  /** 刚启动下载的那个版本，用于“现在去替换应用”的通知。局部状态：它是一次性
+   *  解释，不是一个更新状态。 */
   const [started, setStarted] = useState<string | null>(null);
-  /** Brief, positive "checked, you are current" flash after a MANUAL check that
-   *  found no update. Without it a successful check settles silently back to the
-   *  grey "latest" chip, which is indistinguishable from a click that did
-   *  nothing, and that is exactly why the badge read as broken. */
+  /** 手动检查未发现更新后，短暂、正面的“已检查，你是最新的”闪现。没有它，
+   *  一次成功的检查会安静地回到灰色“最新”胶囊，与一次点击什么也没发生无法
+   *  区分——而这正是徽章看起来坏了的原因。 */
   const [checkedOk, setCheckedOk] = useState(false);
 
   useEffect(() => {
-    // Subscribe first, then pull — main may have emitted before this window
-    // finished loading (or before a reload), and `update:current` re-serves it.
+    // 先订阅再拉取——main 可能在这个窗口加载完（或一次重载之前）就发出过，
+    // 而 `update:current` 会重新派发它。
     const off = window.cth.onUpdateStatus?.((next) => setStatus((prev) => reduceStatus(prev, next)));
     void window.cth.updateCurrent?.().then((cur) => {
       if (cur) setStatus((prev) => reduceStatus(prev, cur));
-    }).catch(() => { /* older main without the handler — the push channel still works */ });
+    }).catch(() => { /* 没有该 handler 的旧 main——推送通道仍可用 */ });
     return off;
   }, []);
 
-  // The acknowledgement is a flash, not a mode: clear it after a few seconds so
-  // the badge returns to its quiet resting state.
+  // 这个确认是一次闪现，不是一种模式：几秒后清掉，让徽章回到它安静的静止状态。
   useEffect(() => {
     if (!checkedOk) return;
     const t = setTimeout(() => setCheckedOk(false), 3500);
     return () => clearTimeout(t);
   }, [checkedOk]);
 
-  const view = describeUpdate(status, __APP_VERSION__);
+  const rawView = describeUpdate(status, __APP_VERSION__);
+  const pendingV = pendingVersion(status, __APP_VERSION__);
+  // 与 UpdatesSection 同样的模式：保留共享函数的语气/动作/忙碌，把人类可读的
+  // 标签/标题经 i18n 重新推导。
+  const view = (() => {
+    switch (status?.state) {
+      case 'downloading':
+        return { ...rawView, label: t('updateBadge.downloadingChip', { percent: clampPct(status.percent) }), title: t('updateBadge.downloadingTitle', { version: status.version, percent: clampPct(status.percent) }) };
+      case 'downloaded':
+        return { ...rawView, label: t('updateBadge.downloadedChip', { version: pendingV }), title: t('updateBadge.downloadedTitle', { version: pendingV }) };
+      case 'available':
+        return { ...rawView, label: t('updateBadge.availableChip', { version: pendingV }), title: t('updateBadge.availableTitle', { version: pendingV }) };
+      case 'available-manual':
+        return {
+          ...rawView,
+          label: t('updateBadge.manualChip', { version: pendingV }),
+          title: status.reason
+            ? t('updateBadge.manualTitleReason', { version: pendingV, reason: status.reason })
+            : t('updateBadge.manualTitle', { version: pendingV })
+        };
+      case 'checking':
+        return { ...rawView, label: t('updateBadge.checking'), title: t('updateBadge.checkingTitle', { v: __APP_VERSION__ }) };
+      case 'error':
+        return { ...rawView, label: t('updateBadge.checkFailed'), title: t('updateBadge.errorTitle', { message: status.message }) };
+      case 'not-available':
+      case 'just-updated':
+        return { ...rawView, label: t('updateBadge.latest'), title: t('updateBadge.latestTitle', { v: __APP_VERSION__ }) };
+      case 'idle':
+      default:
+        return { ...rawView, label: null, title: t('updateBadge.idleTitle', { v: __APP_VERSION__ }) };
+    }
+  })();
 
   const onClick = useCallback(async () => {
     if (view.action === 'none' || busy) return;
@@ -57,10 +86,9 @@ export function UpdateBadge() {
     try {
       if (view.action === 'check') {
         const res = await window.cth.updateCheckNow();
-        // A successful "already current" check has to say so out loud. runCheck
-        // has settled lastStatus by the time this resolves, so read it back: a
-        // no-update result flashes the acknowledgement; an available update is
-        // already loud on its own (the chip changes) so it is left alone.
+        // 一次成功的“已是最新”检查必须大声说出来。runCheck 在这解析时已经
+        // 落定了 lastStatus，所以读回来：无更新的结果闪现确认；有可用更新
+        // 本身就已经够响（胶囊会变），所以不管它。
         if (res?.ok) {
           const cur = await window.cth.updateCurrent?.();
           const st = cur?.state;
@@ -70,21 +98,21 @@ export function UpdateBadge() {
       else if (view.action === 'download') await window.cth.updateDownload();
       else if (view.action === 'restart') await window.cth.updateRestartAndInstall();
       else if (view.action === 'manual' && status) {
-        // The click IS the download. Auto-update lives in Settings.
+        // 这次点击本身就是下载。自动更新住在设置里。
         const url = manualDownloadUrl(status, window.cth.platform, window.cth.arch);
         if (url) {
           await window.cth.updateOpenRelease(url);
           setStarted(pendingVersion(status, __APP_VERSION__));
         }
       }
-    } catch { /* the emitted status carries the failure — nothing to do here */ }
+    } catch { /* 发出的状态携带着失败——这里无事可做 */ }
     setBusy(false);
   }, [view.action, busy, status]);
 
   const interactive = view.action !== 'none' && !view.busy;
-  // The chip only earns colour when it wants something: ready = mint (act on
-  // me), warn = amber (something went wrong), busy/idle stay in the titlebar's
-  // own greys so a quiet app looks exactly like it did before.
+  // 胶囊只在有所求时才配上颜色：ready = mint（来点我）、warn = amber（出了
+  // 问题）、busy/idle 留在标题栏自己的灰色里，这样安静的应用看起来和之前
+  // 一模一样。
   const chipBg =
     view.tone === 'ready' ? 'var(--cth-mint-light, #d0f0e0)'
       : view.tone === 'warn' ? 'var(--cth-amber-light, #f6e2b3)'
@@ -105,7 +133,7 @@ export function UpdateBadge() {
       onClick={() => { void onClick(); }}
       disabled={!interactive}
       title={view.title}
-      aria-label={view.label ? `${view.title}` : `Version ${__APP_VERSION__} — check for updates`}
+      aria-label={view.label ? `${view.title}` : t('updateBadge.versionCheckAria', { version: __APP_VERSION__ })}
       aria-busy={view.busy || busy}
       style={{
         display: 'inline-flex', alignItems: 'center', gap: 6,
@@ -114,7 +142,7 @@ export function UpdateBadge() {
         background: chipBg,
         border: 'none',
         borderRadius: 2,
-        // 'latest' is a quiet word after the version, not a chip asking for a click.
+        // 'latest' 是版本号后面一个安静的词，不是求点击的胶囊。
         boxShadow: view.label && view.tone !== 'idle' ? 'inset 0 0 0 1px var(--cth-ink-300)' : 'none',
         fontFamily: 'var(--cth-font-ui)',
         fontSize: 13,
@@ -132,7 +160,7 @@ export function UpdateBadge() {
       )}
     </button>
 
-    {/* Hover card: what the click does and what to do with the file, for this OS. */}
+    {/* 悬浮卡片：点击会做什么、拿到文件后怎么处理，按当前 OS 显示。 */}
     {view.action === 'manual' && hover && !started && (
       <div
         role="tooltip"
@@ -146,10 +174,10 @@ export function UpdateBadge() {
         }}
       >
         <div style={{ fontFamily: 'var(--cth-font-mono, monospace)', fontWeight: 700, fontSize: 12.5 }}>
-          Click to download v{pending}
+          {t('updateBadge.clickToDownload', { pending })}
         </div>
         <div style={{ marginTop: 4, color: 'var(--cth-ink-700)' }}>
-          Download the latest version and replace the app you have. Prefer the app to update itself? Settings &rarr; Updates.
+          {t('updateBadge.preferSelfUpdate')}
         </div>
         <div style={{
           marginTop: 8, fontFamily: 'var(--cth-font-mono, monospace)', fontSize: 9,
@@ -161,11 +189,11 @@ export function UpdateBadge() {
       </div>
     )}
 
-    {/* After the click: the download is in the browser, here is what to do next. */}
+    {/* 点击之后：下载已经在浏览器里，接下来该做什么。 */}
     {started && (
       <div
         role="dialog"
-        aria-label="Install the update"
+        aria-label={t('updateBadge.installUpdateAria')}
         className="cth-titlebar-nodrag"
         style={{
           position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 400,
@@ -176,23 +204,21 @@ export function UpdateBadge() {
         }}
       >
         <div style={{ fontFamily: 'var(--cth-font-mono, monospace)', fontWeight: 700, fontSize: 13 }}>
-          v{started} is downloading in your browser.
+          {t('updateBadge.downloading', { version: started })}
         </div>
         <div style={{ marginTop: 6, color: 'var(--cth-ink-700)' }}>
-          When it lands, quit this app and install the new version over the current one. Open it and
-          pick the same project. Your agents, memory and settings stay where they are.
+          {t('updateBadge.downloadingBody')}
         </div>
         <ol style={{ margin: '8px 0 0', paddingLeft: 18, color: 'var(--cth-ink-700)' }}>
           {steps.steps.map((t) => <li key={t}>{t}</li>)}
         </ol>
         <div style={{ display: 'flex', gap: 8, marginTop: 10, justifyContent: 'flex-end' }}>
-          <PixelButton variant="ghost" size="sm" onClick={() => setStarted(null)}>got it</PixelButton>
+          <PixelButton variant="ghost" size="sm" onClick={() => setStarted(null)}>{t('updateBadge.gotIt')}</PixelButton>
         </div>
       </div>
     )}
-    {/* A successful "you are already current" check must be visible, or it is
-        indistinguishable from a dead click. Shows only for the manual-check
-        no-update result, and auto-dismisses. */}
+    {/* 一次成功的“你已是最新”检查必须可见，否则与一次死点击无法区分。只对
+        手动检查的无更新结果显示，并自动关闭。 */}
     {checkedOk && !started && (
       <div
         role="status"
@@ -212,10 +238,10 @@ export function UpdateBadge() {
             width: 18, height: 18, borderRadius: 999,
             background: 'var(--cth-mint-light, #d0f0e0)', color: 'var(--cth-ink-900)', fontSize: 12
           }}>&#10003;</span>
-          You are on the latest version.
+          {t('updateBadge.youAreCurrent')}
         </div>
         <div style={{ marginTop: 4, color: 'var(--cth-ink-700)' }}>
-          v{__APP_VERSION__} is the newest release. Checked just now.
+          {t('updateBadge.latestChecked', { version: __APP_VERSION__ })}
         </div>
       </div>
     )}

--- a/src/renderer/src/components/UpdateToast.tsx
+++ b/src/renderer/src/components/UpdateToast.tsx
@@ -1,49 +1,44 @@
 /**
- * Auto-update toast (v0.3.4) — the visual half of the background updater.
+ * 自动更新 toast（v0.3.4）——后台更新器的可见半边。
  *
- * Main's updater (src/main/updater.ts) downloads a new release in the
- * background and pushes ONE of two states over `update:status`:
- *   - 'downloaded'        → the update is staged; offer "restart to update".
- *   - 'available-manual'  → this install can't self-update (win-portable,
- *                           updater error); offer a link to the release page.
+ * main 的更新器（src/main/updater.ts）在后台下载新版本，并通过 `update:status`
+ * 推送两种状态之一：
+ *   - 'downloaded'        → 更新已就位；提供“重启以更新”。
+ *   - 'available-manual'  → 这个安装不能自更新（win-portable、
+ *                           更新器错误）；提供到发布页的链接。
  *
- * Mirrors CompletionToast: self-contained + self-subscribing, mounted once in
- * App.tsx, renders nothing when idle. Installation is ALWAYS user-initiated —
- * "later" just hides the toast until the next app start (or the 6h re-check).
+ * 镜像 CompletionToast：自包含 + 自订阅，在 App.tsx 里挂载一次，空闲时什么
+ * 都不渲染。安装永远是用户发起的——“稍后”只是把 toast 藏到下次应用启动
+ * （或 6 小时后的重新检查）为止。
  *
- * ─── v0.4.4: "What's new" ───────────────────────────────────────────────────
- * Both states already carried `notes` (the GitHub release body) and the toast
- * dropped it on the floor, so the only notification this app ever raises said
- * nothing but a version number. It now renders a digest of that body —
- * summarizeReleaseNotes() in src/shared/releaseNotes.ts does the parsing, and
- * lives there rather than here so it can be unit-tested without a renderer.
+ * ─── v0.4.4: “有什么新内容” ─────────────────────────────────────────────────
+ * 两种状态原本都已经携带 `notes`（GitHub 发布正文），toast 却把它丢在地上，
+ * 所以这个应用唯一会弹出的通知除了版本号什么都不说。现在它渲染那段正文的摘要
+ * ——src/shared/releaseNotes.ts 里的 summarizeReleaseNotes() 负责解析，放在
+ * 那里而不是这里，是为了可以在没有渲染器的情况下做单元测试。
  *
- * Three rules this block obeys:
- *   1. No notes, no block. A release body that is missing, empty, or pure
- *      structure yields an empty digest and the toast renders EXACTLY as it did
- *      before — no orphan heading, no shifted buttons. Most bodies are like
- *      that, so this is the common path, not the edge case.
- *   2. Bounded height. The digest is capped in releaseNotes.ts AND clamped with
- *      a scroll here, because a toast that grows with the release notes is a
- *      dialog that covers the app.
- *   3. The star ask is shown AT MOST ONCE EVER, not once per release. A repeated
- *      ask is the kind of nagging that gets a notification muted, which would
- *      cost the updater its only channel. See STAR_ASK_KEY below.
+ * 这个区块遵守三条规则：
+ *   1. 没有 notes 就没有区块。缺失、为空或纯结构的发布正文会得到一个空摘要，
+ *      toast 渲染得和之前完全一样——没有孤儿标题，没有移动的按钮。多数正文
+ *      都是这样，所以这是常见路径，不是边界情况。
+ *   2. 高度有界。摘要上限在 releaseNotes.ts 里，这里再用滚动夹紧，因为一个
+ *      随发布说明增长而增长的 toast 是一个盖住应用的对话框。
+ *   3. 星标请求至多显示一次，不是每个版本一次。重复请求是那种会让通知被
+ *      静音的唠叨，那会夺走更新器唯一的渠道。参见下面的 STAR_ASK_KEY。
  *
- * No new IPC and no new network call: "read more" reuses `updateOpenRelease`
- * (the same bridge the manual state's button has always used) and the star link
- * goes through the existing `openExternal` opener.
+ * 没有新的 IPC，也没有新的网络调用：“read more”复用 `updateOpenRelease`
+ * （手动状态的按钮一直在用的同一个桥），星标链接走现有的 `openExternal` 打开器。
  */
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Icon } from '@/components/Icon';
 import { summarizeReleaseNotes } from '@shared/releaseNotes';
 import { extractDropHtml } from '@shared/releaseDrop';
 import { ReleaseDrop } from '@/components/ReleaseDrop';
 import type { UpdateStatus } from '@shared/updateState';
 
-/** The toast is the LOUD half — it only interrupts for the two states a user has
- *  to act on. Everything else (checking, available, download progress, errors)
- *  lives quietly in the toolbar badge next to the logo. */
+/** toast 是“响”的半边——只为用户必须行动的那两种状态打断。其它一切（检查中、
+ * 可用、下载进度、错误）都安静地待在徽章里，挨着 logo。 */
 type ToastStatus = Extract<UpdateStatus, { state: 'downloaded' | 'available-manual' | 'just-updated' }>;
 
 function toastable(s: UpdateStatus): ToastStatus | null {
@@ -51,79 +46,74 @@ function toastable(s: UpdateStatus): ToastStatus | null {
 }
 
 const GITHUB_REPO_URL = 'https://github.com/chaitanyagiri/munder-difflin';
-/** Only ever the `href` — the click is handled by `updateOpenRelease`, which
- *  resolves `undefined` to this same page in main. */
+/** 只作为 `href` 使用——点击由 `updateOpenRelease` 处理，它在 main 里把
+ * `undefined` 解析为这同一个页面。 */
 const GITHUB_RELEASES_URL = `${GITHUB_REPO_URL}/releases/latest`;
 
-/** One-time flag for the star ask. `cth.`-prefixed localStorage is this app's
- *  convention for renderer-only UI memory (see App.tsx's skipHivePickerOnce and
- *  design/theme.ts) — and SettingsModal's "reset & start over" clears every
- *  `cth.` key, which is right: a wiped install is a new user who has not been
- *  asked yet. It is deliberately NOT a HarnessConfig key; that file is the
- *  agent runtime's contract, hand-mirrored across main/preload/renderer, and a
- *  cosmetic nudge does not belong in it. */
+/** 星标请求的一次性标记。`cth.` 前缀的 localStorage 是这个应用对纯渲染器
+ *  UI 记忆的约定（见 App.tsx 的 skipHivePickerOnce 和 design/theme.ts）——
+ *  而 SettingsModal 的“重置并重新开始”会清掉每个 `cth.` 键，这是对的：清空
+ *  的安装就是一个还没被问过的新用户。它刻意不是一个 HarnessConfig 键；那个
+ *  文件是 agent 运行时的契约，在 main/preload/renderer 间手工镜像，一个
+ *  装饰性的提示不属于它。 */
 const STAR_ASK_KEY = 'cth.updateStarAsked';
 
 function starAskPending(): boolean {
   try {
     return window.localStorage.getItem(STAR_ASK_KEY) !== '1';
   } catch {
-    // Storage unavailable means we cannot honour "at most once, ever" — so ask
-    // zero times rather than risk asking on every single update.
+    // 存储不可用意味着我们无法兑现“至多一次，永远”——所以宁可问零次，
+    // 也不要冒着在每次更新时都问的风险。
     return false;
   }
 }
 
 function markStarAsked(): void {
-  try { window.localStorage.setItem(STAR_ASK_KEY, '1'); } catch { /* nothing to do */ }
+  try { window.localStorage.setItem(STAR_ASK_KEY, '1'); } catch { /* 无事可做 */ }
 }
 
 export function UpdateToast() {
+  const { t } = useTranslation();
   const [status, setStatus] = useState<ToastStatus | null>(null);
   const [busy, setBusy] = useState(false);
-  // Read once per window, so persisting the flag below cannot make the link
-  // vanish from under the cursor of the person currently looking at it.
+  // 每个窗口只读一次，这样下面持久化标记不会让链接从正看着它的人光标下消失。
   const [starAsk] = useState(starAskPending);
-  /** The version the ask was spent on. A version rather than a boolean because
-   *  flipping a boolean the moment we persist would yank the link out from
-   *  under the cursor of the person looking at it — this keeps it on the toast
-   *  that is showing it, and withholds it from any later one. */
+  /** 那次请求花在哪个版本上。存版本而不是布尔，因为一持久化就翻转布尔会把链接
+   *  从正看着它的人光标下拽走——用版本可以让它停在正显示它的那个 toast 上，
+   *  并从任何后来的 toast 上撤掉。 */
   const [starSpentOn, setStarSpentOn] = useState<string | null>(null);
 
   useEffect(() => window.cth.onUpdateStatus?.((next) => {
     const t = toastable(next);
-    // A non-toastable state (a re-check, say) must not erase a toast the user
-    // hasn't answered yet — only a new actionable state replaces it.
+    // 一个不可 toast 的状态（比如一次重新检查）绝不能抹掉用户还没回答的 toast
+    // ——只有新的可行动状态才替换它。
     if (t) setStatus(t);
   }), []);
 
-  // Main may have emitted before this window existed (a downloaded update
-  // from a previous session, or the dev-only MD_DROP_PREVIEW boot hook), and a
-  // push nobody was listening to is gone. Pull the last status once on mount so
-  // that state is not lost.
+  // main 可能在这个窗口存在之前就发出过（上次会话下载的更新，或仅开发用的
+  // MD_DROP_PREVIEW 启动钩子），而没人听的推送已经没了。挂载时拉一次最后状态，
+  // 这样那个状态不会丢。
   useEffect(() => {
     let alive = true;
     void window.cth.updateCurrent?.().then((cur) => {
       const t = toastable(cur);
       if (alive && t) setStatus((prev) => prev ?? t);
-    }).catch(() => { /* nothing to show */ });
+    }).catch(() => { /* 没什么可显示的 */ });
     return () => { alive = false; };
   }, []);
 
-  // Settings' hero card asks to re-open the release notes. This surface owns the
-  // last status and the drop renderer, so it answers rather than duplicating
-  // either. `updateCurrent()` is used instead of the remembered state because
-  // "later" clears the local copy while main still holds it — dismissing a
-  // release must not make it unreadable afterwards. With genuinely nothing to
-  // show (a dev build, or an install already on the newest release) the honest
-  // answer is the releases page, not an empty modal.
+  // 设置的 hero 卡片会请求重新打开发布说明。这个界面持有最后的状态和 drop
+  // 渲染器，所以由它来回应，而不是二者重复。“稍后”会清掉本地副本而 main 仍
+  // 持有它，所以用 `updateCurrent()` 而不是记住的状态——关闭一次发布绝不能让
+  // 它之后变得不可读。当真没什么可显示（开发构建，或已装最新版）时，诚实的
+  // 回答是发布页，而不是一个空弹窗。
   useEffect(() => {
     const onShow = async () => {
       try {
         const cur = await window.cth.updateCurrent();
         const t = toastable(cur);
         if (t) { setStatus(t); return; }
-      } catch { /* fall through to the page */ }
+      } catch { /* 落到页面 */ }
       void window.cth.updateOpenRelease();
     };
     window.addEventListener('cth:show-release-notes', onShow);
@@ -131,21 +121,18 @@ export function UpdateToast() {
   }, []);
 
   const notes = useMemo(() => summarizeReleaseNotes(status?.notes), [status?.notes]);
-  /** An authored <!-- drop --> block in the release body upgrades this whole
-   *  moment from a corner toast to a centered release page. Absent (every
-   *  release published so far), everything below behaves exactly as before —
-   *  the digest path stays the default, not a fallback nobody exercises. */
+  /** 发布正文里一段作者撰写的 <!-- drop --> 块，会把这一刻从角落 toast 升级成
+   *  居中的发布页。没有它（迄今发布的每个版本都没有），下面的一切行为都和之前
+   *  完全一样——摘要路径保持为默认路径，而不是一个没人走的回退。 */
   const dropHtml = useMemo(() => extractDropHtml(status?.notes), [status?.notes]);
   const version = status?.version ?? null;
-  // Shown = spent. Not "clicked" — an ask the user read and ignored is an
-  // answer too, and asking again next release is exactly what rule 3 forbids.
-  // `notes.length > 0` was standing in for "this toast has something to show".
-  // A drop-only release body digests to zero bullets while being the richest
-  // release page we ship, so it has to count too — otherwise the star ask
-  // silently disappears on exactly the releases most worth starring.
-  // A drop no longer counts. The star ask is a BUTTON, the drop has none, and
-  // spending a once-ever ask on a surface that cannot show it burns it for
-  // nothing — a drop release that wants a star authors the link in its own HTML.
+  // 显示即视为已花费。不是“已点击”——用户读过并忽略的请求也是回答，下个版本
+  // 再问正是规则 3 禁止的。
+  // `notes.length > 0` 一直代替“这个 toast 有内容可显示”。一个只有 drop 的
+  // 发布正文摘要出零个圆点，却同时是我们发布过最丰富的发布页，所以它也必须
+  // 算数——否则星标请求恰恰会在最值得加星的那些发布上静默消失。
+  // drop 不再算数。星标请求是按钮，drop 没有，把一次一次性请求花在一个没法
+  // 显示它的界面上等于白烧——想要星的 drop 发布会把自己链接写进自己的 HTML。
   const showStar = starAsk && notes.length > 0
     && (starSpentOn === null || starSpentOn === version);
   useEffect(() => {
@@ -157,13 +144,11 @@ export function UpdateToast() {
 
   if (!status) return null;
 
-  /** Close the notice FIRST, then ask main to quit and install. The quit path
-   *  raises the kill-and-quit warning when agents are running, and leaving a
-   *  "restarting…" notice on screen behind it just gives the user two things to
-   *  read. (The warning outranking every modal is a separate fix — this one is
-   *  about not asking two questions at once.) If main reports it could not quit,
-   *  the notice comes back so the user can retry; a user CANCEL of the warning
-   *  is not a failure, and the notice stays closed. */
+  /** 先关闭通知，再让 main 退出并安装。退出路径在 agent 运行时抬起
+   *  kill-and-quit 警告，而在它后面留一个“正在重启…”的通知只是让用户同时读
+   *  两样东西。（警告凌驾于每个弹窗之上是另一个修复——这个修复是关于不要一次
+   *  问两个问题。）如果 main 报告它无法退出，通知会回来让用户重试；用户对警告
+   *  点 CANCEL 不是失败，通知保持关闭。 */
   const restart = async () => {
     const prev = status;
     setBusy(true);
@@ -174,24 +159,22 @@ export function UpdateToast() {
     } catch { setStatus(prev); setBusy(false); }
   };
 
-  /** Same call the manual state's button makes: main resolves `undefined` to
-   *  the releases page and refuses any URL outside this repo. */
+  /** 与手动状态的按钮相同的调用：main 把 `undefined` 解析为发布页，并拒绝
+   *  这个 repo 之外的任何 URL。 */
   const openRelease = () => {
     void window.cth.updateOpenRelease(
       status.state === 'available-manual' ? (status.downloadUrl ?? status.url) : undefined
     );
   };
-  /** True when the release carries an installer for THIS machine, so the button
-   *  can promise a download rather than a page to go hunting on. */
+  /** 当发布为这台机器携带一个安装器时为真，这样按钮可以承诺一次下载，而不是
+   *  一个要人去翻找的页面。 */
   const hasDownload = status.state === 'available-manual' && !!status.downloadUrl;
 
-  // An authored release: hand the whole moment to the centered drop instead of
-  // the corner toast. Nothing is passed in but the content — the drop carries no
-  // app buttons, and its own links go out through the OS browser.
+  // 一段作者撰写的发布：把整个时刻交给居中的 drop，而不是角落 toast。除了
+  // 内容什么都不传——drop 不携带应用按钮，它自己的链接走操作系统浏览器出去。
   //
-  // Restart-to-install is NOT lost with the button: autoInstallOnAppQuit is off,
-  // so the update needs an explicit restart, and the title-bar UpdateBadge (and
-  // Settings -> Updates) still offer it after this is dismissed.
+  // 重启以安装并不会随按钮丢失：autoInstallOnAppQuit 是关的，所以更新需要一个
+  // 显式重启，而标题栏的 UpdateBadge（以及 设置 → 更新）在被关闭后仍然提供它。
   if (dropHtml && version) {
     return (
       <ReleaseDrop
@@ -201,7 +184,7 @@ export function UpdateToast() {
       />
     );
   }
-  // Freshly updated with nothing authored for this release: nothing to say.
+  // 刚更新完，且这次发布没有作者撰写的内容：无话可说。
   if (status.state === 'just-updated') return null;
 
   const buttonStyle: React.CSSProperties = {
@@ -231,14 +214,14 @@ export function UpdateToast() {
         <Icon name="sparkle" />
         <span style={{ fontSize: 13, color: 'var(--cth-ink-900)', fontWeight: 600 }}>
           {status.state === 'downloaded'
-            ? `Update v${status.version} downloaded`
-            : `v${status.version} is available`}
+            ? t('updateToast.downloadedTitle', { version: status.version })
+            : t('updateToast.availableTitle', { version: status.version })}
         </span>
       </div>
       <span style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-700)' }}>
         {status.state === 'downloaded'
-          ? 'Restart Munder Difflin whenever you like to apply it — nothing restarts on its own.'
-          : 'This install can’t update itself — grab the new build from the releases page.'}
+          ? t('updateToast.downloadedBody')
+          : t('updateToast.manualBody')}
       </span>
 
       {notes.length > 0 && (
@@ -247,10 +230,10 @@ export function UpdateToast() {
             fontFamily: 'var(--cth-font-display)', fontSize: 8, lineHeight: '12px',
             color: 'var(--cth-ink-500)', textTransform: 'uppercase'
           }}>
-            What’s new
+            {t('updateToast.whatsNew')}
           </div>
-          {/* The digest is already capped at ~280 chars; the clamp is the second
-              belt, for the day a release body defeats the parser. */}
+          {/* 摘要已在上限 ~280 字符；这个 clamp 是第二道保险，留给哪天发布正文
+              骗过解析器的时候。 */}
           <ul style={{
             listStyle: 'none', margin: 0, padding: '0 0 0 2px',
             maxHeight: 96, overflowY: 'auto',
@@ -271,13 +254,13 @@ export function UpdateToast() {
               href={status.state === 'available-manual' ? status.url : GITHUB_RELEASES_URL}
               onClick={(e) => { e.preventDefault(); openRelease(); }}
               style={linkStyle}
-            >Read more</a>
+            >{t('updateToast.readMore')}</a>
             {showStar && (
               <a
                 href={GITHUB_REPO_URL}
                 onClick={(e) => { e.preventDefault(); void window.cth.openExternal(GITHUB_REPO_URL); }}
                 style={linkStyle}
-              >⭐ Star us on GitHub</a>
+              >{t('updateToast.starOnGitHub')}</a>
             )}
           </div>
         </div>
@@ -288,18 +271,18 @@ export function UpdateToast() {
           onClick={() => setStatus(null)}
           style={{ ...buttonStyle, background: 'var(--cth-cream-100)' }}
         >
-          later
+          {t('updateToast.later')}
         </button>
         {status.state === 'downloaded' ? (
           <button onClick={restart} disabled={busy} style={buttonStyle}>
-            {busy ? 'restarting…' : 'restart to update'}
+            {busy ? t('updateToast.restarting') : t('updateToast.restartToUpdate')}
           </button>
         ) : (
           <button
             onClick={openRelease}
             style={buttonStyle}
           >
-            {hasDownload ? `download ${status.version}` : 'open releases'}
+            {hasDownload ? t('updateToast.downloadVersion', { version: status.version }) : t('updateToast.openReleases')}
           </button>
         )}
       </div>

--- a/src/renderer/src/components/UpdatesSection.tsx
+++ b/src/renderer/src/components/UpdatesSection.tsx
@@ -1,15 +1,14 @@
 /**
- * Settings → General → "Updates".
+ * 设置 → 通用 → “更新”。
  *
- * The toolbar already carries an update chip (UpdateBadge), but a chip that
- * stays blank when everything is fine is not somewhere you go to *ask* — and
- * "is there a new version?" is exactly the question people open Settings with.
- * This block always answers it: the version you're on, whether it's the latest,
- * and one button that names what pressing it does.
+ * 工具栏已经有一个更新胶囊（UpdateBadge），但一个一切正常时保持空白的胶囊，
+ * 不是一个你会去“问”的地方——而“有没有新版本？”正是人们打开设置时要问的问题。
+ * 这个区块总是回答它：你现在用的版本、是不是最新的，以及一个按钮，按钮上写着
+ * 按下去会做什么。
  *
- * Same status stream as the badge, same reducer, same states — only the wording
- * differs (`describeUpdateSettings` vs `describeUpdate`), so the two can never
- * disagree about what is installed.
+ * 与徽章相同的状态流、相同的 reducer、相同的状态——只是措辞不同
+ * （`describeUpdateSettings` 对比 `describeUpdate`），所以两者永远不可能对
+ * “装的是什么”产生分歧。
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -25,17 +24,17 @@ export function UpdatesSection() {
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    // Subscribe before pulling: main may have emitted while this modal was
-    // closed, and `update:current` re-serves the last known state.
+    // 先订阅再拉取：main 可能在这个弹窗关闭期间就发出过事件，而 `update:current`
+    // 会重新派发最后已知的状态。
     const off = window.cth.onUpdateStatus?.((next) => setStatus((prev) => reduceStatus(prev, next)));
     void window.cth.updateCurrent?.().then((cur) => {
       if (cur) setStatus((prev) => reduceStatus(prev, cur));
-    }).catch(() => { /* older main without the handler — the push channel still works */ });
+    }).catch(() => { /* 没有该 handler 的旧 main——推送通道仍可用 */ });
     return off;
   }, []);
 
   const view = describeUpdateSettings(status, __APP_VERSION__);
-  /** The manual path is always on offer next to the automatic one. */
+  /** 手动路径始终和自动路径并列提供。 */
   const pending = pendingVersion(status, __APP_VERSION__);
   const [manualStarted, setManualStarted] = useState<string | null>(null);
   const steps = manualInstallSteps(window.cth.platform ?? 'darwin');
@@ -47,10 +46,9 @@ export function UpdatesSection() {
     setManualStarted(pending);
   };
 
-  // The shared describeUpdateSettings() renders English prose (it also feeds the
-  // toolbar badge and the toast, which are not i18n'd yet). For THIS block we
-  // re-derive the three prose fields from the status through i18n, keeping the
-  // shared function as the single source of truth for tone/action/busy.
+  // 共享的 describeUpdateSettings() 渲染英文文案（它也喂给工具栏徽章和 toast，
+  // 而它们还没做 i18n）。对于这个区块，我们通过 i18n 从状态重新推导三个文案
+  // 字段，把共享函数作为语气/动作/忙碌状态的唯一事实来源。
   const v = __APP_VERSION__;
   const localized: { headline: string; detail: string; button: string | null } = (() => {
     switch (status?.state) {
@@ -105,10 +103,9 @@ export function UpdatesSection() {
   })();
   const viewText = { ...view, headline: localized.headline, detail: localized.detail, button: localized.button };
 
-  // Same digest the update toast renders (src/shared/releaseNotes.ts), for the
-  // same reason: the release body is already in hand, and "what would I get?"
-  // is the second question anyone asks after "is there a new version?". Only
-  // the states that carry notes have any — the rest render nothing extra.
+  // 与更新 toast 渲染的摘要相同（src/shared/releaseNotes.ts），理由也一样：
+  // 发布内容已经在手，“我能得到什么？”是继“有没有新版本？”之后每个人都会问的
+  // 第二个问题。只有带 notes 的状态才有它们——其余的不渲染额外内容。
   const notes = useMemo(
     () => summarizeReleaseNotes(status && 'notes' in status ? status.notes : undefined),
     [status]
@@ -124,7 +121,7 @@ export function UpdatesSection() {
       else if (view.action === 'open-release') {
         await window.cth.updateOpenRelease(status?.state === 'available-manual' ? status.url : undefined);
       }
-    } catch { /* the emitted status carries the failure — nothing to do here */ }
+    } catch { /* 发出的状态携带着失败——这里无事可做 */ }
     setBusy(false);
   }, [view.action, busy, status]);
 
@@ -140,8 +137,8 @@ export function UpdatesSection() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
           <span style={{
             fontSize: 13, lineHeight: '20px', color: 'var(--cth-ink-900)',
-            // Only an actionable state earns emphasis; "you're up to date" is
-            // information, not a call to action.
+            // 只有可操作的状态才配得上强调；“你已是最新”是信息，
+            // 不是行动号召。
             fontWeight: viewText.tone === 'ready' ? 600 : 400
           }}>
             {viewText.headline}
@@ -168,13 +165,11 @@ export function UpdatesSection() {
               size="sm"
               onClick={() => { void onClick(); }}
               disabled={busy || viewText.busy}
-              // The label is a phrase ("Check for updates", "Restart to update"),
-              // and this row is a flex line whose left column carries two lines of
-              // prose. Without these the button is the flexible item: it gets
-              // squeezed, the label wraps to two lines, and because the button's
-              // height comes from its size variant the second line prints straight
-              // through the bottom border. Refuse to shrink and refuse to wrap —
-              // the prose column already has minWidth: 0, so it yields instead.
+              // 标签是一个短语（“检查更新”、“重启以更新”），而这一行是 flex
+              // 行，左列承载两行文案。没有这些属性，按钮会成为弹性项：它被压缩、
+              // 标签换行成两行，而且因为按钮高度来自它的尺寸变体，第二行会直接
+              // 穿过底边框打印出来。拒绝收缩、拒绝换行——文案列已有 minWidth: 0，
+              // 所以是它让步。
               style={{ flexShrink: 0, whiteSpace: 'nowrap' }}
             >
               {viewText.button}

--- a/src/renderer/src/components/WorkersTab.tsx
+++ b/src/renderer/src/components/WorkersTab.tsx
@@ -4,15 +4,15 @@ import { PixelButton } from './PixelButton';
 import { useStore } from '@/store/store';
 
 /**
- * WORKERS — live god-triggered ephemeral Slack workers (the Phase-1 spawn loop):
- * fresh isolated worktree → does a job → replies in-thread → safe teardown. This
- * tab reads main's `liveWorkers` map (via workers:list) so a human can SEE what's
- * running and stop one by hand; it also surfaces worktrees PRESERVED at teardown
- * (held until their work integrates, then auto-GC'd) so nothing silently piles up.
+ * WORKERS——由 god 触发的实时临时 Slack worker（Phase-1 spawn 循环）：
+ * 全新隔离的 worktree → 干活 → 在主题内回复 → 安全拆除。本标签页通过
+ * workers:list 读取 main 的 `liveWorkers` 映射，让人能看到什么在运行并手动
+ * 停掉一个；它也展示拆除时被保留的 worktrees（一直持有到它们的工作被整合，
+ * 然后自动 GC），这样就不会静默堆积。
  */
 
-// Types flow from main's `workers:list` handler via the typed `window.cth` global
-// (declared in preload/index.d.ts) — derived here so there's no cross-package import.
+// 类型经类型化的 `window.cth` 全局（在 preload/index.d.ts 声明）来自 main 的
+// `workers:list` 处理器——在这里派生，以免跨包 import。
 type WorkersData = Awaited<ReturnType<typeof window.cth.listWorkers>>;
 type WorkerSnapshot = WorkersData['live'][number];
 type PreservedWorktreeSnapshot = WorkersData['preserved'][number];
@@ -71,7 +71,7 @@ export function WorkersTab() {
   const [stopping, setStopping] = useState<Record<string, boolean>>({});
 
   const refresh = useCallback(() => {
-    window.cth.listWorkers().then(setData).catch(() => { /* main not ready */ });
+    window.cth.listWorkers().then(setData).catch(() => { /* main 未就绪 */ });
   }, []);
 
   useEffect(() => {
@@ -83,7 +83,7 @@ export function WorkersTab() {
   const stop = useCallback((workerId: string) => {
     setStopping((s) => ({ ...s, [workerId]: true }));
     window.cth.stopWorker(workerId)
-      .catch(() => { /* surfaced by the row vanishing or not */ })
+      .catch(() => { /* 由行消失与否来呈现 */ })
       .finally(() => { refresh(); });
   }, [refresh]);
 
@@ -123,7 +123,7 @@ export function WorkersTab() {
                       <span title={t('workersTab.repliesToSlack')} style={{
                         fontFamily: 'var(--cth-font-mono)', fontSize: 10, color: 'var(--cth-ink-700)',
                         boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)', padding: '0 5px'
-                      }}>slack</span>
+                      }}>{t('workersTab.slack')}</span>
                     )}
                   </div>
                   <PixelButton

--- a/src/renderer/src/components/ansiText.ts
+++ b/src/renderer/src/components/ansiText.ts
@@ -1,23 +1,20 @@
 /**
- * Strip ANSI escape sequences from scraped terminal output.
+ * 从抓取的终端输出中剥离 ANSI 转义序列。
  *
- * The pty parser used to remove ONLY SGR color codes (`ESC[…m`), so every other
- * escape flavor leaked into the text the thought bubbles and desk cards show
- * (issue #141): the CLI repaints its live status line with cursor-forward moves
- * (`ESC[1C`) standing in for runs of spaces it knows are already on screen,
- * plus cursor addressing (`ESC[14;6H`) and erases — scraped, that rendered as
- * "all␛[1Cthree␛[1Cland…".
+ * pty 解析器过去只移除 SGR 颜色代码（`ESC[…m`），因此其它各种转义都会
+ * 泄漏到气泡思考和桌面卡片显示的文本里（issue #141）：CLI 用光标前移
+ * （`ESC[1C`）代替它知道已在屏幕上的空格串来重绘实时状态行，还有光标定位
+ * （`ESC[14;6H`）和擦除操作——抓取后渲染成了 "all␛[1Cthree␛[1Cland…"。
  *
- * Cursor-forward is TRANSLATED into the spaces it stands for (dropping it would
- * fuse adjacent words); everything else is control, not content, and is
- * removed: OSC strings (window title, hyperlinks), any remaining CSI (SGR,
- * cursor, erase, modes), charset selects, and whatever two-byte escape is left.
+ * 光标前移被“翻译”成它所代表的空格（丢弃它会粘合相邻单词）；其余都是控制
+ * 而非内容，一律移除：OSC 字符串（窗口标题、超链接）、任何剩余的 CSI（SGR、
+ * 光标、擦除、模式）、字符集选择，以及残留的任何两字节转义。
  */
-const CUF_RE = /\x1b\[(\d*)C/g; // cursor-forward: the TUI's stand-in for spaces
-const OSC_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g; // OSC … BEL/ST (titles, links)
-const CSI_RE = /\x1b\[[0-9;:?]*[ -/]*[@-~]/g; // any CSI: SGR, cursor, erase, modes
-const CHARSET_RE = /\x1b[()][0-9A-B]/g; // charset selects (ESC ( B …)
-const ESC2_RE = /\x1b./g; // stray two-byte escapes (ESC 7, ESC = …)
+const CUF_RE = /\x1b\[(\d*)C/g; // 光标前移：TUI 用来代替空格的写法
+const OSC_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g; // OSC … BEL/ST（标题、链接）
+const CSI_RE = /\x1b\[[0-9;:?]*[ -/]*[@-~]/g; // 任意 CSI：SGR、光标、擦除、模式
+const CHARSET_RE = /\x1b[()][0-9A-B]/g; // 字符集选择（ESC ( B …）
+const ESC2_RE = /\x1b./g; // 游离的两字节转义（ESC 7、ESC = …）
 
 export function stripAnsi(chunk: string): string {
   return chunk
@@ -29,21 +26,18 @@ export function stripAnsi(chunk: string): string {
 }
 
 /**
- * A pty write can split an escape sequence across two chunks (`ESC[3` in one
- * read, `2m` in the next). `stripAnsi` is stateless, so the head of the
- * sequence was dropped as a stray two-byte escape and the tail rendered as
- * literal text ("2m"). The stream stripper holds the unfinished tail of a
- * chunk and prepends it to the next one.
+ * pty 的写入可能把一个转义序列拆到两个 chunk 里（一个 chunk 里是 `ESC[3`，
+ * 下一个才是 `2m`）。`stripAnsi` 是无状态的，所以序列的开头会被当成游离的
+ * 两字节转义丢弃，结尾则渲染成字面文本（"2m"）。流式剥离器会保留一个 chunk
+ * 未完成的尾部，并把它接到下一个 chunk 前面。
  *
- * The carry is bounded: a lone ESC that is never completed (or an OSC string
- * that never terminates) must not buffer forever, so once the carry passes
- * MAX_CARRY it is flushed through the stateless stripper as-is.
+ * 这个暂存是有界的：一个永远无法完成的孤立 ESC（或永不终止的 OSC 字符串）
+ * 不能无限缓冲，所以一旦暂存内容超过 MAX_CARRY，就原样交给无状态剥离器冲刷。
  */
 export const MAX_CARRY = 256;
 
-// An ESC whose sequence has not reached its final byte yet: ESC alone, a CSI
-// with params/intermediates but no final, an OSC with no BEL/ST, or a bare
-// charset-select prefix.
+// 一个序列尚未到达其最终字节的 ESC：单独的 ESC、带参数/中间字节但无最终的 CSI、
+// 无 BEL/ST 的 OSC，或裸的字符集选择前缀。
 const PARTIAL_TAIL_RE = /^\x1b(?:\[[0-9;:?]*[ -/]*|\][^\x07\x1b]*|[()])?$/;
 
 export function createAnsiStripper(): (chunk: string) => string {

--- a/src/renderer/src/components/askMeOrder.ts
+++ b/src/renderer/src/components/askMeOrder.ts
@@ -1,30 +1,27 @@
 /**
- * Ordering for the ASK ME board.
+ * ASK ME 看板的排序规则。
  *
- * The board had NO comparator at all: `tasks.filter(waitsOnHuman)` rendered in
- * whatever order the cards happened to sit in a 440KB tasks.json, which is
- * roughly card-creation order across the whole file and has nothing to do with
- * when a question was asked. A question from five minutes ago could land below
- * one from three days ago, and the order shifted as unrelated cards were added.
+ * 这块看板原本根本没有比较器：`tasks.filter(waitsOnHuman)` 按卡片在
+ * 440KB 的 tasks.json 中恰好所处的顺序渲染，而这大致等于整个文件里的建卡顺序，
+ * 与问题是什么时候提出来的毫无关系。五分钟前的问题可能排到三天前的问题下面，
+ * 而且随着无关卡片的加入，顺序还会变动。
  *
- * This module is the ordering rule ONLY, kept free of every import (no React,
- * no store) so the comparator is unit-testable on its own — the same reason
- * queueDelivery.ts keeps its gate structural.
+ * 本模块只是排序规则，刻意不引入任何 import（没有 React、没有 store），
+ * 这样比较器可以独立做单元测试——queueDelivery.ts 保持其 gate 结构化也是同理。
  *
- * IMPORTANT — there are two orderings on this screen and only the OUTER one is
- * sorted here: the list of CARDS (this file). The `humanQA` array WITHIN a card
- * is a conversation history, rendered oldest-first through the "VIEW N EARLIER
- * ANSWERS" collapse, and must stay chronological. Never reverse it.
+ * 重要——这个界面有两种排序，这里只对其中“外层”的一种排序：卡片的列表（本文件）。
+ * 卡片内部的 `humanQA` 数组是对话历史，通过“查看前 N 条更早的回答”折叠
+ * 按旧到新渲染，必须保持时间顺序。切勿反转它。
  */
 
-/** The only thing the ordering needs from a card's open ask. Structural so the
- *  test does not have to construct a whole HiveTask. */
+/** 排序只需要卡片打开的那个 ask 的这几项。做成结构化类型，这样
+ *  测试不必构造完整的 HiveTask。 */
 export interface AskLike {
   askedAt?: string;
 }
 
-/** `askedAt` as epoch ms, or null when it is missing or unparseable.
- *  Never throws — a hand-edited ledger must not be able to crash the board. */
+/** `askedAt` 转成 epoch 毫秒，缺失或无法解析时为 null。
+ *  永不抛错——手工编辑的账本不能把看板搞崩。 */
 export function askedAtMs(open: AskLike | undefined): number | null {
   const raw = open?.askedAt;
   if (!raw) return null;
@@ -33,20 +30,19 @@ export function askedAtMs(open: AskLike | undefined): number | null {
 }
 
 /**
- * Newest ask first, oldest last.
+ * 最新的 ask 排最前，最旧的排最后。
  *
- * Callers pass each card's OPEN question (from `openQuestion()`), so "open"
- * is derived from the same predicate `waitsOnHuman` already uses rather than
- * being defined a second time here.
+ * 调用方传入每张卡片的 OPEN 问题（来自 `openQuestion()`），所以“open”
+ * 是从 `waitsOnHuman` 已经在用的同一个谓词推导出来的，而不是在这里再定义一遍。
  *
- * Cards whose open ask carries no parseable `askedAt` sort LAST, so a bad
- * timestamp costs that one card its position instead of throwing.
+ * 打开 ask 没有可解析 `askedAt` 的卡片排到最后，这样坏时间戳只会让那一张卡
+ * 丢位置，而不会抛错。
  */
 export function compareByNewestAsk(a: AskLike | undefined, b: AskLike | undefined): number {
   const ax = askedAtMs(a);
   const bx = askedAtMs(b);
   if (ax === null && bx === null) return 0;
-  if (ax === null) return 1;  // a has no time -> after b
-  if (bx === null) return -1; // b has no time -> after a
-  return bx - ax;             // descending
+  if (ax === null) return 1;  // a 没有时间 -> 排在 b 之后
+  if (bx === null) return -1; // b 没有时间 -> 排在 a 之后
+  return bx - ax;             // 降序
 }

--- a/src/renderer/src/components/git/CommitGraph.tsx
+++ b/src/renderer/src/components/git/CommitGraph.tsx
@@ -2,26 +2,22 @@ import { useMemo } from 'react';
 import { layoutGraph, LANE_COLORS } from './graph';
 
 /**
- * Commit history — lane rail + one line per commit.
+ * 提交历史——泳道轨道 + 每个提交一行。
  *
- * WHY THIS IS HAND-ROLLED. This used to render through the `commit-graph` npm
- * package, which cannot be made to fit a resizable sidebar:
+ * 为什么是手写的。过去通过 `commit-graph` npm 包渲染，但那个包无法塞进可
+ * 调整大小的侧栏：
  *
- *   - it positions every commit row ABSOLUTELY at a hardcoded `height: 4rem`,
- *     independent of the `commitSpacing` it lays the graph out with, so any
- *     compact spacing makes consecutive rows overlap;
- *   - it reserves a fixed `max-width: 500px` for the graph SVG regardless of how
- *     much room there actually is, so in a narrow panel the text is squeezed into
- *     whatever is left over, wraps, and collides again;
- *   - its class names carry a build hash, so the CSS needed to correct any of
- *     that is substring-matched and breaks on a version bump;
- *   - and it never showed the commit SUBJECT at all — the one field anyone
- *     actually reads a history for.
+ *   - 它把每个提交行 ABSOLUTE 定位在硬编码的 `height: 4rem` 上，与它用来
+ *     布局图的 `commitSpacing` 无关，所以任何紧凑间距都会让相邻行重叠；
+ *   - 无论实际空间有多少，它都给图形 SVG 预留固定的 `max-width: 500px`，
+ *     所以在窄面板里文本被挤进剩余空间、换行、再次碰撞；
+ *   - 它的类名带构建哈希，所以修正这些问题所需的 CSS 只能子串匹配，
+ *     版本一升就坏；
+ *   - 而且它从不显示提交的 SUBJECT——这是任何人看历史时真正会读的那个字段。
  *
- * The lane algorithm in ./graph.ts was already written for this and sitting
- * unused. Rows here are a fixed height with single-line text, the rail is sized
- * from the lanes actually in use, and everything past the rail is normal flex —
- * so it stays readable from a 240px sidebar to a full-width panel.
+ * ./graph.ts 中的泳道算法本来就是为这个写的，一直闲置着。这里的行固定高度、
+ * 单行文本，轨道根据实际使用的泳道确定尺寸，轨道之外都是普通 flex——
+ * 所以它从 240px 侧栏到全宽面板都能保持可读。
  */
 
 interface CommitLite {
@@ -36,22 +32,21 @@ interface CommitLite {
 
 export interface CommitGraphProps {
   commits: CommitLite[];
-  /** Name of the currently checked-out branch, for highlighting. */
+  /** 当前检出的分支名，用于高亮。 */
   currentBranch?: string | null;
-  /** v0.3.4: commit click → per-commit file list / diff in the IDE HISTORY pane. */
+  /** v0.3.4：点击提交 → 在 IDE HISTORY 面板中显示每个提交的文件列表 / diff。 */
   onCommitClick?: (sha: string) => void;
 }
 
-/** One line of 12px text plus breathing room. */
+/** 一行 12px 文本加上呼吸空间。 */
 const ROW_H = 24;
-/** Horizontal pitch between lanes. */
+/** 泳道之间的水平间距。 */
 const LANE_W = 13;
-/** Lanes past this are clamped into the last one: the rail is a wayfinding aid,
- *  and letting a 12-way merge push the subject off-screen trades the thing being
- *  read for the decoration beside it. */
+/** 超过这个数量的泳道会被钳制到最后一格：轨道是寻路辅助，让 12 路合并把主题
+ *  挤出屏幕，是用装饰品换掉正在读的东西。 */
 const MAX_LANES = 6;
 const DOT_R = 3.5;
-/** Corner radius where a line crosses lanes. */
+/** 线条跨泳道时的圆角半径。 */
 const BEND = 8;
 
 function relTime(ms: number): string {
@@ -63,7 +58,7 @@ function relTime(ms: number): string {
   return `${Math.round(delta / (86400 * 30))}mo`;
 }
 
-/** Strip git's decoration noise down to something chip-sized. */
+/** 把 git 的装饰噪音裁成适合芯片展示的样子。 */
 function cleanRefs(refs: string[]): string[] {
   const out: string[] = [];
   for (const raw of refs) {
@@ -95,8 +90,8 @@ export function CommitGraph({ commits, currentBranch, onCommitClick }: CommitGra
 
   return (
     <div className="cth-commit-graph" style={{ position: 'relative', minWidth: 0 }}>
-      {/* The rail is decoration: absolutely positioned and pointer-transparent so
-          it can never intercept a row click or contribute to layout width. */}
+      {/* 轨道只是装饰：绝对定位且对指针透明，因此
+          它永远不会拦截行点击，也不会贡献布局宽度。 */}
       <svg
         width={railW}
         height={height}
@@ -109,8 +104,8 @@ export function CommitGraph({ commits, currentBranch, onCommitClick }: CommitGra
           return r.parents.map((p) => {
             const j = rowIndex.get(p.sha);
             const color = LANE_COLORS[Math.min(p.lane, MAX_LANES - 1) % LANE_COLORS.length];
-            // Parent outside the fetched window: run the line to the bottom edge
-            // rather than dropping it, so the lane doesn't just stop mid-air.
+            // 父提交在已拉取的窗口之外：把线一直画到底边，而不是丢掉它，
+            // 这样泳道不会凭空断在半空中。
             if (j === undefined) {
               return (
                 <path
@@ -124,8 +119,8 @@ export function CommitGraph({ commits, currentBranch, onCommitClick }: CommitGra
             const y2 = rowY(j);
             const d = x1 === x2
               ? `M ${x1} ${y1} L ${x2} ${y2}`
-              // Straight down the child's lane, then a quarter-turn into the
-              // parent — the shape a git graph is expected to make.
+              // 沿子提交的泳道笔直向下，然后四分之一转向进入父提交——
+              // 这是 git 图形应有的形状。
               : `M ${x1} ${y1} L ${x1} ${y2 - BEND} Q ${x1} ${y2} ${x2} ${y2}`;
             return (
               <path
@@ -176,8 +171,8 @@ export function CommitGraph({ commits, currentBranch, onCommitClick }: CommitGra
               fontFamily: 'var(--cth-font-mono)', color: 'var(--cth-ink-500)', flexShrink: 0
             }}>{c.shortSha}</span>
 
-            {/* The subject is the point of the list, so it is the one thing that
-                gets the leftover width — and the only one allowed to ellipse. */}
+            {/* 主题（subject）是列表的重点，因此它是唯一获得
+                剩余宽度的东西 —— 也是唯一允许省略号截断的。 */}
             <span style={{
               flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
               color: 'var(--cth-ink-900)'

--- a/src/renderer/src/components/git/graph.ts
+++ b/src/renderer/src/components/git/graph.ts
@@ -1,7 +1,6 @@
-// Lay out a list of commits into swim lanes for a left-side graph rail.
-// We don't try to match `git log --graph` exactly — instead we walk the
-// commits top-to-bottom, assigning each one to the leftmost free lane and
-// drawing connections to its parents in the lanes they occupy.
+// 把提交列表排布成泳道，供左侧图形轨道使用。
+// 我们不打算精确复刻 `git log --graph`——而是自上而下遍历提交，把每个提交
+// 分配到最靠左的空闲泳道，并画上到其父提交（位于它们各自泳道）的连接。
 
 export interface CommitInput {
   sha: string;
@@ -10,36 +9,36 @@ export interface CommitInput {
 
 export interface CommitLayout {
   sha: string;
-  /** lane this commit's dot sits in */
+  /** 该提交的小圆点所在的泳道 */
   lane: number;
-  /** parents and the lane they live in (or -1 if not in window) */
+  /** 父提交及其所在的泳道（若不在窗口内则为 -1） */
   parents: Array<{ sha: string; lane: number }>;
 }
 
 export interface GraphLayout {
   rows: CommitLayout[];
-  /** max lane index used */
+  /** 用到的最大泳道索引 */
   maxLane: number;
 }
 
 export function layoutGraph(commits: CommitInput[]): GraphLayout {
-  // `lanes[i]` = sha that lane i is currently "expecting" as the next commit, or undefined
+  // `lanes[i]` = 泳道 i 目前「期待」作为下一个提交的 sha，或 undefined
   const lanes: (string | undefined)[] = [];
   const rows: CommitLayout[] = [];
   let maxLane = 0;
 
-  // Initially nothing is expected; lanes get populated as commits introduce parents.
+  // 一开始没有任何期待；提交引入父提交时泳道才会被填充。
   for (const c of commits) {
-    // Pick the lane for this commit
+    // 为这个提交挑选泳道
     let lane = lanes.findIndex(s => s === c.sha);
     if (lane === -1) {
-      // No descendant; allocate a fresh lane on the right of the busy area
+      // 没有后代；在忙碌区域的右侧分配一条新泳道
       lane = lanes.findIndex(s => s === undefined);
       if (lane === -1) { lane = lanes.length; lanes.push(c.sha); }
       else lanes[lane] = c.sha;
     }
-    // The commit occupies `lane`; its parents will continue in lanes.
-    // The first parent stays in our lane; additional parents go to fresh lanes.
+    // 提交占据 `lane`；它的父提交会继续留在泳道中。
+    // 第一个父提交留在我们的泳道；其余父提交去往新泳道。
     const parents: CommitLayout['parents'] = [];
     if (c.parents.length === 0) {
       lanes[lane] = undefined;
@@ -50,7 +49,7 @@ export function layoutGraph(commits: CommitInput[]): GraphLayout {
           lanes[lane] = p;
           parents.push({ sha: p, lane });
         } else {
-          // Place in new lane (leftmost free)
+          // 放到新泳道（最靠左的空闲泳道）
           let pl = lanes.findIndex(s => s === undefined);
           if (pl === -1) { pl = lanes.length; lanes.push(p); }
           else lanes[pl] = p;
@@ -58,7 +57,7 @@ export function layoutGraph(commits: CommitInput[]): GraphLayout {
         }
       }
     }
-    // Compact: trim trailing undefined lanes
+    // 压缩：去掉尾部的 undefined 泳道
     while (lanes.length > 0 && lanes[lanes.length - 1] === undefined) lanes.pop();
 
     rows.push({ sha: c.sha, lane, parents });
@@ -68,7 +67,7 @@ export function layoutGraph(commits: CommitInput[]): GraphLayout {
   return { rows, maxLane };
 }
 
-// Color cycle per lane for the rail
+// 轨道每条泳道的颜色循环
 export const LANE_COLORS = [
   'var(--cth-sky)',
   'var(--cth-lemon)',

--- a/src/renderer/src/components/memoryGraph/buildGraph.ts
+++ b/src/renderer/src/components/memoryGraph/buildGraph.ts
@@ -1,9 +1,9 @@
-// Build the memory-graph model from existing hive data — no new IPC needed.
-// Inputs come straight from the preload bridge / store:
+// 从现有 hive 数据构建记忆图模型——无需新的 IPC。
+// 输入直接来自 preload 桥 / store：
 //   - agents:   useStore(s => s.agents)
-//   - log:      window.cth.hiveLog(200)   (we read kind:'message' entries)
-//   - memories: window.cth.hiveMemory(id) per agent (only when topics are on)
-// See MEMORY_GRAPH_SPEC.md §3–§5.
+//   - log:      window.cth.hiveLog(200)   （我们读取 kind:'message' 条目）
+//   - memories: window.cth.hiveMemory(id) 每个代理各一次（仅当主题开启时）
+// 参见 MEMORY_GRAPH_SPEC.md §3–§5。
 
 import type { AccentColorName } from '@/design/tokens';
 import type { StatusKind } from '@/components/PixelBadge';
@@ -17,14 +17,14 @@ export interface AgentNode {
   accent: AccentColorName;
   status: StatusKind;
   isGod: boolean;
-  /** number of message edges touching this agent (drives node size) */
+  /** 触及该代理的消息边数量（驱动节点大小） */
   degree: number;
 }
 export interface TopicNode {
   kind: 'topic';
   id: string;
   label: string;
-  /** how many agents share the topic */
+  /** 有多少代理共享这个主题 */
   weight: number;
 }
 export interface PseudoNode {
@@ -39,9 +39,9 @@ export interface GraphEdge {
   kind: 'message' | 'topic';
   source: string;
   target: string;
-  /** message: # messages on the pair; topic: 1 */
+  /** message：该对之间的消息数；topic：1 */
   weight: number;
-  /** message edges only — direction of traffic between the pair */
+  /** 仅 message 边——该对之间流量的方向 */
   dir?: 'fwd' | 'bwd' | 'both';
   lastAct?: MessageAct;
   lastSubject?: string;
@@ -50,13 +50,13 @@ export interface GraphEdge {
 export interface GraphData {
   nodes: GraphNode[];
   edges: GraphEdge[];
-  /** topics actually shown */
+  /** 实际显示的主题 */
   topicShown: number;
-  /** total qualifying topics (for the "showing N of M" cap notice) */
+  /** 符合条件的主题总数（用于「显示 N / 共 M」的上限提示） */
   topicTotal: number;
 }
 
-/** Minimal shapes we depend on (kept loose — hiveLog is loosely typed). */
+/** 我们所依赖的最小形态（保持宽松——hiveLog 是弱类型）。 */
 export interface MinimalAgent {
   id: string;
   name: string;
@@ -85,8 +85,8 @@ function sortedPairKey(a: string, b: string): string {
 }
 
 /**
- * Assemble nodes + edges. Agent + message layer is always built; the topic
- * layer is added only when `showTopics` is set and `memories` are supplied.
+ * 组装节点 + 边。代理 + 消息层总是构建；只有当 `showTopics` 开启且提供了
+ * `memories` 时才添加主题层。
  */
 export function buildGraph(
   agents: MinimalAgent[],
@@ -96,10 +96,10 @@ export function buildGraph(
   const byId = new Map(agents.map((a) => [a.id, a]));
   const degree = new Map<string, number>();
 
-  // ── message edges: aggregate per unordered pair, remember direction + latest ─
+  // ── 消息边：按无序对聚合，记住方向 + 最新一条 ─
   interface PairAcc {
     a: string; b: string;            // a < b
-    fwd: number; bwd: number;        // a->b, b->a counts
+    fwd: number; bwd: number;        // a->b、b->a 计数
     lastTs: number; lastAct?: MessageAct; lastSubject?: string;
   }
   const pairs = new Map<string, PairAcc>();
@@ -110,7 +110,7 @@ export function buildGraph(
     if (byId.has(ep)) return ep;
     if (ep === 'broadcast') { pseudoUsed.add('broadcast'); return 'broadcast'; }
     if (ep === 'human') { pseudoUsed.add('human'); return 'human'; }
-    return null; // unknown id — skip defensively
+    return null; // 未知 id——防御性跳过
   };
 
   for (let i = 0; i < log.length; i++) {
@@ -121,7 +121,7 @@ export function buildGraph(
     if (!from || !to || from === to) continue;
 
     const key = sortedPairKey(from, to);
-    const ts = typeof e.ts === 'number' ? e.ts : i; // fall back to log order
+    const ts = typeof e.ts === 'number' ? e.ts : i; // 回退到日志顺序
     let p = pairs.get(key);
     if (!p) {
       const [a, b] = from < to ? [from, to] : [to, from];
@@ -131,7 +131,7 @@ export function buildGraph(
     if (from === p.a) p.fwd++; else p.bwd++;
     if (ts >= p.lastTs) { p.lastTs = ts; p.lastAct = e.act; p.lastSubject = e.subject; }
 
-    // degree counts agents only (pseudo nodes don't get sized)
+    // degree 只统计代理（伪节点不参与大小计算）
     if (byId.has(from)) degree.set(from, (degree.get(from) ?? 0) + 1);
     if (byId.has(to)) degree.set(to, (degree.get(to) ?? 0) + 1);
   }
@@ -139,8 +139,8 @@ export function buildGraph(
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
 
-  // agent nodes — only those that actually appear, plus god, to avoid lone dots.
-  // We include every roster agent so the floor is fully represented.
+  // 代理节点——只包含实际出现的，外加 god，以免出现孤立的小圆点。
+  // 我们包含名册中的每个代理，让地面被完整呈现。
   for (const a of agents) {
     nodes.push({
       kind: 'agent',
@@ -169,7 +169,7 @@ export function buildGraph(
     });
   }
 
-  // ── topic layer (optional) ──────────────────────────────────────────────────
+  // ── 主题层（可选）────────────────────────────────────────────────────
   let topicShown = 0;
   let topicTotal = 0;
   if (opts.showTopics && opts.memories) {

--- a/src/renderer/src/components/memoryGraph/extractTopics.ts
+++ b/src/renderer/src/components/memoryGraph/extractTopics.ts
@@ -1,33 +1,32 @@
-// Topic extraction for the memory graph — pure, dependency-free, client-side.
+// 记忆图的主题提取——纯函数、无依赖、客户端本地完成。
 //
-// Agent memory.md files are structured markdown: dated `## <date> — <title>`
-// section headers, `**bold**` key terms, bullet lists. We pull candidate topic
-// phrases from headings + bold spans, normalise them, and keep only the ones
-// mentioned by >= 2 distinct agents (shared knowledge is the interesting signal;
-// an agent's solo notes aren't a hive-wide "topic"). See MEMORY_GRAPH_SPEC.md §5.
+// 代理的 memory.md 文件是结构化的 markdown：带日期的 `## <date> — <title>`
+// 小节标题、`**bold**` 关键词、无序列表。我们从标题 + 加粗片段中抽取候选主题
+// 短语，进行规范化，只保留被 >= 2 个不同代理提到的那些（共享知识才是有趣的
+// 信号；某个代理的私人笔记不是 hive 级别的「主题」）。参见 MEMORY_GRAPH_SPEC.md §5。
 //
-// This is deliberately heuristic, not semantic — MemPalace (searchMemory) owns
-// the semantic side and returns ranked snippets per query, not an enumerable set.
+// 这刻意是启发式的，不是语义式的——MemPalace（searchMemory）负责语义侧，
+// 并且按查询返回排名的片段，而不是一个可枚举的集合。
 
 export interface Topic {
-  /** stable node id, e.g. "topic:landing page redesign" */
+  /** 稳定的节点 id，例如 "topic:landing page redesign" */
   id: string;
-  /** human-facing label (first-seen original casing) */
+  /** 面向人类显示的标签（首次出现时的原始大小写） */
   label: string;
-  /** ids of agents whose memory mentions this topic */
+  /** 记忆里提到过这个主题的代理的 id */
   agentIds: string[];
-  /** = agentIds.length; how many agents share it */
+  /** = agentIds.length；有多少代理共享它 */
   weight: number;
 }
 
 export interface TopicResult {
-  /** topics sorted by weight desc, then label — already capped to `max` */
+  /** 主题按 weight 降序、再按 label 排序——已按 `max` 封顶 */
   topics: Topic[];
-  /** total number of qualifying topics (weight >= 2) before the cap */
+  /** 达到上限之前符合条件的主题总数（weight >= 2） */
   total: number;
 }
 
-// Generic words/phrases that show up as headings or bold but aren't real topics.
+// 会作为标题或加粗出现、但并非真正主题的通用词/短语。
 const STOP = new Set([
   'update', 'updates', 'done', 'note', 'notes', 'next', 'open', 'todo', 'todos',
   'fixed', 'resolved', 'wip', 'status', 'context', 'memory', 'summary', 'decision',
@@ -35,23 +34,23 @@ const STOP = new Set([
   'why', 'how', 'what', 'gap', 'gaps', 'needed', 'open / next', 'important', 'fact', 'facts'
 ]);
 
-/** Strip a leading `YYYY-MM-DD —`/`-`/`:` date prefix from a heading tail. */
+/** 去掉标题尾部开头的 `YYYY-MM-DD —`/`-`/`:` 日期前缀。 */
 function stripDatePrefix(s: string): string {
   return s.replace(/^\s*\d{4}-\d{2}-\d{2}\s*[—\-:·]*\s*/, '');
 }
 
-/** Lowercase, collapse whitespace, drop surrounding markup/punctuation. */
+/** 转小写、压缩空白、去掉周围的标记/标点。 */
 function normalise(raw: string): string {
   return raw
-    .replace(/[`*_~]/g, '')           // strip inline md markup
-    .replace(/\(.*?\)/g, '')          // drop parentheticals
-    .replace(/[#:.,;!?]+$/g, '')      // trailing punctuation
+    .replace(/[`*_~]/g, '')           // 去掉内联 md 标记
+    .replace(/\(.*?\)/g, '')          // 去掉括号内容
+    .replace(/[#:.,;!?]+$/g, '')      // 尾部标点
     .replace(/\s+/g, ' ')
     .trim()
     .toLowerCase();
 }
 
-/** Pull raw candidate phrases out of one memory file's markdown. */
+/** 从一个记忆文件的 markdown 中抽取原始候选短语。 */
 function candidatesFrom(markdown: string): string[] {
   const out: string[] = [];
   for (const line of markdown.split('\n')) {
@@ -65,18 +64,18 @@ function candidatesFrom(markdown: string): string[] {
 function isUsable(norm: string): boolean {
   if (norm.length < 3 || norm.length > 40) return false;
   if (STOP.has(norm)) return false;
-  if (/^[\d\s\-—.]+$/.test(norm)) return false;   // pure numbers/dates
-  if (!/[a-z]/.test(norm)) return false;          // must contain letters
+  if (/^[\d\s\-—.]+$/.test(norm)) return false;   // 纯数字/日期
+  if (!/[a-z]/.test(norm)) return false;          // 必须包含字母
   return true;
 }
 
 /**
- * Build the shared-topic set across all agents' memory files.
- * @param memories agentId -> raw memory.md text
- * @param max      cap on returned topics (default 24, per spec)
+ * 构建所有代理记忆文件中的共享主题集合。
+ * @param memories agentId -> 原始 memory.md 文本
+ * @param max      返回主题的上限（默认 24，按规范）
  */
 export function extractTopics(memories: Record<string, string>, max = 24): TopicResult {
-  // normalised topic -> { display label, set of agent ids }
+  // 规范化主题 -> { 显示标签, 代理 id 集合 }
   const acc = new Map<string, { label: string; agents: Set<string> }>();
 
   for (const [agentId, text] of Object.entries(memories)) {

--- a/src/renderer/src/components/memoryGraph/forceLayout.ts
+++ b/src/renderer/src/components/memoryGraph/forceLayout.ts
@@ -1,27 +1,26 @@
-// Tiny deterministic force-directed layout — Fruchterman–Reingold with mild
-// centre gravity. No dependency (d3-force isn't in node_modules and the project
-// keeps deps lean); for < 100 nodes a fixed-iteration integrator is plenty.
-// See MEMORY_GRAPH_SPEC.md §6.
+// 微型确定性力导向布局——带轻微向心引力的 Fruchterman–Reingold。
+// 无依赖（d3-force 不在 node_modules 中，项目保持依赖精简）；对于 < 100 个节点，
+// 固定迭代次的积分器绰绰有余。参见 MEMORY_GRAPH_SPEC.md §6。
 //
-// Deterministic: nodes are seeded on a phyllotaxis spiral by index (no Math.random),
-// so the graph doesn't reshuffle between polls. Pinned nodes (dragged) stay fixed
-// and the rest relax around them.
+// 确定性：节点按索引布置在向日葵（phyllotaxis）螺旋上（无 Math.random），
+// 因此图不会在两次轮询之间重新洗牌。被钉住的节点（拖动过）保持固定，
+// 其余节点围绕它们松弛下来。
 
 export interface LayoutNode {
   id: string;
-  /** extra centre-pull multiplier (god reads as the hub) */
+  /** 额外的向心拉力倍数（god 被当作枢纽） */
   gravityBias?: number;
 }
 export interface LayoutEdge {
   source: string;
   target: string;
-  /** spring strength multiplier (topic edges pull weaker) */
+  /** 弹簧强度倍数（topic 边拉得更弱） */
   strength?: number;
 }
 export interface LayoutOpts {
   width: number;
   height: number;
-  /** fixed positions for dragged/pinned nodes */
+  /** 被拖动/钉住的节点的固定位置 */
   pinned?: Record<string, { x: number; y: number }>;
   iterations?: number;
   padding?: number;
@@ -29,9 +28,9 @@ export interface LayoutOpts {
 
 export type Positions = Map<string, { x: number; y: number }>;
 
-const GOLDEN_ANGLE = 2.399963229728653; // radians
+const GOLDEN_ANGLE = 2.399963229728653; // 弧度
 
-/** Deterministic seed: phyllotaxis spiral centred in the frame. */
+/** 确定性种子：以帧为中心的向日葵螺旋。 */
 function seed(ids: string[], cx: number, cy: number, radius: number): Positions {
   const pos: Positions = new Map();
   const n = Math.max(1, ids.length);
@@ -59,12 +58,12 @@ export function forceLayout(
   const usableR = Math.max(40, Math.min(width, height) / 2 - padding);
   const pos = seed(ids, cx, cy, usableR);
 
-  // honour pins from the start
+  // 从一开始就尊重钉住的位置
   for (const id of ids) if (pinned[id]) pos.set(id, { ...pinned[id] });
 
   if (ids.length <= 1) return pos;
 
-  // Fruchterman–Reingold ideal edge length, scaled down so labels have room.
+  // Fruchterman–Reingold 理想边长，缩小一些以便给标签留空间。
   const area = width * height;
   const k = Math.sqrt(area / ids.length) * 0.55;
   const k2 = k * k;
@@ -74,12 +73,12 @@ export function forceLayout(
   const disp = new Map<string, { x: number; y: number }>(ids.map((id) => [id, { x: 0, y: 0 }]));
 
   let temp = Math.min(width, height) * 0.12;
-  const cool = Math.pow(0.02, 1 / iterations); // temp → ~2% of start by the end
+  const cool = Math.pow(0.02, 1 / iterations); // 结束时温度 → 约为起始的 2%
 
   for (let it = 0; it < iterations; it++) {
     for (const id of ids) { const d = disp.get(id)!; d.x = 0; d.y = 0; }
 
-    // repulsion — every pair pushes apart (O(n²), fine at this scale)
+    // 斥力——每对都相互推开（O(n²)，这个规模下没问题）
     for (let i = 0; i < ids.length; i++) {
       const pi = pos.get(ids[i])!;
       const di = disp.get(ids[i])!;
@@ -98,7 +97,7 @@ export function forceLayout(
       }
     }
 
-    // attraction — edges pull their endpoints together
+    // 引力——边把两端拉到一起
     for (const e of edges) {
       const ps = pos.get(e.source);
       const pt = pos.get(e.target);
@@ -115,7 +114,7 @@ export function forceLayout(
       dt.x += ux * force; dt.y += uy * force;
     }
 
-    // mild gravity toward centre keeps disconnected nodes on-screen
+    // 轻微的向心引力让断开的节点保持在屏幕内
     for (const id of ids) {
       const p = pos.get(id)!;
       const d = disp.get(id)!;
@@ -124,7 +123,7 @@ export function forceLayout(
       d.y += (cy - p.y) * g;
     }
 
-    // integrate (skip pinned), clamp step by temperature, keep in frame
+    // 积分（跳过钉住的），按温度钳制位移，保持在帧内
     for (const id of ids) {
       if (pinned[id]) { pos.set(id, { ...pinned[id] }); continue; }
       const p = pos.get(id)!;

--- a/src/renderer/src/components/termColor.ts
+++ b/src/renderer/src/components/termColor.ts
@@ -1,18 +1,16 @@
 /**
- * Colour helpers for the terminal's OSC 10/11 replies.
+ * 终端 OSC 10/11 回复的颜色辅助函数。
  *
- * Free of xterm and of every browser global on purpose, so the parsing rules are
- * unit-testable. `terminalPool.ts` itself cannot be loaded in a test: it imports
- * xterm, which touches `self`. Same reasoning as `hooks/queueDelivery.ts` and
- * `store/focusMode.ts`.
+ * 刻意不依赖 xterm 和任何浏览器全局，以便解析规则可以做单元测试。
+ * `terminalPool.ts` 本身无法在测试中加载：它 import 了 xterm，而 xterm 会碰
+ * `self`。与 `hooks/queueDelivery.ts` 和 `store/focusMode.ts` 同理。
  */
 
 /**
- * `#rgb` or `#rrggbb` to [r, g, b], or null for anything else.
+ * `#rgb` 或 `#rrggbb` 转 [r, g, b]，其它任何形式返回 null。
  *
- * Null means "stay silent". Answering an OSC colour query with a guess is worse
- * than not answering at all, because the TUI then styles itself confidently
- * wrong, which is the exact failure this code exists to fix.
+ * null 表示“保持沉默”。用猜测回答 OSC 颜色查询比完全不回答更糟，因为 TUI 会
+ * 因此自信地用错误的样式呈现自己——这正是这段代码存在要修复的故障。
  */
 export function parseHexColor(hex: string): [number, number, number] | null {
   const m = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
@@ -22,8 +20,8 @@ export function parseHexColor(hex: string): [number, number, number] | null {
 }
 
 /**
- * The body of an OSC 10/11 reply for a colour, in xterm's 16-bit-per-channel
- * form. Doubling each byte is the conventional widening, so 0x1a becomes 0x1a1a.
+ * 某种颜色的 OSC 10/11 回复正文，采用 xterm 的每通道 16 位形式。
+ * 把每个字节翻倍是常规的加宽方式，所以 0x1a 变成 0x1a1a。
  */
 export function oscColorBody(rgb: [number, number, number]): string {
   const wide = (v: number) => v.toString(16).padStart(2, '0').repeat(2);
@@ -31,16 +29,15 @@ export function oscColorBody(rgb: [number, number, number]): string {
 }
 
 /**
- * Is this background colour a dark one?
+ * 这个背景色是深色吗？
  *
- * Used to answer "which theme are we?" for a program that just enabled DEC 2031,
- * where the only thing we hold is the palette itself. Rec. 601 luma, which is
- * good enough for a light/dark split and does not need the full sRGB transfer
- * curve.
+ * 用于回答“我们现在是哪个主题？”，当程序刚启用 DEC 2031、而我们手上只有
+ * 调色板本身的时候。采用 Rec. 601 亮度，足以区分明暗，不需要完整的 sRGB
+ * 传递曲线。
  */
 export function isDarkBackground(hex: string): boolean {
   const rgb = parseHexColor(hex);
-  if (!rgb) return true; // unknown: assume dark, the safer default for a terminal
+  if (!rgb) return true; // 未知：假定深色，对终端来说是更稳妥的默认值
   const [r, g, b] = rgb;
   return (0.299 * r + 0.587 * g + 0.114 * b) < 128;
 }

--- a/src/renderer/src/components/terminalAutomation.ts
+++ b/src/renderer/src/components/terminalAutomation.ts
@@ -1,5 +1,5 @@
-/** Slash commands that open an interactive picker/panel instead of starting a
- * normal agent turn. Automated queue delivery must wait until that UI closes. */
+/** 会打开交互式选择器/面板而不是开始一次普通 agent 回合的斜杠命令。
+ * 自动化队列投递必须等到该 UI 关闭为止。 */
 const INTERACTIVE_COMMANDS = new Set([
   '/model',
   '/reasoning',
@@ -19,43 +19,40 @@ const INTERACTIVE_COMMANDS = new Set([
 ]);
 
 export function opensInteractiveTerminalUi(input: string): boolean {
-  // Only a BARE command opens a picker. `/model` prompts you to choose;
-  // `/model sonnet` applies the argument and returns to the prompt with no UI
-  // to close. Matching on the first token alone latched the block on the second
-  // form too, and nothing could ever clear it — the agent's message queue then
-  // silently stopped delivering for the rest of the session.
+  // 只有裸命令才会打开选择器。`/model` 会提示你选择；
+  // `/model sonnet` 应用参数并回到提示符，没有任何 UI 需要关闭。
+  // 只按第一个 token 匹配会把第二种形式也锁死，而没有任何东西能清除它——
+  // 于是该 agent 的消息队列在本会话余下的时间里静默停止投递。
   const trimmed = input.trim().toLowerCase();
   if (/\s/.test(trimmed)) return false;
   return INTERACTIVE_COMMANDS.has(trimmed);
 }
 
-/** Follow output only if the user was already at (or one line from) the bottom.
- * This keeps live TUIs visible without yanking someone reading scrollback. */
+/** 只有当用户已经位于底部（或离底部一行以内）时才跟随输出。
+ * 这样既能保持实时 TUI 可见，又不会把正在读滚动缓冲的人拽走。 */
 export function shouldFollowTerminalOutput(viewportY: number, baseY: number): boolean {
   return baseY - viewportY <= 1;
 }
 
-/** How long an untouched draft on the prompt keeps blocking queue delivery.
+/** 提示符上一个未被触碰的草稿会阻塞队列投递多久。
  *
- * The block exists so automation can't fuse its text onto a half-written line.
- * It still has to expire, because the flag is set from KEYSTROKES and a TUI that
- * swallows keys for its own UI can leave it set while the prompt is visibly
- * empty — a phantom draft, which wedged the queue for the rest of the session.
+ * 这个阻塞存在，是为了让自动化不会把自己的文本拼接到半截写了一半的行上。
+ * 它仍必须过期，因为该标记是由按键设置的，而一个把按键吞进自己 UI（如菜单、
+ * 确认框）的 TUI 可能在提示符明显为空时仍让标记置位——一个幽灵草稿，把队列
+ * 卡住直到本会话结束。
  *
- * Half an hour, not a minute. The old 60s window fired while the user had merely
- * paused to think, and treating a real draft as abandoned is the expensive
- * mistake; leaving a queued message parked a while longer is the cheap one. When
- * it does fire, delivery simply types after the existing text (the two fuse into
- * one prompt) — automation never deletes what the user wrote. */
+ * 半小时，而不是一分钟。旧的 60 秒窗口会在用户只是停下来思考时触发，把真实
+ * 草稿当成废弃是代价高昂的错误；把排队消息多停一会儿是廉价的选择。当真触发时，
+ * 投递只是在现有文本后面继续输入（二者拼成同一个提示）——自动化从不删除用户写
+ * 的内容。 */
 export const STALE_INPUT_MS = 1_800_000;
 
-/** How long an untouched picker keeps blocking queue delivery.
- * The picker latch is set when the user submits a bare `/model`-style command
- * and is cleared by an Enter, Escape or Ctrl-C typed into that terminal — so a
- * picker closed any other way leaves it set with no path back. Same half hour,
- * same reason: it is the user's menu, so wait a long time, then deliver. We
- * never send Escape ourselves; closing someone's open menu to make room for a
- * queued message is not ours to do. */
+/** 未被触碰的选择器会阻塞队列投递多久。
+ * 选择器锁存是在用户提交裸 `/model` 风格命令时设置的，并由在该终端输入的
+ * Enter、Escape 或 Ctrl-C 清除——因此以其它任何方式关闭的选择器会留下锁存，
+ * 且没有回来的路径。同样半小时、同理：这是用户的菜单，所以要等很久，然后才
+ * 投递。我们从不自己发送 Escape；关闭某人打开的菜单来给一条排队消息腾地方，
+ * 不是我们该做的事。 */
 export const STALE_PICKER_MS = 1_800_000;
 
 export interface TerminalAutomationState {
@@ -63,11 +60,11 @@ export interface TerminalAutomationState {
   pickerOpen: boolean;
   inputDirty: boolean;
   settleUntil: number;
-  inputDirtyAt?: number; // last keystroke that left a draft; absent ⇒ never expires
-  pickerOpenedAt?: number; // when the picker latched; absent ⇒ never expires
+  inputDirtyAt?: number; // 留下草稿的最后一次按键；缺省 ⇒ 永不过期
+  pickerOpenedAt?: number; // 选择器锁存的时刻；缺省 ⇒ 永不过期
 }
 
-/** A picker nobody has interacted with for STALE_PICKER_MS is treated as gone. */
+/** 一个超过 STALE_PICKER_MS 无人交互的选择器视为已消失。 */
 export function isStaleTerminalPicker(
   state: TerminalAutomationState,
   now = Date.now()
@@ -77,10 +74,10 @@ export function isStaleTerminalPicker(
     && now - state.pickerOpenedAt >= STALE_PICKER_MS;
 }
 
-/** Why automation may not own the prompt right now, or null when it may. */
+/** 为什么自动化此刻可能不能拥有提示符，或者当它可以时为 null。 */
 export type TerminalAutomationBlock = 'exited' | 'picker' | 'draft' | 'settling' | null;
 
-/** A draft nobody has touched for STALE_INPUT_MS is treated as abandoned. */
+/** 一个超过 STALE_INPUT_MS 无人触碰的草稿视为已废弃。 */
 export function isStaleTerminalDraft(
   state: TerminalAutomationState,
   now = Date.now()
@@ -101,7 +98,7 @@ export function terminalAutomationBlock(
   return null;
 }
 
-/** Automatic writes may own the prompt only when no user draft or picker does. */
+/** 只有没有用户草稿或选择器占用时，自动写入才能拥有提示符。 */
 export function canAutomateTerminal(
   state: TerminalAutomationState,
   now = Date.now()

--- a/src/renderer/src/components/terminalFontSize.ts
+++ b/src/renderer/src/components/terminalFontSize.ts
@@ -1,14 +1,12 @@
 import { useSyncExternalStore } from 'react';
 
-/** The terminal zoom level, shared by every component that should scale with it.
+/** 终端缩放级别，由每个应随之缩放的组件共享。
  *
- *  It used to be component-local state inside PtyTerminalView, persisted to
- *  localStorage. That kept the xterm panes in sync only because each one read the
- *  stored value at mount — anything OUTSIDE the terminal (notably the message
- *  composer) could not follow the user's Cmd +/- at all, so on a large display the
- *  terminal text grew while the box you type into stayed at its hardcoded 13px.
- *  Holding the value in one module with subscribers makes the zoom a first-class
- *  app-wide setting: PtyTerminalView writes it, anyone can read it live. */
+ *  它以前是 PtyTerminalView 内部的组件局部状态，持久化到 localStorage。
+ *  这样 xterm 面板只因为在挂载时各自读取存储值而保持同步——终端之外的任何东西
+ *  （尤其是消息编辑器）根本无法跟随用户的 Cmd +/-，于是大屏上终端文字变大了，
+ *  而输入框仍停留在写死的 13px。把值放在一个带订阅者的模块里，让缩放成为
+ *  一等公民的全局设置：PtyTerminalView 写入它，任何人都能实时读取。 */
 
 export const DEFAULT_TERMINAL_FONT_SIZE = 12;
 export const MIN_TERMINAL_FONT_SIZE = 8;
@@ -31,8 +29,8 @@ export function getTerminalFontSize(): number {
   return current;
 }
 
-/** Set the shared zoom level (clamped) and persist it. No-op when unchanged, so
- *  a redundant set can't churn every subscriber's effects. */
+/** 设置共享缩放级别（受限）并持久化。未变化时是 no-op，这样
+ *  重复的 set 不会搅动每个订阅者的 effect。 */
 export function setTerminalFontSize(next: number): number {
   const clamped = Math.min(MAX_TERMINAL_FONT_SIZE, Math.max(MIN_TERMINAL_FONT_SIZE, Math.round(next)));
   if (clamped === current) return current;
@@ -47,8 +45,7 @@ function subscribe(listener: () => void): () => void {
   return () => { listeners.delete(listener); };
 }
 
-/** Live terminal font size. Re-renders the caller whenever the zoom changes,
- *  wherever it was changed from. */
+/** 实时终端字体大小。无论缩放从哪里被改变，只要一变就重新渲染调用方。 */
 export function useTerminalFontSize(): number {
   return useSyncExternalStore(subscribe, getTerminalFontSize, getTerminalFontSize);
 }

--- a/src/renderer/src/components/terminalPool.ts
+++ b/src/renderer/src/components/terminalPool.ts
@@ -1,17 +1,14 @@
 /**
- * A process-wide pool of live xterm terminals, one per ptyId.
+ * 进程级活动 xterm 终端池，每个 ptyId 对应一个。
  *
- * Why: node-pty keeps no scrollback. If we created/disposed an xterm every time
- * the user switched agents (or toggled fullscreen), the new terminal would be
- * empty and stay blank until the TUI happened to repaint — which is exactly the
- * "terminal vanishes until I drag the splitter" bug.
+ * 原因：node-pty 不保留滚动缓冲。如果每次用户切换 agent（或切换全屏）都
+ * 新建/销毁一个 xterm，新终端会是空的，并且要一直空白到 TUI 碰巧重绘为止——
+ * 这正是“终端消失，直到我拖动分隔条”的 bug。
  *
- * Instead each pty gets ONE Terminal for the app's lifetime. It is opened into a
- * detached host <div> and subscribes to the pty stream once, so its buffer is
- * always populated. A view (the sidebar tab or the fullscreen overlay) simply
- * re-parents that host element into itself when it mounts and detaches it on
- * unmount — the rendered content moves with it, so the terminal is always
- * visible immediately, no repaint required.
+ * 相反，每个 pty 在应用生命周期内只用一个 Terminal。它被打开进一个分离的
+ * host <div>，并且只订阅一次 pty 流，因此它的缓冲始终有内容。视图（侧边栏
+ * 标签页或全屏覆盖层）在挂载时只需把那个 host 元素重新挂到自身之下，卸载时
+ * 再分离——渲染出的内容随之移动，所以终端总是立刻可见，无需重绘。
  */
 import { useEffect, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
@@ -42,49 +39,46 @@ import { sanitizeTerminalSelection } from './terminalSelection';
 import '@xterm/xterm/css/xterm.css';
 
 export interface TerminalEntry {
-  /** The pty this terminal mirrors — needed to poke `resizePty` on a reflow. */
+  /** 该终端镜像的 pty——重排时需要用来触发 `resizePty`。 */
   ptyId: string;
   term: Terminal;
   fit: FitAddon;
-  /** The element xterm renders into; views re-parent this in/out of the DOM. */
+  /** xterm 渲染进去的元素；视图把它挂入/移出 DOM。 */
   host: HTMLDivElement;
-  /** xterm is only `open()`ed once its host is first attached to the document. */
+  /** xterm 只有在其 host 首次挂载到文档后才会被 `open()`。 */
   opened: boolean;
   exited: boolean;
-  /** Stream subscriptions to tear down on dispose. */
+  /** 要在销毁时拆除的流订阅。 */
   unsub: Array<() => void>;
-  /** Current consumer callbacks — set by whichever view is mounted. */
+  /** 当前的消费者回调——由当前挂载的视图设置。 */
   onData?: (chunk: string) => void;
   onPrompt?: (text: string) => void;
   recovery: TerminalRecoveryState;
   needsRendererRepaint: boolean;
-  /** A user-opened slash-command picker (for example Codex `/model`) owns the
-   * input line. Queue automation waits until the picker closes. */
+  /** 用户打开的斜杠命令选择器（例如 Codex `/model`）拥有输入行。
+   * 队列自动化会一直等到选择器关闭。 */
   automationBlocked: boolean;
-  /** Has the running program enabled DEC private mode 2031, terminal theme-change
-   *  notifications? A TUI that paints its own colours cannot see the app theme
-   *  flip: xterm repaints its own cells, but cells the program coloured
-   *  explicitly keep those colours until the program redraws them. 2031 is how it
-   *  asks to be told, and we only tell the ones that asked. */
+  /** 运行中的程序是否已启用 DEC 私有模式 2031（终端主题变更通知）？
+   *  自己绘制颜色的 TUI 看不到应用主题切换：xterm 会重绘自己的单元格，
+   *  但程序显式着色的单元格会一直保持那些颜色，直到程序重绘它们。2031
+   *  正是程序请求被通知的方式，而我们只通知那些提出请求的。 */
   themeNotify: boolean;
-  /** When the picker latch was set — the block expires, see PICKER_BLOCK_MS. */
+  /** 选择器锁存被设置的时间——该阻塞会过期，参见 PICKER_BLOCK_MS。 */
   automationBlockedAt: number;
-  /** True while the user has unsubmitted text in the live TUI prompt. */
+  /** 用户是否在实时 TUI 提示符里留有未提交的文本。 */
   inputDirty: boolean;
-  inputDirtyAt: number; // when the draft was last typed into; drives staleness expiry
+  inputDirtyAt: number; // 草稿最后一次被键入的时间；用于驱动过期判定
   automationSettleUntil: number;
-  /** Our model of the text on the live prompt line. On the ENTRY, not a closure
-   * variable: `inputDirty` is derived from it, so anything that clears the
-   * prompt (Ctrl-U, a respawn reset) has to clear both or the next keystroke
-   * resurrects the deleted text as a phantom draft. */
+  /** 我们对实时提示行上文本的模型。放在条目（ENTRY）上而非闭包变量里：
+   * `inputDirty` 由它推导，所以任何清除提示符的路径（Ctrl-U、重启重置）都得
+   * 两者一起清，否则下一次按键会把已删除的文本复活成一个幽灵草稿。 */
   lineBuf: string;
-  /** Bumped every time this pty is respawned under the same id. Late events from
-   * the OLD process carry the generation they were registered under, so they can
-   * be recognised and dropped instead of corrupting the replacement. */
+  /** 每次该 pty 在相同 id 下被重启都会自增。旧进程的迟到事件带着它们注册时的
+   * 代数，因此可以被识别并丢弃，而不是污染替代进程。 */
   generation: number;
   webgl?: WebglAddon;
-  /** Live Arabic/RTL rendering handles, present only while it is ON. Held so
-   *  the mode can be switched off again without disposing the terminal. */
+  /** 实时的阿拉伯文/RTL 渲染句柄，仅在开启时存在。持有它们是为了可以在不
+   *  销毁终端的情况下再次关掉该模式。 */
   arabic?: { joiner: number; detachSpacing: () => void };
 }
 
@@ -95,15 +89,14 @@ import { parseHexColor, oscColorBody, isDarkBackground } from './termColor';
 type ThemeMap = Record<string, string>;
 
 
-/** Tell a running program the terminal's theme changed.
+/** 告诉正在运行的程序终端主题已改变。
  *
- *  The reply half of DEC mode 2031: `CSI ? 997 ; 1 n` for dark, `; 2 n` for
- *  light. Sent ONLY to programs that enabled 2031, because a program that did not
- *  ask would receive this as unsolicited bytes on its input.
+ *  DEC 模式 2031 的回复半部分：暗色为 `CSI ? 997 ; 1 n`，亮色为 `; 2 n`。
+ *  只发送给启用了 2031 的程序，因为一个没有请求的程序收到这些字节会被当作
+ *  未请求的输入。
  *
- *  Without it the app theme and the TUI disagree until the agent restarts:
- *  xterm's own cells flip, and everything the program painted explicitly does
- *  not. */
+ *  没有它，应用主题和 TUI 就会在 agent 重启前一直不一致：xterm 自己的单元格
+ *  会翻转，而程序显式绘制的那些不会。 */
 export function notifyThemeChangeAll(theme: 'light' | 'dark'): void {
   const all = [...pool.keys()];
   const told = all.filter((id) => pool.get(id)?.themeNotify);
@@ -118,8 +111,8 @@ function notifyThemeChange(ptyId: string, theme: 'light' | 'dark'): void {
   window.cth.writePty(ptyId, `\x1b[?997;${theme === 'dark' ? 1 : 2}n`);
 }
 
-/** Get (or lazily create) the persistent terminal for a pty. Theme/font are
- *  only used at creation; an attaching view re-applies its own afterwards. */
+/** 获取（或惰性创建）某个 pty 的持久化终端。Theme/font 只在创建时使用；
+ *  挂载的视图之后会重新应用自己的设置。 */
 export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14): TerminalEntry {
   const existing = pool.get(ptyId);
   if (existing) return existing;
@@ -130,36 +123,34 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
 
   const term = new Terminal({
     theme,
-    // v0.3.4: JetBrains Mono replaces VT323 — the narrow CRT face strained at
-    // data density. lineHeight stays 1.0 so TUI box-drawing rows stay joined.
-    fontFamily: '"JetBrains Mono", "SF Mono", Menlo, monospace',
+    // v0.3.4: JetBrains Mono 取代 VT323——窄的 CRT 字形在处理数据密度时很吃力。
+    // lineHeight 保持 1.0，这样 TUI 的方框线行能保持连在一起。
+    fontFamily: '"JetBrains Mono", "Sarasa Mono SC", ui-monospace, "SF Mono", Menlo, "PingFang SC", "Microsoft YaHei", "Noto Sans Mono CJK SC", "Noto Sans CJK SC", monospace',
     fontSize,
     lineHeight: 1.0,
     cursorBlink: true,
     cursorStyle: 'block',
     scrollback: 100000,
-    // Guarantee legible text no matter what colors a running program sets.
-    // When a program paints a coloured cell background (e.g. a git-diff add line
-    // with a green bg, or a yellow-highlighted line) while leaving the default
-    // foreground, the theme's dark ink would otherwise render dark-on-colour and
-    // be unreadable on the light/cream theme. xterm auto-adjusts the foreground
-    // per cell to keep at least this contrast ratio (WCAG AA = 4.5) against the
-    // actual background — so it also rescues low-contrast coloured *text* on the
-    // cream paper. Untouched for already-high-contrast cells (the dark theme).
+    // 无论运行中的程序设置什么颜色，都保证文字可读。
+    // 当程序绘制彩色单元格背景（例如 git-diff 的绿色加行背景，或黄色高亮行）
+    // 而保留默认前景色时，主题的深色墨迹会渲染成深底深字，在亮色/奶油色主题
+    // 下不可读。xterm 会按单元格自动调整前景色，以至少保持这个对比度
+    // （WCAG AA = 4.5）相对实际背景——所以它也能拯救奶油纸上低对比度的彩色
+    // *文本*。对已经高对比度的单元格（暗色主题）则保持不变。
     minimumContrastRatio: 4.5,
     allowProposedApi: true
   });
   const fit = new FitAddon();
   term.loadAddon(fit);
-  // Unicode 11 width tables: xterm's default (Unicode 6) counts most emoji as
-  // ONE cell wide, but Claude Code positions text with modern widths (emoji =
-  // two cells) — the glyph then overflows its single cell and merges with the
-  // following text (e.g. "✅FIX-…"). Match the app's idea of character width.
+  // Unicode 11 宽度表：xterm 的默认（Unicode 6）把多数 emoji 计为 1 个单元格宽，
+  // 但 Claude Code 用现代宽度（emoji = 2 个单元格）来排布文本——于是字形会溢出
+  // 单个单元格并和后面的文字粘在一起（例如 "✅FIX-…"）。这里与应用对字符宽度的
+  // 认知保持一致。
   term.loadAddon(new Unicode11Addon());
   term.unicode.activeVersion = '11';
   registerMarkdownLinkProvider(term, ptyId);
-  // NOTE: don't open() yet — xterm needs its host connected to the document to
-  // measure correctly. We open on first attach (see attachTerminal).
+  // NOTE: 先不要 open()——xterm 需要它的 host 连接上文档才能正确测量。
+  // 我们在首次 attach 时再 open（参见 attachTerminal）。
 
   const entry: TerminalEntry = {
     ptyId,
@@ -181,76 +172,66 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     generation: 0
   };
 
-  // Subscribe to the pty stream ONCE for the terminal's whole lifetime, so the
-  // buffer keeps filling even while this terminal isn't mounted in any view.
+  // 在终端的整个生命周期里只订阅一次 pty 流，这样即使这个终端没有挂载在
+  // 任何视图里，缓冲也会持续填充。
+  // 写节流：首 chunk 立即 flush，后续 chunk 合并进 100ms 窗口。
+  // 把 qwen TUI 60fps 全屏重绘降到 ~10fps，根治持续闪烁。
   entry.unsub.push(window.cth.onPtyData(ptyId, (rawChunk) => {
     const chunk = normalizePtyChunk(rawChunk);
     if (!chunk) return;
-    const active = term.buffer.active;
-    const follow = shouldFollowTerminalOutput(active.viewportY, active.baseY);
-    term.write(chunk, () => {
-      if (follow) {
-        try { term.scrollToBottom(); } catch { /* terminal may be detaching */ }
-      }
-    });
+    enqueueWrite(ptyId, chunk);
     entry.onData?.(chunk);
   }));
-  // A restart does killPty() then spawnPty() under the SAME pty id, so a stale
-  // exit from the killed process could in principle latch `exited` on its
-  // replacement (which would silently drop every keystroke). It can't: kill()
-  // removes the session from the map synchronously (main/pty.ts kill), and the
-  // process's own onExit checks it still owns that id before emitting — so the
-  // stale event is suppressed in the main process and never reaches here.
+  // 重启流程是先 killPty() 再在同一个 pty id 下 spawnPty()，所以被杀死进程的
+  // 过期 exit 事件原则上可能把 `exited` 锁在它的替代进程上（这会静默丢弃每次
+  // 按键）。它做不到：kill() 会同步地从 map 移除会话（main/pty.ts kill），
+  // 而进程自身的 onExit 在发出事件前会检查它是否仍拥有该 id——所以过期事件
+  // 在主进程就被抑制了，永远不会到达这里。
   entry.unsub.push(window.cth.onPtyExit(ptyId, ({ exitCode, signal }) => {
     entry.exited = true;
     term.writeln(`\r\n\x1b[2m─ process exited (code ${exitCode}${signal ? `, signal ${signal}` : ''}) ─\x1b[0m`);
   }));
-  // A first-time engine-CLI install just finished and the agent is auto
-  // restart-and-continuing into THIS same pty (main re-ran the spawn). Re-arm the
-  // terminal in place — clear the latched exit (so keystrokes flow again) and wipe
-  // the install banner + "process exited" line — so the relaunched CLI's TUI paints
-  // onto a clean, typeable grid. Mirrors resetTerminal but works on this closure.
+  // 首次引擎 CLI 安装刚完成，agent 正在自动重启并继续进到同一个 pty（主进程
+  // 重新跑了 spawn）。就地重新武装终端——清除锁存的 exit（让按键重新流通），擦掉
+  // 安装横幅和“process exited”行——这样重新启动的 CLI 的 TUI 会画到一个干净、
+  // 可输入的网格上。行为类似 resetTerminal，但作用在这个闭包上。
   entry.unsub.push(window.cth.onPtyRelaunch(ptyId, () => {
     entry.exited = false;
-    try { term.reset(); } catch { /* not yet open */ }
+    try { term.reset(); } catch { /* 尚未打开 */ }
   }));
 
-  // ── Copy / paste ──────────────────────────────────────────────────────────
-  // With an accelerated renderer there is no DOM text, so the browser's native
-  // copy can't see the terminal — the selection lives inside xterm. Wire the
-  // usual terminal conventions:
-  //   Ctrl/Cmd+C with a selection → copy (without one it stays SIGINT)
-  //   Ctrl/Cmd+Shift+C            → copy ;  Ctrl/Cmd+Shift+V → paste
-  //   right-click                 → copy the selection, else paste (console style)
+  // ── 复制 / 粘贴 ──────────────────────────────────────────────────────────
+  // 使用加速渲染器时没有 DOM 文本，浏览器的原生复制看不到终端——选区存在
+  // xterm 里面。接线常规的终端约定：
+  //   Ctrl/Cmd+C 且有选区 → 复制（没有选区则保持 SIGINT）
+  //   Ctrl/Cmd+Shift+C     → 复制；Ctrl/Cmd+Shift+V → 粘贴
+  //   右键                 → 复制选区，否则粘贴（控制台风格）
   const copySelection = (): boolean => {
     if (!term.hasSelection()) return false;
-    // Selections come off the character GRID, so any gutter the CLI painted
-    // there (Claude Code renders a blockquote as `▎ text`) is part of the
-    // copied cells. Strip it — see terminalSelection.ts.
+    // 选区来自字符 GRID，所以 CLI 画在那里的任何沟槽（Claude Code 把 blockquote
+    // 渲染成 `▎ text`）都是被复制单元格的一部分。把它剥掉——参见 terminalSelection.ts。
     const text = sanitizeTerminalSelection(term.getSelection());
-    // Still `true` when a rail-only selection sanitizes to nothing: the gesture
-    // was a copy and must stay one, or right-click would fall through to paste.
+    // 当只有沟槽的选区被清理成空后仍为 `true`：该手势是一次复制，就必须保持
+    // 为复制，否则右键会落到粘贴上。
     if (text) void window.cth.copyToClipboard(text);
     return true;
   };
-  /** Paste the clipboard into the terminal.
+  /** 把剪贴板粘贴进终端。
    *
-   *  The read is SYNCHRONOUS on purpose. Dictation tools (muesli.works, Wispr
-   *  Flow, …) "type" by stashing the clipboard, writing the transcript, sending
-   *  the paste key, and restoring the old clipboard immediately after. The async
-   *  read this used to do came back a tick or two later — after the restore — so
-   *  the terminal pasted the text that had been on the clipboard BEFORE, and the
-   *  words the user had just spoken were dropped. Reading inside the keydown
-   *  handler closes that window entirely.
+   *  读取是刻意同步的。听写工具（muesli.works、Wispr Flow 等）“打字”的方式是
+   *  暂存剪贴板、写入转录文本、发送粘贴键、然后立刻恢复旧剪贴板。过去用的异步
+   *  读取会晚一两个 tick 才回来——已经在恢复之后——于是终端粘贴的是在此之前
+   *  剪贴板上的文本，而用户刚说出的词被丢弃了。在 keydown 处理器内部读取正好
+   *  关死了这个窗口期。
    *
-   *  Falls back to the async read if the sync bridge is unavailable (an older
-   *  preload), so this degrades to the previous behaviour rather than to nothing. */
+   *  如果同步桥不可用（更老的 preload），就回退到异步读取，所以它会降级为
+   *  之前的行为，而不是退化为什么都不做。 */
   const pasteClipboard = (): void => {
     if (entry.exited) return;
     try {
       const text = window.cth.readClipboardSync?.();
       if (typeof text === 'string') { if (text) term.paste(text); return; }
-    } catch { /* fall through to the async path */ }
+    } catch { /* 落到异步路径 */ }
     void window.cth.readClipboard().then((t) => { if (t) term.paste(t); });
   };
   term.attachCustomKeyEventHandler((ev) => {
@@ -258,8 +239,8 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     if (!(ev.ctrlKey || ev.metaKey)) return true;
     const key = ev.key.toLowerCase();
     if (key === 'c' && (ev.shiftKey || term.hasSelection())) {
-      // Copy-on-Ctrl+C only while a selection exists; clear it after, so a
-      // second Ctrl+C still interrupts the agent as usual.
+      // 仅在存在选区时在 Ctrl+C 上复制；复制后清除选区，这样第二次 Ctrl+C
+      // 仍可照常中断 agent。
       if (copySelection() && !ev.shiftKey) term.clearSelection();
       ev.preventDefault();
       return false;
@@ -277,49 +258,43 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     pasteClipboard();
   });
 
-  // Answer the terminal-colour queries (OSC 10 foreground, OSC 11 background).
+  // 回答终端颜色查询（OSC 10 前景色、OSC 11 背景色）。
   //
-  // A TUI that wants to match the terminal asks for its colours with
-  // `ESC ] 11 ; ? BEL` and styles itself from the reply. We registered NO OSC
-  // handler at all, so the query went unanswered and the app fell back to its own
-  // default, which for OpenCode is LIGHT. That is why OpenCode painted near-white
-  // panels inside a dark window even with its theme set to `system`, and why it
-  // showed up across agents rather than on one engine: any TUI that asks gets the
-  // same silence.
+  // 想匹配终端的 TUI 会用 `ESC ] 11 ; ? BEL` 查询颜色，并据回复给自己上样式。
+  // 我们之前一个 OSC 处理器都没注册，于是查询无人应答，应用回退到自己的默认值，
+  // 对 OpenCode 来说就是亮色（LIGHT）。这就是为什么 OpenCode 在深色窗口里画
+  // 出近白色的面板，即使它的主题设成了 `system`，也是为什么它跨 agent 出现
+  // 而不是只在一个引擎上：任何会查询的 TUI 得到的都是同样的沉默。
   //
-  // COLORFGBG (set at spawn) is the older, coarser channel and only carries
-  // "light or dark". This carries the ACTUAL colour, so a TUI can match the
-  // window rather than guess a side.
+  // COLORFGBG（生成时设置）是更老、更粗的信道，只携带“亮或暗”。而这里携带
+  // 实际的颜色，所以 TUI 可以匹配窗口而不是猜一边。
   const oscColorReply = (index: 10 | 11) => (data: string): boolean => {
-    if (data !== '?') return false;          // only the QUERY form; a SET is not ours to handle
-    if (entry.exited) return true;           // swallow it rather than write to a dead pty
+    if (data !== '?') return false;          // 只处理 QUERY 形式；SET 不是我们该处理的
+    if (entry.exited) return true;           // 吞掉它，而不是写给一个已死的 pty
     const map = (term.options.theme ?? theme) as ThemeMap | undefined;
     const hex = index === 11 ? map?.background : map?.foreground;
     const rgb = hex && parseHexColor(hex);
-    if (!rgb) return false;                  // unknown colour: stay silent rather than lie
+    if (!rgb) return false;                  // 未知颜色：保持沉默而不是撒谎
     window.cth.writePty(ptyId, `\x1b]${index};${oscColorBody(rgb)}\x1b\\`);
     return true;
   };
   term.parser.registerOscHandler(10, oscColorReply(10));
   term.parser.registerOscHandler(11, oscColorReply(11));
 
-  // DEC private mode 2031: the program is asking to be told when the terminal's
-  // theme changes. Answering OSC 11 only covers STARTUP; a program that painted
-  // its panels from that answer keeps them until something tells it to repaint,
-  // which is why flipping the app theme left OpenCode's boxes in the old colours.
-  // Return false so xterm still applies the mode itself; we are only listening.
+  // DEC 私有模式 2031：程序在请求终端主题变化时被通知。只回答 OSC 11 只能
+  // 覆盖启动时刻；程序凭那次回答画出的面板会一直保持旧色，直到有什么东西告诉
+  // 它重绘——这就是切换应用主题后 OpenCode 的框还留在旧颜色的原因。
+  // 返回 false 让 xterm 仍自行应用该模式；我们只是监听。
   term.parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
     if (params.includes(2031)) {
       entry.themeNotify = true;
-      // The protocol expects the CURRENT theme the moment a program opts in, not
-      // only on the next change. Without this a CLI set to follow the terminal has
-      // nothing to go on at startup and falls back to its own default, which is
-      // how a light window ended up with black message highlights.
+      // 协议期望程序一选择加入就立刻收到当前主题，而不只是在下次变化时。
+      // 没有这句，设为跟随终端的 CLI 启动时没有依据，会回退到自己的默认值，
+      // 这就是浅色窗口最终出现黑色消息高亮的原因。
       const bg = (term.options.theme as ThemeMap | undefined)?.background;
       notifyThemeChange(ptyId, bg && !isDarkBackground(bg) ? 'light' : 'dark');
-      // Deliberately logged. Whether a TUI opts in is the difference between "the
-      // theme fix works" and "we are talking to something that is not listening",
-      // and that is not observable from the outside.
+      // 刻意打日志。TUI 是否选择加入，是“主题修复生效”和“我们在跟一个不听的
+      // 东西说话”之间的区别，而这从外部观察不到。
       console.log(`[theme] ${ptyId} enabled theme-change notifications (DEC 2031)`);
     }
     return false;
@@ -329,29 +304,26 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
     return false;
   });
 
-  // Keystrokes → pty. A small line buffer surfaces the last submitted prompt.
-  // It lives on the entry (see TerminalEntry.lineBuf) so every prompt-clearing
-  // path resets it too.
+  // 按键 → pty。一个小行缓冲会记录最后一次提交的提示。
+  // 它放在条目上（见 TerminalEntry.lineBuf），这样所有清提示的路径也会重置它。
   term.onData((data) => {
     if (entry.exited) return;
     window.cth.writePty(ptyId, data);
-    // A lone Escape or Ctrl-C closes interactive pickers. Arrow-key escape
-    // sequences must NOT clear the block while the user navigates a picker.
+    // 单独的 Escape 或 Ctrl-C 会关闭交互式选择器。用户在选择器内导航时，
+    // 方向键转义序列绝不能清除阻塞。
     if (data === '\x1b' || data === '\x03') {
       releasePickerBlock(entry);
       entry.lineBuf = '';
     }
-    // The user's own Ctrl-U (kill-line) clears the prompt exactly like ours does.
+    // 用户自己的 Ctrl-U（杀行）会像我们的一样清除提示符。
     if (data === '\x15') entry.lineBuf = '';
-    // Bracketed paste is still user-owned draft text; remove only its wrapper so
-    // pasted content marks the prompt dirty instead of looking automation-safe.
+    // 括号粘贴仍是用户拥有的草稿文本；只剥掉它的包装，这样粘贴的内容会把提示
+    // 标记为脏的，而不是看起来对自动化安全。
     const input = data.replace(/\x1b\[200~/g, '').replace(/\x1b\[201~/g, '');
-    // A PASTE is never a submit: the TUI drops its newlines into the input box
-    // and waits for a real Enter. xterm rewrites pasted newlines to "\r", so
-    // without this a five-line paste would look like five submitted messages —
-    // and the Enter that actually sends it would then be a sixth. (TELEMETRY.md
-    // → message_sent; the paste's own Enter keystroke arrives as its own chunk
-    // and is counted there.)
+    // PASTE 永远不会成为提交：TUI 把换行放进输入框，然后等一个真正的 Enter。
+    // xterm 会把粘贴的换行改写成 "\r"，所以没有这条，五行粘贴会被当成五条提交
+    // 的消息——而真正发送它的那个 Enter 则会变成第六条。（TELEMETRY.md
+    // → message_sent；粘贴自己的 Enter 按键会作为自己的 chunk 到达并在那里计数。）
     const pasted = data.includes('\x1b[200~');
     let submitted = false;
     for (let i = 0; i < input.length; i++) {
@@ -360,14 +332,13 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
         const t = entry.lineBuf.trim();
         entry.lineBuf = '';
         if (entry.automationBlocked) {
-          // Enter chooses an item and closes the current picker.
+          // Enter 会选中一项并关闭当前选择器。
           releasePickerBlock(entry);
         }
-        // NOT an `else`: this Enter is the one that SUBMITTED the command, so it
-        // must both close any picker that was already open and latch a new one
-        // for the command it just submitted. As an `else if`, a line like
-        // `/model sonnet` latched the block and then had no later Enter to clear
-        // it — every queued message to that agent was skipped forever.
+        // 不是 `else`：这个 Enter 就是那个提交命令的 Enter，所以它既要关闭任何
+        // 已经打开的选择器，也要为刚提交的命令锁存一个新的。如果写成 `else if`，
+        // 类似 `/model sonnet` 的行会锁存阻塞，之后又没有 Enter 能清除它——发往
+        // 该 agent 的每条排队消息都被永久跳过。
         if (opensInteractiveTerminalUi(t)) {
           entry.automationBlocked = true;
           entry.automationBlockedAt = Date.now();
@@ -379,19 +350,18 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
       } else if (ch === '\x7f' || ch === '\b') {
         entry.lineBuf = entry.lineBuf.slice(0, -1);
       } else if (ch === '\x1b') {
-        break; // skip escape sequences (arrow keys, etc.)
+        break; // 跳过转义序列（方向键等）
       } else if (ch >= ' ') {
         entry.lineBuf += ch;
       }
     }
-    // ONE message per input chunk, at the SUBMIT boundary — not per keystroke
-    // (that is what `pty:write` sees, and counting there would meter typing) and
-    // not per line inside a paste. This is the only place the renderer can cause
-    // an analytics event; it sends a surface name and nothing else.
+    // 每个输入 chunk 只在 SUBMIT 边界上报一条消息——不是每次按键（那是
+    // `pty:write` 看到的，在那里计数会按打字计量），也不是粘贴内的每一行。
+    // 这是渲染器唯一能触发分析事件的地方；它只发送一个表面名，其它什么都不发。
     if (submitted && !pasted) void window.cth.trackMessageSent('terminal');
     entry.inputDirty = entry.lineBuf.length > 0;
-    // Re-stamped on every keystroke, so the staleness clock measures time since
-    // the user last touched the draft — not since they started it.
+    // 每次按键都重新盖章，所以过期时钟度量的是用户最后一次触碰草稿以来的时间
+    // ——而不是他们开始写以来的时间。
     if (entry.inputDirty) entry.inputDirtyAt = Date.now();
   });
 
@@ -399,67 +369,58 @@ export function acquireTerminal(ptyId: string, theme?: ThemeMap, fontSize = 14):
   return entry;
 }
 
-/** Whether queued automation can safely own this terminal's input line. A PTY
- * without a pooled terminal cannot have a user-opened local picker. */
+/** 排队的自动化是否还能安全地拥有该终端的输入行。没有池化终端的 PTY
+ * 不可能有用户打开的本地选择器。 */
 export function isTerminalAutomationSafe(ptyId: string, now = Date.now()): boolean {
   const entry = pool.get(ptyId);
   if (!entry) return true;
   return canAutomateTerminal(automationStateOf(entry, now), now);
 }
 
-/** Characters a TUI paints around its input line that are not the user's text:
- *  the box the prompt sits in and the prompt marker itself. */
+/** TUI 画在输入行周围的、不属于用户文本的字符：提示符所在的框和提示符标记本身。 */
 const PROMPT_CHROME = /[─-╿\s>❯$#|]/g;
 
-/** How long after a keystroke the rendered screen is not yet evidence of anything.
+/** 按键之后多久，渲染出的屏幕还算不上任何证据。
  *
- *  `inputDirty` is set the instant a key is pressed, but the character only
- *  reaches xterm's buffer once the PTY echoes it back — a round trip through the
- *  child process. Inside that gap the buffer still shows the OLD line, so a read
- *  of a freshly started draft returns "empty" and would hand the prompt to
- *  automation while the user is mid-word. The screen is only allowed to overrule
- *  the keystroke count once it has had time to catch up. */
+ *  `inputDirty` 在按键的瞬间就被设置，但字符要等 PTY 把它回显回来才进入 xterm
+ *  的缓冲——这是经过子进程的一次往返。在这个间隙里，缓冲仍然显示旧行，所以读取
+ *  一个刚开头的草稿会返回“空”，并会在用户打到一半时把提示符交给自动化。屏幕
+ *  只有在有机会追上来之后，才被允许推翻按键计数。 */
 const ECHO_GRACE_MS = 1000;
 
-/** Does the terminal's rendered prompt line actually hold text right now?
+/** 终端渲染出的提示行现在真的有文本吗？
  *
- *  `inputDirty` is inferred by counting keystrokes, and that model DRIFTS: a TUI
- *  that swallows keys for its own UI (a menu, a confirm) leaves the count above
- *  zero while the visible prompt is empty. Nothing ever corrected it, so the
- *  queue stayed blocked by a draft that did not exist — the "messages never
- *  arrive" bug. xterm already holds the rendered screen, so read it instead of
- *  trusting the count.
+ *  `inputDirty` 是通过数按键推断的，而这个模型会 DRIFT：把按键吞进自己 UI
+ *  （菜单、确认框）的 TUI 会在可见提示符为空时仍让计数高于零。没有任何东西
+ *  纠正过它，于是队列被一个并不存在的草稿卡住——这就是“消息永远不送达”的
+ *  bug。xterm 已经持有渲染出的屏幕，所以直接读它，而不是相信计数。
  *
- *  Returns null when the screen is not evidence of anything: the terminal has not
- *  been opened, the row is missing, or the last keystroke is too recent for the
- *  echo to have landed. Deliberately only ever used to CLEAR a phantom, never to
- *  invent a draft: "empty" drops the block, while "has text" or "don't know"
- *  falls back to the keystroke model and keeps it. The asymmetry matters because
- *  the two mistakes do not cost the same — a wrong "empty" hands the prompt to
- *  automation and fuses a message onto what the user is writing, where a wrong
- *  "has text" only parks a queued message until the draft expires. */
+ *  当屏幕算不上任何证据时返回 null：终端还没打开、行缺失、或最后一次按键太近、
+ *  回显还没落地。刻意只用于清除幽灵，绝不用于凭空捏造草稿：“空”会去掉阻塞，
+ *  而“有文本”或“不知道”则回退到按键模型并保留它。这种不对称很重要，因为
+ *  两种错误的代价不一样——错误的“空”会把提示符交给自动化，把一条消息拼接到
+ *  用户正在写的内容上；而错误的“有文本”只是把排队消息停放一会儿，直到草稿
+ *  过期。 */
 function promptLineHasText(entry: TerminalEntry, now = Date.now()): boolean | null {
   if (!entry.opened || entry.exited) return null;
-  // Too soon after the last keystroke for the echo to have landed — the buffer
-  // is showing us the past, so it cannot clear anything.
+  // 离最后一次按键太近，回显还没落地——缓冲展示的是过去，所以它清除不了任何东西。
   if (entry.inputDirtyAt && now - entry.inputDirtyAt < ECHO_GRACE_MS) return null;
   try {
     const buf = entry.term.buffer.active;
     const line = buf.getLine(buf.baseY + buf.cursorY);
     if (!line) return null;
-    // `true` trims trailing whitespace cells, which a TUI pads its box with.
+    // `true` 会修剪尾部空白单元格，TUI 用它们来给框内补白。
     return line.translateToString(true).replace(PROMPT_CHROME, '').length > 0;
   } catch {
-    return null; // never let a buffer read break delivery
+    return null; // 绝不让一次缓冲读取破坏投递
   }
 }
 
-/** Whether the user has unsubmitted text sitting on this terminal's prompt.
- *  Shares its draft detection with the automation gate, so the "typing" badge
- *  reports the same draft the gate is holding delivery for. It does NOT apply the
- *  staleness expiry the gate does: past STALE_INPUT_MS the gate starts delivering
- *  while this still reports the draft — which is the honest reading, because the
- *  text really is still on the prompt. */
+/** 用户是否在该终端的提示符上留有未提交的文本。
+ *  与自动化 gate 共享同样的草稿检测，所以“typing”徽章上报的草稿与 gate
+ *  正为其扣住投递的是同一个。它不应用 gate 的那种过期判定：过了 STALE_INPUT_MS
+ *  之后 gate 开始投递，而这个仍会上报草稿——这是诚实的读法，因为文本确实
+ *  还在提示符上。 */
 export function hasTerminalDraft(ptyId: string | undefined, now = Date.now()): boolean {
   if (!ptyId) return false;
   const entry = pool.get(ptyId);
@@ -467,14 +428,13 @@ export function hasTerminalDraft(ptyId: string | undefined, now = Date.now()): b
   return entry.inputDirty && promptLineHasText(entry, now) !== false;
 }
 
-/** `hasTerminalDraft` as React state. The flag lives on a mutable pool entry
- *  that no component subscribes to, so poll it — cheap (one buffer row read) and
- *  a second of lag on a badge is invisible. */
+/** `hasTerminalDraft` 的 React 状态版本。该标记存在于一个没有任何组件订阅的
+ *  可变池条目上，所以轮询它——廉价（读一行缓冲）而且徽章上的一秒延迟不可见。 */
 export function useHasTerminalDraft(ptyId: string | undefined): boolean {
   const [dirty, setDirty] = useState(() => hasTerminalDraft(ptyId));
   useEffect(() => {
-    // An agent with no pty has no prompt to hold anything — don't run a timer
-    // per card for it (the floor renders one card per agent).
+    // 没有 pty 的 agent 就没有能容纳任何东西的提示符——不要为它每个卡片跑一个
+    // 定时器（地板为每个 agent 渲染一张卡片）。
     if (!ptyId) { setDirty(false); return; }
     const read = () => setDirty(hasTerminalDraft(ptyId));
     read();
@@ -485,7 +445,7 @@ export function useHasTerminalDraft(ptyId: string | undefined): boolean {
 }
 
 function automationStateOf(entry: TerminalEntry, now = Date.now()) {
-  // The screen wins over the keystroke count, but only when it says "empty".
+  // 屏幕胜过按键计数，但只在它说“空”的时候。
   const inputDirty = entry.inputDirty && promptLineHasText(entry, now) !== false;
   return {
     exited: entry.exited,
@@ -497,15 +457,15 @@ function automationStateOf(entry: TerminalEntry, now = Date.now()) {
   };
 }
 
-/** Drop the picker latch and give the TUI a moment to repaint the freed line. */
+/** 放下选择器锁存，给 TUI 一点时间重绘被释放的行。 */
 function releasePickerBlock(entry: TerminalEntry): void {
   entry.automationBlocked = false;
   entry.automationBlockedAt = 0;
   entry.automationSettleUntil = Date.now() + 500;
 }
 
-/** Why queue delivery is currently held back for this pty, or null if it isn't.
- * The composer shows this instead of claiming it is sending. */
+/** 队列投递目前因为这个 pty 被扣住的原因，没有则为 null。
+ * 编辑器会显示这个，而不是声称它正在发送。 */
 export function terminalAutomationBlockFor(
   ptyId: string | undefined,
   now = Date.now()
@@ -516,38 +476,36 @@ export function terminalAutomationBlockFor(
   return terminalAutomationBlock(automationStateOf(entry, now), now);
 }
 
-/** Wipe the TUI prompt's current line and re-arm automation. Ctrl-U is the
- * readline kill-to-start binding every supported CLI's input honors. */
+/** 清掉 TUI 提示符当前行并重新武装自动化。Ctrl-U 是每一款受支持的
+ * CLI 的输入都遵守的 readline 杀到行首绑定。 */
 export function clearTerminalDraft(ptyId: string): string {
   const entry = pool.get(ptyId);
   if (!entry) return '';
-  // Hand the text back so the caller can park it somewhere the user can find it
-  // again. Ctrl-U is not undoable in a TUI, so silently discarding it was data
-  // loss every time an abandoned-looking draft turned out to be a real one.
+  // 把文本交还给调用方，让它能停在一个用户将来找得到的地方。Ctrl-U 在 TUI
+  // 里不可撤销，所以静默丢弃它是数据丢失——每次一个看似被弃的草稿其实是真草稿
+  // 时都会发生。
   const discarded = entry.lineBuf;
   void window.cth.writePty(ptyId, '\x15');
   entry.inputDirty = false;
   entry.inputDirtyAt = 0;
-  // Reset our model of the line too. Leaving it set made the very next keystroke
-  // recompute `inputDirty` from the text we just deleted, so the draft block
-  // came straight back and the deleted text corrupted the next parsed command.
+  // 同时重置我们对该行的模型。留着不重置，会让紧接着的下一次按键根据我们刚
+  // 删除的文本重新计算 `inputDirty`，于是草稿阻塞立刻回来，而且被删的文本还会
+  // 污染下一条被解析的命令。
   entry.lineBuf = '';
-  // NOT cleared: `automationBlocked`. Ctrl-U kills the input line; it does not
-  // close an open picker. Clearing the latch here told automation the prompt was
-  // free while a picker still owned it, so the queued message was typed into the
-  // picker and acknowledged as delivered — the message was lost and the picker
-  // got garbage. The latch is released by a real Enter/Esc/Ctrl-C, or it expires.
-  // Let the TUI repaint the cleared line before automation types into it.
+  // 不重置：`automationBlocked`。Ctrl-U 杀的是输入行；它不会关闭打开的
+  // 选择器。在这里清除锁存会告诉自动化提示符空闲，而其实选择器仍拥有它，
+  // 于是排队消息被打进选择器，并记为已投递——消息丢失，选择器收到垃圾。
+  // 锁存由真正的 Enter/Esc/Ctrl-C 释放，或自行过期。
+  // 让 TUI 重绘被清掉的行之后，自动化再往里输入。
   entry.automationSettleUntil = Date.now() + 300;
   return discarded;
 }
 
-/** Close an open picker by sending Escape, the key that actually closes one.
+/** 通过发送 Escape——真正能关闭选择器的键——来关闭打开的选择器。
  *
- *  ONLY ever called from the composer's own button — i.e. because the user asked
- *  for it. Automation must never do this on its own: the menu belongs to the
- *  user, and we cannot see whether Escape actually closed it, so closing one to
- *  make room for a queued message is both rude and unverifiable. */
+ *  只会被编辑器自己的按钮调用——也就是因为用户要求了。自动化绝不能自行
+ *  做这件事：菜单属于用户，而我们看不到 Escape 是否真的关掉了它，所以为了
+ *  给一条排队消息腾地方而关掉它，既不礼貌也无法验证。 */
 export function dismissTerminalPicker(ptyId: string): void {
   const entry = pool.get(ptyId);
   if (!entry || entry.exited) return;
@@ -555,35 +513,29 @@ export function dismissTerminalPicker(ptyId: string): void {
   releasePickerBlock(entry);
 }
 
-/** Give this terminal a WebGL renderer for as long as it is on screen.
+/** 只要终端在屏幕上，就给它一个 WebGL 渲染器。
  *
- *  The DOM renderer assumes a perfectly monospace font, but VT323 is missing
- *  glyphs (↔, arrows, some box-drawing) and has no real bold — the browser
- *  substitutes fallback glyphs with different advance widths, so box-drawing
- *  tables shear apart and the cursor drifts. WebGL draws every glyph into its
- *  own fixed cell, keeping the grid aligned. NOT the deprecated canvas addon
- *  (its dirty-region tracking garbles scrollback).
+ *  DOM 渲染器假定一个完全等宽的字体，但 VT323 缺少字形（↔、箭头、部分
+ *  方框线）也没有真正的粗体——浏览器用推进宽度不同的回退字形替代，于是方框线
+ *  表格散架、光标漂移。WebGL 把每个字形画进自己固定的单元格，保持网格对齐。
+ *  不是那个被废弃的 canvas addon（它的脏区域跟踪会把滚动缓冲弄乱）。
  *
- *  It is a LEASE, taken on attach and released on detach (see detachTerminal),
- *  because a browser allows only a limited number of live WebGL contexts —
- *  around 16 in Chromium — and silently discards the oldest when a new one
- *  pushes past the cap. Terminals used to hold their context for the whole
- *  session even while detached, so restoring a team (which opens one terminal
- *  per agent in quick succession) blew the cap and the browser killed a
- *  background terminal's context. Its pty, buffer and subscription all stayed
- *  healthy — only the renderer was dead — which is exactly the reported
- *  "terminal is black and typing does nothing": the keystrokes were delivered
- *  and the replies arrived, with nothing left alive to paint them.
+ *  这是一份 LEASE（租约），attach 时取得、detach 时释放（见 detachTerminal），
+ *  因为浏览器只允许有限数量的活动 WebGL context——Chromium 里大约 16 个——
+ *  并且新 context 超出上限时会静默丢弃最老的。终端过去在 detach 之后也一直
+ *  持有 context 到会话结束，于是恢复一个团队（会快速连续地为每个 agent 打开
+ *  一个终端）时突破上限，浏览器杀掉了后台终端的 context。它的 pty、缓冲和
+ *  订阅都保持健康——只有渲染器死了——这正是上报的“终端黑屏、打字无效”：
+ *  按键已投递、回复已到达，却没有活着的东西把它们画出来。
  *
- *  Best-effort: on init failure or context loss, fall back to the DOM renderer
- *  rather than leave a black terminal. */
+ *  尽力而为：初始化失败或上下文丢失时，回退到 DOM 渲染器，而不是留一个
+ *  黑终端。 */
 function leaseWebglRenderer(entry: TerminalEntry): void {
   if (entry.webgl) return;
-  // Arabic mode wants the DOM renderer ON PURPOSE: rows become real text nodes,
-  // so the browser's own engine does shaping and (with the CSS in
-  // design/global.css) bidi — what the WebGL cell painter structurally cannot
-  // (xterm.js has no bidi: xtermjs/xterm.js#701). Skipping the lease IS the
-  // feature, not a fallback.
+  // 阿拉伯文模式刻意要 DOM 渲染器：行变成真正的文本节点，浏览器自己的引擎
+  // 做 shaping，配合（design/global.css 里的 CSS）做 bidi——这是 WebGL 单元格
+  // 画家在结构上做不到的（xterm.js 没有 bidi：xtermjs/xterm.js#701）。跳过
+  // 租约就是该功能本身，而不是一个回退。
   if (isArabicTerminalEnabled()) return;
   try {
     const webgl = new WebglAddon();
@@ -593,18 +545,17 @@ function leaseWebglRenderer(entry: TerminalEntry): void {
       entry.webgl = undefined;
       entry.needsRendererRepaint = true;
       try { webgl.dispose(); } catch { /* noop */ }
-      // Laptop sleep == GPU sleep == WebGL context loss: the likely PRIMARY
-      // trigger for the post-wake "can't scroll past a recent point" bug. The
-      // renderer swap leaves xterm's cached cell-height (and the viewport
-      // scroll-area derived from it) stale, so only part of the intact buffer
-      // is scrollable until something forces a re-measure. Heal it here, on the
-      // next frame so the (waking) layout has settled. Guarded + idempotent, so
-      // it composes safely with the visibilitychange/focus path in the view.
+      // 笔记本休眠 == GPU 休眠 == WebGL context 丢失：这很可能是唤醒后
+      // “无法滚动到更早的位置”bug 的主要触发点。渲染器切换让 xterm 缓存的
+      // 单元格高度（以及由它推导出的视口滚动区）过期，所以完好缓冲只有一部分
+      // 可滚动，直到有什么东西强制重新测量。在这里、下一帧（等醒来的布局稳定）
+      // 修复它。带守卫且幂等，所以能安全地与视图里的 visibilitychange/focus
+      // 路径组合。
       scheduleWebglRecovery(entry.recovery, requestAnimationFrame, () =>
         repaintTerminalAfterRendererLoss(entry));
     });
-    // Set before loadAddon: an immediately-lost context may call the handler
-    // during initialization, and it must be recognized as the active renderer.
+    // 在 loadAddon 之前设置：一个立刻丢失的 context 可能在初始化期间调用
+    // 该处理器，它必须被识别为活动渲染器。
     entry.webgl = webgl;
     entry.term.loadAddon(webgl);
   } catch (e) {
@@ -614,19 +565,17 @@ function leaseWebglRenderer(entry: TerminalEntry): void {
   }
 }
 
-/** Find the live WebGL2 context an addon renderer is drawing into, so teardown
- *  can explicitly release it. @xterm/addon-webgl's dispose() tears down its
- *  renderer and removes its canvases but never calls loseContext(), so the
- *  underlying context lingers past the addon that owned it (xterm/xterm.js#6068).
- *  On a floor where agents are switched repeatedly, each switch disposes one
- *  renderer and leases another, so these orphan contexts pile up until Chromium
- *  hits its live-context cap (~16) and evicts an older one — often the office
- *  floor's own context — blacking out a terminal or the scene. Losing the context
- *  ourselves frees it immediately instead of waiting on GC.
+/** 找到 addon 渲染器正在绘制进去的活动 WebGL2 context，以便拆解时可以显式
+ * 释放它。@xterm/addon-webgl 的 dispose() 会拆掉它的渲染器并移除它的画布，
+ * 但从不调用 loseContext()，所以底层的 context 会残留到拥有它的 addon 之后
+ * （xterm/xterm.js#6068）。在地板上反复切换 agent 时，每次切换会 dispose 一个
+ * 渲染器、租借另一个，于是这些孤儿 context 越积越多，直到 Chromium 撞上它的
+ * 活动 context 上限（~16）并逐出一个较老的——经常是办公室地板自己的 context——
+ * 让某个终端或场景黑屏。自己主动丢失 context 能立刻释放它，而不是等 GC。
  *
- *  Scoped to THIS terminal's element and matched by an active webgl2 context, so
- *  it can never touch another terminal's or the scene's context. Returns null when
- *  no live webgl2 canvas is present (the DOM renderer is in use, or it is gone). */
+ *  限定在这个终端的元素内，并且要匹配一个活动 webgl2 context，所以绝不能碰到
+ *  另一个终端或场景的 context。当没有活动的 webgl2 画布时返回 null（DOM 渲染器
+ *  在用，或者它已经没了）。 */
 function webglContextOf(term: Terminal): WebGL2RenderingContext | null {
   const el = term.element;
   if (!el) return null;
@@ -638,46 +587,42 @@ function webglContextOf(term: Terminal): WebGL2RenderingContext | null {
   return null;
 }
 
-/** Release the WebGL lease so an off-screen terminal isn't holding a GPU context
- *  that an on-screen one needs. xterm falls back to the DOM renderer, which is
- *  fine for a terminal nobody is looking at; the next attach takes a fresh
- *  lease. The buffer and pty subscription are untouched. */
+/** 释放 WebGL 租约，让离屏终端不占用屏幕上的终端需要的 GPU context。xterm
+ * 回退到 DOM 渲染器，对没人在看的终端来说没问题；下次 attach 会拿一份新租约。
+ * 缓冲和 pty 订阅都不动。 */
 function releaseWebglRenderer(entry: TerminalEntry): void {
   const webgl = entry.webgl;
   if (!webgl) return;
   entry.webgl = undefined;
-  // Capture the context BEFORE dispose (dispose may detach the canvas), then
-  // release it explicitly — dispose() alone leaks it (see webglContextOf).
+  // 在 dispose 之前抓取 context（dispose 可能分离画布），然后显式释放它——
+  // 仅 dispose() 会泄漏它（见 webglContextOf）。
   const gl = webglContextOf(entry.term);
   try { webgl.dispose(); } catch { /* noop */ }
   try { gl?.getExtension('WEBGL_lose_context')?.loseContext(); } catch { /* noop */ }
-  // The DOM renderer that takes over inherits xterm's cached cell metrics, which
-  // may be stale by the time this terminal is shown again.
+  // 接管的 DOM 渲染器会继承 xterm 缓存的单元格度量，等到这个终端再次显示时
+  // 可能已经过期。
   entry.needsRendererRepaint = true;
 }
 
-/** Turn Arabic/RTL rendering ON for one open terminal.
+/** 为某个打开的终端打开阿拉伯文/RTL 渲染。
  *
- *  The full recipe is documented in terminal/arabicJoiner.ts: join every Arabic
- *  phrase into one render range, and strip xterm's per-span letter-spacing from
- *  Arabic spans. MUST run after `open()` — registering a joiner on an unopened
- *  terminal throws.
+ *  完整方案记录在 terminal/arabicJoiner.ts：把每段阿拉伯文短语连接成一个
+ *  渲染范围，并去掉 xterm 对阿拉伯文跨度的逐 span 字间距。必须在 `open()`
+ *  之后运行——在未打开的终端上注册 joiner 会抛错。
  *
- *  The `cth-bidi` class is what scopes the bidi CSS in design/global.css to this
- *  terminal. PR #213 applied those rules to every .xterm on the page; they are
- *  `!important` and change span layout, so an English user who fell back to the
- *  DOM renderer (a lost WebGL lease) would have had their TUI box-drawing
- *  shifted by a feature they never enabled. */
+ *  `cth-bidi` 类就是用来把 design/global.css 里的 bidi CSS 限定到这个终端的。
+ *  PR #213 把这些规则应用到页面上每个 .xterm；它们是 `!important` 并改变 span
+ *  布局，所以一个回退到 DOM 渲染器（丢失 WebGL 租约）的英文用户，会看到一个
+ *  他们从未启用的功能把 TUI 方框线挤歪。 */
 function enableArabicRendering(entry: TerminalEntry): void {
   if (entry.arabic) return;
   entry.host.classList.add('cth-bidi');
   const joiner = entry.term.registerCharacterJoiner(arabicJoinRanges);
   const detachSpacing = attachArabicSpacingFix(entry.host);
   entry.arabic = { joiner, detachSpacing };
-  // Terminals open at boot, often BEFORE webfonts finish loading, so xterm
-  // measures Arabic glyphs against fallback metrics and keeps them. When the
-  // real fonts land, poke fontFamily (a self-assign) to force a re-measure and
-  // full repaint.
+  // 终端在启动时打开，常常早于 webfonts 加载完成，所以 xterm 用回退度量测量
+  // 阿拉伯字形并一直保留。当真实字体到达时，拨一下 fontFamily（自我赋值）强制
+  // 重新测量并完整重绘。
   void document.fonts?.ready.then(() => {
     if (entry.exited) return;
     const fam = entry.term.options.fontFamily;
@@ -685,8 +630,8 @@ function enableArabicRendering(entry: TerminalEntry): void {
   });
 }
 
-/** Exactly undo the above. Every step is reversible, which is the reason the
- *  switch can be live at all — nothing here disposes the terminal. */
+/** 精确撤销上面的事。每一步都可逆，这正是这个开关能实时存在的原因——
+ * 这里没有任何东西销毁终端。 */
 function disableArabicRendering(entry: TerminalEntry): void {
   const on = entry.arabic;
   if (!on) return;
@@ -696,41 +641,35 @@ function disableArabicRendering(entry: TerminalEntry): void {
   try { on.detachSpacing(); } catch { /* noop */ }
 }
 
-/** Bring every OPEN terminal in line with the current setting.
+/** 让每个打开的终端都跟上当前设置。
  *
- *  Called when the app language changes and when the Settings toggle is used.
- *  Without it the setting would only reach terminals opened afterwards, and a
- *  user who switched to Arabic would see the terminals they already had still
- *  rendering unshaped, left-to-right — which reads as the feature not working
- *  rather than as a scoping rule.
+ *  在应用语言改变和 Settings 开关被使用时调用。没有它，设置只会影响到之后
+ *  才打开的终端，而一个切到阿拉伯文的用户会看到他们已有的终端仍按未塑形、
+ *  从左到右的方式渲染——这读起来像功能没生效，而不是一个作用域规则。
  *
- *  It UPGRADES IN PLACE rather than rebuilding. The office scene can be rebuilt
- *  on a language switch (a8292697) because it is derived from state we still
- *  hold; a terminal cannot, because its scrollback exists only in xterm's own
- *  buffer and the pty will not resend it — recreating one would silently eat
- *  the user's history. Dropping the WebGL lease is enough: `releaseWebglRenderer`
- *  hands painting to the DOM renderer with the buffer, the pty subscription and
- *  the scrollback all untouched, and that DOM renderer is precisely what Arabic
- *  mode needs. Going the other way re-leases WebGL on the next attach.
+ *  它就地升级，而不是重建。办公室场景在语言切换时（a8292697）可以重建，
+ *  因为它来自我们仍持有的状态；终端不能，因为它的滚动缓冲只存在于 xterm
+ *  自己的缓冲里，pty 也不会重发它——重建一个会静默吞掉用户的历史。放下 WebGL
+ *  租约就够了：`releaseWebglRenderer` 把绘制交给 DOM 渲染器，而缓冲、pty 订阅
+ *  和滚动缓冲全都原封不动，那个 DOM 渲染器正是阿拉伯文模式需要的。反过来时，
+ *  下次 attach 会重新拿 WebGL 租约。
  *
- *  A terminal that has never been opened is skipped: it has no host in the
- *  document and no joiner to register, and `attachTerminal` reads the setting
- *  fresh when it does open. */
+ *  从未打开过的终端会跳过：它在文档里没有 host、没有可注册的 joiner，而且
+ *  `attachTerminal` 会在它真正打开时重新读取设置。 */
 export function notifyArabicTerminalChangeAll(): void {
   const want = isArabicTerminalEnabled();
   const open = [...pool.values()].filter((e) => e.opened && !e.exited);
   const changed = open.filter((e) => !!e.arabic !== want);
   for (const entry of changed) {
     if (want) {
-      // The GPU cell painter ignores CSS and cannot do bidi, so Arabic mode
-      // needs the DOM renderer. Releasing the lease keeps the buffer.
+      // GPU 单元格画家忽略 CSS、做不了 bidi，所以阿拉伯文模式需要 DOM 渲染器。
+      // 释放租约能保住缓冲。
       releaseWebglRenderer(entry);
       enableArabicRendering(entry);
     } else {
       disableArabicRendering(entry);
-      // Deliberately NOT re-leasing WebGL here: the lease is taken on attach,
-      // and taking one now for an off-screen terminal is the exact GPU-context
-      // exhaustion releaseWebglRenderer exists to avoid.
+      // 刻意不在这里重新拿 WebGL 租约：租约是在 attach 时拿的，现在为一个
+      // 离屏终端拿一份正是 releaseWebglRenderer 存在要避免的 GPU context 耗尽。
       entry.needsRendererRepaint = true;
     }
     repaintTerminalAfterRendererLoss(entry);
@@ -739,30 +678,28 @@ export function notifyArabicTerminalChangeAll(): void {
     + `${changed.length}/${open.length} open terminal(s) switched`);
 }
 
-/** Re-parent a pty's terminal into `container`, opening xterm on first attach. */
+/** 把 pty 的终端重新挂进 `container`，首次 attach 时打开 xterm。 */
 export function attachTerminal(entry: TerminalEntry, container: HTMLElement): void {
   container.appendChild(entry.host);
   if (!entry.opened) {
-    // open() must come first — the WebGL addon can only load onto an opened
-    // terminal, and xterm needs its host in the document to measure the cell.
+    // open() 必须先来——WebGL addon 只能加载到已打开的终端上，而且 xterm 需要
+    // host 在文档里才能测量单元格。
     entry.term.open(entry.host);
     entry.opened = true;
-    // Arabic/RTL terminal support (the full recipe is documented in
-    // terminal/arabicJoiner.ts): join every Arabic phrase into one render range,
-    // and strip xterm's per-span letter-spacing from Arabic spans. MUST come
-    // after open(): registering a joiner on an unopened terminal throws.
+    // 阿拉伯文/RTL 终端支持（完整方案记录在 terminal/arabicJoiner.ts）：把每段
+    // 阿拉伯文短语连接成一个渲染范围，并去掉 xterm 对阿拉伯文跨度的逐 span
+    // 字间距。必须在 open() 之后：在未打开的终端上注册 joiner 会抛错。
     //
-    // The `cth-bidi` class is what scopes the bidi CSS in design/global.css to
-    // this terminal. The PR applied those rules to every .xterm on the page;
-    // they are `!important` and change span layout, so an English user who
-    // fell back to the DOM renderer (a lost WebGL lease) would have had their
-    // TUI box-drawing shifted by a feature they never enabled.
+    // `cth-bidi` 类就是用来把 design/global.css 里的 bidi CSS 限定到这个终端的。
+    // 那个 PR 把这些规则应用到页面上每个 .xterm；它们是 `!important` 并改变 span
+    // 布局，所以一个回退到 DOM 渲染器（丢失 WebGL 租约）的英文用户，会看到一个
+    // 他们从未启用的功能把 TUI 方框线挤歪。
     if (isArabicTerminalEnabled()) enableArabicRendering(entry);
   }
   leaseWebglRenderer(entry);
-  // PTY startup output can arrive before this pooled terminal subscribes.
-  // Request one same-size redraw after open/subscription even when fit() later
-  // sees unchanged dimensions and therefore emits no resize of its own.
+  // PTY 启动输出可能在池化终端订阅之前到达。
+  // 在 open/订阅之后请求一次同尺寸重绘，即使 fit() 稍后看到尺寸没变、因而不发出
+  // 自己的 resize 也一样。
   requestInitialPtyRedraw(entry.recovery, () => window.cth.redrawPty(entry.ptyId));
   if (entry.needsRendererRepaint) {
     scheduleWebglRecovery(entry.recovery, requestAnimationFrame, () =>
@@ -770,13 +707,12 @@ export function attachTerminal(entry: TerminalEntry, container: HTMLElement): vo
   }
 }
 
-/** Take the terminal off screen: drop the WebGL lease and unparent the host.
- *  Everything that makes the terminal a terminal — buffer, scrollback, pty
- *  subscription — stays in the pool, so re-attaching shows it fully rendered. */
+/** 把终端移出屏幕：放下 WebGL 租约并取消 host 的挂接。
+ *  让终端成为终端的一切——缓冲、滚动缓冲、pty 订阅——都留在池里，所以重新
+ *  attach 会显示它完整渲染。 */
 export function detachTerminal(entry: TerminalEntry, container: HTMLElement): void {
-  // Guard: another view may have already taken the host (React can mount the new
-  // owner before the old one's cleanup runs). Releasing the renderer then would
-  // blank the terminal that just legitimately claimed it.
+  // 守卫：另一个视图可能已经取走了 host（React 可能在旧 owner 的清理运行之前
+  // 就挂载新 owner）。那时释放渲染器会让刚合法认领它的终端黑屏。
   if (entry.host.parentElement !== container) return;
   releaseWebglRenderer(entry);
   container.removeChild(entry.host);
@@ -791,11 +727,10 @@ function repaintTerminalAfterRendererLoss(entry: TerminalEntry): void {
   reflowTerminal(entry.ptyId);
   try {
     entry.term.refresh(0, Math.max(0, entry.term.rows - 1));
-    // Only NOW is the repaint confirmed. Clearing the marker before the refresh
-    // meant a throw here (the renderer still settling) discarded the last record
-    // that this terminal needed repainting — so it stayed black until something
-    // unrelated happened to resize it, which is why Cmd +/- fixed it only some
-    // of the time.
+    // 只有到这时重绘才算确认。在 refresh 之前清除标记，意味着这里抛错时
+    // （渲染器仍在稳定中）会丢弃“该终端需要重绘”的最后一条记录——于是它一直
+    // 黑屏，直到有什么无关的事碰巧调整了尺寸，这就是为什么 Cmd +/- 只有部分
+    // 时候能修好它。
     entry.needsRendererRepaint = false;
   } catch {
     entry.needsRendererRepaint = true;
@@ -803,59 +738,142 @@ function repaintTerminalAfterRendererLoss(entry: TerminalEntry): void {
 }
 
 /**
- * Re-measure cell metrics and rebuild the viewport scroll-area for a pooled
- * terminal. Use after a display wake / GPU (WebGL) context loss / DPR change:
- * xterm caches the cell height measured at open() and only recomputes it on a
- * font change or resize. When that cached metric goes stale (sleep/wake), the
- * .xterm-viewport scroll-area height (rows × cellHeight) is wrong, so only PART
- * of the still-intact buffer is scrollable — the user otherwise has to zoom to
- * force a fit() and reveal the rest.
+ * 重新测量单元格度量，并为池化终端重建视口滚动区。在显示器唤醒 / GPU（WebGL）
+ * context 丢失 / DPR 变化之后使用：xterm 会缓存 open() 时测得的单元格高度，
+ * 只在字体变化或 resize 时重新计算。当那个缓存的度量过期（休眠/唤醒）时，
+ * .xterm-viewport 滚动区高度（rows × cellHeight）是错的，所以完好的缓冲只有
+ * PART 一部分可滚动——用户只能靠缩放来强制 fit() 并露出其余部分。
  *
- * Mirrors the document.fonts.ready re-measure in PtyTerminalView: re-applying the
- * SAME font invalidates xterm's cached cell metrics, clearTextureAtlas re-rasters
- * the WebGL glyph atlas at the right size, then fit() recomputes cols/rows and
- * rebuilds the viewport. Preserves scroll position (NO scrollToBottom) so a user
- * reading history isn't yanked down. No-op until the terminal is opened and its
- * host has a real size, so it composes safely with multiple triggers firing
- * together (onContextLoss + visibilitychange + focus) — a cheap reflow twice is
- * harmless; the guards make an early/duplicate call a no-op.
+ * 镜像 PtyTerminalView 里的 document.fonts.ready 重测：重新应用 SAME 字体使
+ * xterm 缓存的单元格度量失效，clearTextureAtlas 以正确尺寸重新栅格化 WebGL
+ * 字形图集，然后 fit() 重新计算 cols/rows 并重建视口。保留滚动位置（不
+ * scrollToBottom），所以读历史的人不会被拽到底。在终端已打开且 host 有真实
+ * 尺寸之前是 no-op，所以多个触发器同时触发（onContextLoss +
+ * visibilitychange + focus）也能安全组合——便宜的两次 reflow 无害；守卫让
+ * 过早/重复调用变成 no-op。
  */
+// ── resizePty 防抖（启动横幅叠帧根治）─────────────────────────────────
+// qwen/Claude Code 的 TUI 每次收到 SIGWINCH 都整屏重绘，并把上一帧推进
+// scrollback。挂载级联（rAF×2、60ms、240ms、字体加载、ResizeObserver、
+// 唤醒 reflow）会在几百毫秒内发出多次 resizePty——每次都被 TUI 渲染成一帧
+// 新横幅，造成启动横幅垂直堆叠（qwen 实测约 9 份 D:\MunderDiffLin）。
+// 把发往同一 pty（不同 pty 互不干扰）的 resize 合并进一个 140ms 窗口：
+// 窗口内只发最后一次（最终网格），既保留对窗口拖动的最终响应，又掐掉瞬发
+// 重复的 SIGWINCH。这是对所有引擎（qwen/Claude/Codex）通用的最小修复。
+// DOM lib 下 setTimeout 返回 number，Node 下返回 Timeout —— 命名的句柄类型
+// 让两套环境共用同一声明。
+type TimerHandle = ReturnType<typeof setTimeout>;
+const pendingResizes = new Map<string, { cols: number; rows: number }>();
+let resizePtyFlushTimer: TimerHandle | undefined;
+
+export function debouncedResizePty(ptyId: string, cols: number, rows: number): void {
+  pendingResizes.set(ptyId, { cols, rows });
+  if (resizePtyFlushTimer !== undefined) return; // 已有合并窗口在跑
+  resizePtyFlushTimer = setTimeout(() => {
+    resizePtyFlushTimer = undefined;
+    for (const [id, size] of pendingResizes) {
+      try {
+        window.cth.resizePty(id, size.cols, size.rows);
+      } catch { /* 宿主可能已销毁 */ }
+    }
+    pendingResizes.clear();
+  }, 140);
+}
+// ── term.write 节流（持续闪烁根治）─────────────────────────────────────
+// qwen TUI 内部 SCROLL_FRAME_MS=16（~60fps 全屏重绘），在 ConPTY 下每帧
+// 调用 term.write 都会触发 xterm 渲染——叠加出视觉上的持续闪烁（用户报告
+// "一直闪"）。写节流：把发往同一 pty 的 write 合并进 100ms 窗口，把 60fps
+// 降到 ~10fps。前沿 flush（距上次 >=100ms）立即写，追沿合并+单次定时器。
+// 这是 xterm 层节流，不影响字节保真——flush 后的 write 仍是正确的 OSC/CSI
+// 序列，只是批量发送而非逐帧。
+const writeBufs = new Map<string, string[]>();
+const writeFlushTimers = new Map<string, TimerHandle>();
+const writeLastFlushAt = new Map<string, number>();
+const WRITE_FLUSH_MS = 100;
+
+function enqueueWrite(ptyId: string, chunk: string): void {
+  let buf = writeBufs.get(ptyId);
+  if (!buf) { buf = []; writeBufs.set(ptyId, buf); }
+  buf.push(chunk);
+  const last = writeLastFlushAt.get(ptyId) ?? 0;
+  const elapsed = Date.now() - last;
+  if (elapsed >= WRITE_FLUSH_MS) {
+    // 前沿 flush：距上次 flush 已够久，立即写（保按键响应性）
+    flushWrite(ptyId);
+  } else {
+    // 追沿 schedule：距边界还有 (WRITE_FLUSH_MS - elapsed) ms，调度一次
+    const remaining = WRITE_FLUSH_MS - elapsed;
+    const timer = writeFlushTimers.get(ptyId);
+    if (timer !== undefined) clearTimeout(timer);
+    const t = setTimeout(() => {
+      writeFlushTimers.delete(ptyId);
+      flushWrite(ptyId);
+    }, remaining);
+    writeFlushTimers.set(ptyId, t);
+  }
+}
+
+function flushWrite(ptyId: string): void {
+  const buf = writeBufs.get(ptyId);
+  if (!buf || buf.length === 0) { writeBufs.delete(ptyId); return; }
+  const entry = pool.get(ptyId);
+  if (!entry) { writeBufs.delete(ptyId); return; }
+  const active = entry.term.buffer.active;
+  const follow = shouldFollowTerminalOutput(active.viewportY, active.baseY);
+  entry.term.write(buf.join(''), () => {
+    if (follow) {
+      try { entry.term.scrollToBottom(); } catch { /* 终端可能正在分离 */ }
+    }
+  });
+  writeBufs.delete(ptyId);
+  writeLastFlushAt.set(ptyId, Date.now());
+}
+
+export function flushPendingWrites(): void {
+  for (const ptyId of writeBufs.keys()) {
+    const timer = writeFlushTimers.get(ptyId);
+    if (timer !== undefined) clearTimeout(timer);
+    writeFlushTimers.delete(ptyId);
+    flushWrite(ptyId);
+  }
+}
+
 export function reflowTerminal(ptyId: string): void {
   const entry = pool.get(ptyId);
   if (!entry || !entry.opened) return;
   const host = entry.host;
-  // Skip while detached or unsized — fitting a 0×0 host makes xterm propose a
-  // tiny grid and resize the pty to it (clipped/oversized banner).
+  // 分离或无尺寸时跳过——对 0×0 的 host 做 fit 会让 xterm 提出一个极小的
+  // 网格，并把 pty 调整到它（裁剪/过大的横幅）。
   if (!host.isConnected || !host.clientWidth || !host.clientHeight) return;
   try {
-    // Re-apply the SAME font options to force xterm's CharSizeService to
-    // re-measure the cell against the now-correct (woken) layout, then drop the
-    // glyph atlas so it re-rasters at the corrected metrics.
+    // 重新应用 SAME 字体选项，强制 xterm 的 CharSizeService 针对现在正确的
+    // （唤醒后的）布局重新测量单元格，然后丢弃字形图集，让它以修正后的度量
+    // 重新栅格化。
     entry.term.options.fontFamily = entry.term.options.fontFamily;
     entry.term.options.fontSize = entry.term.options.fontSize;
     entry.term.clearTextureAtlas?.();
     const before = { cols: entry.term.cols, rows: entry.term.rows };
     entry.fit.fit();
-    // Only poke the pty when the grid actually changed (every resize repaints
-    // the TUI and pushes a frame into scrollback).
+    // 只在网格真的变化时触发 pty（每次 resize 都会重绘 TUI 并向滚动缓冲推入
+    // 一帧）。经防抖合并：唤醒级联（visibilitychange + focus + onContextLoss）
+    // 会连续重测，只把最终网格发给 pty。
     if (entry.term.cols !== before.cols || entry.term.rows !== before.rows) {
-      window.cth.resizePty(ptyId, entry.term.cols, entry.term.rows);
+      debouncedResizePty(ptyId, entry.term.cols, entry.term.rows);
     }
     entry.term.refresh(0, Math.max(0, entry.term.rows - 1));
-  } catch { /* host may not be sized yet */ }
+  } catch { /* 宿主可能尚未确定尺寸 */ }
 }
 
 /**
- * Soft-reset a pooled terminal for an IN-PLACE pty respawn (the same ptyId is
- * reused — e.g. a model change or agent restart). Clears the screen + scrollback
- * and re-arms input while keeping the SAME Terminal, its live data subscription
- * and its DOM attachment, so the mounted view stays visible and typeable across
- * the restart.
+ * 对池化终端做“就地”软重置，用于 pty 原地重生（同一个 ptyId 被复用——例如
+ * 模型切换或 agent 重启）。清屏 + 清滚动缓冲并重新武装输入，同时保留同一个
+ * Terminal、它的实时数据订阅和 DOM 挂接，这样已挂载的视图能在重启期间保持
+ * 可见和可输入。
  *
- * Why not disposeTerminal here: the view (PtyTerminalView) keys its attach effect
- * on the ptyId, which doesn't change on a restart — so it never re-attaches a
- * replacement terminal. Disposing therefore left a dead, detached pane that
- * swallowed every keystroke. Resetting in place avoids that entirely.
+ * 为什么这里不 disposeTerminal：视图（PtyTerminalView）把它的 attach effect
+ * 绑定在 ptyId 上，而 ptyId 在重启时不变——所以它永远不会重新 attach 一个
+ * 替代终端。dispose 因此会留下一个死的、分离的、吞掉每次按键的面板。就地重置
+ * 完全避免了这一点。
  */
 export function resetTerminal(
   ptyId: string,
@@ -863,14 +881,13 @@ export function resetTerminal(
 ): void {
   const entry = pool.get(ptyId);
   if (!entry) return;
-  // Re-arm input — a prior exit (or the kill that precedes the respawn) may have
-  // latched `exited`, which otherwise makes onData drop keystrokes silently.
+  // 重新武装输入——先前的退出（或重生前的 kill）可能已锁存 `exited`，
+  // 否则会让 onData 静默丢弃按键。
   entry.exited = false;
   entry.inputDirty = false;
   entry.inputDirtyAt = 0;
-  // The old process's prompt is gone with it — drop our model of that line and
-  // any picker it had open, or the replacement inherits a phantom draft and a
-  // block that nothing can clear.
+  // 旧进程的提示符随它而去——丢掉我们对那行以及它可能打开的任何选择器的模型，
+  // 否则替代进程会继承一个幽灵草稿和一个无法清除的阻塞。
   entry.lineBuf = '';
   entry.automationBlocked = false;
   entry.automationBlockedAt = 0;
@@ -878,19 +895,19 @@ export function resetTerminal(
     if (opts.preserveScrollback) {
       entry.term.writeln('\r\n\x1b[2m─ resuming existing session ─\x1b[0m');
     } else {
-      // Fresh sessions need a clean grid; resume keeps the existing scrollback.
+      // 新会话需要干净的网格；resume 则保留现有滚动缓冲。
       entry.term.reset();
     }
-  } catch { /* not yet open */ }
+  } catch { /* 尚未打开 */ }
 }
 
-/** Tear down a pty's terminal (call when the agent/pty is gone for good). */
+/** 拆掉某个 pty 的终端（agent/pty 永久消失时调用）。 */
 export function disposeTerminal(ptyId: string): void {
   const entry = pool.get(ptyId);
   if (!entry) return;
   entry.unsub.forEach((u) => { try { u(); } catch { /* noop */ } });
-  // Release the GPU context the webgl addon leaves behind; dispose() alone leaks
-  // it (see webglContextOf). Captured before dispose in case it detaches the canvas.
+  // 释放 webgl addon 留下的 GPU context；仅 dispose() 会泄漏它（见
+  // webglContextOf）。在 dispose 之前抓取，以防它分离画布。
   const gl = webglContextOf(entry.term);
   try { entry.webgl?.dispose(); } catch { /* noop */ }
   try { gl?.getExtension('WEBGL_lose_context')?.loseContext(); } catch { /* noop */ }
@@ -899,36 +916,33 @@ export function disposeTerminal(ptyId: string): void {
   pool.delete(ptyId);
 }
 
-// ─── v0.3.4: ⌘-click a path in terminal output ──────────────────────────────
-// A custom ILinkProvider (NOT WebLinksAddon, which only matches URLs): detects
-// path tokens in the visible buffer line, resolves relative ones against the
-// owning agent's cwd, and on Cmd/Ctrl+click verifies existence via the
-// metadata-only fs:statAbs IPC before acting.
-// Plain click stays with the TUI (matches VS Code's terminal convention).
-// The path string is agent output — treated as hostile: it flows only into a
-// read-only stat, the existing read pipeline, or a REVEAL (never an "open with
-// the default app", which would turn a printed path into an execution), and
-// only on an explicit modifier-click.
+// ─── v0.3.4: ⌘-点击终端输出里的路径 ────────────────────────────────────────
+// 一个自定义 ILinkProvider（不是只匹配 URL 的 WebLinksAddon）：检测可见缓冲行
+// 里的路径 token，把相对路径按所属 agent 的 cwd 解析，在 Cmd/Ctrl+点击时通过
+// 只读元数据的 fs:statAbs IPC 验证存在性后再动作。
+// 普通点击仍交给 TUI（与 VS Code 的终端约定一致）。
+// 路径字符串是 agent 输出——按敌意对待：它只流入一次只读 stat、现有的读取管线、
+// 或一次 REVEAL（绝不做“用默认应用打开”，那会把一个打印出来的路径变成一次
+// 执行），而且只在显式的修饰键点击时发生。
 //
-// v0.4.5 widened this from markdown-only to every path token. What each type
-// does lives in @shared/terminalPaths, not here — this file only knows how to
-// find tokens on a line and how to run the three verdicts.
+// v0.4.5 把范围从仅 markdown 扩展到每个路径 token。每种类型做什么记录在
+// @shared/terminalPaths，不在这里——本文件只知道怎么在行上找 token，以及怎么
+// 运行三种判定。
 const mdStatCache = new Map<string, { isFile: boolean; path: string }>();
 
 function resolvePathCandidate(ptyId: string, raw: string): string | null {
   const p = stripPathToken(raw);
   if (!isPathToken(p)) return null;
   if (p.startsWith('~/') || p.startsWith('/') || /^[A-Za-z]:[\\/]/.test(p)) return p;
-  // relative → resolve against the owning agent's cwd. Async store import keeps
-  // this module usable in the node test harness (no zustand/react at load).
+  // 相对 → 按所属 agent 的 cwd 解析。异步 store import 让本模块能在 node 测试
+  // 环境里使用（加载时不依赖 zustand/react）。
   const cwd = storeApi?.getState().agents.find((a) => a.ptyId === ptyId)?.cwd ?? null;
   if (!cwd) return null;
   return `${cwd}/${p.replace(/^\.\//, '')}`;
 }
 
-// The store is loaded lazily via dynamic import (resolved once, cached): a
-// static import would drag zustand/react into the node --test transpile of the
-// pure automation helpers that share this file's import graph.
+// store 通过动态 import 惰性加载（只解析一次、有缓存）：静态 import 会把
+// zustand/react 拖进共享本文件导入图的纯自动化 helper 的 node --test 转译。
 interface MdStoreShape {
   getState: () => {
     agents: Array<{ ptyId?: string; cwd: string }>;
@@ -938,16 +952,15 @@ interface MdStoreShape {
 let storeApi: MdStoreShape | null = null;
 void import('@/store/store')
   .then((m) => { storeApi = (m as unknown as { useStore: MdStoreShape }).useStore; })
-  .catch(() => { /* store unavailable (tests) — link provider stays inert */ });
+  .catch(() => { /* 存储不可用（测试中）—— 链接提供方保持惰性 */ });
 
-/** Act on a verified path. `reveal` also takes any directory that reaches here:
- *  the IDE needs a file. A miss is silent by design — the token is agent output
- *  and may simply not exist.
+/** 对已验证的路径执行动作。`reveal` 也接受任何到达这里的目录：
+ *  IDE 需要一个文件。未命中时按设计保持静默——token 是 agent 输出，可能
+ *  就是不存在。
  *
- *  Both non-reveal verdicts land in the IDE. The IDE already routes by type
- *  (Monaco for source, preview for markdown, the viewer for images), so this
- *  does not need to pass the verdict along — it only needs to know whether the
- *  file is ours to open at all. */
+ *  两个非 reveal 的判定都落在 IDE。IDE 已经按类型路由（源码走 Monaco、markdown
+ *  走预览、图片走查看器），所以这里不需要把判定传下去——它只需要知道这个文件
+ *  到底是不是我们能打开的。 */
 async function activatePath(abs: string, action: PathAction): Promise<void> {
   let hit = mdStatCache.get(abs);
   if (!hit) {
@@ -958,7 +971,7 @@ async function activatePath(abs: string, action: PathAction): Promise<void> {
     mdStatCache.set(abs, hit);
   }
   if (action === 'reveal' || !hit.isFile) {
-    void window.cth.revealPath(hit.path).catch(() => { /* file browser refused */ });
+    void window.cth.revealPath(hit.path).catch(() => { /* 文件浏览器被拒绝 */ });
     return;
   }
   storeApi?.getState().openFileInIde(hit.path);
@@ -987,7 +1000,7 @@ function registerMarkdownLinkProvider(term: Terminal, ptyId: string): void {
             text: raw,
             decorations: { underline: true, pointerCursor: true },
             activate: (event: MouseEvent | undefined) => {
-              // ⌘/Ctrl+click only — a plain click must keep going to the TUI.
+              // 只接受 ⌘/Ctrl+点击——普通点击必须继续交给 TUI。
               if (event && !(event.metaKey || event.ctrlKey)) return;
               void activatePath(abs, action);
             }
@@ -996,5 +1009,5 @@ function registerMarkdownLinkProvider(term: Terminal, ptyId: string): void {
         callback(links && links.length ? links : undefined);
       }
     });
-  } catch { /* proposed API unavailable — feature silently off */ }
+  } catch { /* 提案中的 API 不可用 —— 该功能静默关闭 */ }
 }

--- a/src/renderer/src/components/terminalRecovery.ts
+++ b/src/renderer/src/components/terminalRecovery.ts
@@ -7,13 +7,13 @@ export function createTerminalRecoveryState(): TerminalRecoveryState {
   return { initialRedrawRequested: false, webglRecoveryPending: false };
 }
 
-/** React key for one disposable xterm instance attached to a stable PTY id. */
+/** 附着到稳定 PTY id 上的一次性 xterm 实例的 React key。 */
 export function terminalInstanceKey(ptyId: string, generation = 0): string {
   return `${ptyId}:${generation}`;
 }
 
-/** Accept output from the current string protocol and the short-lived replay
- * protocol so a renderer hot reload stays usable until the app next exits. */
+/** 同时接受当前字符串协议和短暂的 replay 协议，这样渲染器热重载在应用下次
+ * 退出前都保持可用。 */
 export function normalizePtyChunk(value: unknown): string {
   if (typeof value === 'string') return value;
   if (value && typeof value === 'object' && 'data' in value) {
@@ -23,21 +23,20 @@ export function normalizePtyChunk(value: unknown): string {
   return '';
 }
 
-/** Request exactly one redraw after the renderer has subscribed to PTY output.
+/** 在渲染器订阅 PTY 输出后，请求正好一次重绘。
  *
- *  The latch is only set once the redraw has actually SUCCEEDED. It used to be
- *  set up front, before the fire-and-forget IPC resolved — so a redraw that
- *  failed or raced left a terminal that had already consumed its one chance,
- *  with no output to repaint it and no retry path. That is a blank pane with a
- *  perfectly healthy pty behind it. A rejected redraw now leaves the latch clear
- *  so the next attach tries again. */
+ *  这个锁存只在重绘真正 SUCCEED 之后才设置。过去是在前面就设置的——在
+ *  fire-and-forget IPC 解析之前——所以一次失败或竞态的重绘会留下一个已经
+ *  耗尽它唯一机会的终端，没有输出可以重画它，也没有重试路径。那是一个空白
+ *  面板，背后却是一个完全健康的 pty。被拒绝的重绘现在会让锁存保持清空，
+ *  于是下一次 attach 会再试一次。 */
 export function requestInitialPtyRedraw(
   state: TerminalRecoveryState,
   requestRedraw: () => void | Promise<unknown>
 ): boolean {
   if (state.initialRedrawRequested) return false;
-  // Set before awaiting so two attaches in the same tick can't both fire; a
-  // failure clears it again below.
+  // 在 await 之前设置，这样同一 tick 内的两次 attach 不会都触发；下面的失败
+  // 会再次清除它。
   state.initialRedrawRequested = true;
   try {
     const result = requestRedraw();
@@ -52,14 +51,12 @@ export function requestInitialPtyRedraw(
   return true;
 }
 
-/** Wait two paint frames after WebGL disposal so the DOM renderer can repaint.
+/** 在 WebGL 销毁后等待两个绘制帧，让 DOM 渲染器可以重绘。
  *
- *  `recover` reports whether it actually repainted. When it could not (the host
- *  is detached or still unsized), the pending flag is cleared AND the caller
- *  keeps its needs-repaint marker, so a later attach can schedule another
- *  attempt. Clearing the flag unconditionally before the repaint was confirmed
- *  is what made the blank terminal recover "sometimes" — whether a later resize
- *  happened to rebuild the renderer was pure luck. */
+ *  `recover` 报告它是否真的重绘了。当它做不到时（host 已分离或仍未定尺寸），
+ *  pending 标记被清除，同时调用方保留它的 needs-repaint 标记，这样稍后的
+ *  attach 可以再安排一次尝试。在确认重绘之前无条件清除标记，正是让空白终端
+ *  “有时候”能恢复的原因——稍后一次 resize 是否碰巧重建渲染器全凭运气。 */
 export function scheduleWebglRecovery(
   state: TerminalRecoveryState,
   requestFrame: (cb: () => void) => void,

--- a/src/renderer/src/components/terminalSelection.ts
+++ b/src/renderer/src/components/terminalSelection.ts
@@ -1,47 +1,44 @@
 /**
- * Copy hygiene for terminal selections.
+ * 终端选区的复制卫生。
  *
- * Agent CLIs paint their decoration INTO the character grid. Claude Code draws
- * a markdown blockquote as `▎ text`, so the rail is a real cell on that line —
- * not a border drawn beside it. Selecting the line (which is exactly what a
- * triple-click or a full-width drag does) therefore copies the rail with the
- * prose, and the paste lands as:
+ * agent CLI 会把它们的装饰画进字符网格。Claude Code 把 markdown 引用画成
+ * `▎ text`，所以那条竖轨是该行上的一个真实单元格——不是画在旁边的边框。
+ * 选中该行（三击或全宽拖拽正是这么做的）会把竖轨连同正文一起复制，粘贴出来
+ * 就成了：
  *
  *     ▎ Munder Difflin — clones for you and your team, working 24/7.
  *
- * Nothing downstream wants that glyph, so strip it on the way to the clipboard.
+ * 下游没有任何东西想要那个字形，所以在进剪贴板的路上把它剥掉。
  *
- * The guard that stops this from eating real content: a rail only counts when a
- * space follows it or it ends the line — the shape a quote gutter always has. A
- * bar chart (`▌▌▌▌ 40%`) or block art keeps its bars because they run together.
+ * 防止这个吃掉真实内容的守卫：只有当竖轨后面跟着空格或是在行尾时才算数——
+ * 这正是引用槽的形状。条形图（`▌▌▌▌ 40%`）或块状艺术会保留它们的条，
+ * 因为它们连在一起。
  *
- * Deliberately narrow. Only the left/right BLOCK elements CLIs use as a gutter
- * are in the set; box-drawing verticals (`│`, `┃`) are not. `tree`, `git log
- * --graph` and every framed table indent continuation lines with `│   `, and
- * stripping that would corrupt far more copies than it would fix.
+ * 刻意做得很窄。集合里只放 CLI 用作槽的左右 BLOCK 元素；方框线竖线
+ * （`│`、`┃`）不在其中。`tree`、`git log --graph` 以及每个带边框的表格都会用
+ * `│   ` 缩进续行，剥掉它破坏的复制会比修复的多得多。
  */
 
-/** ▌ ▍ ▎ ▏ (left half → left one-eighth) and ▐ ▕ (right half, right eighth). */
+/** ▌ ▍ ▎ ▏（左半 → 左八分之一）和 ▐ ▕（右半、右八分之一）。 */
 const RAIL_CHARS = '▌▍▎▏▐▕';
 
-/** Leading indent, then one or more `rail + space` / `rail + end-of-line` runs.
- *  Nested quotes render as `▎ ▎ text`, hence the repeat. */
+/** 前导缩进，然后一个或多个 `竖轨 + 空格` / `竖轨 + 行尾` 序列。
+ *  嵌套引用渲染成 `▎ ▎ text`，所以要用重复。 */
 const LEADING_RAIL = new RegExp(`^([ \\t]*)(?:[${RAIL_CHARS}](?: |(?=\\r?$)))+`);
 
 const ANY_RAIL = new RegExp(`[${RAIL_CHARS}]`);
 
-/** Drop a quote/gutter rail from the start of a single line, keeping its indent. */
+/** 从单行开头去掉引用/槽竖轨，保留缩进。 */
 export function stripLeadingRail(line: string): string {
   return line.replace(LEADING_RAIL, '$1');
 }
 
 /**
- * Clean a terminal selection for the clipboard: per line, drop the gutter rail
- * the CLI painted into column 0. Everything else — indentation, box drawing,
- * inline glyphs — is left byte-for-byte alone.
+ * 清理要进剪贴板的终端选区：逐行去掉 CLI 画在第 0 列的槽竖轨。其它一切——
+ * 缩进、方框线、行内字形——都逐字节原样保留。
  */
 export function sanitizeTerminalSelection(text: string): string {
-  // The overwhelming majority of copies contain no rail at all; skip the split.
+  // 绝大多数复制的文本根本没有竖轨；跳过 split。
   if (!text || !ANY_RAIL.test(text)) return text;
   return text.split('\n').map(stripLeadingRail).join('\n');
 }

--- a/src/renderer/src/components/triggers/ContextSection.tsx
+++ b/src/renderer/src/components/triggers/ContextSection.tsx
@@ -9,9 +9,9 @@ import {
 import { useRtl } from '@/i18n/useDirection';
 
 /**
- * CONTEXT — the trigger that fires on an agent's own terminal filling up rather
- * than on the clock alone. Two rules, and they are not the same operation:
- * compaction SUMMARISES the context, clearing THROWS IT AWAY.
+ * CONTEXT —— 触发条件是代理自身终端被填满，而不是仅仅靠时钟。两条规则，而且
+ * 它们不是同一种操作：compaction（压缩）对上下文做 SUMMARISE（概括），
+ * clearing（清空）则 THROWS IT AWAY（把它丢掉）。
  */
 
 const WRITE_DEBOUNCE_MS = 400;
@@ -39,8 +39,8 @@ export function ContextSection({ onSummary }: { onSummary?: (s: string) => void 
     onSummary?.(on.length ? on.join(' + ') : t('contextSection.bothOff'));
   }, [cfg, onSummary, t]);
 
-  // Optimistic + debounced: the controls answer instantly, and a burst of typing
-  // in the message box collapses into one write instead of one per keystroke.
+  // 乐观 + 防抖：控件即时响应，消息框里的一阵输入会合并成一次写入，而不是
+  // 每次按键一次。
   const commit = (next: ContextTriggerConfig) => {
     setCfg(next);
     if (timer.current) clearTimeout(timer.current);
@@ -106,9 +106,8 @@ function RuleCard({ title, blurb, rule, messageLabel, messageHint, messagePlaceh
         sub={blurb}
         right={<Toggle on={rule.enabled} onClick={() => onPatch({ enabled: !rule.enabled })} />}
       />
-      {/* The caution is always on screen — it is why this ships off — but it only
-          goes coral once the destructive rule is actually armed. A red box over a
-          switched-off setting is crying wolf. */}
+      {/* 警告始终显示在屏幕上 —— 这正是它随关闭一起下线的意义 —— 但它只有
+          在破坏性规则真正启用时才变成珊瑚色。对已关闭的设置亮红框是狼来了。 */}
       {caution && <Callout tone={rule.enabled ? 'warn' : 'note'}>{caution}</Callout>}
       {!open && (
         <Hint>
@@ -120,9 +119,9 @@ function RuleCard({ title, blurb, rule, messageLabel, messageHint, messagePlaceh
       {open && (
         <div style={{ marginTop: 4 }}>
           <Field label={t('contextSection.noSoonerThan')}>
-            {/* Main clamps a context cadence to 1 minute … 24 hours, so the
-                picker offers exactly that range and never labels a value it
-                cannot actually store. */}
+            {/* Main 将上下文节奏限制在 1 分钟 … 24 小时，因此
+                选择器只提供该范围，绝不会标记一个它实际上
+                无法存储的值。 */}
             <IntervalPicker
               value={rule.everyMs}
               onChange={(everyMs) => onPatch({ everyMs })}

--- a/src/renderer/src/components/triggers/JsonEditor.tsx
+++ b/src/renderer/src/components/triggers/JsonEditor.tsx
@@ -5,10 +5,10 @@ import { tags } from '@lezer/highlight';
 import { json } from '@codemirror/lang-json';
 
 /**
- * A small JSON editor for a webhook's schema. Same CodeMirror the IDE uses, cut
- * down for a sidebar: no line numbers, no fold gutter, no search bar — those eat
- * a third of the width here and none of them help edit twenty lines of schema.
- * Colors come from `--cth-*` tokens so it follows the theme like everything else.
+ * 用于 webhook schema 的小型 JSON 编辑器。与 IDE 用的是同一个 CodeMirror，
+ * 为侧栏做了精简：没有行号、没有折叠沟槽、没有搜索栏——那些在这里会吃掉
+ * 三分之一的宽度，而且对编辑二十行 schema 毫无帮助。颜色来自 `--cth-*`
+ * tokens，所以它和其他东西一样跟随主题。
  */
 
 const editorTheme = EditorView.theme({

--- a/src/renderer/src/components/triggers/OrgSection.tsx
+++ b/src/renderer/src/components/triggers/OrgSection.tsx
@@ -6,16 +6,14 @@ import { getOrgTrigger, setOrgTrigger as persistOrgTrigger } from './api';
 import { Callout, Field, Hint, ModePicker, SecretField, Toggle } from './ui';
 
 /**
- * ORGANISATION — peer messaging between teammates' clone nodes.
+ * ORGANISATION —— 队友克隆节点之间的对等消息传递。
  *
- * Configuration only. There is no transport service yet, so a key saved here
- * starts nothing; it is the setting the service will read once it exists. The
- * copy says exactly that rather than implying a connection.
+ * 只有配置。目前还没有传输服务，所以在这里保存一个 key 不会启动任何东西；
+ * 它只是将来服务一旦存在就会读取的设置。文案正是这样说的，而不是暗示已有连接。
  *
- * Renders off the store mirror that Settings → Connections also renders off, and
- * follows the same mirror-then-persist rule: typing the key updates the mirror
- * (so Settings stays live) and commits on blur; the toggle and the trust mode
- * persist on the spot.
+ * 与 Settings → Connections 一样基于 store 镜像渲染，并遵循同样的先镜像后
+ * 持久化规则：输入 key 会更新镜像（这样 Settings 保持实时），并在 blur 时提交；
+ * 开关和信任模式则当场持久化。
  */
 export function OrgSection({ onSummary }: { onSummary?: (s: string) => void }) {
   const { t } = useTranslation();
@@ -24,8 +22,8 @@ export function OrgSection({ onSummary }: { onSummary?: (s: string) => void }) {
   const [revealed, setRevealed] = useState(false);
 
   useEffect(() => {
-    // Only when the mirror looks unseeded — adopting unconditionally could
-    // clobber a key being typed in Settings this second.
+    // 只在镜像看起来未播种时读取——无条件采纳可能会覆盖 Settings 里此刻
+    // 正在输入的 key。
     if (useStore.getState().orgTrigger.apiKey) return;
     void getOrgTrigger().then((c) => {
       if (c && !useStore.getState().orgTrigger.apiKey) mirror(c);

--- a/src/renderer/src/components/triggers/SchedulesSection.tsx
+++ b/src/renderer/src/components/triggers/SchedulesSection.tsx
@@ -12,17 +12,16 @@ import { formatWeekly, nextWeeklyFireMs } from '@shared/weeklySchedule';
 import { useRtl } from '@/i18n/useDirection';
 
 /**
- * SCHEDULES — recurring auto-dispatched missions. The oldest trigger type, and
- * until now the whole of this tab.
+ * SCHEDULES —— 周期性自动派发的任务。最古老的触发器类型，直到现在都是整个
+ * 标签页的全部内容。
  *
- * Two gaps closed on the way over: a mission's PROMPT (`body`) is now visible on
- * the row and editable when the row is expanded — the seeded missions used to
- * dispatch text nobody could read — and the frequency is editable on every
- * mission, not just the retired compact one.
+ * 一路上补上了两个缺口：任务的 PROMPT（`body`）现在在行上可见，并在行展开时
+ * 可编辑——过去预置任务派发的是没人读得到的文本——而且频率在每项任务上都可
+ * 编辑，不只是那个退役的紧凑任务。
  */
 
-/** Mirrors `ScheduledMission` in src/main/config.ts (and preload). Declared here
- *  so this component owns no cross-package import. */
+/** 镜像 `ScheduledMission`（src/main/config.ts 与 preload 中）。在此声明，这样
+ *  本组件不持有跨包导入。 */
 interface ScheduledMission {
   id: string;
   label: string;
@@ -34,14 +33,14 @@ interface ScheduledMission {
   lastFiredAt?: number;
   kind?: 'dispatch' | 'heartbeat' | 'compact';
   quietThresholdMs?: number;
-  /** Day-of-week + time. Present ⇒ this replaces intervalMs (main/config.ts). */
+  /** 星期几 + 时刻。存在 ⇒ 它取代 intervalMs（见 main/config.ts）。 */
   weekly?: { days: number[]; minute: number };
 }
 
 const DEFAULT_INTERVAL_MS = 3_600_000;
 
-/** Relative-time label. Needs the translator because the qualifiers ("ago",
- *  "in", "just now") are UI copy, not data. */
+/** 相对时间标签。需要翻译器，因为限定词（"ago"、"in"、"just now"）是 UI 文案，
+ *  不是数据。 */
 function relTime(ms: number, t: TFunction): string {
   const past = ms >= 0;
   const a = Math.abs(ms);
@@ -59,7 +58,7 @@ export function SchedulesSection({ onSummary }: { onSummary?: (s: string) => voi
   const [adding, setAdding] = useState(false);
   const [mLabel, setMLabel] = useState('');
   const [mInterval, setMInterval] = useState<number>(DEFAULT_INTERVAL_MS);
-  // null ⇒ the interval above is what runs. Non-null ⇒ days and a time do.
+  // null ⇒ 上面的间隔就是实际运行的。非 null ⇒ 由天和时刻决定。
   const [mWeekly, setMWeekly] = useState<WeeklyDraft | null>(null);
   const [mTo, setMTo] = useState<string>('god');
   const [mBody, setMBody] = useState('');
@@ -67,7 +66,7 @@ export function SchedulesSection({ onSummary }: { onSummary?: (s: string) => voi
   useEffect(() => {
     const load = () => { window.cth.listMissions().then(setMissions).catch(() => { /* noop */ }); };
     load();
-    // Refresh "last fired" when the scheduler stamps a beat/dispatch.
+    // 调度器盖上一次心跳/派发印记时刷新「上次触发时间」。
     return window.cth.onMissionsUpdated(load);
   }, []);
 
@@ -76,16 +75,16 @@ export function SchedulesSection({ onSummary }: { onSummary?: (s: string) => voi
     onSummary?.(missions.length === 0 ? t('schedulesSection.summaryNone') : t('schedulesSection.summary', { on, total: missions.length }));
   }, [missions, onSummary, t]);
 
-  // Optimistic: the list is the truth on screen the moment you click, and the
-  // write is fire-and-forget (the house pattern across the Command Center).
+  // 乐观更新：你点击的瞬间列表就成为屏幕上的真相，写入即发即忘（这是 Command
+  // Center 一贯的模式）。
   const persist = (next: ScheduledMission[]) => {
     setMissions(next);
-    void window.cth.saveMissions(next).catch(() => { /* noop */ });
+    void window.cth.saveMissions(next).catch(() => { /* 无操作 */ });
   };
   const patch = (id: string, fields: Partial<ScheduledMission>) =>
     persist(missions.map((m) => (m.id === id ? { ...m, ...fields } : m)));
-  // The backend merge in missions:save keeps only what the renderer sends back,
-  // so deleting is "save the list without it".
+  // missions:save 中的后端合并只保留渲染器发回的内容，所以删除就是「保存
+  // 不含它的列表」。
   const remove = (id: string) => persist(missions.filter((m) => m.id !== id));
 
   const add = () => {
@@ -93,8 +92,8 @@ export function SchedulesSection({ onSummary }: { onSummary?: (s: string) => voi
     persist([...missions, {
       id: `m_${Date.now().toString(36)}`,
       label: mLabel.trim(),
-      // The interval rides along even in weekly mode, so flipping back to
-      // "every…" later restores the cadence rather than a default.
+      // 即使在每周模式下间隔也会随行保存，这样以后切回「每隔…」时会恢复
+      // 原来的节律，而不是回到默认值。
       intervalMs: mInterval,
       ...(mWeekly ? { weekly: mWeekly } : {}),
       to: mTo,
@@ -103,7 +102,7 @@ export function SchedulesSection({ onSummary }: { onSummary?: (s: string) => voi
     }]);
     setMLabel(''); setMBody(''); setMWeekly(null); setAdding(false);
   };
-  /** A weekly draft with no days picked would never fire, so it cannot be saved. */
+  /** 没有选任何天的每周草稿永远不会触发，所以不能保存。 */
   const whenIsUsable = !mWeekly || weeklyIsUsable(mWeekly);
 
   const targetName = (to: string) =>
@@ -180,7 +179,7 @@ export function SchedulesSection({ onSummary }: { onSummary?: (s: string) => voi
   );
 }
 
-/* ─────────────────────────────── one mission ─────────────────────────────── */
+/* ─────────────────────────────── 单个任务 ─────────────────────────────── */
 
 interface RosterAgent { id: string; name: string; isGod?: boolean }
 
@@ -201,8 +200,8 @@ function MissionRow({ mission, targetName, agents, onPatch, onDelete }: {
   const [body, setBody] = useState(mission.body);
   const [saved, setSaved] = useState(false);
 
-  // Seed the draft when the row opens — never on every render, or the scheduler
-  // stamping `lastFiredAt` mid-edit would wipe what you are typing.
+  // 行打开时播种草稿——绝不在每次渲染时做，否则调度器在编辑中途盖上
+  // `lastFiredAt` 会抹掉你正在输入的内容。
   useEffect(() => {
     if (!open) return;
     setLabel(mission.label);
@@ -216,8 +215,8 @@ function MissionRow({ mission, targetName, agents, onPatch, onDelete }: {
 
   const heartbeat = mission.kind === 'heartbeat';
   const storedWeekly = weeklyDraft(mission.weekly);
-  // Compare the CANONICAL form, not the raw object: [1,3] and [3,1] mean the
-  // same schedule, and a row that reads as dirty after a no-op click is noise.
+  // 比较的是规范形态而不是原始对象：[1,3] 和 [3,1] 表示同一个计划，而一个
+  // 在无操作点击后仍显示为「已修改」的行只会制造噪音。
   const weeklyKey = (w: WeeklyDraft | null) => (w ? `${[...w.days].sort((a, b) => a - b).join(',')}@${w.minute}` : '');
   const dirty = label !== mission.label || to !== mission.to
     || intervalMs !== mission.intervalMs || body !== mission.body
@@ -227,9 +226,8 @@ function MissionRow({ mission, targetName, agents, onPatch, onDelete }: {
   const fired = mission.lastFiredAt
     ? t('schedulesSection.fired', { time: relTime(Date.now() - mission.lastFiredAt, t) })
     : t('schedulesSection.notFired');
-  // A weekly mission's next run comes from the calendar, not from lastFiredAt +
-  // interval — and unlike the interval case it is knowable before the first run,
-  // so a schedule that has never fired can still say when it will.
+  // 每周任务的下次运行来自日历，而不是 lastFiredAt + 间隔——而且与间隔模式
+  // 不同，它在首次运行之前就可得知，所以从未触发过的计划也能说出何时触发。
   const nextAt = storedWeekly
     ? nextWeeklyFireMs(storedWeekly, Date.now())
     : mission.lastFiredAt ? mission.lastFiredAt + mission.intervalMs : null;
@@ -240,12 +238,11 @@ function MissionRow({ mission, targetName, agents, onPatch, onDelete }: {
   const save = () => {
     const trimmed = label.trim();
     if (!trimmed) return;
-    // Fold the trim back into the draft too, or the row would read as still
-    // dirty against a label that was only ever going to be stored trimmed.
+    // 把修剪后的值也折回草稿，否则这一行会一直显示为「已修改」，而其实那个
+    // 标签从一开始就只会以修剪后的形式存储。
     setLabel(trimmed);
-    // `weekly: undefined` is the switch back to interval mode. It has to be sent
-    // explicitly — the backend merges by id and spreads, so simply omitting the
-    // key would leave the old schedule in place and the row would snap back.
+    // `weekly: undefined` 是切回间隔模式的开关。必须显式发送——后端按 id 合并
+    // 并展开，所以仅仅省略这个键会留下旧的计划，行会弹回原状。
     onPatch({ label: trimmed, to, intervalMs, body, weekly: weekly ?? undefined });
     setSaved(true);
     setTimeout(() => setSaved(false), 1300);
@@ -270,8 +267,8 @@ function MissionRow({ mission, targetName, agents, onPatch, onDelete }: {
         right={<Toggle on={mission.enabled} onClick={() => onPatch({ enabled: !mission.enabled })} />}
       />
 
-      {/* The prompt is the mission. Closed, you get the first line of it; open,
-          you get the whole thing in an editor. It used to be invisible. */}
+      {/* 提示词就是任务本身。收起时你只看到它的第一行；展开时
+          你在编辑器里看到全部内容。它以前是完全不可见的。 */}
       {!open && (
         <div style={{
           marginTop: 6, padding: '4px 6px',
@@ -294,8 +291,8 @@ function MissionRow({ mission, targetName, agents, onPatch, onDelete }: {
             </Select>
           </Field>
           <Field label={t('schedulesSection.when')}>
-            {/* The heartbeat has no calendar: it is a cadence that adapts to how
-                busy the floor is, so pinning it to Tuesdays would be a lie. */}
+            {/* 心跳没有日历：它是一种随楼层繁忙程度自适应的节奏，
+                所以把它固定到周二反而是在说谎。 */}
             {heartbeat
               ? <SchedulePicker intervalMs={intervalMs} weekly={null} onInterval={setIntervalMs} onWeekly={() => { /* interval only */ }} />
               : <SchedulePicker intervalMs={intervalMs} weekly={weekly} onInterval={setIntervalMs} onWeekly={setWeekly} />}

--- a/src/renderer/src/components/triggers/TriggerHistoryTab.tsx
+++ b/src/renderer/src/components/triggers/TriggerHistoryTab.tsx
@@ -7,32 +7,27 @@ import type { TriggerHistoryEntry } from '@shared/triggers';
 import { useRtl } from '@/i18n/useDirection';
 
 /**
- * TRIGGER HISTORY — the ledger of everything an outside party said to this hive
- * and everything we said back, read as conversations rather than log lines.
+ * TRIGGER HISTORY —— 外部方对这个 hive 说过什么、我们又回答了什么的台账，
+ * 当作对话而不是日志行来读。
  *
- * The ledger is flat (one row per message, newest first). The operator's actual
- * question is never "what rows exist" but "what did they ask, and what did we
- * answer" — so rows are folded into EXCHANGES by `correlationId` here, in the
- * renderer, and drawn as one card per exchange with both bodies in full.
+ * 台账是扁平的（每个消息一行，新的在前）。操作者真正的问题从来不是「有哪些
+ * 行」，而是「他们问了什么，我们答了什么」——所以行在这里按 `correlationId`
+ * 在渲染器中折叠成 EXCHANGES（往来），每条往来画成一张卡片，双方正文完整展示。
  *
- * Two sources share the ledger (webhook, org) and they are switched, not
- * stacked: this lives in a ~360px sidebar, so two full lists on one scroll
- * would bury whichever one you came for.
+ * 两个来源共享这份台账（webhook、org），它们是切换而不是堆叠：这里是一个
+ * ~360px 的侧栏，两份完整列表放在同一个滚动区里会把你想看的那份埋掉。
  *
- * The only actionable rows are inbound messages a `strict` /
- * `communication-only` trigger mode held back (`decision: 'pending'`). Those
- * float to the top of their section, because approving one dispatches real
- * work into the hive and a held message that scrolls out of sight is a message
- * that never gets answered.
+ * 唯一可操作的行是被 `strict` / `communication-only` 触发模式拦下的入站消息
+ * （`decision: 'pending'`）。它们浮到所在分区顶部，因为批准一条就会向 hive
+ * 派发真实工作，而一条滚出视野的滞留消息就是一条永远不会被回答的消息。
  */
 
-/* ─────────────────────────────── ipc surface ─────────────────────────────── */
+/* ─────────────────────────────── ipc 界面 ─────────────────────────────── */
 
 /**
- * The trigger-history IPC lands with the main-process change that owns preload;
- * the typed `window.cth` members arrive with it. Until then this narrow local
- * surface + one cast keeps the tab compiling without touching preload — and
- * needs no edit once the real types show up, since the shapes match.
+ * trigger-history IPC 与拥有 preload 的主进程改动同时落地；类型化的 `window.cth`
+ * 成员也随之而来。在那之前，这个窄小的本地界面 + 一次转换让标签页无需触碰
+ * preload 就能编译——而且真实类型出现后也无需编辑，因为形态一致。
  */
 interface TriggerHistoryApi {
   listTriggerHistory?: () => Promise<TriggerHistoryEntry[]>;
@@ -44,38 +39,36 @@ interface TriggerHistoryApi {
   clearTriggerHistory?: (source?: 'webhook' | 'org') => Promise<unknown>;
 }
 
-/** Read lazily: `window.cth` is installed by preload, not by module load order. */
+/** 惰性读取：`window.cth` 由 preload 安装，而不是由模块加载顺序保证。 */
 function api(): TriggerHistoryApi {
   return (window.cth ?? {}) as unknown as TriggerHistoryApi;
 }
 
-/* ─────────────────────────────── exchanges ───────────────────────────────── */
+/* ─────────────────────────────── 往来 ───────────────────────────────── */
 
 type Source = 'webhook' | 'org';
 
 interface Exchange {
   key: string;
-  /** Oldest first — an exchange reads downward, the way the conversation happened. */
+  /** 旧的在前——往来自上而下阅读，就像对话发生时的顺序。 */
   msgs: TriggerHistoryEntry[];
-  /** Whose name and peer label the card: the inbound that started it, else the lone outbound. */
+  /** 决定卡片名字和对端标签的那条：发起它的入站消息，否则是孤立的出站消息。 */
   head: TriggerHistoryEntry;
-  /** The inbound still held for the operator, if any. */
+  /** 仍被扣住等待操作者的入站消息（如果有）。 */
   pending: TriggerHistoryEntry | null;
   answered: boolean;
   latestAt: number;
 }
 
 /**
- * Fold the flat ledger into exchanges.
+ * 把扁平台账折叠成往来。
  *
- * `correlationId` is the pairing key. Rows without one cannot be paired with
- * anything, so each becomes its own one-sided exchange keyed by its id — an
- * un-correlated inbound still deserves a card (it may be pending), and an
- * un-correlated outbound is a message we sent that simply has no recorded
- * prompt. A correlation group may also hold more than two rows (a follow-up, a
- * second reply); those render in time order rather than being dropped.
+ * `correlationId` 是配对键。没有它的行无法与任何东西配对，所以每行都成为以
+ * 自己 id 为键的单边往来——未关联的入站消息仍值得一张卡片（它可能是 pending），
+ * 未关联的出站消息则是我们发出的、只是没有记录到对应提示词的回复。一个关联组
+ * 也可能含有多于两行（一次追问、第二次回复）；这些按时间顺序渲染，而不是被丢弃。
  *
- * Pending exchanges sort to the top; everything else stays newest-first.
+ * 待决（pending）的往来排在最前；其余保持新的在前。
  */
 function buildExchanges(rows: TriggerHistoryEntry[]): Exchange[] {
   const buckets = new Map<string, TriggerHistoryEntry[]>();
@@ -104,9 +97,9 @@ function buildExchanges(rows: TriggerHistoryEntry[]): Exchange[] {
   });
 }
 
-/* ──────────────────────────────── helpers ────────────────────────────────── */
+/* ──────────────────────────────── 辅助 ────────────────────────────────── */
 
-// Copied, not imported: SchedulesTab.tsx is being deleted.
+// 复制而来，不是导入：SchedulesTab.tsx 正在被删除。
 function relTime(ms: number, t: TFunction): string {
   const past = ms >= 0;
   const a = Math.abs(ms);
@@ -119,7 +112,7 @@ function relTime(ms: number, t: TFunction): string {
 const CLAMP_CHARS = 320;
 const CLAMP_LINES = 8;
 
-/** Collapse a long body for the resting state. Expanding always shows all of it. */
+/** 为静止状态折叠长正文。展开时总是显示全部。 */
 function clampBody(body: string): { text: string; clipped: boolean } {
   const lines = body.split('\n');
   if (body.length <= CLAMP_CHARS && lines.length <= CLAMP_LINES) return { text: body, clipped: false };
@@ -128,7 +121,7 @@ function clampBody(body: string): { text: string; clipped: boolean } {
   return { text: `${cut.trimEnd()}…`, clipped: true };
 }
 
-/* ───────────────────────────────── styles ────────────────────────────────── */
+/* ───────────────────────────────── 样式 ────────────────────────────────── */
 
 const tinyCaps: CSSProperties = {
   fontFamily: 'var(--cth-font-display)', fontSize: 9, lineHeight: '12px',
@@ -198,7 +191,7 @@ function DecisionBadge({ decision }: { decision: NonNullable<TriggerHistoryEntry
   }
 }
 
-/* ─────────────────────────────── one message ─────────────────────────────── */
+/* ─────────────────────────────── 单条消息 ─────────────────────────────── */
 
 function MessageBlock({
   msg,
@@ -231,7 +224,7 @@ function MessageBlock({
   );
 }
 
-/* ────────────────────────────── one exchange ─────────────────────────────── */
+/* ────────────────────────────── 单次往来 ─────────────────────────────── */
 
 function ExchangeCard({
   ex,
@@ -254,8 +247,8 @@ function ExchangeCard({
   const pending = ex.pending;
   const taskId = ex.msgs.find((m) => m.taskId)?.taskId;
 
-  // The trailing line for an exchange with nothing sent back yet. Silence here
-  // is normal — it is a message still in flight, never a failure.
+  // 还没有任何回复的往来的尾行。这里的沉默是正常的——这是一条仍在途中的消息，
+  // 绝不是失败。
   const tail = (() => {
     if (pending || ex.answered) return null;
     if (decision === 'rejected') return t('triggerHistory.tailRejected');
@@ -344,7 +337,7 @@ function ExchangeCard({
   );
 }
 
-/* ───────────────────────────── empty states ──────────────────────────────── */
+/* ───────────────────────────── 空状态 ──────────────────────────────── */
 
 function EmptyState({ title, body }: { title: string; body: string }) {
   return (
@@ -368,7 +361,7 @@ const SECTIONS: { key: Source; labelKey: string; blurbKey: string }[] = [
   }
 ];
 
-/* ──────────────────────────────── the tab ────────────────────────────────── */
+/* ──────────────────────────────── 标签页本体 ────────────────────────────────── */
 
 export function TriggerHistoryTab() {
   const { t } = useTranslation();
@@ -385,12 +378,12 @@ export function TriggerHistoryTab() {
     if (!list) return;
     list()
       .then((rows) => setEntries(Array.isArray(rows) ? rows : []))
-      .catch(() => { /* main not ready; the update event will bring us back */ });
+      .catch(() => { /* main 尚未就绪；更新事件会把我们带回来 */ });
   }, []);
 
   useEffect(() => {
     load();
-    // Same shape as onMissionsUpdated: subscribe, get an unsubscribe back.
+    // 与 onMissionsUpdated 相同的形态：订阅，拿回一个退订函数。
     const off = api().onTriggerHistoryUpdated?.(load);
     return () => { if (typeof off === 'function') off(); };
   }, [load]);
@@ -404,8 +397,8 @@ export function TriggerHistoryTab() {
     if (!call) return;
     setBusy((b) => ({ ...b, [id]: true }));
     setError(null);
-    // Optimistic: the row's verdict is the operator's own input, so it should
-    // land the instant they click. The update event reconciles either way.
+    // 乐观更新：行的判定是操作者自己的输入，所以它应该在他们点击的瞬间落地。
+    // 更新事件无论如何都会把它校准回来。
     setEntries((rows) => rows.map((r) => (r.id === id ? { ...r, decision } : r)));
     call({ id, decision })
       .then((res) => {
@@ -453,7 +446,7 @@ export function TriggerHistoryTab() {
       flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column',
       background: 'var(--cth-paper-200)'
     }}>
-      {/* Section switcher — the panel is too narrow to stack both lists. */}
+      {/* 区块切换器 —— 面板太窄，无法上下堆叠两个列表。 */}
       <div style={{
         display: 'flex', flexShrink: 0,
         background: 'var(--cth-cream-200)', boxShadow: 'inset 0 -1px 0 var(--cth-ink-300)'

--- a/src/renderer/src/components/triggers/TriggersTab.tsx
+++ b/src/renderer/src/components/triggers/TriggersTab.tsx
@@ -7,15 +7,14 @@ import { OrgSection } from './OrgSection';
 import { Muted, Scroll, TriggerCard } from './ui';
 
 /**
- * TRIGGERS — every way the floor gets woken up without a human typing, in one
- * tab. Four types (src/shared/triggers.ts is the contract): schedules, context,
- * webhooks and organisation. Schedules is the oldest and used to BE this tab.
+ * TRIGGERS —— 无需人工输入就能唤醒地面的所有方式，集中在一个标签页里。
+ * 四种类型（src/shared/triggers.ts 是契约）：schedules、context、webhooks 和
+ * organisation。Schedules 最古老，过去就是这整个标签页。
  *
- * This panel is a sidebar, so four flat forms would open as a wall. Each type is
- * a collapsed card carrying its name, a one-line "what this is", and a live
- * summary chip; schedules opens expanded because it is the incumbent and the
- * office calendar deep-links here. Inside a card, each row collapses the same
- * way, so nothing is more than two disclosures from legible.
+ * 这个面板是侧栏，所以四个扁平表单会像一面墙一样展开。每种类型是一个折叠的
+ * 卡片，带着自己的名字、一行「这是什么」和一个实时摘要 chip；schedules 默认
+ * 展开，因为它是老牌选手，而且办公室日历会深链接到这里。卡片内部，每一行以
+ * 同样的方式折叠，所以任何东西最多隔两层就能看清。
  */
 export function TriggersTab() {
   const { t } = useTranslation();

--- a/src/renderer/src/components/triggers/WebhooksSection.tsx
+++ b/src/renderer/src/components/triggers/WebhooksSection.tsx
@@ -14,17 +14,16 @@ import {
 } from './ui';
 
 /**
- * WEBHOOKS — one inbound HTTP endpoint per caller. Several share one port and
- * one tunnel and are told apart by the id in the path, so the URL you hand out
- * is per endpoint, never the tunnel root.
+ * WEBHOOKS —— 每个调用方一个入站 HTTP 端点。多个调用方共享一个端口和一个
+ * 隧道，靠路径中的 id 区分，所以你给出的 URL 是每个端点一个，绝不是隧道根。
  *
- * The list lives in the store, not here. Settings → Connections edits the same
- * endpoints off the same mirror, so a save on either surface repaints the other
- * with no refetch — two local copies would drift the moment either one wrote.
+ * 列表存在 store 里，不在这里。Settings → Connections 编辑的是同一份镜像上的
+ * 相同端点，所以任一处保存后无需重新拉取，另一处也会同步刷新——如果存在两份
+ * 本地副本，任何一方写入后它们就会分叉。
  *
- * MIRROR-THEN-PERSIST: keystroke edits (a name) update the mirror only, so the
- * other surface stays live while you type without a disk write per character;
- * everything discrete (toggle, mode, schema, add, delete) persists on the spot.
+ * MIRROR-THEN-PERSIST（先镜像后持久化）：按键级编辑（如名字）只更新镜像，这样
+ * 你输入时另一个界面保持实时，而不会每个字符都写一次磁盘；所有离散操作
+ * （开关、模式、schema、添加、删除）则当场持久化。
  */
 
 const STATUS_POLL_MS = 5000;
@@ -38,10 +37,9 @@ export function WebhooksSection({ onSummary }: { onSummary?: (s: string) => void
 
   useEffect(() => {
     let alive = true;
-    // App seeds the mirror from getConfig() at boot, and both editing surfaces
-    // keep it current — so this read only covers the case where it was never
-    // seeded. Adopting unconditionally could clobber an edit being typed in
-    // Settings right now.
+    // App 在启动时用 getConfig() 播种镜像，两个编辑界面都让它保持最新——
+    // 所以这次读取只覆盖从未播种过的情况。无条件采纳可能会覆盖 Settings 中
+    // 正在输入的一次编辑。
     if (useStore.getState().webhookTriggers.length === 0) {
       void listWebhooks().then((l) => {
         if (alive && l && useStore.getState().webhookTriggers.length === 0) setHooks(l);
@@ -57,9 +55,8 @@ export function WebhooksSection({ onSummary }: { onSummary?: (s: string) => void
     onSummary?.(hooks.length === 0 ? t('webhooksSection.summaryNone') : t('webhooksSection.summary', { count: hooks.length, state: status.running ? t('webhooksSection.live') : t('webhooksSection.offline') }));
   }, [hooks, status.running, onSummary, t]);
 
-  /** Update the shared mirror; optionally write it through. Main sanitises what
-   *  it stores (it will not enable a secretless endpoint), so we adopt its
-   *  answer when it comes back rather than assuming ours was accepted. */
+  /** 更新共享镜像；可选地写入到底层。Main 会净化它存储的内容（不会启用无密钥
+   *  的端点），所以当它返回答案时我们采纳它的答案，而不是假设我们的被接受了。 */
   const apply = (next: WebhookTrigger[], persist = true) => {
     setHooks(next);
     if (!persist) return;
@@ -114,7 +111,7 @@ export function WebhooksSection({ onSummary }: { onSummary?: (s: string) => void
   );
 }
 
-/* ─────────────────────────────── one endpoint ────────────────────────────── */
+/* ─────────────────────────────── 单个端点 ────────────────────────────── */
 
 function WebhookRow({ hook, url, serverRunning, onPatch, onDelete }: {
   hook: WebhookTrigger;
@@ -134,8 +131,8 @@ function WebhookRow({ hook, url, serverRunning, onPatch, onDelete }: {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // A closed row must not keep a revealed secret on screen, and re-opening the
-  // schema editor should start from what is actually stored.
+  // 折叠的行绝不能把已揭示的密钥留在屏幕上，而且重新打开 schema 编辑器应该
+  // 从实际存储的内容开始。
   useEffect(() => {
     if (open) return;
     setRevealed(false);
@@ -164,8 +161,8 @@ function WebhookRow({ hook, url, serverRunning, onPatch, onDelete }: {
     try {
       JSON.parse(schemaText);
     } catch (e) {
-      // Never persist a schema that cannot be parsed — a broken one would lock
-      // the caller out of their own endpoint with nothing on screen to say why.
+      // 绝不能持久化无法解析的 schema——损坏的 schema 会把调用方锁在自己的
+      // 端点外，而屏幕上没有任何说明原因的东西。
       setSchemaError(e instanceof Error ? e.message : String(e));
       return;
     }
@@ -190,7 +187,7 @@ function WebhookRow({ hook, url, serverRunning, onPatch, onDelete }: {
       {open && (
         <div style={{ marginTop: 4 }}>
           <Field label={t('webhooksSection.name')}>
-            {/* Mirror while typing, write through on blur. */}
+            {/* 输入时镜像，失焦时写穿。 */}
             <input
               value={hook.name}
               onChange={(e) => onPatch({ name: e.target.value }, false)}

--- a/src/renderer/src/components/triggers/api.ts
+++ b/src/renderer/src/components/triggers/api.ts
@@ -9,21 +9,20 @@ import {
 } from '@shared/triggers';
 
 /**
- * TRIGGER IPC — the renderer's side of the trigger config surface.
+ * TRIGGER IPC —— 触发器配置界面的渲染器侧。
  *
- * Thin on purpose: `window.cth` already types every call (preload bridges
- * `triggers:*`, `webhooks:*` and `org:*`), so this module exists only for the
- * three things a raw invoke does not do — deep-fill a half-written context rule
- * before it reaches a number input, turn a rejected read into "keep what you
- * have" rather than "adopt nothing", and mint a new endpoint in the same shape
- * Settings → Connections mints one.
+ * 有意保持轻薄：`window.cth` 已经为每个调用提供了类型（preload 桥接了
+ * `triggers:*`、`webhooks:*` 和 `org:*`），所以本模块只存在于三种原始 invoke
+ * 做不到的事——在到达数字输入之前深度填充一份写了一半的 context 规则；把被
+ * 拒绝的读取变成「保留你已有的」而不是「什么都不采纳」；以及以 Settings →
+ * Connections 铸造新端点时相同的形态铸造一个。
  */
 
-/** Shape flows from preload's `webhooks:status` handler, derived rather than
- *  retyped (the WorkersTab convention) so it cannot drift from the real reply. */
+/** 形态来自 preload 的 `webhooks:status` 处理器，是推导而不是重打的
+ *  （WorkersTab 的惯例），因此它不会与真实应答脱节。 */
 export type WebhooksStatus = Awaited<ReturnType<typeof window.cth.webhooksStatus>>;
 
-/* ───────────────────────────── context trigger ───────────────────────────── */
+/* ───────────────────────────── context 触发器 ───────────────────────────── */
 
 function fillRule(partial: Partial<ContextRule> | undefined, fallback: ContextRule): ContextRule {
   return {
@@ -37,8 +36,8 @@ function fillRule(partial: Partial<ContextRule> | undefined, fallback: ContextRu
   };
 }
 
-/** Read the context trigger, deep-filled. A half-written sub-object must never
- *  reach the number inputs as `undefined` — React would flip them uncontrolled. */
+/** 读取 context 触发器，深度填充。写了一半的子对象绝不能以 `undefined` 到达
+ *  数字输入——React 会让它们变成不受控的。 */
 export async function getContextTrigger(): Promise<ContextTriggerConfig> {
   try {
     const cfg: Partial<ContextTriggerConfig> | null = await window.cth.getContextTrigger();
@@ -51,16 +50,15 @@ export async function getContextTrigger(): Promise<ContextTriggerConfig> {
   }
 }
 
-/** Fire and forget — the controls have already moved, which is the house
- *  pattern for config writes across the Command Center. */
+/** 即发即忘——控件已经移动，这是 Command Center 中配置写入的惯例模式。 */
 export function setContextTrigger(cfg: ContextTriggerConfig): void {
-  void window.cth.setContextTrigger(cfg).catch(() => { /* optimistic */ });
+  void window.cth.setContextTrigger(cfg).catch(() => { /* 乐观更新 */ });
 }
 
-/* ─────────────────────────────── webhooks ────────────────────────────────── */
+/* ─────────────────────────────── webhook 端点 ────────────────────────────── */
 
-/** `null` on failure, never `[]` — a caller would adopt an empty list and wipe
- *  a perfectly good store mirror over one dropped IPC. */
+/** 失败时返回 `null`，绝不是 `[]`——否则调用方会采纳一个空列表，并因为一次
+ *  掉线的 IPC 而抹掉一份好好的存储镜像。 */
 export async function listWebhooks(): Promise<WebhookTrigger[] | null> {
   try {
     return (await window.cth.listWebhooks()) ?? null;
@@ -70,9 +68,9 @@ export async function listWebhooks(): Promise<WebhookTrigger[] | null> {
 }
 
 /**
- * Persist and hand back main's canonical list — it sanitises what the renderer
- * sends (trims names, refuses an id that is not URL-safe, forces `enabled: false`
- * on a secretless endpoint), so the saved truth can differ from what was sent.
+ * 持久化并交回 main 的权威列表——它会净化渲染器发送的内容（修剪名字、拒绝
+ * 非 URL 安全的 id、在无密钥端点上强制 `enabled: false`），所以保存后的真实
+ * 结果可能与发送的内容不同。
  */
 export async function saveWebhooks(list: WebhookTrigger[]): Promise<WebhookTrigger[] | null> {
   try {
@@ -98,9 +96,9 @@ export async function webhooksStatus(): Promise<WebhooksStatus> {
   }
 }
 
-/** 256 bits of hex, the shape main mints. Only reached if the mint call fails —
- *  a locally minted secret still persists through `saveWebhooks`, so "add
- *  webhook" never silently hands out a blank credential. */
+/** 256 位十六进制，即 main 铸造的形态。只在铸造调用失败时才会走到这里——
+ *  本地铸造的密钥仍会通过 `saveWebhooks` 持久化，所以「添加 webhook」绝不会
+ *  悄悄给出一个空白凭据。 */
 function localSecret(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
@@ -111,20 +109,19 @@ export async function generateWebhookSecret(): Promise<string> {
   try {
     const secret = await window.cth.generateWebhookSecret();
     if (secret) return secret;
-  } catch { /* fall through to a local mint */ }
+  } catch { /* 回退到本地铸造 */ }
   return localSecret();
 }
 
 /**
- * A fresh endpoint. Two deliberate choices, both matched to Settings → Connections
- * so an endpoint made in either surface is the same thing:
+ * 一个新端点。两个刻意的选择，都与 Settings → Connections 对齐，这样无论在
+ * 哪个界面创建的端点都是同一个东西：
  *
- *  - the id shape is `wh-<base36 time>-<rand>`. It becomes a public URL path
- *    segment, so it is stable for the endpoint's whole life (never renumbered on
- *    save) and stays inside main's URL-safe charset.
- *  - it arrives DISABLED. The operator copies the URL and the secret, then opts
- *    in — an endpoint that went live the instant it was created would be open
- *    before anyone had been told the address.
+ *  - id 形态是 `wh-<base36 时间>-<随机>`。它会成为公开 URL 路径段，因此在整个
+ *    端点生命周期内保持稳定（保存时绝不再编号），并且落在 main 的 URL 安全
+ *    字符集内。
+ *  - 创建时是 DISABLED（禁用）。操作者先复制 URL 和密钥，然后选择启用——一个
+ *    创建瞬间就上线的端点，会在任何人被告知地址之前就门户大开。
  */
 export function newWebhook(secret: string, index: number): WebhookTrigger {
   return {
@@ -138,9 +135,9 @@ export function newWebhook(secret: string, index: number): WebhookTrigger {
   };
 }
 
-/* ───────────────────────────── organisation ──────────────────────────────── */
+/* ───────────────────────────── organisation 配置 ──────────────────────────────── */
 
-/** `null` on failure; the store mirror stands. */
+/** 失败时返回 `null`；存储镜像保持不变。 */
 export async function getOrgTrigger(): Promise<OrgTriggerConfig | null> {
   try {
     return (await window.cth.getOrgTrigger()) ?? null;
@@ -150,5 +147,5 @@ export async function getOrgTrigger(): Promise<OrgTriggerConfig | null> {
 }
 
 export function setOrgTrigger(cfg: OrgTriggerConfig): void {
-  void window.cth.setOrgTrigger(cfg).catch(() => { /* optimistic */ });
+  void window.cth.setOrgTrigger(cfg).catch(() => { /* 乐观更新 */ });
 }

--- a/src/renderer/src/components/triggers/ui.tsx
+++ b/src/renderer/src/components/triggers/ui.tsx
@@ -7,15 +7,15 @@ import {
 } from '@shared/weeklySchedule';
 
 /**
- * Shared chrome for the Triggers tab.
+ * Triggers 标签页的共享外观。
  *
- * The Command Center's own `Section`/`Scroll`/`Muted` are module-private to
- * `CommandCenterPanel.tsx`, so these mirror them exactly (same paddings, same
- * fonts, same `inset` hairlines) and add the collapse behaviour this tab needs —
- * four types of dense config do not fit down a sidebar as flat forms.
+ * Command Center 自带的 `Section`/`Scroll`/`Muted` 是 `CommandCenterPanel.tsx`
+ * 模块私有的，所以这里精确地复刻了它们（同样的内边距、同样的字体、同样的
+ * `inset` 细线），并加上本标签页需要的折叠行为——四种密集的配置不适合以扁平
+ * 表单的形式塞进一条侧栏。
  */
 
-/* ───────────────────────────── shared styles ─────────────────────────────── */
+/* ───────────────────────────── 共享样式 ─────────────────────────────── */
 
 export const inputStyle: CSSProperties = {
   width: '100%', boxSizing: 'border-box', padding: '6px 8px',
@@ -42,14 +42,14 @@ export const selectStyle: CSSProperties = {
   cursor: 'pointer', minWidth: 0, maxWidth: '100%'
 };
 
-/* ───────────────────────────── text helpers ──────────────────────────────── */
+/* ───────────────────────────── 文本辅助 ──────────────────────────────── */
 
 export function Muted({ children }: { children: ReactNode }) {
   return <div style={{ fontSize: 12, lineHeight: '16px', color: 'var(--cth-ink-500)' }}>{children}</div>;
 }
 
-/** One line of explanation under a control. Smaller than Muted, never a tooltip —
- *  a sidebar hides tooltips behind the window edge half the time. */
+/** 控件下方的一行说明。比 Muted 更小，绝不是 tooltip——侧栏里 tooltip 有一半
+ *  时间会被窗口边缘挡住。 */
 export function Hint({ children }: { children: ReactNode }) {
   return <div style={{ fontSize: 11, lineHeight: '15px', color: 'var(--cth-ink-500)', marginTop: 3 }}>{children}</div>;
 }
@@ -78,7 +78,7 @@ export function Callout({ children, tone = 'warn' }: { children: ReactNode; tone
   );
 }
 
-/* ─────────────────────────────── controls ────────────────────────────────── */
+/* ─────────────────────────────── 控件 ────────────────────────────────── */
 
 export function Toggle({ on, onClick, onLabel, offLabel }: {
   on: boolean; onClick: () => void; onLabel?: string; offLabel?: string;
@@ -128,8 +128,8 @@ export function Select({ value, onChange, children, style }: {
   );
 }
 
-/** Label above a control. Stacked, never side-by-side — the sidebar is too
- *  narrow for a label column that does not truncate the thing it labels. */
+/** 控件上方的标签。纵向堆叠，绝不并排——侧栏太窄，容不下一个不会截断所标注
+ *  内容的标签列。 */
 export function Field({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div style={{ marginTop: 8 }}>
@@ -142,7 +142,7 @@ export function Field({ label, children }: { label: string; children: ReactNode 
   );
 }
 
-/* ───────────────────────────── containers ───────────────────────────────── */
+/* ───────────────────────────── 容器 ───────────────────────────────── */
 
 export function Scroll({ children }: { children: ReactNode }) {
   return (
@@ -154,13 +154,11 @@ export function Scroll({ children }: { children: ReactNode }) {
 }
 
 /**
- * One of the four trigger types. Collapsed it is a title, a one-line "what this
- * is", and a live summary — so opening the tab reads as four kinds of trigger
- * rather than a wall of forms.
+ * 四种触发器类型之一。折叠时显示标题、一行「这是什么」和一个实时摘要——这样
+ * 打开标签页读起来是四种触发器，而不是一面表单墙。
  *
- * Children stay MOUNTED while collapsed (hidden, not unmounted) for two reasons:
- * the summary chip is fed by the section itself and would go blank the moment
- * you closed it, and a section's own open rows survive collapsing its parent.
+ * 折叠时子元素保持挂载（隐藏而不是卸载），原因有二：摘要 chip 由分区自身供给，
+ * 一关闭就会变空白；而且分区自己的展开行在折叠其父级后依然存在。
  */
 export function TriggerCard({ title, blurb, summary, defaultOpen = false, children }: {
   title: string; blurb: string; summary?: ReactNode; defaultOpen?: boolean; children: ReactNode;
@@ -195,7 +193,7 @@ export function TriggerCard({ title, blurb, summary, defaultOpen = false, childr
   );
 }
 
-/** A card inside a card — one webhook, one context rule. */
+/** 卡片里的卡片——一个 webhook、一条 context 规则。 */
 export function SubCard({ children }: { children: ReactNode }) {
   return (
     <div style={{
@@ -205,7 +203,7 @@ export function SubCard({ children }: { children: ReactNode }) {
   );
 }
 
-/** Header row inside a SubCard: a disclosure caret, a title, and controls. */
+/** SubCard 内部的标题行：展开箭头、标题和控件。 */
 export function SubHeader({ open, onToggle, title, sub, right }: {
   open: boolean; onToggle: () => void; title: ReactNode; sub?: ReactNode; right?: ReactNode;
 }) {
@@ -237,10 +235,10 @@ export function SubHeader({ open, onToggle, title, sub, right }: {
   );
 }
 
-/* ──────────────────────────── trigger mode ───────────────────────────────── */
+/* ──────────────────────────── 触发器模式 ───────────────────────────────── */
 
-/** The shared `strict / allow-all / communication-only` gate. Labels and blurbs
- *  come from `TRIGGER_MODES` so webhooks and org can never drift apart. */
+/** 共享的 `strict / allow-all / communication-only` 门。标签和说明来自
+ *  `TRIGGER_MODES`，这样 webhooks 和 org 永远不会分道扬镳。 */
 export function ModePicker({ value, onChange }: { value: TriggerMode; onChange: (m: TriggerMode) => void }) {
   const current = TRIGGER_MODES.find((m) => m.value === value) ?? TRIGGER_MODES[0];
   return (
@@ -253,7 +251,7 @@ export function ModePicker({ value, onChange }: { value: TriggerMode; onChange: 
   );
 }
 
-/* ──────────────────────────── interval picker ────────────────────────────── */
+/* ──────────────────────────── 间隔选择器 ────────────────────────────── */
 
 const MINUTE = 60_000;
 const HOUR = 3_600_000;
@@ -271,9 +269,8 @@ export const INTERVAL_OPTS: { ms: number; label: string }[] = [
   { ms: WEEK, label: 'weekly' }
 ];
 
-/** A truthful label for ANY stored interval, preset or not. Arbitrary intervals
- *  persist now, so the label is computed rather than looked up — a select that
- *  falls back to the nearest preset would quietly lie about the stored value. */
+/** 针对任意已存间隔的真实标签，无论是否预设。任意间隔现在也会被持久化，所以
+ *  标签是计算出来的而不是查表——回退到最近预设的下拉框会悄悄地谎报存储值。 */
 export function fmtInterval(ms: number): string {
   if (!Number.isFinite(ms) || ms <= 0) return 'off';
   if (ms === WEEK) return 'weekly';
@@ -287,10 +284,9 @@ export function fmtInterval(ms: number): string {
 const CUSTOM = '__custom';
 
 /**
- * @param minMs/maxMs the range MAIN will actually store. Context rules are
- * clamped to 1 minute … 24 hours on the way in, so offering "weekly" there would
- * put a label on screen that the saved value does not match. Schedules take any
- * interval and pass the default range.
+ * @param minMs/maxMs MAIN 实际会存储的范围。context 规则在进入时被钳制在
+ * 1 分钟 … 24 小时之间，所以如果在那里提供 "weekly" 选项，屏幕上显示的标签
+ * 就会与保存的值不符。Schedules 接受任意间隔并传入默认范围。
  */
 export function IntervalPicker({ value, onChange, minMs = MINUTE, maxMs = Number.POSITIVE_INFINITY }: {
   value: number; onChange: (ms: number) => void; minMs?: number; maxMs?: number;
@@ -335,7 +331,7 @@ export function IntervalPicker({ value, onChange, minMs = MINUTE, maxMs = Number
   );
 }
 
-/* ───────────────────────────── percent field ─────────────────────────────── */
+/* ───────────────────────────── 百分比字段 ─────────────────────────────── */
 
 export function PctField({ value, onChange }: { value: number; onChange: (pct: number) => void }) {
   const pct = Math.max(0, Math.min(100, Math.round(value)));
@@ -363,10 +359,10 @@ export function PctField({ value, onChange }: { value: number; onChange: (pct: n
   );
 }
 
-/* ────────────────────────────── secret field ─────────────────────────────── */
+/* ────────────────────────────── 密钥字段 ─────────────────────────────── */
 
-/** Masked by default; reveals only on demand. The value never lands in a
- *  `title`/tooltip — those leak into screenshots and accessibility trees. */
+/** 默认遮蔽；仅在需要时揭示。值绝不进入 `title`/tooltip——那些会泄漏到截图和
+ *  无障碍树中。 */
 export function SecretField({ value, revealed, onReveal, onCopy, copied, placeholder, onChange, onBlur }: {
   value: string;
   revealed: boolean;
@@ -396,27 +392,26 @@ export function SecretField({ value, revealed, onReveal, onCopy, copied, placeho
   );
 }
 
-/* ──────────────────────────── weekly schedule ────────────────────────────── */
+/* ──────────────────────────── 每周计划 ────────────────────────────── */
 
-/** A weekly schedule the picker can hold mid-edit. Days may be empty while the
- *  user is deselecting, which `normalizeWeekly` would reject — so the draft type
- *  is looser than the stored one, and the SAVE is what has to be valid. */
+/** 选择器在编辑中途可以持有的一份每周计划。用户取消选择时天可能为空，
+ *  而 `normalizeWeekly` 会拒绝这种状态——所以草稿类型比存储类型更宽松，
+ *  需要有效的是「保存」这个动作。 */
 export type WeeklyDraft = { days: number[]; minute: number };
 
 export const DEFAULT_WEEKLY: WeeklyDraft = { days: [1, 2, 3, 4, 5], minute: 9 * 60 };
 
-/** True when this draft is safe to store. The one gate every call site shares. */
+/** 这份草稿是否可以安全存储。所有调用点共享的那一道门。 */
 export function weeklyIsUsable(w: WeeklyDraft): boolean {
   return normalizeWeekly(w) !== null;
 }
 
 /**
- * Day-of-week + time-of-day picker.
+ * 星期几 + 一天中时刻的选择器。
  *
- * Seven toggles rather than a multi-select, because picking "Mon Wed Fri" is the
- * whole job and a native multi-select makes it a modifier-key puzzle. The order
- * is Sunday-first to match `Date.getDay()`, so no index maths sits between what
- * is clicked and what is stored.
+ * 用七个开关而不是多选下拉框，因为选择「周一 周三 周五」本来就是全部工作，
+ * 而原生多选会把它变成修饰键谜题。顺序是星期日在前，与 `Date.getDay()` 一致，
+ * 这样点击内容和存储内容之间不需要任何索引运算。
  */
 export function WeeklyPicker({ value, onChange }: {
   value: WeeklyDraft; onChange: (w: WeeklyDraft) => void;
@@ -457,9 +452,9 @@ export function WeeklyPicker({ value, onChange }: {
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
         <span style={{ fontSize: 11, color: 'var(--cth-ink-500)' }}>{t('triggersUi.at')}</span>
-        {/* A native time field, so typing 0930 works and the value is already
-            the HH:MM the schedule stores. Minute granularity, not 5-minute
-            steps: "09:47 on Tuesdays" is a legitimate thing to want. */}
+        {/* 原生时间字段，因此输入 0930 即可，值也已经是
+            计划存储的 HH:MM 格式。分钟粒度，而非 5 分钟步进：
+            "周二 09:47" 是合理需求。 */}
         <input
           type="time"
           value={formatMinute(value.minute)}
@@ -479,12 +474,11 @@ export function WeeklyPicker({ value, onChange }: {
 }
 
 /**
- * The whole "when does this run" control: pick a repeating gap, or pick days and
- * a time. Both call sites (the new-schedule form and an expanded row) use this
- * so the two can never drift apart.
+ * 完整的「它什么时候运行」控件：选择重复间隔，或选择天和时刻。两个调用点
+ * （新建计划表单和展开的行）都使用它，这样两者永远不会不一致。
  *
- * `weekly === null` IS interval mode. Keeping the mode in the value rather than
- * in local state means a row that reloads from disk cannot show the wrong tab.
+ * `weekly === null` 即间隔模式。把模式保存在值里而不是本地状态中，意味着
+ * 从磁盘重新加载的行不会显示错误的标签页。
  */
 export function SchedulePicker({ intervalMs, weekly, onInterval, onWeekly }: {
   intervalMs: number;
@@ -513,8 +507,8 @@ export function SchedulePicker({ intervalMs, weekly, onInterval, onWeekly }: {
   );
 }
 
-/** Narrow a stored mission's `weekly` to a draft, or null for interval mode.
- *  One place decides what "this mission is weekly" means. */
+/** 把已存任务的 `weekly` 收窄为草稿；间隔模式则返回 null。由一个地方来决定
+ *  「这个任务是每周制的」意味着什么。 */
 export function weeklyDraft(w: WeeklySchedule | { days: number[]; minute: number } | undefined): WeeklyDraft | null {
   const n = normalizeWeekly(w);
   return n ? { days: n.days, minute: n.minute } : null;

--- a/src/renderer/src/design/theme.ts
+++ b/src/renderer/src/design/theme.ts
@@ -1,22 +1,20 @@
 /**
- * App-wide theme (v0.3.4) — ONE light/dark switch for the whole UI, not just
- * the terminal.
+ * 全局主题 (v0.3.4) —— 整个 UI 共用一个明/暗开关，而不仅仅是终端。
  *
- * The entire renderer is styled through the `--cth-*` tokens, so dark mode is
- * a token swap: this module stamps `data-cth-theme` on <html> and tokens.css
- * carries the dark overrides. The xterm palette (PtyTerminalView) and the
- * per-agent Claude session theme (config.terminalTheme, applied on spawn)
- * follow the same state, so terminals and TUIs match the chrome.
+ * 整个渲染层都通过 `--cth-*` 变量来设置样式，因此暗色模式就是一次变量
+ * 切换：本模块在 <html> 上写入 `data-cth-theme`，由 tokens.css 承载暗色
+ * 覆盖。xterm 调色板 (PtyTerminalView) 与每个 agent 的 Claude 会话主题
+ * (config.terminalTheme，spawn 时应用) 跟随同一状态，保证终端与界面外观一致。
  *
- * Shared subscribable module (same pattern as terminalFontSize): components
- * read it with `useAppTheme()`; the ONE toggle lives in the title bar.
+ * 可订阅的共享模块（与 terminalFontSize 同一模式）：组件通过 `useAppTheme()`
+ * 读取；唯一开关位于标题栏。
  */
 import { useSyncExternalStore } from 'react';
 
 export type AppTheme = 'light' | 'dark';
 
 const LS_KEY = 'cth.theme';
-/** Pre-0.3.4 the terminal had its own theme key — honor it once as the seed. */
+/** 0.3.4 之前终端有独立的主题键 —— 仅作为种子值读取一次。 */
 const LEGACY_LS_KEY = 'cth.ptyTheme';
 
 function load(): AppTheme {

--- a/src/renderer/src/design/tokens.css
+++ b/src/renderer/src/design/tokens.css
@@ -56,7 +56,7 @@
      slot falls through to a system face rather than to generic monospace. */
   --cth-font-display: "Press Start 2P", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", monospace;
   --cth-font-ui:      "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", sans-serif;
-  --cth-font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, "PingFang SC", "Microsoft YaHei", "Noto Sans Mono CJK SC", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", monospace;
+  --cth-font-mono:    "JetBrains Mono", "Sarasa Mono SC", ui-monospace, "SF Mono", Menlo, "PingFang SC", "Microsoft YaHei", "Noto Sans Mono CJK SC", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", monospace;
 
   /* Type scale — v0.3.4: one step tighter (Inter reads larger than Pixelify
      at equal px, and the controls were oversized) */

--- a/src/renderer/src/design/tokens.ts
+++ b/src/renderer/src/design/tokens.ts
@@ -1,5 +1,5 @@
-// Design tokens — single source of truth. Mirrors tokens.css for non-styled consumers (Pixi).
-// Any change here must also update tokens.css.
+// 设计令牌 —— 唯一事实来源。为非样式消费方 (Pixi) 镜像 tokens.css。
+// 此处任何改动都必须同步更新 tokens.css。
 
 export const colors = {
   cream: {
@@ -19,7 +19,7 @@ export const colors = {
     300: 0xa899b5,
     100: 0xd9cfe0
   },
-  // v0.3.4 recalibration: same hues, professional saturation (mirrors tokens.css)
+  // v0.3.4 重新校准：同色相、专业饱和度（与 tokens.css 对齐）
   accent: {
     coral: 0xd96a62,
     coralLight: 0xf3d3cd,
@@ -59,10 +59,10 @@ export const space = {
 export const type = {
   display: '"Press Start 2P", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", monospace',
   ui: '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", sans-serif',
-  mono: '"JetBrains Mono", ui-monospace, "SF Mono", Menlo, "PingFang SC", "Microsoft YaHei", "Noto Sans Mono CJK SC", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", monospace'
+  mono: '"JetBrains Mono", "Sarasa Mono SC", ui-monospace, "SF Mono", Menlo, "PingFang SC", "Microsoft YaHei", "Noto Sans Mono CJK SC", "Noto Sans CJK SC", "Geeza Pro", "Noto Naskh Arabic", "Segoe UI Historic", monospace'
 } as const;
 
-export const tileSize = 32; // px — the world is built from 32×32 tiles
+export const tileSize = 32; // 像素 —— 世界由 32×32 的瓦片构成
 
 export type AccentColorName =
   | 'coral' | 'mint' | 'sky' | 'lemon' | 'lilac' | 'peach';
@@ -85,7 +85,7 @@ export const accentLightByName: Record<AccentColorName, number> = {
   peach: colors.accent.peachLight
 };
 
-// Convert 0xRRGGBB to "#RRGGBB"
+// 将 0xRRGGBB 转换为 "#RRGGBB"
 export function hex(c: number): string {
   return '#' + c.toString(16).padStart(6, '0').toUpperCase();
 }

--- a/src/renderer/src/freeflow/holdOption.ts
+++ b/src/renderer/src/freeflow/holdOption.ts
@@ -1,49 +1,49 @@
 /**
- * Free Flow entry point B — hold-Option-to-talk (the human's chosen activation).
+ * Free Flow 入口 B —— 按住 Option 键说话（用户选定的激活方式）。
  *
- * Hold the Option (⌥) key ALONE for a short threshold to ARM recording; release
- * to stop and transcribe into the focused agent's composer draft (same path as
- * the mic button — review before send). Active only while Free Flow is enabled.
+ * 单独按住 Option (⌥) 键一个短阈值即可开始录音；松开
+ * 则停止并将语音转写为目标 agent 的 composer 草稿（与
+ * 麦克风按钮同一路径 —— 发送前可 review）。仅在 Free Flow 启用时有效。
  *
- * The hard part is the TERMINAL Alt/Meta conflict: in a terminal Option is Meta
- * (Alt+key combos, special chars), so a naive "Option is down → record" would
- * clobber normal input. Disambiguation:
- *   - A solo-hold THRESHOLD (~320ms): Option must be held alone, with no other
- *     key, before recording arms. A quick Alt+key combo never reaches it.
- *   - ABORT the instant any other key joins while Option is down (and before
- *     recording armed) — it's a real Alt combo; we never call preventDefault, so
- *     the terminal/composer sees the keystroke untouched.
- *   - Auto-repeat keydowns (e.repeat) are ignored so a held Option doesn't re-arm.
- *   - Listeners are CAPTURE-phase on window, so the gesture still fires while
- *     xterm (or the composer textarea) holds DOM focus.
- *   - We never preventDefault, so when not recording, Option behaves exactly as
- *     before for terminals and text fields.
+ * 难点在于终端的 Alt/Meta 冲突：在终端中 Option 是 Meta
+ * （Alt+键组合、特殊字符），因此朴素的 "Option 按下 → 录音" 会
+ * 破坏正常输入。消歧义：
+ *   - 单独按住 THRESHOLD（约 320ms）：Option 必须单独按住，不加其他
+ *     键，录音才会开始。快速的 Alt+键组合不会触发它。
+ *   - 任何其它键在 Option 按下时（且录音未就绪时）立刻 ABORT ——
+ *     这是真正的 Alt 组合键；我们从不调用 preventDefault，因此
+ *     终端/composer 看到按键原文未改。
+ *   - 自动重复的 keydown（e.repeat）会被忽略，已按住的 Option 不会重复开始。
+ *   - 监听器挂载在 window 的 CAPTURE 阶段，因此手势在
+ *     xterm（或 composer 的 textarea）持有 DOM 焦点时仍然触发。
+ *   - 从不调用 preventDefault，因此未录音时 Option 对终端和文本框的行为与
+ *     之前完全一致。
  *
- * Scope: works app-wide while the window is focused (covers any agent's terminal
- * screen per the requirement). Target = the fullscreen agent, else the selected
- * agent. A window blur resets state so a release missed off-window can't strand a
- * recording.
+ * 作用范围：窗口获得焦点时全应用生效（覆盖任意 agent 的终端
+ * 屏幕，满足需求）。目标 = 全屏 agent，否则 = 选中的
+ * agent。窗口失焦时重置状态，因此窗口外的松开不会让一次
+ * 录音卡住。
  */
 import { useEffect } from 'react';
 import { useStore } from '@/store/store';
 import { freeflowRecorder } from './recorder';
 
-/** How long Option must be held ALONE before recording arms. Long enough that a
- *  normal Alt+key combo (which disqualifies immediately) never trips it. */
+/** Option 必须单独按住多久才会开始录音。足够长，使得
+ *  正常的 Alt+键组合（会立刻被取消资格）绝不会触发它。 */
 const ARM_MS = 320;
 
 function isOptionKey(e: KeyboardEvent): boolean {
   return e.code === 'AltLeft' || e.code === 'AltRight' || e.key === 'Alt' || e.key === 'AltGraph';
 }
 
-/** Install the hold-Option-to-talk gesture for as long as the component is
- *  mounted. Reads enablement + the focused agent from the store live. */
+/** 只要组件挂载就安装按住 Option 说话的手势。实时读取
+ *  启用状态和当前焦点 agent。 */
 export function useHoldOptionToTalk(): void {
   useEffect(() => {
-    let optionDown = false;     // Option physically held right now
+    let optionDown = false;     // Option 此刻物理按下
     let armTimer: ReturnType<typeof setTimeout> | null = null;
-    let recording = false;      // THIS gesture started a recording
-    let disqualified = false;   // another key joined → treat as a normal Alt combo
+    let recording = false;      // 本次手势开启了录音
+    let disqualified = false;   // 其它键加入 → 当作普通 Alt 组合键
 
     const focusedAgentId = (): string | null => {
       const s = useStore.getState();
@@ -63,14 +63,14 @@ export function useHoldOptionToTalk(): void {
     };
 
     const onKeyDown = (e: KeyboardEvent): void => {
-      // Only active when Free Flow is on.
+      // 仅在 Free Flow 开启时有效。
       if (!useStore.getState().freeflowEnabled) return;
 
       if (isOptionKey(e)) {
         if (e.repeat || optionDown) return; // ignore auto-repeat / already tracking
         optionDown = true;
         disqualified = false;
-        // Don't start a second capture if one is already running/uploading.
+        // 如果已有录音正在运行/上传，不要启动第二个。
         if (freeflowRecorder.isBusy()) { disqualified = true; return; }
         const target = focusedAgentId();
         if (!target) { disqualified = true; return; }
@@ -85,8 +85,8 @@ export function useHoldOptionToTalk(): void {
         return;
       }
 
-      // Any non-Option key while Option is held, BEFORE recording armed, means a
-      // real Alt combo (or plain typing) — disqualify and let it pass untouched.
+      // Option 按住期间任何非 Option 键、且录音尚未就绪时，是
+      // 真正的 Alt 组合键（或普通打字）—— 取消资格并让它原样通过。
       if (optionDown && !recording) {
         disqualified = true;
         clearArm();
@@ -102,7 +102,7 @@ export function useHoldOptionToTalk(): void {
       disqualified = false;
     };
 
-    // Capture phase so xterm/textarea focus can't swallow the events first.
+    // CAPTURE 阶段：确保 xterm/textarea 的焦点不会先吃掉事件。
     window.addEventListener('keydown', onKeyDown, true);
     window.addEventListener('keyup', onKeyUp, true);
     window.addEventListener('blur', reset);

--- a/src/renderer/src/freeflow/recorder.ts
+++ b/src/renderer/src/freeflow/recorder.ts
@@ -1,21 +1,20 @@
 /**
- * Free Flow recorder — a single shared push-to-talk capture engine for the whole
- * renderer. Both entry points use it, so only ONE recording can run at a time:
- *   (A) the "Free Flow" button in MessageQueueComposer (click to start/stop), and
- *   (B) hold-Option-to-talk (see freeflow/holdOption.ts) — start on arm, stop on
- *       Option release.
+ * Free Flow 录音器 —— 整个渲染器共享的单个推按说话捕获引擎。
+ * 两个入口都使用它，因此同一时间只能有一条录音：
+ *   (A) MessageQueueComposer 中的 "Free Flow" 按钮（点击开始/停止），和
+ *   (B) 按住 Option 说话（参见 freeflow/holdOption.ts）—— 就绪时开始，松开 Option 停止。
  *
- * Flow: getUserMedia(audio) → MediaRecorder (webm/opus) → on stop, the blob's
- * bytes go to main over IPC (`freeflowTranscribe`), which calls Groq Whisper and
- * returns the transcript. The transcript is APPENDED to the target agent's
- * composer draft (store.drafts) — never auto-sent — faithful to freeflow: the
- * user reviews, then presses Send/Enter.
+ * 流程：getUserMedia(audio) → MediaRecorder (webm/opus) → 停止后，blob 的
+ * 字节通过 IPC（`freeflowTranscribe`）传到 main，main 调用 Groq Whisper 并
+ * 返回转写文本。转写文本被追加到目标 agent 的
+ * composer 草稿（store.drafts）—— 不会自动发送 —— 忠实于 freeflow：
+ * 用户 review 后才按下 Send/Enter。
  *
- * Hold-to-talk makes the start/stop race real: a user can release Option before
- * getUserMedia resolves. `wantActive` tracks the user's intent so a stop that
- * lands mid-open discards the about-to-start recording instead of stranding it.
+ * 按住说话让开始/停止的竞态成为现实：用户可能在
+ * getUserMedia 解析前松开 Option。`wantActive` 跟踪用户意图，因此
+ * 在打开途中到达的 stop 会丢弃即将开始的录音，而不是卡住它。
  *
- * Exposed as a module singleton + a `useFreeflow()` hook (useSyncExternalStore).
+ * 以模块单例 + `useFreeflow()` hook（useSyncExternalStore）形式暴露。
  */
 import { useSyncExternalStore } from 'react';
 import { useStore } from '@/store/store';
@@ -24,9 +23,9 @@ export type FreeflowStatus = 'idle' | 'recording' | 'transcribing';
 
 export interface FreeflowState {
   status: FreeflowStatus;
-  /** The agent whose draft a finished transcript will land in. */
+  /** 完成转写后落到的 agent 草稿目标。 */
   targetAgentId: string | null;
-  /** Last error (mic denied, Groq failure…). Cleared when a new capture starts. */
+  /** 最近错误（麦克风被拒、Groq 失败…）。新录制开始时清除。 */
   error: string | null;
 }
 
@@ -51,15 +50,14 @@ function getSnapshot(): FreeflowState {
 let recorder: MediaRecorder | null = null;
 let stream: MediaStream | null = null;
 let chunks: Blob[] = [];
-/** True between start() and the next stop(): the user wants a recording. A stop
- *  that arrives while getUserMedia is still opening flips this so the open path
- *  discards instead of recording. */
+/** start() 与下一次 stop() 之间为 true：用户想要录音。在
+ *  getUserMedia 仍在打开时到达的 stop 会翻转此值，让打开路径
+ *  直接丢弃而非录音。 */
 let wantActive = false;
-/** True while getUserMedia is in flight, to ignore re-entrant start() calls. */
+/** getUserMedia 进行中时为 true，用于忽略重入的 start() 调用。 */
 let opening = false;
 
-/** Prefer webm/opus (Groq-supported, Chromium default); fall back to whatever the
- *  platform offers. Returns '' to let MediaRecorder pick its default. */
+/** 优先 webm/opus（Groq 支持、Chromium 默认）；否则回退到平台能提供的。返回 '' 让 MediaRecorder 选其默认。 */
 function pickMimeType(): string {
   const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus'];
   const supported = typeof MediaRecorder !== 'undefined' && typeof MediaRecorder.isTypeSupported === 'function';
@@ -71,13 +69,13 @@ function pickMimeType(): string {
   return '';
 }
 
-/** Release the mic stream so the OS recording indicator clears. */
+/** 释放麦克风流，让系统录音指示器清除。 */
 function teardownStream(): void {
   try { stream?.getTracks().forEach((t) => t.stop()); } catch { /* noop */ }
   stream = null;
 }
 
-/** Append `text` to the target agent's composer draft (with a separating space). */
+/** 将 `text` 追加到目标 agent 的 composer 草稿（带分隔空格）。 */
 function deliverTranscript(agentId: string, text: string): void {
   const st = useStore.getState();
   const cur = st.drafts[agentId] ?? '';
@@ -85,13 +83,12 @@ function deliverTranscript(agentId: string, text: string): void {
   st.setDraft(agentId, cur + sep + text);
 }
 
-/** Begin capturing for `agentId`. Safe to call only from the idle state; surfaces
- *  a friendly error if the mic can't be opened. */
+/** 为 `agentId` 开始捕获。仅在 idle 状态下安全调用；麦克风无法打开时显示友好错误。 */
 async function start(agentId: string): Promise<void> {
   if (state.status !== 'idle' || opening) return;
-  if (!agentId) { setState({ error: 'no agent selected' }); return; }
+  if (!agentId) { setState({ error: '未选择 agent' }); return; }
   if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
-    setState({ error: 'microphone not available' });
+    setState({ error: '麦克风不可用' });
     return;
   }
   wantActive = true;
@@ -106,12 +103,12 @@ async function start(agentId: string): Promise<void> {
     const name = e instanceof DOMException ? e.name : '';
     setState({
       status: 'idle',
-      error: name === 'NotAllowedError' ? 'microphone permission denied' : 'could not open microphone'
+      error: name === 'NotAllowedError' ? '麦克风权限被拒绝' : '无法打开麦克风'
     });
     return;
   }
   opening = false;
-  // Released before the mic finished opening (a quick tap) — discard cleanly.
+  // 麦克风尚未完全打开就被释放（快速点按）——干净地丢弃。
   if (!wantActive) {
     try { opened.getTracks().forEach((t) => t.stop()); } catch { /* noop */ }
     return;
@@ -124,7 +121,7 @@ async function start(agentId: string): Promise<void> {
   } catch {
     teardownStream();
     wantActive = false;
-    setState({ status: 'idle', error: 'recording not supported' });
+    setState({ status: 'idle', error: '不支持录音' });
     return;
   }
   recorder.ondataavailable = (ev: BlobEvent) => { if (ev.data && ev.data.size > 0) chunks.push(ev.data); };
@@ -133,8 +130,7 @@ async function start(agentId: string): Promise<void> {
   setState({ status: 'recording', targetAgentId: agentId, error: null });
 }
 
-/** Stop the active recording (triggers transcription via `onstop`). If a start is
- *  still opening the mic, this cancels it (the open path discards). */
+/** 停止当前录音（通过 `onstop` 触发转写）。如果 start 仍在打开麦克风，则取消它（打开路径会丢弃）。 */
 function stop(): void {
   wantActive = false;
   if (opening) return; // the in-flight start() will see !wantActive and discard
@@ -142,7 +138,7 @@ function stop(): void {
   try { recorder.stop(); } catch { /* already stopped */ }
 }
 
-/** Called when MediaRecorder finishes: assemble the clip, transcribe, deliver. */
+/** MediaRecorder 结束时调用：组装片段、转写、送达。 */
 async function finish(agentId: string): Promise<void> {
   const type = recorder?.mimeType || 'audio/webm';
   teardownStream();
@@ -150,7 +146,7 @@ async function finish(agentId: string): Promise<void> {
   const blob = new Blob(chunks, { type });
   chunks = [];
   if (blob.size === 0) {
-    setState({ status: 'idle', error: 'nothing recorded' });
+    setState({ status: 'idle', error: '未录制任何内容' });
     return;
   }
   setState({ status: 'transcribing', error: null });
@@ -166,29 +162,27 @@ async function finish(agentId: string): Promise<void> {
       deliverTranscript(agentId, res.text);
       setState({ status: 'idle', error: null });
     } else {
-      setState({ status: 'idle', error: res.error || 'transcription failed' });
+      setState({ status: 'idle', error: res.error || '转写失败' });
     }
   } catch (e) {
-    setState({ status: 'idle', error: e instanceof Error ? e.message : 'transcription failed' });
+    setState({ status: 'idle', error: e instanceof Error ? e.message : '转写失败' });
   }
 }
 
-/** Toggle capture for `agentId` (used by the composer button): start if idle,
- *  stop if recording. During transcription it's a no-op (the upload is in flight). */
+/** 切换 `agentId` 的捕获（由 composer 按钮使用）：idle 时开始，recording 时停止。转写期间是空操作（上传进行中）。 */
 function toggle(agentId: string): void {
   if (state.status === 'recording') stop();
   else if (state.status === 'idle') void start(agentId);
 }
 
-/** True while a clip is recording or uploading — the hold gesture uses this to
- *  avoid starting a second capture. */
+/** 片段录制或上传期间为 true —— 按住手势用它来避免启动第二个捕获。 */
 function isBusy(): boolean {
   return state.status !== 'idle' || opening;
 }
 
 export const freeflowRecorder = { start, stop, toggle, isBusy, subscribe, getSnapshot };
 
-/** React hook: subscribe to the shared recorder state. */
+/** React hook：订阅共享的录音器状态。 */
 export function useFreeflow(): FreeflowState {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/renderer/src/hooks/queueDelivery.ts
+++ b/src/renderer/src/hooks/queueDelivery.ts
@@ -1,5 +1,5 @@
-/** Run one queued delivery and acknowledge it only after the sender resolves.
- * Rejections deliberately leave the queue item untouched for the next retry. */
+/** 运行一条排队的投递，且仅当发送方 resolve 后才确认。
+ * 拒绝会刻意保留队列项，留给下一次重试。 */
 export async function deliverWithAcknowledgement(
   send: () => Promise<void>,
   acknowledge: () => void
@@ -14,36 +14,33 @@ export async function deliverWithAcknowledgement(
 }
 
 /**
- * May the drain type into this agent's terminal right now?
+ * 现在是否允许把队列内容输入该 agent 的终端？
  *
- * The gate used to be `status === 'idle'`, full stop, and that stranded mail
- * indefinitely. `looping` is not a terminal state the agent recovers from on its
- * own — it is the circuit breaker's PIN, re-asserted on every beat for as long
- * as the agent is `constrained` or `stopped`. The PTY-quiescence fallback only
- * un-pins `working`, so a breaker-armed agent never returned to `idle` and its
- * queue never drained. Observed live: an agent over its token cap sat pinned
- * while a nudge enqueued two seconds after the message landed went undelivered
- * for minutes, until something outside the app woke it.
+ * 之前的门控是单纯的 `status === 'idle'`，这会让邮件无限滞留。
+ * `looping` 不是 agent 能自行恢复的终态——它是熔断器的 PIN，只要 agent
+ * 处于 `constrained` 或 `stopped` 状态，就会在每个心跳上重新断言。
+ * PTY 静默回退只会解除 `working` 的 PIN，因此挂上熔断的 agent 永远回不到
+ * `idle`，其队列也永远排不空。线上观察到的现象：一个超出 token 上限的
+ * agent 被钉住，而消息落地两秒后入队的 nudge 投递不了，一直等到应用外
+ * 的什么东西把它唤醒，延误了好几分钟。
  *
- * That is self-defeating, because the breaker STEERS by mailing the agent it
- * armed ("stop, write a plan, send it to god"). Under the old gate the one
- * message meant to unwedge a wedged agent was exactly the message that could
- * never arrive.
+ * 这是弄巧成拙的，因为熔断器的 STEER 方式就是给它所熔断的 agent 发邮件
+ * （“停下来，写个计划，发给 god”）。在旧门控下，那个本意用来解开
+ * 卡死 agent 的消息，恰恰是永远无法送达的那一条。
  *
- * So a pinned agent is deliverable once its terminal has been silent for
- * `quiesceMs` — the same evidence the idle fallback already trusts to decide a
- * turn is over. The pin stays on the avatar and the badge; it just stops
- * doubling as a delivery lock.
+ * 所以：被钉住的 agent 只要其终端已静默 `quiesceMs` 就允许投递——这与
+ * idle 回退用来判断一轮是否结束所依赖的证据相同。PIN 仍保留在头像和
+ * 徽章上，只是不再兼任投递锁。
  *
- * Everything else still holds the prompt:
- *   - `working` / `thinking`: mid-turn. The quiescence fallback flips a genuinely
- *     finished turn to `idle`, and then the ordinary gate applies.
- *   - `waiting` / `blocked`: an interactive prompt is on screen. The drain ends
- *     every delivery with Enter, which would ANSWER it — the same reason the
- *     one-time TUI seed refuses to type at those two statuses.
+ * 其余状态依然拦住提示符输入：
+ *   - `working` / `thinking`：回合进行中。静默回退会把真正结束的回合翻转为
+ *     `idle`，然后走常规门控。
+ *   - `waiting` / `blocked`：屏幕上有一个交互提示符。排空流程每次投递都
+ *     以 Enter 结尾，那会“回答”它——这也是单次 TUI 种子在这两个状态下
+ *     拒绝输入的原因。
  *
- * Fails CLOSED on an unknown `ptyQuietMs` (no reading, or a PTY that has never
- * emitted): silence we cannot measure is not evidence of silence.
+ * 当 `ptyQuietMs` 未知时按“关闭”安全处理（没有读取，或 PTY 从未输出）：
+ * 无法测量的静默不能当作静默的证据。
  */
 export function canDeliverToAgent(
   status: string,
@@ -55,30 +52,26 @@ export function canDeliverToAgent(
   return ptyQuietMs !== null && ptyQuietMs >= quiesceMs;
 }
 
-/** The subset of a QueuedMessage this module needs. Kept structural so the
- *  gate is testable without dragging the store (and zustand) into the test. */
+/** 本模块所需的 QueuedMessage 子集。保持结构化，以便门控逻辑可以不依赖
+ *  store（以及 zustand）即可测试。 */
 export interface DeliveryGateMessage {
   precondition?: 'inbox-nonempty';
 }
 
 export type PreconditionVerdict = 'send' | 'drop';
 
-/** Re-check a queued message's delivery-time precondition, immediately before it
- *  is typed into a PTY.
+/** 在投入 PTY 之前，立即重新检查队列消息投递时的前置条件。
  *
- *  A queue item is decided at enqueue time and delivered an arbitrary interval
- *  later, so some messages describe a world that may no longer exist by the time
- *  their turn comes. The inbox-wake nudge is the motivating case: an agent that
- *  is already awake routinely drains its whole inbox during the same turn the
- *  nudge was queued from, and delivering it afterwards spends a full turn
- *  discovering there is nothing to read.
+ *  队列项在入队时做出决策，而实际投递时间可能间隔任意长，因此某些消息所
+ *  描述的世界状态到它轮到时可能已不存在。inbox 唤醒 nudge 就是典型场景：
+ *  一个已经醒着的 agent 通常会在 nudge 入队的同一个回合内排空整个 inbox，
+ *  之后再投递该 nudge 会白白浪费一个回合去发现没什么可读的。
  *
- *  Returns 'drop', never 'defer': a stale message left at the head of the queue
- *  would block every message behind it forever.
+ *  返回 'drop' 而不是 'defer'：一条过期消息留在队首会永远阻塞它后面的
+ *  所有消息。
  *
- *  Fails OPEN. If the inbox cannot be read we send, because a spurious nudge
- *  costs one turn whereas a swallowed one can leave real mail unread
- *  indefinitely. */
+ *  失败时开放放行。如果读不到 inbox 就发送，因为一次多余的 nudge 只浪费
+ *  一个回合，而一次被吞掉的消息可能让真正的邮件无限期无法阅读。 */
 export async function checkPrecondition(
   message: DeliveryGateMessage,
   readInbox: () => Promise<{ id?: string }[]>

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -25,35 +25,33 @@ import { canDeliverToAgent, deliverWithAcknowledgement, checkPrecondition } from
 import { OFFICE_CAST, DEFAULT_CHARACTER } from '@/scene/office/cast';
 
 const GOD_ID = 'god';
-/** Accent palette for MAIN-spawned (voice-hired) agents — picked deterministically
- *  from the agent id so the same agent always gets the same colour. Mirrors the
- *  AddAgentModal palette. */
+/** MAIN 拉起（语音雇佣）agent 用的强调色板——由 agent id 确定性选取，
+ *  同一个 agent 总是得到同一个颜色。与 AddAgentModal 调色板保持一致。 */
 const SPAWN_ACCENTS = ['coral', 'mint', 'sky', 'lemon', 'lilac', 'peach'] as const;
 const GOD_PTY = `pty-${GOD_ID}`;
 
 const REMOTE_CONTROL_SETTLE_MS = 1500;
-// Provider-agnostic PTY-quiescence idle fallback (#2e). A non-Claude bridge that
-// fires a 'working' event but never its turn-end signal (Stop / session.idle /
-// agent_end) would pin the agent 'working' forever → the idle-only inbox-wake nudge
-// never fires → a god stops draining mail and the floor stalls. So a 'working'
-// agent whose PTY has emitted NOTHING for this window is treated as turn-done and
-// flipped idle. A streaming turn (incl. a long tool) keeps emitting bytes → stays
-// working; only true silence drifts it idle. Hook events still win — a fresh
-// PreToolUse/Stop refreshes status on the next event. Checked on QUIESCE_POLL_MS.
+// 与 provider 无关的 PTY 静默空闲回退 (#2e)。非 Claude 桥如果发出了
+// 'working' 事件却从不发出回合结束信号（Stop / session.idle / agent_end），
+// 会把 agent 永久钉在 'working' → 仅空闲触发的 inbox 唤醒 nudge 永不触发 →
+// god 停止排空邮件，楼层停摆。因此，PTY 在该窗口内没有任何输出的
+// 'working' agent 会被当作回合结束并翻转为 idle。流式回合（包括长时间
+// 工具调用）会持续输出字节 → 保持 working；只有真正的静默才漂移到 idle。
+// hook 事件仍然优先——新的 PreToolUse/Stop 会在下一个事件上刷新状态。
+// 按 QUIESCE_POLL_MS 检查。
 const QUIESCE_IDLE_MS = 12000;
 const QUIESCE_POLL_MS = 4000;
-// After a god/agent spawn, hold off the inbox-wake + queue-drain typers for this
-// long while the readiness handshake + provider-specific boot sequence runs.
+// god/agent spawn 之后，在就绪握手 + provider 特有启动序列运行期间，
+// 抑制 inbox 唤醒 + 队列排空输入。
 const BOOT_GRACE_MS = 35_000;
-// Delay before typing a one-time TUI protocol seed into a fresh worker (3b) —
-// long enough for the TUI to finish painting and surface any permission prompt.
-// submitToPty additionally waits for the terminal's readiness handshake.
+// 把一次性 TUI 协议种子输入新 worker 前的延迟 (3b)——足够 TUI 完成绘制并
+// 弹出任何权限提示。submitToPty 还会额外等待终端的就绪握手。
 const SEED_BOOT_MS = 12_000;
 
-/** Hive-aware / hooks-bridge engines get standing goals via HookServer
- *  (SessionStart + UserPromptSubmit). Cursor and other no-hook engines need the
- *  goal prepended onto queued PTY deliveries so an Edit Agent save still lands
- *  on the next drain cycle without a restart. */
+/** 支持 hive / hooks 桥的引擎通过 HookServer 获得常驻目标
+ *  (SessionStart + UserPromptSubmit)。Cursor 和其他无 hook 引擎需要把目标
+ *  前置到排队的 PTY 投递上，这样 Edit Agent 保存后无需重启就能在下一个
+ *  排空周期落地。 */
 function usesHookStandingGoal(agent: Agent): boolean {
   const provider = inferAgentProvider(agent.command, agent.provider);
   const preset = providerPreset(provider);
@@ -61,8 +59,8 @@ function usesHookStandingGoal(agent: Agent): boolean {
   return bridgeOf(provider)?.kind === 'hooks';
 }
 
-/** Prepend `<goal>…</goal>` for engines that cannot inject via hooks. Reads the
- *  live store field, so a just-saved goal is picked up on the next queue flush. */
+/** 为无法通过 hooks 注入的引擎前置 `<goal>…</goal>`。读取实时 store 字段，
+ *  因此刚保存的目标会在下一次队列冲刷时被拾取。 */
 function withStandingGoal(agent: Agent, text: string): string {
   const goal = agent.goal?.trim();
   if (!goal || usesHookStandingGoal(agent)) return text;
@@ -70,8 +68,8 @@ function withStandingGoal(agent: Agent, text: string): string {
   return `<goal>\n${goal}\n</goal>\n\n${text}`;
 }
 
-// The first thing Michael (god) is told on a fresh spawn — orient him and put
-// him to work running the floor. Kept terse and action-oriented.
+// 全新 spawn 后告诉 Michael (god) 的第一件事——让他认清方向并开始运行
+// 楼层。保持简洁、行动导向。
 const INITIAL_GOD_PROMPT = [
   "You're online as Michael, the orchestrator of the hive. Get oriented, then start running the floor:",
   '1. Read your memory.md and drain every message in your inbox.',
@@ -81,10 +79,10 @@ const INITIAL_GOD_PROMPT = [
   'Then begin orchestrating: triage requests, delegate work to the team, and keep everyone unblocked. You are fully autonomous — there is no approval queue, so handle tool-permission prompts in this session yourself (the human can approve them remotely from their phone).'
 ].join('\n');
 
-// Per-pty submission chain. Every submitToPty for a given pty is appended here so
-// two callers (e.g. the boot sequence's /remote-control and the inbox-wake nudge)
-// can NEVER interleave their text + Enter — which jammed them onto one line and
-// produced "Unknown command: /remote-control<next prompt>".
+// 每条 pty 的提交流水线。对同一 pty 的每次 submitToPty 都追加到这里，确保
+// 两个调用方（如启动序列的 /remote-control 与 inbox 唤醒 nudge）绝不互相
+// 交错 text + Enter——那会把它们挤到同一行，产生 “Unknown command:
+// /remote-control<下一个提示符>”。
 const writeChains = new Map<string, Promise<void>>();
 const readyPids = new Map<string, number>();
 
@@ -109,23 +107,20 @@ async function waitForTerminalReady(
 }
 
 /**
- * Type a line into an agent's Claude Code TUI and actually submit it.
+ * 向 agent 的 Claude Code TUI 输入一行文字并真正提交。
  *
- * Writing the text and the carriage return in a single chunk makes the TUI
- * treat the whole thing as a paste, so the "\r" lands as a newline inside the
- * input box instead of submitting — the command just sits there as text. We
- * send the text first, then the Enter as a separate keystroke a tick later so
- * the prompt is registered and executed. Idle autonomous agents thus act on a
- * dispatched instruction on their own.
+ * 把文字与回车写进同一个块会让 TUI 把整段当作粘贴处理，于是 "\r" 变成输入
+ * 框里的一行回车而不是提交——命令只是作为文本停在那里。所以我们先发送
+ * 文字，稍后把 Enter 作为独立按键发出去，提示符才被注册并执行。空闲的
+ * 自主 agent 因此能自行执行收到的指令。
  *
- * Submissions to the same pty are serialized (and each settles for `settleMs`
- * after Enter) so concurrent callers can't jam their input together.
+ * 对同一 pty 的提交是串行化的（并且每次 Enter 之后都等待 `settleMs`），
+ * 并发调用方不会把输入挤在一起。
  *
- * The text is wrapped in bracketed-paste markers (ESC[200~ … ESC[201~) so the
- * TUI treats it as ONE paste: embedded newlines land as literal newlines in the
- * input box. Without them, every "\n" in a multi-line message acted as Enter —
- * the message submitted line-by-line in fragments (the agent saw only the last
- * chunk). The closing Enter, sent a tick later, submits the whole block. (#24) */
+ * 文本用方括号粘贴标记（ESC[200~ … ESC[201~）包起来，让 TUI 视为一次
+ * 粘贴：内嵌换行以字面换行落入输入框。没有这些标记时，多行消息里的每个
+ * "\n" 都会充当 Enter——消息被逐行分片提交（agent 只看到最后一块）。
+ * 稍后一拍才发送的收尾 Enter 会提交整个块。 (#24) */
 function submitToPty(
   ptyId: string,
   text: string,
@@ -133,18 +128,17 @@ function submitToPty(
   settleMs = 250
 ): Promise<void> {
   const prev = writeChains.get(ptyId) ?? Promise.resolve();
-  const next = prev.catch(() => { /* a failed prior write must not stall the chain */ }).then(async () => {
+  const next = prev.catch(() => { /* 前一次失败的写入不能卡死整条流水线 */ }).then(async () => {
     await waitForTerminalReady(ptyId, provider);
-    // Bracketed paste (ESC[200~ … ESC[201~) only matters for MULTI-LINE text, so a
-    // stray "\n" doesn't submit early (#24). Single-line text (nudges, slash
-    // commands) is sent raw — some TUIs (Antigravity's agy) treat the paste
-    // markers as literal input and never submit, so skipping them is more robust.
+    // 方括号粘贴 (ESC[200~ … ESC[201~) 只对多行文本有意义，防止多余的
+    // "\n" 提前提交 (#24)。单行文本（nudge、斜杠命令）原样发送——有些 TUI
+    // (Antigravity 的 agy) 会把粘贴标记当作字面输入而永不提交，跳过它们
+    // 更稳妥。
     const payload = text.includes('\n') ? `\x1b[200~${text}\x1b[201~` : text;
-    // writePty NEVER rejects for a dead pty — it resolves { ok:false, error:
-    // 'no pty: …' } — so an unchecked await here made every failed delivery look
-    // successful (the queue-drain then destroyed the message it had already
-    // popped, #36). Surface the failure as a rejection; the chain itself is
-    // immune (the prev.catch above absorbs it for the next writer).
+    // writePty 对已死的 pty 永不 reject——它 resolve { ok:false, error:
+    // 'no pty: …' }——因此这里未检查的 await 曾让每次失败投递都显得成功
+    // （队列排空随即销毁它已弹出的消息，#36）。把失败以 rejection 形式
+    // 抛出；流水线本身免疫（上面的 prev.catch 会为下一个写入者吸收它）。
     const wrote = await window.cth.writePty(ptyId, payload);
     if (!wrote?.ok) throw new Error(wrote?.error ?? `pty write failed: ${ptyId}`);
     await new Promise((r) => setTimeout(r, 140));
@@ -156,8 +150,8 @@ function submitToPty(
   return next;
 }
 
-/** Wrap a user message as an enrich task for the assistant. The assistant's
- *  system prompt has the full instructions; this just frames the one task. */
+/** 把用户消息包装成给助手的 enrich 任务。助手的系统提示里已有完整指令；
+ *  这里只框出这一件事。 */
 function enrichTaskPrompt(text: string): string {
   return [
     `ENRICH TASK: ${text}`,
@@ -187,13 +181,13 @@ function terminalWorkOrderPrompt(msg: {
     msg.body,
     '',
     'Notes:',
-    '- This arrived through your terminal because this provider does not support hive inbox.',
+    '- This message is also queued in your hive inbox — read it there and move handled messages to inbox/.done/.',
     '- Work in your current cwd.',
     '- When done, report changes, validation, blockers, and next step in this terminal.'
   ].join('\n');
 }
 
-/** Tool name → where the avatar walks + what it carries. */
+/** 工具名 → 头像走向何处 + 携带什么。 */
 const TOOL_STATION: Record<string, { station: StationKind; carry?: ToolKind }> = {
   Read: { station: 'shelf', carry: 'Read' },
   Edit: { station: 'desk', carry: 'Edit' },
@@ -204,19 +198,18 @@ const TOOL_STATION: Record<string, { station: StationKind; carry?: ToolKind }> =
   WebFetch: { station: 'web', carry: 'WebFetch' },
   WebSearch: { station: 'web', carry: 'WebSearch' },
   TodoWrite: { station: 'board', carry: 'TodoWrite' },
-  // #5A — delegating to a sub-agent reads as "handing off at the outbox".
+  // #5A — 委托给子 agent 视为“在收件箱交接”。
   Task: { station: 'mailbox', carry: 'TodoWrite' }
 };
 
-/** Resolve a tool name to its station/glyph. Falls back: any `mcp__*` tool →
- *  the MCP station (previously these silently sat at the desk, #5A gap); anything
- *  else → the desk. */
+/** 把工具名解析为站位/图标。回退规则：任何 `mcp__*` 工具 → MCP 站位
+ *  （此前它们会静默停在工位上，#5A 缺口）；其他一律 → 工位。 */
 function stationForTool(tool: string): { station: StationKind; carry?: ToolKind } {
   if (TOOL_STATION[tool]) return TOOL_STATION[tool];
   if (tool.startsWith('mcp__')) return { station: 'mcp', carry: 'MCP' };
-  // Heuristic fallback for non-Claude tool names (Antigravity sends run_command,
-  // ListDir, write_file, … — its hook names differ from Claude's exact tags).
-  // Match write/edit BEFORE read so "write_file" → desk, not shelf.
+  // 非 Claude 工具名的启发式回退（Antigravity 发送 run_command、ListDir、
+  // write_file 等——它的 hook 名与 Claude 的确切标签不同）。
+  // 先匹配 write/edit 再匹配 read，保证 "write_file" → 工位，而不是书架。
   const t = tool.toLowerCase();
   if (/command|bash|shell|exec|terminal|run_/.test(t)) return { station: 'terminal', carry: 'Bash' };
   if (/web|fetch|browser|http|url/.test(t)) return { station: 'web', carry: 'WebFetch' };
@@ -225,40 +218,36 @@ function stationForTool(tool: string): { station: StationKind; carry?: ToolKind 
   return { station: 'desk' };
 }
 
-/** At/above this window size an agent counts as "large context" and is judged
- *  against `minContextPctLargeWindow` instead. Sits between the two real-world
- *  window sizes the app ever sees (200k and 1M) so neither lands ambiguously. */
+/** 上下文窗口达到/超过此大小时，agent 算“大上下文”，改按
+ *  `minContextPctLargeWindow` 判定。它位于应用实际会遇到的两种窗口尺寸
+ *  （200k 与 1M）之间，避免两边都落入歧义。 */
 const LARGE_CONTEXT_WINDOW = 500_000;
 
 /**
- * How full this agent's context window is, 0-100, or null when we have no
- * reading at all.
+ * 该 agent 上下文窗口的占用百分比，0-100；完全读不到时返回 null。
  *
- * Two sources feed the store and only one is exact: the status-line shim pushes
- * real `contextTokens` + `contextLimit` (effect 2d), while the transcript poll
- * (2c) backfills tokens ONLY. So an agent can legitimately know its token count
- * without knowing its window — infer the window the same way 2c does rather
- * than throwing the token reading away.
+ * 有两个来源写入 store，只有一个是精确的：状态栏 shim 推送真实的
+ * `contextTokens` + `contextLimit`（effect 2d），而 transcript 轮询 (2c)
+ * 只回填 tokens。因此 agent 可能合理地只知道 token 数而不知道窗口大小——
+ * 用与 2c 相同的方式推断窗口，而不是把 token 读数丢掉。
  */
 function contextFillPct(a: Agent): number | null {
   if (a.contextTokens === undefined || !Number.isFinite(a.contextTokens)) return null;
   const limit = a.contextLimit && a.contextLimit > 0
     ? a.contextLimit
-    : (/1m/i.test(a.model ?? '') ? 1_000_000 : 200_000);
+    : 1_000_000;
   return (a.contextTokens / limit) * 100;
 }
 
 /**
- * The context-pressure gate: is this agent full enough to be worth interrupting?
+ * 上下文压力门：该 agent 是否满到值得打断？
  *
- * `minContextPct` of 0 disables the gate (the rule's cadence alone fires it).
+ * `minContextPct` 为 0 时禁用此门（仅按规则自身的节奏触发）。
  *
- * FAIL-OPEN when we have no reading. That is the deliberate choice: context
- * telemetry arrives over the Claude status-line/hook path, so most non-Claude
- * providers report nothing at all. Failing closed there would silently reinstate
- * the very bug this replaces — a fleet that never compacts — only harder to
- * notice. An unmetered agent therefore falls back to time-only firing, which is
- * exactly the old behaviour and no worse.
+ * 没有读数时开放放行。这是刻意选择：上下文遥测走 Claude 状态栏/hook
+ * 路径，因此大多数非 Claude provider 什么都不报。在那里保守关闭会静默
+ * 复活本修复要消灭的 bug——一个永不压缩的舰队——而且更难发现。因此
+ * 未计量的 agent 回退为仅按时间触发，这正是旧行为，绝不更差。
  */
 function passesContextPressure(a: Agent, rule: ContextRule): boolean {
   const large = (a.contextLimit ?? 0) >= LARGE_CONTEXT_WINDOW;
@@ -270,90 +259,84 @@ function passesContextPressure(a: Agent, rule: ContextRule): boolean {
 }
 
 /**
- * The renderer-side glue for the hive:
- *   1. spawns the god agent into Michael's room when none is running,
- *   2. drives avatar state from real Claude Code hook events, and
- *   3. wakes idle agents that have unread inbox messages so collaboration
- *      doesn't stall while an agent sits at its prompt.
+ * 渲染端的 hive 胶水：
+ *   1. 没有 god 在运行时，把 god agent spawn 进 Michael 的房间，
+ *   2. 用真实的 Claude Code hook 事件驱动头像状态，并且
+ *   3. 唤醒有未读 inbox 消息的空闲 agent，让协作不会在 agent 坐在提示符
+ *      前时停滞。
  */
 export function useHive(config: HarnessConfig | null): void {
-  // Per-agent dedup for the inbox-wake nudge: every inbox message id we have
-  // already nudged this agent about. A SET, not a high-water mark.
+  // 每个 agent 的 inbox 唤醒 nudge 去重：我们已就该 agent 的每条 inbox
+  // 消息 id 提醒过它。用 SET 而不是高水位标记。
   //
-  // This used to hold one string — the lexicographically largest id in the inbox,
-  // read as "the newest". Message ids are usually `<timestamp>-<rand>`, so that
-  // held, but an agent may set its own `id` in the outbox JSON and the hive keeps
-  // it verbatim (hive.ts normalize: `partial.id ?? ...`). One such id in god's
-  // inbox — `dev15-progress-canvas-v4` — sorts above EVERY `2026-*` timestamp and
-  // never drains, so the "newest" id was frozen on it: Michael was nudged once per
-  // app launch and then never again, however much real mail piled up behind it.
-  // Tracking the ids we have seen has no such ordering assumption, and it keeps
-  // the property the high-water mark was there for: draining removes ids from the
-  // INBOX without adding anything new, so a drain still produces no nudge.
+  // 这里以前只存一个字符串——inbox 里字典序最大的 id，当作“最新”。消息 id
+  // 通常形如 `<timestamp>-<rand>`，所以这个假设成立，但 agent 可以在 outbox
+  // JSON 里自定义 `id`，hive 会原样保留（hive.ts normalize: `partial.id ?? ...`）。
+  // god 的 inbox 里就有这样一个 id——`dev15-progress-canvas-v4`——它把每个
+  // `2026-*` 时间戳都比下去且永不排空，于是“最新”id 就冻结在它上面：
+  // Michael 每次启动应用只被提醒一次，之后无论后面堆了多少真邮件都不再提醒。
+  // 记录已见过的 id 没有这种排序假设，同时保留了高水位标记的本意：
+  // 排空会从 INBOX 中移除 id 而不新增任何内容，所以一次排空依然不会产生
+  // nudge。
   //
-  // Note what this set does NOT do: it never shrinks. Ids accumulate for the life
-  // of the window (a restart clears it), because forgetting an id we have already
-  // nudged for would re-nudge the moment that message reappeared in a listing. The
-  // cost is a few tens of bytes per message, which for a 24/7 floor is real but
-  // negligible next to a stalled agent. Evicting ids that have left the inbox would
-  // bound it exactly; deliberately not done here to keep this fix minimal.
+  // 注意这个集合不做的事：它只会增长不会缩小。id 会累积到窗口生命周期结束
+  // （重启即清空），因为忘记一个已提醒过的 id，会让该消息一出现在列表里就
+  // 被重新提醒。代价是每条消息几十字节，对 7x24 的楼层而言真实存在，但与
+  // 一个停摆的 agent 相比微不足道。驱逐已离开 inbox 的 id 本可以把集合
+  // 限制到精确大小；这里刻意不做，以保持修复最小化。
   const nudged = useRef<Record<string, Set<string>>>({});
-  // Per-agent context size at the last auto-/compact queued. See the latch note
-  // in the context-trigger effect: an idle agent's token count is frozen, so
-  // without this the pressure gate re-fires on the identical number every cycle.
+  // 上次排到自动 /compact 时各 agent 的上下文字节数。参见 context-trigger
+  // effect 中的闩锁说明：空闲 agent 的 token 数是冻结的，没有这个闩锁，
+  // 压力门会每个周期都对着同一个数字重新触发。
   const lastCompactUsed = useRef<Record<string, number>>({});
-  // Per-agent timestamp of the last queued-message we submitted. Guards against
-  // re-sending the next message before the agent's hooks have flipped it to
-  // 'working' (there's a short window where it still reads 'idle' right after we
-  // type into it). One message per cooldown keeps delivery strictly one-by-one.
+  // 每个 agent 上次提交队列消息的时间戳。防止在 agent 的 hooks 把它翻成
+  // 'working' 之前重发下一条消息（我们输入后有一个短暂窗口它仍显示
+  // 'idle'）。每个冷却窗口一条消息，保证严格逐条投递。
   const lastFlush = useRef<Record<string, number>>({});
-  // Queue-drain delivery tracking (#36): a message now stays IN the queue until
-  // its PTY write chain resolves, so `inFlightSends` (message ids mid-write)
-  // stops a store-update burst from double-sending the head, and `sendFailures`
-  // bounds retries — after MAX_SEND_ATTEMPTS failed writes the message is
-  // dropped WITH a console.warn instead of being silently destroyed.
+  // 队列排空投递跟踪 (#36)：消息现在会留在队列里，直到其 PTY 写入链
+  // resolve，因此 `inFlightSends`（正在写入的消息 id）防止 store 更新突发
+  // 时重复发送队首，`sendFailures` 限制重试——写失败达到 MAX_SEND_ATTEMPTS
+  // 后，消息会带着 console.warn 被丢弃，而不是被静默销毁。
   const inFlightSends = useRef<Set<string>>(new Set());
   const sendFailures = useRef<Record<string, number>>({});
-  // In-flight spawn guard so a re-render / StrictMode double-mount can't spawn
-  // Michael twice (the window between the listPtys check and spawnPty is racy).
+  // 进行中的 spawn 守卫，防止重渲染 / StrictMode 双挂载把 Michael spawn
+  // 两次（listPtys 检查与 spawnPty 之间的窗口有竞争）。
   const godSpawning = useRef(false);
-  // Per-agent timestamp until which auto-typers (inbox-wake #3, queue-drain #4)
-  // must leave the agent alone — set while its boot sequence is typing so nothing
-  // collides with /remote-control + the orientation prompt.
+  // 每个 agent 在此时间戳之前，自动输入器（inbox 唤醒 #3、队列排空 #4）
+  // 必须放过它——在其启动序列输入期间设置，防止任何东西与 /remote-control
+  // 和定向提示碰撞。
   const bootGraceUntil = useRef<Record<string, number>>({});
-  // Agents whose one-time TUI protocol seed (Crush, seedDelivery:'type-into-tui')
-  // has already been typed — guards effect #3b against re-seeding. (ondev-b)
+  // 已输入一次性 TUI 协议种子（Crush，seedDelivery:'type-into-tui'）的
+  // agent——守卫 effect #3b 不重复播种。(ondev-b)
   const seeded = useRef<Set<string>>(new Set());
   const seenTerminalHandoffs = useRef<Set<string>>(new Set());
-  // Per-pty timestamp guarding auto-revive (effect #7) against a double-respawn
-  // when power-resume + screen-unlock arrive back-to-back: an id revived (or
-  // mid-revive) within REVIVE_DEBOUNCE_MS is skipped. Set BEFORE the async spawn
-  // so a re-entrant event can't race a second respawn for the same id.
+  // 每条 pty 的时间戳，守卫自动复活（effect #7）在电源恢复 + 屏幕解锁
+  // 接连到达时重复 spawn：REVIVE_DEBOUNCE_MS 内已复活（或正在复活）的 id
+  // 被跳过。在异步 spawn 之前设置，防止重入事件为同一 id 竞争第二次
+  // respawn。
   const reviving = useRef<Record<string, number>>({});
-  // Reactive so the assistant bootstrap (effect #1b) re-runs once Michael is ready.
+  // 响应式的：Michael 就绪后助手引导（effect #1b）会重新运行。
   const godStatus = useStore((s) => s.godStatus);
-  // Per-pty `lastOutputAt`, refreshed by the quiescence sweep (#2e) and read by
-  // the queue drain (#4) so it can tell a terminal parked at its prompt from one
-  // mid-turn. Kept here rather than fetched again in #4 — #2e already polls
-  // listPtys on exactly the cadence the drain needs, and one reading keeps the
-  // two loops from disagreeing about whether an agent is quiet.
+  // 每条 pty 的 `lastOutputAt`，由静默扫描 (#2e) 刷新、队列排空 (#4) 读取，
+  // 用来区分“停在提示符前”的终端与“回合中途”的终端。放在这里而不是在
+  // #4 里重新抓取——#2e 已经按排空所需的精确节奏轮询 listPtys，单次读数
+  // 让两个循环对“agent 是否安静”的判断保持一致。
   const ptyLastOutput = useRef<Record<string, number>>({});
-    /** How long this terminal has been silent, or null when we have no reading
-   *  (never polled, PTY gone, or it has emitted nothing at all). canDeliverToAgent
-   *  fails closed on null — unmeasured silence is not evidence of silence.
-   *  Hook-level (not effect-local) because both the drain effect and the
-   *  context-trigger effect gate delivery through the same check. */
+    /** 该终端已静默多久；没有读数时返回 null（从未轮询、PTY 已消失、或
+   *  从未输出任何内容）。canDeliverToAgent 对 null 保守关闭——无法测量的
+   *  静默不是静默的证据。钩子级（而非 effect 局部），因为排空 effect 和
+   *  context-trigger effect 都用同一个检查门控投递。 */
   const ptyQuietMs = (ptyId: string, now: number): number | null => {
     const last = ptyLastOutput.current[ptyId];
     return typeof last === 'number' && last > 0 ? now - last : null;
   };
-  // #5C/#7C.4 — latest circuit-breaker level per agent. When 'constrained'/
-  // 'stopped' the avatar is pinned to 'looping' and hook events must NOT flip it
-  // back to 'working' (the flicker the spec calls out); only a genuine Stop clears it.
+  // #5C/#7C.4 — 每个 agent 最新的熔断器等级。为 'constrained'/'stopped'
+  // 时头像被钉在 'looping'，hook 事件绝不能把它翻回 'working'（规范指出的
+  // 闪烁问题）；只有真正的 Stop 能清除。
   const breakerLevel = useRef<Record<string, string>>({});
 
-  // 0) Heal roster `description` from hive `role` when the floor caption was
-  //    overwritten by a status string ("on standby") after hire.
+  // 0) 当楼层说明被状态字符串（雇佣后的“on standby”）覆盖后，用 hive
+  //    `role` 修复名单里的 `description`。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     void window.cth.hiveRegistry().then((reg) => {
@@ -369,10 +352,10 @@ export function useHive(config: HarnessConfig | null): void {
           void window.cth.hivePatchAgentRole(a.id, next);
         }
       }
-    }).catch(() => { /* hive not ready yet */ });
+    }).catch(() => { /* hive 尚未就绪 */ });
   }, [config?.onboardingComplete]);
 
-  // 1) Bootstrap the god agent (source of truth = live PTYs, to dodge restarts).
+  // 1) 引导 god agent（事实来源 = 活跃 PTY，以规避重启）。
   useEffect(() => {
     if (!config?.onboardingComplete || !config.harnessHome) return;
     let cancelled = false;
@@ -380,19 +363,19 @@ export function useHive(config: HarnessConfig | null): void {
     const t = setTimeout(async () => {
       if (cancelled) return;
       const live = await window.cth.listPtys().catch(() => []);
-      if (live.some((p) => p.id === GOD_PTY)) { // already running — keep restored entry
+      if (live.some((p) => p.id === GOD_PTY)) { // 已在运行——保留已恢复的条目
         if (!cancelled) useStore.getState().setGodStatus('ready');
         return;
       }
-      // Synchronous guard (no await between check and set) → exactly one spawn.
+      // 同步守卫（检查与设置之间没有 await）→ 恰好一次 spawn。
       if (cancelled || godSpawning.current) return;
       godSpawning.current = true;
-      useStore.getState().removeAgent(GOD_ID); // clear any stale restored entry
+      useStore.getState().removeAgent(GOD_ID); // 清除任何过期的已恢复条目
 
-      // A prior rename (Edit Agent panel → renameAgent() → hive.ts's renameAgent())
-      // persists straight into registry.json, so read it back here rather than
-      // hardcoding DEFAULT_GOD_NAME below — otherwise a custom name reverts on
-      // every respawn even though the registry still has it right.
+      // 之前的重命名（Edit Agent 面板 → renameAgent() → hive.ts 的
+      // renameAgent()）会直接持久化到 registry.json，所以在这里读回而不是
+      // 硬编码下面的 DEFAULT_GOD_NAME——否则即使注册表仍然正确，自定义名
+      // 也会在每次 respawn 时被还原。
       const reg = await window.cth.hiveRegistry().catch(() => null);
       const godName = resolveGodName(reg?.agents?.[GOD_ID]?.name);
 
@@ -408,11 +391,10 @@ export function useHive(config: HarnessConfig | null): void {
         args,
         cols: 100,
         rows: 30,
-        // Restore Michael's prior conversation across an app restart. His session
-        // id lives in the hive registry (recorded from his hooks), so the main
-        // process attaches `--resume <id>`; a missing transcript falls back to a
-        // fresh session. Without this the most important context on the floor —
-        // the orchestrator's — was lost on every restart.
+        // 跨应用重启恢复 Michael 之前的对话。他的会话 id 存在 hive 注册表里
+        // （由其 hooks 记录），所以主进程会附加 `--resume <id>`；transcript
+        // 缺失则回退为新会话。没有这个，楼层上最重要的上下文——编排者的——
+        // 就会在每次重启时丢失。
         resume: true,
         hive: { id: GOD_ID, name: godName, provider: godProvider, cwd: config.harnessHome!, isGod: true, role: 'orchestrator (god)' }
       });
@@ -428,7 +410,7 @@ export function useHive(config: HarnessConfig | null): void {
         tmuxTarget: '',
         cwd: config.harnessHome!,
         status: 'idle',
-        action: 'running the floor',
+        action: '正在巡视办公室',
         progress: 0,
         currentStation: 'desk',
         ptyId: GOD_PTY,
@@ -441,92 +423,91 @@ export function useHive(config: HarnessConfig | null): void {
       useStore.getState().addAgent(god);
       useStore.getState().setGodStatus('ready');
 
-      // Kick Michael off once his TUI is up. Always re-enable remote control so
-      // the human can approve permission prompts from their phone (best-effort — a
-      // failed/unknown slash command just prints to his terminal and is harmless).
-      // Then, ONLY on a genuinely fresh spawn, hand him the orientation prompt —
-      // a RESUMED Michael already has his full context and must not be re-oriented
-      // mid-thread (that would reset the floor's situational awareness). Both go
-      // through the per-pty submit chain, so they're strictly sequential and can't
-      // jam together; the boot-grace window keeps the inbox-wake/drain loops off
-      // Michael until he's settled. The live-PTY branch above skips this entirely.
+      // Michael 的 TUI 起来后立刻踢他一脚。总是重新启用远程控制，让人类
+      // 能从手机批准权限提示（尽力而为——一条失败/未知的斜杠命令只会打印到
+      // 他的终端，无害）。
+      // 然后，只在真正全新 spawn 时才把定向提示交给他——一个 RESUMED 的
+      // Michael 已经拥有全部上下文，不能中途被重新定向（那会重置楼层的
+      // 态势感知）。两者都走每条 pty 的提交流水线，因此严格串行、不会挤在
+      // 一起；boot-grace 窗口让 inbox 唤醒/排空循环在 Michael 安定之前不去
+      // 打扰他。上面的活跃-PTY 分支完全跳过这一切。
       const resumedGod = res.resumed === true;
       bootGraceUntil.current[GOD_ID] = Date.now() + BOOT_GRACE_MS;
       void (async () => {
         try {
           const remoteCommand = remoteControlCommandForProvider(godProvider, godName);
           if (remoteCommand) {
-            // settleMs pauses the chain ~1.5s after /remote-control before the
-            // orientation prompt (fresh spawns only) is submitted next.
+            // settleMs 让流水线在 /remote-control 之后暂停约 1.5s，再提交
+            // 定向提示（仅全新 spawn）。
             await submitToPty(GOD_PTY, remoteCommand, godProvider, REMOTE_CONTROL_SETTLE_MS);
           }
           if (!cancelled && !resumedGod) {
-            // A type-into-tui god (Crush) can't ride its hive protocol on argv, so the
-            // main process hands it back as seedPrompt — type it FIRST (identity), then
-            // the orientation kick. Serialized via writeChains so they can't jam. (ondev-b)
+            // type-into-tui 的 god (Crush) 无法通过 argv 带上 hive 协议，所以
+            // 主进程以 seedPrompt 交回——先输入它（身份），再输入定向提示。
+            // 经 writeChains 串行化，不会挤在一起。(ondev-b)
             if (res.seedPrompt) await submitToPty(GOD_PTY, res.seedPrompt, godProvider);
             await submitToPty(GOD_PTY, INITIAL_GOD_PROMPT, godProvider);
           }
-        } catch { /* PTY may have died during startup */ }
+        } catch { /* PTY 可能在启动期间死亡 */ }
         finally { bootGraceUntil.current[GOD_ID] = 0; }
       })();
     }, 1200);
     return () => { cancelled = true; clearTimeout(t); };
   }, [config?.onboardingComplete, config?.harnessHome]);
 
-  // 2) Drive avatars from real hook events emitted by each agent's shim.
+  // 2) 用每个 agent 的 shim 发出的真实 hook 事件驱动头像。
   useEffect(() => {
     return window.cth.onHiveHookEvent((e) => {
       if (!e.agentId) return;
       const { updateAgent, agents } = useStore.getState();
       const self = agents.find((a) => a.id === e.agentId);
       if (!self) return;
-      // Breaker precedence (#5C): a constrained/stopped agent stays 'looping'
-      // regardless of in-flight tool/prompt/compact events.
+      // 熔断器优先级 (#5C)：constrained/stopped 的 agent 保持 'looping'，
+      // 不受进行中的工具/提示/压缩事件影响。
       const blevel = breakerLevel.current[e.agentId];
       const breakerArmed = blevel === 'constrained' || blevel === 'stopped';
-      // Hook events are the authoritative status source for real agents (the
-      // pty-stream parser only refines the on-floor action/station).
+      // hook 事件是真实 agent 状态的权威来源（pty 流解析器只细化楼层的
+      // 动作/站位）。
       if (e.event === 'PreCompact') {
-        // #5C — agent entered /compact; show it's boxing up context, not frozen.
-        if (!breakerArmed) updateAgent(e.agentId, { status: 'compacting', action: 'compacting context', carrying: undefined });
+        // #5C — agent 进入 /compact；显示它正在打包上下文，而不是冻结。
+        if (!breakerArmed) updateAgent(e.agentId, { status: 'compacting', action: '正在压缩上下文', carrying: undefined });
       } else if (e.event === 'PostCompact') {
-        if (!breakerArmed) updateAgent(e.agentId, { status: 'working', action: 'resumed', carrying: undefined });
+        if (!breakerArmed) updateAgent(e.agentId, { status: 'working', action: '已恢复', carrying: undefined });
       } else if (e.event === 'PreToolUse' && e.tool) {
         const m = stationForTool(e.tool);
-        if (!breakerArmed) updateAgent(e.agentId, { status: 'working', currentStation: m.station, carrying: m.carry, action: `using ${e.tool}` });
-        useStore.getState().bumpToolCount(e.agentId); // usage proxy for the command center
+        if (!breakerArmed) updateAgent(e.agentId, { status: 'working', currentStation: m.station, carrying: m.carry, action: `正在使用 ${e.tool}` });
+        useStore.getState().bumpToolCount(e.agentId); // 指挥中心的用量代理
       } else if (e.event === 'PostToolUse' || e.event === 'UserPromptSubmit') {
-        // A turn is in progress (prompt submitted / tool just finished) — keep
-        // it working so it doesn't flicker idle between tool calls.
+        // 回合进行中（提示已提交 / 工具刚结束）——保持 working，
+        // 让它在工具调用之间不会闪烁成 idle。
         if (!breakerArmed) updateAgent(e.agentId, { status: 'working' });
       } else if (e.event === 'PreInvocation') {
-        // Antigravity (agy): the model is being called — it's thinking/working.
-        if (!breakerArmed) updateAgent(e.agentId, { status: 'working', action: 'thinking' });
+        // Antigravity (agy)：模型正在被调用——它在思考/工作。
+        if (!breakerArmed) updateAgent(e.agentId, { status: 'working', action: '思考中' });
       } else if (e.event === 'PostInvocation') {
-        // agy's per-turn boundary. Unlike Claude, agy's Stop fires only on process
-        // EXIT, so without this an agy worker would never register as idle and the
-        // inbox-wake nudge (idle-only) could never reach it — its mail would sit
-        // undrained. Treat it as idle; a follow-up tool/turn re-sets working.
+        // agy 的每回合边界。与 Claude 不同，agy 的 Stop 只在进程 EXIT 时
+        // 触发，所以没有这个事件，agy worker 永远不会登记为 idle，
+        // inbox 唤醒 nudge（仅 idle）也就永远够不到它——它的邮件会一直
+        // 排不空。当作 idle 处理；后续的工具/回合会重新置回 working。
         if (!breakerArmed) updateAgent(e.agentId, { status: 'idle', action: 'idle', carrying: undefined });
       } else if (e.event === 'Stop' || e.event === 'SubagentStop') {
-        // A blocked Stop means the agent is being re-engaged to process its
-        // inbox — it's NOT idle, so keep it working until it genuinely stops.
+        // 被阻塞的 Stop 意味着 agent 正被重新拉回来处理 inbox——它不是
+        // idle，所以保持 working，直到它真正停下。
         if (e.blocked) {
-          if (!breakerArmed) updateAgent(e.agentId, { status: 'working', action: 'reading inbox', carrying: undefined });
+          if (!breakerArmed) updateAgent(e.agentId, { status: 'working', action: '正在读取收件箱', carrying: undefined });
         } else {
-          // A genuine stop clears any breaker override — the run is over.
+          // 真正的停止清除任何熔断覆盖——回合结束了。
           breakerLevel.current[e.agentId] = 'healthy';
           updateAgent(e.agentId, { status: 'idle', action: 'idle', carrying: undefined });
         }
       } else if (e.event === 'Notification' && !breakerArmed) {
-        // Claude Code fires Notification for two very different situations:
-        //   1. it genuinely needs the human (a permission / approval prompt), or
-        //   2. the prompt has merely gone idle ("Claude is waiting for your
-        //      input") — i.e. the agent answered and has nothing queued.
-        // Only (1) is a real "needs you". Treating (2) as blocked made Michael
-        // march to the door with a red "!" right after finishing, so detect the
-        // idle case and let him linger on the floor instead.
+        // Claude Code 会在两种截然不同的情况下触发 Notification：
+        //   1. 它真的需要人类（权限/审批提示），或
+        //   2. 提示符只是进入空闲（“Claude is waiting for your input”）
+        //      ——即 agent 已回答完且没有排队内容。
+        // 只有 (1) 才是真正的“需要你”。把 (2) 当作 blocked 会让 Michael
+        // 每次刚干完活就举着红色“!”走到门口，所以要识别空闲情形，让他
+        // 留在楼层上。
         const msg = (e.message ?? '').toLowerCase();
         const idleWaiting = !msg
           || msg.includes('waiting for your input')
@@ -537,78 +518,74 @@ export function useHive(config: HarnessConfig | null): void {
           || msg.includes('confirm')
           || msg.includes('needs your');
         if (needsHuman && !idleWaiting) {
-          // Only the god agent escalates to the human; sub-agents are autonomous
-          // and read as "waiting" (parked on god, not on you).
+          // 只有 god agent 会升级给人类；子 agent 是自主的，读作 "waiting"
+          // （停在 god 上，而不是等你）。
           updateAgent(e.agentId, { status: self.isGod ? 'blocked' : 'waiting' });
         } else {
-          // Idle notification — responded, nothing to do. Linger, don't flag.
+          // 空闲通知——已应答、无事可做。留下来，别标记。
           updateAgent(e.agentId, { status: 'idle', action: 'idle', carrying: undefined });
         }
       }
     });
   }, []);
 
-  // 2b) Consume circuit-breaker state (#7C.4/#5C). Lane A's breaker policy (#6)
-  //     pushes BreakerState on `control:breakerState`; this gives it PRECEDENCE
-  //     over hook-derived status: a constrained/stopped agent is pinned to
-  //     'looping' (see the breakerArmed guard above) until it genuinely Stops.
+  // 2b) 消费熔断器状态 (#7C.4/#5C)。Lane A 的熔断器策略 (#6) 通过
+  //     `control:breakerState` 推送 BreakerState；这里给它对 hook 派生状态的
+  //     优先级：constrained/stopped 的 agent 被钉在 'looping'（见上面的
+  //     breakerArmed 守卫），直到真正 Stop。
   useEffect(() => {
     return window.cth.onBreakerState((s) => {
       breakerLevel.current[s.agentId] = s.level;
       const { updateAgent, agents } = useStore.getState();
       if (!agents.some((a) => a.id === s.agentId)) return;
       if (s.level === 'constrained' || s.level === 'stopped') {
-        updateAgent(s.agentId, { status: 'looping', action: s.reason || 'breaker armed', carrying: undefined });
+        updateAgent(s.agentId, { status: 'looping', action: s.reason || '熔断已触发', carrying: undefined });
       }
       // 'healthy'/'steering' clear the pin; the next hook event refreshes status.
     });
   }, []);
 
-  // 2c) Context gauge backfill: poll each live agent's current context size
-  //     (tokens) from its session transcript — only until the status line
-  //     (effect 2d) has delivered exact numbers for that agent.
+  // 2c) 上下文计量表回填：轮询每个活跃 agent 当前上下文大小（tokens），
+  //     数据来自其会话 transcript——仅在状态栏（effect 2d）尚未为该 agent
+  //     送达精确数字之前。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     const poll = async () => {
       const { agents, updateAgent } = useStore.getState();
       for (const a of agents) {
         if (!a.ptyId) continue;
-        // The status line pushes exact numbers after every response (effect
-        // 2d) — this transcript poll only backfills agents whose status line
-        // hasn't fired yet (e.g. freshly restored, no response so far).
+        // 状态栏每次响应后都会推送精确数字（effect 2d）——这个 transcript
+        // 轮询只为状态栏尚未触发的 agent 回填（例如刚恢复、尚无响应的）。
         if (a.contextLimit !== undefined) continue;
         try {
           const ctx = await window.cth.agentContext(a.id);
           if (ctx === null) continue;
-          const hinted = /1m/i.test(a.model ?? '') ? 1_000_000 : 200_000;
-          const limit = Math.max(hinted, ctx > 200_000 ? 1_000_000 : 0);
+          const limit = 1_000_000;
           const progress = Math.max(0, Math.min(8, Math.round((ctx / limit) * 8)));
           updateAgent(a.id, { contextTokens: ctx, progress });
-        } catch { /* ignore — try again next tick */ }
+        } catch { /* 忽略——下个 tick 重试 */ }
       }
     };
-    const t = setTimeout(poll, 3000); // first fill shortly after boot
+    const t = setTimeout(poll, 3000); // 启动后不久先填一次
     const iv = setInterval(poll, 15000);
     return () => { clearTimeout(t); clearInterval(iv); };
   }, [config?.onboardingComplete]);
 
-  // 2d) Push-based context gauge: the status-line shim forwards the session's
-  //     EXACT context accounting (tokens + real window size) after every
-  //     response — no probing, no transcript guesswork.
+  // 2d) 推送式上下文计量表：状态栏 shim 在每次响应后转发会话的精确上下文
+  //     账目（tokens + 真实窗口大小）——无需探测，无需猜 transcript。
   useEffect(() => {
     return window.cth.onHiveContextUpdate(({ agentId, tokens, limit }) => {
-      // Defense-in-depth: the main process already filters limit > 0, but the
-      // renderer must not trust IPC blindly — limit 0 would put NaN progress
-      // into the store (NaN survives the Math.min/max clamp).
+      // 纵深防御：主进程已经过滤 limit > 0，但渲染端不能盲目信任 IPC——
+      // limit 为 0 会把 NaN progress 放进 store（NaN 能穿过 Math.min/max
+      // 钳制）。
       if (!Number.isFinite(limit) || limit <= 0 || !Number.isFinite(tokens)) return;
       const progress = Math.max(0, Math.min(8, Math.round((tokens / limit) * 8)));
       useStore.getState().updateAgent(agentId, { contextTokens: tokens, contextLimit: limit, progress });
     });
   }, []);
 
-  // 2e) Non-Claude providers cannot drain hive inbox. Direct hive mail to them
-  //     arrives here as a terminal work order and is queued through the same
-  //     idle-only PTY drain as human-composed messages.
+  // 2e) 非 Claude provider 无法排空 hive inbox。发往它们的 hive 邮件在这里
+  //     以终端工单形式到达，并与人类撰写的消息走同一条仅空闲 PTY 排空通道。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     return window.cth.onHiveTerminalHandoff((msg) => {
@@ -626,43 +603,42 @@ export function useHive(config: HarnessConfig | null): void {
       enqueueMessage(
         GOD_ID,
         [
-          `Terminal handoff failed for ${msg.to}: ${msg.subject}`,
+          `给 ${msg.to} 的终端交接失败: ${msg.subject}`,
           '',
-          `Message ${msg.id} from ${msg.from} could not be queued because ${msg.to} has no live PTY. Route it manually or respawn the agent.`
+          `来自 ${msg.from} 的消息 ${msg.id} 无法入队，因为 ${msg.to} 没有活动的 PTY。请手动路由或重新生成该 agent。`
         ].join('\n')
       );
     });
   }, [config?.onboardingComplete]);
 
-  // 2e) PROVIDER-AGNOSTIC PTY-QUIESCENCE IDLE FALLBACK (the linchpin that makes
-  //     canReceiveInbox:true safe for the live-unverified OpenCode/Crush/pi bridges).
-  //     Hook events are the authoritative status source, but a bridge whose turn-end
-  //     signal (Stop/session.idle/agent_end) doesn't fire leaves the agent pinned
-  //     'working' — and BOTH delivery paths (#3 nudge, #4 queue-drain) are idle-gated,
-  //     so the agent silently stops draining mail. usePtyParser has a 4s idle drift,
-  //     but it's Claude-TUI-tuned AND only runs for the mounted terminal — a
-  //     backgrounded god gets none. This is the floor-wide, provider-agnostic backstop:
-  //     it reads each live PTY's lastOutputAt (already tracked in the main process) and
-  //     flips any 'working' agent quiet for QUIESCE_IDLE_MS to idle so the nudge can
-  //     drain it. Safe because a genuinely-working agent (incl. a long streaming tool)
-  //     keeps emitting bytes; a false idle self-corrects on the next hook event.
+  // 2e) 与 PROVIDER 无关的 PTY 静默空闲回退（让 canReceiveInbox:true 对
+  //     未经实盘验证的 OpenCode/Crush/pi 桥也安全的关键机制）。
+  //     hook 事件是权威状态来源，但回合结束信号（Stop/session.idle/
+  //     agent_end）不触发的桥会把 agent 钉在 'working'——而两条投递路径
+  //     （#3 nudge、#4 队列排空）都以 idle 为门，agent 会静默停止排空邮件。
+  //     usePtyParser 有 4s 空闲漂移，但它是为 Claude TUI 调校的，且只作用于
+  //     已挂载的终端——后台化的 god 一个都拿不到。这里是楼层级、与
+  //     provider 无关的最后防线：读取每个活跃 PTY 的 lastOutputAt（主进程
+  //     已在跟踪），把 QUIESCE_IDLE_MS 内保持安静的 'working' agent 翻转
+  //     为 idle，让 nudge 能排空它。安全因为真正在工作的 agent（包括长时间
+  //     流式工具）会持续输出字节；误判的 idle 会在下一个 hook 事件自纠。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     const iv = setInterval(async () => {
       const ptys = await window.cth.listPtys().catch(() => []);
       const lastOut: Record<string, number> = {};
       for (const p of ptys) lastOut[p.id] = p.lastOutputAt;
-      // Publish BEFORE the early return and before the 'working' filter below,
-      // so the drain (#4) also gets a reading for breaker-pinned agents — and so
-      // a vanished PTY clears its entry instead of leaving a stale one.
+      // 在提前返回和下面的 'working' 过滤之前发布，让排空 (#4) 也为被
+      // 熔断钉住的 agent 拿到读数——也让消失的 PTY 清除其条目而不是留下
+      // 过期值。
       ptyLastOutput.current = lastOut;
       if (!ptys.length) return;
       const now = Date.now();
       const { agents, updateAgent } = useStore.getState();
       for (const a of agents) {
         if (!a.ptyId || a.status !== 'working') continue;
-        // Never fight the breaker pin (a constrained/stopped agent stays 'looping')
-        // or a still-booting agent (its boot sequence is mid-type).
+        // 绝不与熔断钉住对抗（constrained/stopped 的 agent 保持 'looping'），
+        // 也不碰仍在启动的 agent（其启动序列正在输入中）。
         const bl = breakerLevel.current[a.id];
         if (bl === 'constrained' || bl === 'stopped') continue;
         if ((bootGraceUntil.current[a.id] ?? 0) > now) continue;
@@ -675,18 +651,15 @@ export function useHive(config: HarnessConfig | null): void {
     return () => clearInterval(iv);
   }, [config?.onboardingComplete]);
 
-  // 3) Wake agents holding unread inbox messages. The assistant is send-only
-  //    (it never receives inbox mail), so it's excluded.
+  // 3) 唤醒持有未读 inbox 消息的 agent。助手只发不收（它从不接收 inbox
+  //    邮件），所以被排除。
   //
-  //    QUEUES the nudge rather than typing it. This loop used to write straight
-  //    into the terminal, which made it the one automatic writer that could land
-  //    on top of whatever the user was typing — its text fused onto the user's
-  //    half-written line and the pair got submitted as one garbled prompt. Going
-  //    through the queue means effect #4 owns every decision about when a
-  //    terminal may be typed into: idle, off cooldown, past boot grace, delivery
-  //    not paused, and no user draft in the way. One gate, one place, and this
-  //    loop stops needing prompt logic of its own. /compact (effect #6) has
-  //    always worked this way.
+  //    把 nudge QUEUE 起来而不是直接输入。这个循环以前直接写终端，使它
+  //    成为唯一可能落在用户正在输入内容之上的自动写入者——它的文本与用户
+  //    写到一半的行融合，整对被当作一条乱码提示提交。改走队列意味着
+  //    effect #4 全权决定何时可以向终端输入：idle、冷却期外、过了启动宽限、
+  //    投递未暂停、且没有用户草稿挡路。一个门、一处集中，这个循环不再需要
+  //    自己的提示逻辑。/compact (effect #6) 一直就是这么做的。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     const iv = setInterval(async () => {
@@ -694,28 +667,23 @@ export function useHive(config: HarnessConfig | null): void {
       for (const a of agents) {
         try {
           const inbox = await window.cth.hiveInbox(a.id);
-          // Nudge on any id we have not nudged for yet (#130's per-id Set).
-          // Draining shrinks the set and introduces nothing new, so this POLL
-          // stays quiet; a genuinely new message fires regardless of how its id
-          // happens to sort.
+          // 对任何尚未提醒过的 id 触发 nudge (#130 的按 id Set)。
+          // 排空会缩小集合且不引入新内容，所以这个 POLL 保持安静；真正
+          // 的新消息无论其 id 碰巧怎么排序都会触发。
           //
-          // That reasoning covers the poll only — it does NOT survive the gap
-          // between enqueue and delivery, which is why the nudge carries an
-          // 'inbox-nonempty' precondition that the drain re-checks before typing.
-          // Without it: mail lands and queues a nudge, the already-awake agent
-          // drains the whole inbox in that same turn, and the nudge is typed into
-          // an empty inbox afterwards — a wasted turn, and the most expensive one
-          // on the floor when the agent is god.
+          // 这个推理只覆盖轮询——它撑不过 enqueue 与投递之间的间隙，所以
+          // nudge 携带 'inbox-nonempty' 前置条件，排空在输入前会重新检查。
+          // 没有它：邮件落地并排队 nudge，已经醒着的 agent 在同一回合排空
+          // 整个 inbox，之后 nudge 被输入到一个空 inbox——浪费一个回合，
+          // 而当 agent 是 god 时这是楼层上最贵的回合。
           const seen = nudged.current[a.id] ?? (nudged.current[a.id] = new Set());
           const fresh = inbox.filter((m) => m.id && !seen.has(m.id));
           if (fresh.length) {
-            // Name the ids: the nudge is queued now and typed whenever the agent
-            // next goes idle, so it can arrive long after the agent drained and
-            // filed this very mail. Carrying the ids is what lets it tell
-            // "already handled" from "woken for nothing". The queue keeps only
-            // one nudge pending per agent (see enqueueMessage), so a suppressed
-            // copy's ids stay unnamed — hence the text points at the pending
-            // inbox as the authority rather than at the list.
+            // 指名 id：nudge 现在入队、在 agent 下次空闲时输入，所以它可能
+            // 在 agent 已经排空并归档这封邮件很久之后才到达。携带 id 才能
+            // 区分“已处理”与“白唤醒”。队列每个 agent 只保留一条待决
+            // nudge（见 enqueueMessage），被抑制的副本的 id 保持无名——
+            // 因此文本指向待决 inbox 作为权威，而不是这份列表。
             useStore.getState().enqueueMessage(
               a.id,
               inboxNudgeText(fresh.map((m) => m.id)),
@@ -723,20 +691,19 @@ export function useHive(config: HarnessConfig | null): void {
             );
             for (const m of fresh) seen.add(m.id);
           }
-        } catch { /* ignore */ }
+        } catch { /* 忽略 */ }
       }
     }, 4000);
     return () => clearInterval(iv);
   }, [config?.onboardingComplete]);
 
-  // 3b) Seed a fresh "type-into-tui" worker (Crush) with the hive protocol. Its
-  //     bare TUI rejects a positional seed (Cobra reads it as a subcommand →
-  //     `Unknown command`), so the main process spawns it bare and hands the
-  //     protocol back as `seedPrompt`; we TYPE it as the worker's first turn after a
-  //     boot-grace (TUI finished painting), ONCE per agent. Routed through the SAME
-  //     per-pty submit chain + boot-grace as the inbox-wake nudge so the seed and a
-  //     nudge can never jam onto one line. (god-as-Crush is seeded in its own boot
-  //     sequence above; this covers workers.) (ondev-b)
+  // 3b) 用 hive 协议给全新 “type-into-tui” worker (Crush) 播种。它的裸
+  //     TUI 拒绝位置参数种子（Cobra 把它当作子命令 → `Unknown command`），
+  //     所以主进程裸 spawn 它，把协议以 `seedPrompt` 交回；我们把它作为
+  //     worker 的第一回合在启动宽限后输入（TUI 完成绘制后），每个 agent
+  //     一次。与 inbox 唤醒 nudge 走同一条 per-pty 提交流水线 + 启动宽限，
+  //     种子与 nudge 永远不会挤到同一行。(god-as-Crush 在其自有启动序列中
+  //     播种；这里覆盖 workers。) (ondev-b)
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     const iv = setInterval(() => {
@@ -746,16 +713,15 @@ export function useHive(config: HarnessConfig | null): void {
         seeded.current.add(a.id);
         const ptyId = a.ptyId;
         const seed = a.seedPrompt;
-        // Hold the nudge/quiesce typers off this agent until the seed lands + settles.
+        // 在种子落地并安定之前，让 nudge/静默输入器离这个 agent 远点。
         bootGraceUntil.current[a.id] = Date.now() + BOOT_GRACE_MS;
-        // Clear the record now so it isn't re-seen (the ref also guards) or persisted.
+        // 现在就清掉记录，避免被再次看到（ref 也是守卫）或持久化。
         updateAgent(a.id, { seedPrompt: undefined });
         setTimeout(() => {
-          // Permission-prompt safety (#5): if the worker surfaced an approval /
-          // needs-human prompt while its TUI booted ('waiting'/'blocked'), the
-          // seed's trailing Enter would confirm it. Put the seed back and let a
-          // later tick retry once the prompt clears; if the agent vanished
-          // (killed mid-boot), don't type into its orphaned pty at all.
+          // 权限提示安全 (#5)：如果 worker 在其 TUI 启动期间浮出审批/需要
+          // 人类的提示（'waiting'/'blocked'），种子的收尾 Enter 会确认它。
+          // 把种子放回去，等提示清除后由稍后的 tick 重试；如果 agent 消失
+          // （启动中被杀），就完全不要向它的孤儿 pty 输入。
           const live = useStore.getState().agents.find((x) => x.id === a.id);
           if (!live) return;
           if (live.status === 'waiting' || live.status === 'blocked') {
@@ -768,33 +734,31 @@ export function useHive(config: HarnessConfig | null): void {
             withStandingGoal(live, seed),
             inferAgentProvider(live.command, live.provider)
           )
-            .catch(() => { /* pty may have died */ });
+            .catch(() => { /* pty 可能已死 */ });
         }, SEED_BOOT_MS);
       }
     }, 1500);
     return () => clearInterval(iv);
   }, [config?.onboardingComplete]);
 
-  // 4) Drain each agent's queued messages to its terminal, one at a time, the
-  //    moment the agent goes idle. This is what lets the user keep sending
-  //    messages while the agent's "cloud terminal" is mid-run: the messages
-  //    park in the store and get typed in (and submitted) as soon as it's free.
+  // 4) 在 agent 空闲的那一刻，把每个 agent 排队的消息逐条排空到它的终端。
+  //    这让用户可以在 agent 的“云端终端”运行期间继续发消息：消息停在
+  //    store 里，等它一有空就被输入（并提交）。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     const FLUSH_COOLDOWN_MS = 4500;
-    // A message that fails this many PTY writes (dead/crashed pty that the store
-    // still thinks is idle) is dropped WITH a console.warn — bounded so the drain
-    // never spins forever on a corpse, loud so the loss is diagnosable. (#113)
+    // 一条消息若连续这么多次 PTY 写入失败（store 仍以为它空闲的死/崩 pty）
+    // 会被丢弃并带 console.warn——有界以免排空在尸体上永远打转，发声以便
+    // 损失可诊断。(#113)
     const MAX_SEND_ATTEMPTS = 3;
     const inFlight = new Set<string>();
     const sendFailures: Record<string, number> = {};
 
 
-    // Send the front of `srcId`'s queue into `target`'s pty (verbatim or wrapped),
-    // gated on the target being idle, free of interactive menus, and off
-    // cooldown. The queue item is acknowledged only after BOTH PTY writes
-    // succeed; failures stay visible and retry automatically (bounded by
-    // MAX_SEND_ATTEMPTS so the drain never spins forever on a corpse).
+    // 把 `srcId` 队列头部的消息发送到 `target` 的 pty（原样或包装后），
+    // 以 target 空闲、没有交互菜单、且不在冷却期为门。队列项只有在两次
+    // PTY 写入都成功后才会被确认；失败保持可见并按 MAX_SEND_ATTEMPTS
+    // 有界自动重试，排空不会在尸体上永远打转。
     const dispatch = async (
       srcId: string,
       target: Agent | undefined,
@@ -804,32 +768,28 @@ export function useHive(config: HarnessConfig | null): void {
       const next = messageQueues[srcId]?.[0];
       if (!next || !target?.ptyId) return { sent: false };
       const now = Date.now();
-      // Idle, or breaker-pinned with a terminal that has genuinely gone quiet.
-      // This gate is a don't-type-mid-stream safety check, so `manual` does NOT
-      // bypass it — "send now" releases the auto-delivery PAUSE below, not this.
+      // 空闲，或被熔断钉住但终端真正安静了。
+      // 这个门是不在流中输入的 safety 检查，`manual` 不会绕过它——
+      // “立即发送”只解除下面的自动投递暂停，不解除此门。
       if (!canDeliverToAgent(target.status, ptyQuietMs(target.ptyId, now), QUIESCE_IDLE_MS)) {
         return { sent: false };
       }
       const control = await window.cth.controlSnapshot(target.id);
-      // The pause gate holds everything EXCEPT messages the user explicitly
-      // released with "send now" (m.manual) — otherwise a paused floor leaves
-      // the queue with no escape hatch at all. Idle/draft/picker safety below
-      // still applies to manual messages; only the pause is bypassed.
+      // 暂停门拦截所有消息，除了用户用“立即发送”明确放行的（m.manual）——
+      // 否则暂停的楼层会让队列完全没有逃生通道。下面的 idle/草稿/选择器
+      // 安全对 manual 消息仍然适用；只有暂停被绕过。
       if (control?.autoDeliveryPaused && !next.manual) return { sent: false };
-      // Hold queued messages until the target finishes its boot sequence.
+      // 在 target 完成启动序列之前扣住排队消息。
       if ((bootGraceUntil.current[target.id] ?? 0) >= now) return { sent: false };
-      // The user owns the prompt: a draft they are writing, or a menu they
-      // opened, holds delivery. Both blocks expire after half an hour, and when
-      // one does we simply type after whatever is there — automation never
-      // erases the user's text and never closes the user's menu.
+      // 提示符归用户所有：正在写的草稿，或打开的菜单，都会扣住投递。两者
+      // 半小时后过期，过期后我们只在现有内容后面输入——自动化绝不擦除用户
+      // 的文本，也绝不关闭用户的菜单。
       if (!isTerminalAutomationSafe(target.ptyId, now)) return { sent: false };
       if (now - (lastFlush.current[target.id] ?? 0) < FLUSH_COOLDOWN_MS) return { sent: false };
-      // Last gate before we type: re-check the message's delivery-time
-      // precondition. A queue item is decided at enqueue time and delivered an
-      // arbitrary interval later, and the inbox nudge is only worth sending if
-      // there is still something in the inbox — the agent routinely drains it in
-      // the very turn the nudge was queued from. Stale ones are DROPPED, not
-      // deferred, so they cannot park at the queue head and starve the rest.
+      // 输入前的最后一道门：重新检查消息投递时的前置条件。队列项在入队时
+      // 决策、在间隔任意长之后投递，inbox nudge 只有在 inbox 里还有东西时
+      // 才值得发送——agent 通常会在 nudge 入队的同一回合排空它。过期的
+      // 直接 DROP 而不是 defer，避免它们停在队首饿死其余消息。
       if (await checkPrecondition(next, () => window.cth.hiveInbox(srcId)) === 'drop') {
         removeQueuedMessage(srcId, next.id);
         return { sent: false };
@@ -840,8 +800,8 @@ export function useHive(config: HarnessConfig | null): void {
       lastFlush.current[target.id] = now;
       try {
         const sent = await deliverWithAcknowledgement(
-          // `instruction` (when present) is the authoritative text to type into
-          // the PTY; UI/card surfaces continue to show the readable `text`.
+          // `instruction`（若有）是要输入 PTY 的权威文本；UI/卡片界面继续
+          // 显示可读的 `text`。
           () => submitToPty(
             target.ptyId!,
             withStandingGoal(
@@ -852,9 +812,9 @@ export function useHive(config: HarnessConfig | null): void {
           ),
           () => {
             removeQueuedMessage(srcId, next.id);
-            // Zero the gauge on a DELIVERED /clear — the new session's context
-            // isn't known until statusLine fires after the first post-clear
-            // response, so leaving it at the old value shows a stale-full bar.
+            // 已投递的 /clear 之后把计量表清零——新会话的上下文要等
+            // statusLine 在清空后的首次响应才会出现，留着旧值会显示一个
+            // 过期的满格条。
             if (next.text.trim().toLowerCase() === '/clear') {
               useStore.getState().updateAgent(target.id, {
                 contextTokens: 0,
@@ -868,9 +828,9 @@ export function useHive(config: HarnessConfig | null): void {
           delete sendFailures[next.id];
           return { sent: true, message: next };
         }
-        // Failed write (dead/crashed pty the store still thinks is idle): retry
-        // on the next cooldown-spaced flush, but only MAX_SEND_ATTEMPTS times —
-        // then drop LOUDLY so the loss is diagnosable. (#113/#36)
+        // 写入失败（store 仍以为空闲的死/崩 pty）：在下一次冷却间隔的冲刷
+        // 重试，但只重试 MAX_SEND_ATTEMPTS 次——然后带响动丢弃，让损失
+        // 可诊断。(#113/#36)
         const attempts = (sendFailures[next.id] ?? 0) + 1;
         sendFailures[next.id] = attempts;
         if (attempts >= MAX_SEND_ATTEMPTS) {
@@ -887,12 +847,11 @@ export function useHive(config: HarnessConfig | null): void {
       }
     };
 
-    // Promote a genuine Slack-origin work item to a stamped kanban card the first
-    // time it's dispatched to the office. The card carries slack:{channel,thread_ts}
-    // (origin thread) so the main-process done-observer can post its one summary
-    // reply in-thread once the card later reaches 'done'. ADDITIVE + idempotent +
-    // best-effort: a failure here never affects the dispatch that already happened,
-    // and only dispatched work items land here (slash commands/acks never do).
+    // 第一次分发到办公室时，把真正的 Slack 来源工作项升级为带戳的看板卡片。
+    // 卡片携带 slack:{channel,thread_ts}（来源线程），让主进程的完成观察者
+    // 能在卡片稍后达到 'done' 时在原始线程里回复一条总结。加性 + 幂等 +
+    // 尽力而为：这里的失败绝不影响已经发生的分发，而且只有已分发的工作项
+    // 会走到这里（斜杠命令/ack 永远不会）。
     type SlackTaskCard = Parameters<typeof window.cth.hiveAddTask>[0];
     const ensureSlackCard = async (m: QueuedMessage): Promise<void> => {
       const slack = m.slack;
@@ -904,7 +863,7 @@ export function useHive(config: HarnessConfig | null): void {
             ? (raw as { tasks: SlackTaskCard[] }).tasks
             : [];
         const id = `slack-${slack.thread_ts}-${m.id}`;
-        if (existing.some((t) => t.id === id)) return; // already promoted — no dup
+        if (existing.some((t) => t.id === id)) return; // 已升级——不重复
         const title = m.text.length > 80 ? `${m.text.slice(0, 79)}…` : m.text;
         const card: SlackTaskCard = {
           id,
@@ -917,7 +876,7 @@ export function useHive(config: HarnessConfig | null): void {
           slack
         };
         await window.cth.hiveAddTask(card);
-      } catch { /* best-effort: card promotion must never sink dispatch */ }
+      } catch { /* 尽力而为：卡片升级绝不能拖垮分发 */ }
     };
 
     const flush = () => {
@@ -926,14 +885,13 @@ export function useHive(config: HarnessConfig | null): void {
       const now = Date.now();
 
       for (const a of agents) {
-        // Same gate as dispatch() — this pre-filter runs first, so relaxing only
-        // the one inside dispatch would have changed nothing.
+        // 与 dispatch() 相同的门——这个预过滤先跑，只放宽 dispatch 内部的
+        // 一个门不会有任何改变。
         if (!a.ptyId || !canDeliverToAgent(a.status, ptyQuietMs(a.ptyId, now), QUIESCE_IDLE_MS)) continue;
         if (!messageQueues[a.id]?.length) continue;
                 void dispatch(a.id, a).then(({ sent, message }) => {
           if (sent && message?.slack) void ensureSlackCard(message);
-          // Write the compact latch only once delivery genuinely happened — see
-          // the comment in fire() above.
+          // 只在真正投递后写入压缩闩锁——见上面 fire() 中的注释。
           if (sent && message?.compactUsed !== undefined) {
             lastCompactUsed.current[a.id] = message.compactUsed;
           }
@@ -941,8 +899,8 @@ export function useHive(config: HarnessConfig | null): void {
       }
     };
 
-    // Run on every store change (status flips, new queue items) — debounced so a
-    // burst of pty-stream updates coalesces — plus a periodic backstop.
+    // 在每次 store 变化时运行（状态翻转、新队列项）——去抖让 pty 流更新
+    // 突发合并——外加一个周期兜底。
     let debounce: ReturnType<typeof setTimeout> | null = null;
     const schedule = () => {
       if (debounce) return;
@@ -954,33 +912,32 @@ export function useHive(config: HarnessConfig | null): void {
     return () => { unsub(); if (debounce) clearTimeout(debounce); clearInterval(iv); };
   }, [config?.onboardingComplete]);
 
-  // 5) Pipe inbound Slack messages into Michael's queue. The main-process Slack
-  //    webhook server pushes each verified message here via IPC; enqueueing to
-  //    GOD_ID lands it in Michael's queue exactly as if the user had typed it
-  //    into the composer — effect #4 above then drains it to his PTY.
-  //    We immediately ack in the triggering thread and stash the thread coords
-  //    so the office can post its summary back later.
+  // 5) 把入站 Slack 消息导入 Michael 的队列。主进程 Slack webhook 服务器经
+  //    IPC 把每条验证过的消息推到这里；入队到 GOD_ID 让它像用户亲手在
+  //    输入框输入一样落进 Michael 的队列——上面的 effect #4 随后把它排空
+  //    到他的 PTY。
+  //    我们立即在触发线程里 ack，并暂存线程坐标，供办公室稍后把总结
+  //    发回去。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     return window.cth.onSlackMessage((msg) => {
       const hasFiles = Array.isArray(msg.files) && msg.files.length > 0;
       if (!msg?.text?.trim() && !hasFiles) return;
       let text = msg.text.trim();
-      // Append local file paths so the agent (Claude Code) can Read them directly.
+      // 追加本地文件路径，让 agent (Claude Code) 可以直接 Read 它们。
       if (hasFiles) {
         const fileLines = msg.files!.map((f) => `- ${f.path} (${f.name})`).join('\n');
-        text = text ? `${text}\n\nAttached files:\n${fileLines}` : `Attached files:\n${fileLines}`;
+        text = text ? `${text}\n\n附件文件:\n${fileLines}` : `附件文件:\n${fileLines}`;
       }
       const slack = { channel: msg.channel, thread_ts: msg.thread_ts };
-      // `text` (raw user request + any attachment lines) drives the human-facing
-      // kanban card title/description. The autonomy preamble — supplied verbatim
-      // by main, the authoritative source — is prepended ONLY to god's working
-      // instruction (what gets typed into his PTY), so the board stays readable
-      // while every Slack-origin god-session runs under the autonomy policy. When
-      // main sends no preamble (older build), god just gets the raw text.
+      // `text`（原始用户请求 + 任何附件行）驱动面向人类的看板卡片标题/
+      // 描述。自治前言——由 main（权威来源）逐字提供——只前置到 god 的
+      // 工作指令上（要输入他 PTY 的内容），这样看板保持可读，同时每条
+      // Slack 来源的 god 会话都在自治策略下运行。当 main 不发送前言
+      // （旧构建）时，god 只拿到原始文本。
       const instruction = msg.autonomyPreamble ? `${msg.autonomyPreamble}${text}` : undefined;
       useStore.getState().enqueueMessage(GOD_ID, text, { slack, instruction });
-      // Immediate "queued" acknowledgement in the originating Slack thread.
+      // 在来源 Slack 线程里立即“已排队”确认。
       void window.cth.slackReply({
         channel: msg.channel,
         thread_ts: msg.thread_ts,
@@ -989,11 +946,11 @@ export function useHive(config: HarnessConfig | null): void {
     });
   }, [config?.onboardingComplete]);
 
-  // 5b) Pipe hive tasks addressed to non-Claude agents (e.g. Codex) into their
-  //     terminal queues. When main routes a message to a non-claude provider it
-  //     emits 'hive:enqueueToAgent' instead of bouncing; we enqueue the raw
-  //     task text here so effect #4 types it into the REPL when the agent idles.
-  //     No inbox nudge, no /compact — just the verbatim subject+body text.
+  // 5b) 把发给非 Claude agent（如 Codex）的 hive 任务导入其终端队列。
+  //     当 main 把消息路由给非 claude provider 时，它发出
+  //     'hive:enqueueToAgent' 而不是弹回；我们在这里把原始任务文本入队，
+  //     好让 effect #4 在 agent 空闲时把它输入 REPL。
+  //     没有 inbox nudge，没有 /compact——只是逐字的 subject+body 文本。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     return window.cth.onHiveEnqueue?.((msg) => {
@@ -1002,30 +959,28 @@ export function useHive(config: HarnessConfig | null): void {
     });
   }, [config?.onboardingComplete]);
 
-  // 5b) MAIN-initiated roster changes (rt-5 voice spawn/kill). The renderer store is
-  //     only mutated by renderer-initiated hires (AddAgentModal); a voice hire/kill
-  //     runs in MAIN (spawnAgentCore / teardownPty, owner=null) and would otherwise
-  //     be invisible on the floor. Main broadcasts; we build/archive the card here.
+  // 5b) MAIN 发起的名单变更（rt-5 语音 spawn/kill）。渲染端 store 只被渲染端
+  //     发起的雇佣（AddAgentModal）变更；语音雇佣/击杀运行在 MAIN
+  //     (spawnAgentCore / teardownPty, owner=null)，否则在楼层上不可见。
+  //     Main 广播；我们在这里建/归档卡片。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     const offSpawn = window.cth.onHiveAgentSpawned?.((rec) => {
       if (!rec?.id) return;
-      // addAgent is idempotent, but bail early if the renderer already carded it.
+      // addAgent 是幂等的，但若渲染端已建卡就提前返回。
       if (useStore.getState().agents.some((a) => a.id === rec.id)) return;
-      // An explicit character wins; otherwise infer it from the name, which is
-      // what makes "spawn one called Meredith" land on the Meredith avatar with
-      // nothing else asked for. The explicit field covers what inference cannot
-      // express: an agent named something else that should still look like a
-      // particular character. Unknown values fall through to the inference rather
-      // than breaking the card.
+      // 显式角色优先；否则从名字推断——这就是“spawn one called Meredith”
+      // 无需其他条件就落在 Meredith 头像上的原因。显式字段覆盖推断无法
+      // 表达的情形：一个叫别的名字但看起来仍应是特定角色的 agent。未知值
+      // 落到推断上而不是弄坏卡片。
       const castMember = (q?: string) =>
         q ? OFFICE_CAST.find((m) => m.name === q || m.displayName.toLowerCase() === q)?.name : undefined;
       const character =
         castMember(rec.character?.trim().toLowerCase()) ??
         castMember((rec.name || rec.id).toLowerCase()) ??
         DEFAULT_CHARACTER;
-      // Accent is otherwise hashed from the worker id, which is stable but not
-      // choosable. An unrecognised accent keeps the hash.
+      // 强调色原本是从 worker id 哈希出来的，稳定但不可选。未识别的强调色
+      // 保持哈希。
       const askedAccent = SPAWN_ACCENTS.find((a) => a === rec.accent?.trim().toLowerCase());
       let h = 0;
       for (const ch of rec.id) h = (h + ch.charCodeAt(0)) % SPAWN_ACCENTS.length;
@@ -1040,7 +995,7 @@ export function useHive(config: HarnessConfig | null): void {
         tmuxTarget: '',
         cwd: rec.cwd,
         status: 'idle',
-        action: 'starting up',
+        action: '正在启动',
         progress: 0,
         currentStation: 'desk',
         ptyId: rec.id,
@@ -1057,10 +1012,9 @@ export function useHive(config: HarnessConfig | null): void {
     return () => { offSpawn?.(); offArchive?.(); };
   }, [config?.onboardingComplete]);
 
-  // 5c) v0.3.4 voice bridge: main stages queue insertions (clear_context) and
-  //     pushes them here, so delivery rides EVERY existing gate — idle-only,
-  //     boot grace, draft/picker safety, auto-delivery pause. Main owns the
-  //     confirm policy; this is just the enqueue.
+  // 5c) v0.3.4 语音桥：main 暂存队列插入（clear_context）并推到这边，
+  //     让投递走遍每道既有门——仅空闲、启动宽限、草稿/选择器安全、
+  //     自动投递暂停。确认策略归 main 管；这里只是入队。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
     return window.cth.onRealtimeEnqueue?.((evt) => {
@@ -1071,23 +1025,21 @@ export function useHive(config: HarnessConfig | null): void {
     });
   }, [config?.onboardingComplete]);
 
-  // 6) CONTEXT TRIGGERS (compact / clear). Main decides WHEN — cadence, and which
-  //    half of the rule fired — and pushes `{action, rule}`; this decides WHO, then
-  //    queues the provider's own command so the drain (#4) delivers it only at an
-  //    idle prompt, never jamming a working terminal.
+  // 6) CONTEXT TRIGGERS (compact / clear)。Main 决定何时——节奏、以及规则
+  //    的哪一半触发——并推送 `{action, rule}`；这里决定对谁，然后把
+  //    provider 自己的命令入队，让排空 (#4) 只在空闲提示符投递它，绝不
+  //    挤进一个工作中的终端。
   //
-  //    THE PRESSURE GATE. main/config.ts has long DOCUMENTED that auto-compact
-  //    "only compacts agents whose context has filled past a threshold (30% for
-  //    ~250k windows, 20% for ~1M windows)". No such check was ever implemented:
-  //    every live agent with a resolvable command got compacted on every tick,
-  //    hourly, however empty its window was. This makes the documented behaviour
-  //    real — `rule.minContextPct`, or `minContextPctLargeWindow` once the window
-  //    is >= LARGE_CONTEXT_WINDOW, must be met before an agent is interrupted.
-  //    (The shipped bars are now 60/40, twice the stale doc's numbers; see
-  //    DEFAULT_CONTEXT_TRIGGER. The doc comment in config.ts is still stale.)
+  //    压力门。main/config.ts 早就 DOCUMENTED 自动压缩“只压缩上下文已
+  //    填过阈值（~250k 窗口 30%，~1M 窗口 20%）的 agent”。这个检查从未
+  //    实现过：每个有可解析命令的活跃 agent 每个 tick 都被压缩，每小时，
+  //    无论窗口多空。这里让文档行为成真——`rule.minContextPct`，或窗口
+  //    >= LARGE_CONTEXT_WINDOW 时的 `minContextPctLargeWindow`，必须先满足
+  //    才能打断一个 agent。（发版数值现在是 60/40，是那份过期文档的两倍；
+  //    见 DEFAULT_CONTEXT_TRIGGER。config.ts 里的 doc 注释仍是旧的。）
   //
-  //    Dedupe generalises to both actions: keyed on the command's own verb, so a
-  //    queued `/compact` blocks a second compact without blocking a `/clear`.
+  //    去重推广到两种动作：以命令自身的动词为键，排队中的 /compact 会
+  //    拦住第二个 compact，而不会拦 /clear。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
 
@@ -1096,56 +1048,50 @@ export function useHive(config: HarnessConfig | null): void {
       const now = Date.now();
       for (const a of agents) {
         if (!a.ptyId) continue;
-        // Gate #109-2: don't enqueue a context command for an agent that cannot
-        // currently receive one (e.g. god 'blocked' on a human prompt). Enqueuing
-        // anyway left a stuck /compact at the head of the queue that dedupe then
-        // collapsed every subsequent hourly attempt against, forever — the exact
-        // same check the drain itself uses immediately before typing, so a
-        // command is never queued in a state the drain would refuse to deliver.
+        // Gate #109-2：不要为当前无法接收上下文命令的 agent 入队（例如
+        // god 'blocked' 在人类提示前）。照旧入队会让一条卡死的 /compact
+        // 停在队首，去重随后把它对着的每次每小时尝试都永久折叠掉——
+        // 这正是排空本身在输入前用的那道检查，所以绝不会在排空拒绝投递
+        // 的状态下入队一条命令。
         if (!canDeliverToAgent(a.status, ptyQuietMs(a.ptyId, now), QUIESCE_IDLE_MS)) continue;
         const provider = inferAgentProvider(a.command, a.provider);
         const command = action === 'clear'
           ? clearCommandForProvider(provider, rule.message)
           : compactionCommandForProvider(provider, rule.message);
-        // No trustworthy command for this CLI (Crush's palette-only TUI, Copilot's
-        // print mode, an unknown custom binary) — leave its terminal alone.
+        // 该 CLI 没有可信命令（Crush 的纯调色板 TUI、Copilot 的打印模式、
+        // 未知自定义二进制）——别碰它的终端。
         if (!command) continue;
         if (!passesContextPressure(a, rule)) continue;
         const verb = command.trimStart().split(/\s+/)[0];
         const queued = messageQueues[a.id] ?? [];
         if (queued.some((m) => m.text.trimStart().startsWith(verb))) continue;
-        // The latch, compact only. `used` reaches this gate from Claude's status
-        // line, which only reports after an API call. A /compact on an agent that
-        // has done nothing since the last one makes no call at all — Claude refuses
-        // it locally with "Not enough messages to compact" — so the count stays
-        // byte-identical and the pressure gate passes on the same number the next
-        // cycle, and the next. Seen in the wild: /compact every hour for 15 straight
-        // hours at exactly 400958 tokens, then 11 more at exactly 221772, each a
-        // no-op the agent still had to read and answer. Higher thresholds make it
-        // rarer, not absent: any agent parked above its bar repeats forever.
+        // 闩锁，仅 compact。`used` 从 Claude 状态栏到达此门，而状态栏只在
+        // API 调用后报告。对一个自上次压缩以来什么都没做的 agent 发
+        // /compact 根本不会触发调用——Claude 本地拒绝它，报 "Not enough
+        // messages to compact"——所以计数保持逐字节相同，压力门下个周期、
+        // 再下个周期都对着同一个数字放行。线上见到的：连续 15 个小时每小时
+        // 一次 /compact、恰好 400958 tokens，然后又在恰好 221772 上再来 11
+        // 次，每次都是 agent 仍然要读要答的无操作。提高阈值只会让它更少见
+        // 而非消失：任何停在阈值之上的 agent 都会无限重复。
         //
-        // So remember the count at the last compact queued and skip while it is
-        // byte-identical. Deliberately equality and not "hasn't grown": the rule's
-        // thresholds own that decision, and an agent still above them deserves its
-        // /compact whether the count moved up or down. A frozen count is the one
-        // state those thresholds cannot reason about, because nothing they could do
-        // would ever change it. /clear needs no equivalent — the queue drain zeroes
-        // the store reading when it lands.
+        // 所以记住上次 compact 入队时的计数，逐字节相同时跳过。刻意用
+        // 相等而非“没增长”：阈值决策归规则所有，仍在阈值之上的 agent
+        // 无论计数上还是下都该得到它的 /compact。冻结的计数是阈值无法
+        // 推理的唯一状态，因为无论它们做什么都不会改变它。/clear 无需
+        // 等价物——队列排空在它落地时会把 store 读数清零。
                const used = a.contextTokens ?? 0;
         if (action === 'compact' && lastCompactUsed.current[a.id] === used) continue;
-        // The latch is written at successful DELIVERY (see the flush() dispatch
-        // callback below), not here. Writing it at enqueue time recorded
-        // "already compacted at N tokens" for a compaction that might never
-        // actually happen — e.g. blocked by the gate just above, or a failed
-        // send — silently latching out every future attempt at that count.
-        // compactUsed rides on the queued message so the delivery site knows
-        // which count to latch.
+        // 闩锁在成功 DELIVERY 时写入（见下方 flush() 的 dispatch 回调），
+        // 而不是这里。入队时写入会为一次可能根本不会发生的压缩记录
+        // “已在 N tokens 压缩过”——例如被上面这道门挡住，或发送失败——
+        // 静默把该计数下的所有未来尝试都闩死。compactUsed 搭载在排队消息
+        // 上，让投递现场知道要闩哪个计数。
         enqueueMessage(a.id, command, action === 'compact' ? { compactUsed: used } : undefined);
       }
     };
 
-    // The typed `onContextTrigger` arrives with the main-process/preload change
-    // that emits it; access it defensively so this lands independently of that.
+    // 类型化 `onContextTrigger` 随发出它的主进程/preload 变更一起到达；
+    // 防御性地访问它，让本代码独立于该变更落地。
     const off = (window.cth as unknown as {
       onContextTrigger?: (
         cb: (p: { action: 'compact' | 'clear'; rule: ContextRule }) => void
@@ -1155,10 +1101,9 @@ export function useHive(config: HarnessConfig | null): void {
       fire(p.action === 'clear' ? 'clear' : 'compact', p.rule);
     });
 
-    // LEGACY fallback: main still emits the old parameterless auto-compact until
-    // it switches over. Treat it as the default compact rule so behaviour is
-    // continuous across that landing. Harmless if both fire — the dedupe above
-    // drops the duplicate.
+    // LEGACY 回退：在切换完成前，main 仍发出旧的无参数自动压缩。把它当作
+    // 默认压缩规则处理，让行为在其落地期间保持连续。两者都触发也无害——
+    // 上面的去重会丢弃重复。
     const offLegacy = window.cth.onAutoCompact(
       () => fire('compact', DEFAULT_CONTEXT_TRIGGER.compact)
     );
@@ -1166,40 +1111,39 @@ export function useHive(config: HarnessConfig | null): void {
     return () => { off?.(); offLegacy?.(); };
   }, [config?.onboardingComplete]);
 
-  // 7) Auto-revive wedged PTYs after the Mac sleeps/locks. Kevin's main-process
-  //    keepalive catches up its schedules on wake and DETECTS terminals that were
-  //    live before sleep but went silent after resume — it reports those ids on
-  //    `power:resume`. We respawn EXACTLY those, resuming each agent's prior CLI
-  //    session (--resume) so the terminal self-heals instead of the user clicking
-  //    "Restart & Continue". This reuses the same resume-spawn flow as that button
-  //    (CommandCenterPanel.restartWithModel) and restoreTeam's worktree handling.
-  //    Pure addition: an empty `dead[]` is a no-op; healthy PTYs are never touched.
+  // 7) Mac 睡眠/锁屏后自动复活卡死的 PTY。Kevin 的主进程 keepalive 会在
+  //    唤醒时补齐其计划，并 DETECT 睡眠前活着、恢复后却静默的终端——它把
+  //    这些 id 报告在 `power:resume` 上。我们只 respawn 这些，恢复每个
+  //    agent 之前的 CLI 会话（--resume），让终端自愈而不是让用户去点
+  //    “Restart & Continue”。这复用与那个按钮 (CommandCenterPanel.
+  //    restartWithModel) 和 restoreTeam 的 worktree 处理相同的 resume-spawn
+  //    流程。纯增量：空的 `dead[]` 是 no-op；健康的 PTY 永远不会被碰。
   useEffect(() => {
     if (!config?.onboardingComplete) return;
-    // Skip an id we revived (or are mid-reviving) within this window — coalesces
-    // a resume + unlock that arrive back-to-back (main also coalesces on its side).
+    // 跳过该窗口内已复活（或正在复活）的 id——把接连到达的 resume + unlock
+    // 合并（main 在它那边也会合并）。
     const REVIVE_DEBOUNCE_MS = 8000;
 
     const revive = async (deadId: string): Promise<void> => {
       const now = Date.now();
       if (now - (reviving.current[deadId] ?? 0) < REVIVE_DEBOUNCE_MS) return;
-      reviving.current[deadId] = now; // claim BEFORE any await so re-entry can't double-spawn
-      // Only respawn a PTY we actually own; never touch an unknown/healthy id.
+      reviving.current[deadId] = now; // 在任何 await 之前认领，重入不能双 spawn
+      // 只 respawn 我们真正拥有的 PTY；绝不碰未知/健康 id。
       const a = useStore.getState().agents.find((x) => x.ptyId === deadId);
       if (!a) return;
       try {
         const cfg = await window.cth.getConfig();
-        // Isolated agents run inside their worktree (a.cwd is the base repo); re-enter
-        // it if it still exists, else fall back to the base cwd — same as restoreTeam.
+        // 隔离 agent 在其工作树内运行（a.cwd 是基础仓库）；它仍存在就
+        // 重新进入，否则回退到基础 cwd——与 restoreTeam 相同。
         let cwd = a.cwd;
         if (a.worktreePath && (await window.cth.gitIsRepo(a.worktreePath))) cwd = a.worktreePath;
         await window.cth.killPty(deadId);
-        // Soft-reset the pooled xterm in place (no-op if none): re-arm input and
-        // clear the stale frame so the revived TUI paints clean — like the button.
+        // 就地软重置池化的 xterm（没有则是 no-op）：重新武装输入并清掉
+        // 过期帧，让复活的 TUI 干净绘制——与那个按钮一样。
         resetTerminal(deadId);
         const provider = inferAgentProvider(a.command, a.provider);
-        // Prefer the agent's exact recorded command (same model/flags); fall back to
-        // a rebuilt one only if it predates the persisted `command` field.
+        // 优先用 agent 记录的确切命令（相同 model/标志）；只有它早于持久化
+        // 的 `command` 字段时才回退到重建的命令。
         const command = (a.command ?? '').trim() || buildSpawnCommand(cfg, a.model, provider);
         const [exe, ...args] = tokenizeCommand(command);
         const hive = a.isGod
@@ -1207,11 +1151,11 @@ export function useHive(config: HarnessConfig | null): void {
           : a.isAssistant
           ? { id: a.id, name: a.name, cwd, provider, isAssistant: true, role: roleForHiveSpawn(a) }
           : { id: a.id, name: a.name, cwd, provider, role: roleForHiveSpawn(a) };
-        // Spawn at the terminal's real grid so the TUI's absolute cursor moves land
-        // in the right cells (a size mismatch scatters the redraw).
+        // 按终端的真实网格 spawn，让 TUI 的绝对光标移动落到正确的单元格
+        //（尺寸不匹配会打散重绘）。
         const entry = acquireTerminal(deadId);
         let cols = 100, rows = 30;
-        try { entry.fit.fit(); cols = entry.term.cols; rows = entry.term.rows; } catch { /* host not sized yet */ }
+        try { entry.fit.fit(); cols = entry.term.cols; rows = entry.term.rows; } catch { /* 宿主尚未定尺寸 */ }
         const res = await window.cth.spawnPty({
           id: deadId,
           cwd,
@@ -1220,18 +1164,18 @@ export function useHive(config: HarnessConfig | null): void {
           args,
           cols,
           rows,
-          // The worktree (if any) already exists on disk — re-enter it, do NOT
-          // re-isolate (that conflicts on the existing path/branch).
+          // 工作树（如果有）已在磁盘上——重新进入，不要重新隔离
+          // （那会在既有路径/分支上冲突）。
           isolate: false,
-          // Reattach the agent's prior session so no context is lost on revive.
+          // 重新挂接 agent 之前的会话，让复活不丢失上下文。
           resume: true,
           hive
         });
         if (res.ok) {
-          reviving.current[deadId] = Date.now(); // re-stamp so the debounce covers the spawn
-          useStore.getState().updateAgent(a.id, { status: 'idle', action: 'revived after sleep' });
+          reviving.current[deadId] = Date.now(); // 重新盖章，让去抖覆盖本次 spawn
+          useStore.getState().updateAgent(a.id, { status: 'idle', action: '休眠后已唤醒' });
         } else {
-          delete reviving.current[deadId]; // let a later power:resume retry it
+          delete reviving.current[deadId]; // 让稍后的 power:resume 重试它
           console.error('[autorevive] respawn failed for', a.id, res.error);
         }
       } catch (err) {
@@ -1242,7 +1186,7 @@ export function useHive(config: HarnessConfig | null): void {
 
     return window.cth.onPowerResume?.((e) => {
       const dead = Array.isArray(e?.dead) ? e.dead : [];
-      if (!dead.length) return; // healthy wake — nothing wedged, no-op
+      if (!dead.length) return; // 健康唤醒——没有卡死的，no-op
       for (const id of dead) void revive(id);
     });
   }, [config?.onboardingComplete]);

--- a/src/renderer/src/hooks/usePtyParser.ts
+++ b/src/renderer/src/hooks/usePtyParser.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useStore, type ToolKind, type StationKind } from '@/store/store';
 import { createAnsiStripper } from '@/components/ansiText';
 
-// Tool call lines look like: `● Read SPEC.md`, `● Bash npm test`, `● Edit src/foo.ts`
+// 工具调用行形如：`● Read SPEC.md`、`● Bash npm test`、`● Edit src/foo.ts`
 const TOOL_RE = /●\s+([A-Za-z][A-Za-z_]*)(?:\s+(.+))?/g;
 
 const TOOL_TO_STATION: Record<string, StationKind> = {
@@ -21,37 +21,36 @@ const TOOLKIND_BY_NAME: Record<string, ToolKind> = {
   TodoWrite: 'TodoWrite'
 };
 
-// "Blocked" = Claude is genuinely waiting on the user. Match only real prompts
-// (the approval menu / a yes-no question). Do NOT match the bare word
-// "permission": the TUI footer always shows "bypass permissions on (shift+tab
-// to cycle)", which would otherwise flag a busy agent as blocked on every
-// repaint — making it flip-flop between working and blocked.
+// “Blocked” = Claude 确实在等待用户。仅匹配真正的提示符（审批菜单 /
+// 是非问题）。不要匹配裸词 “permission”：TUI 底栏常驻显示 “bypass
+// permissions on (shift+tab to cycle)”，否则会在每次重绘时把忙碌中的
+// agent 误标为 blocked——导致它在 working 与 blocked 之间反复横跳。
 const BLOCK_HINTS = [
   /Do you want to proceed/i,
-  /❯\s*\d+\.\s*Yes/i,            // numbered approval menu, cursor on "1. Yes"
+  /❯\s*\d+\.\s*Yes/i,            // 编号审批菜单，光标停在“1. Yes”上
   /Yes, and don't ask again/i,
   /\(y\/n\)/i,
   /\[y\/n\]/i,
 ];
 
-// The /context output prints "235.3k/1m tokens (24%)" — sniff the DENOMINATOR
-// to learn the session's true context-window size. This is the only reliable
-// source for sessions on the CLI-default model: the "[1m]" alias exists only
-// inside Claude Code; the API model id in the transcript is plain.
+// /context 输出会打印 “235.3k/1m tokens (24%)” ——嗅探分母以获知会话真实的
+// 上下文窗口大小。对使用 CLI 默认模型的会话来说这是唯一可靠来源：
+// “[1m]” 别名只存在于 Claude Code 内部；transcript 里的 API 模型 id 是
+// 纯文本形式。
 const CONTEXT_LIMIT_RE = /[\d.,]+k\s*\/\s*([\d.]+)([km])\s+tokens/i;
 
 /**
- * Subscribe to a pty stream and update the agent's avatar state based on what
- * scrolls past. This is a stopgap until we wire real Claude Code hooks — it
- * inspects the visible terminal output and infers status / station / carrying.
+ * 订阅 pty 流，并根据滚过的内容更新 agent 的头像状态。这是在我们接入真正的
+ * Claude Code hooks 之前的过渡方案——它检查可见终端输出，推断 status /
+ * station / carrying。
  *
- * Returns a function suitable for `<PtyTerminalView onStreamData={...} />`.
+ * 返回一个适用于 `<PtyTerminalView onStreamData={...} />` 的函数。
  */
 export function usePtyParser(agentId: string) {
   const updateAgent = useStore(s => s.updateAgent);
   const pushFeed = useStore(s => s.pushFeed);
   const idleTimerRef = useRef<number | null>(null);
-  // One stripper per agent: it carries an escape split across pty chunks.
+  // 每个 agent 一个剥离器：它需要跨 pty 分片携带转义序列状态。
   const stripRef = useRef(createAnsiStripper());
 
   const scheduleIdle = useCallback(() => {
@@ -59,10 +58,10 @@ export function usePtyParser(agentId: string) {
       window.clearTimeout(idleTimerRef.current);
     }
     idleTimerRef.current = window.setTimeout(() => {
-      // No new tool calls for ~4 s → assume the model went idle
+      // 约 4 秒没有新的工具调用 → 假定模型已进入空闲
       updateAgent(agentId, {
         status: 'idle',
-        action: 'awaiting',
+        action: '等待中',
         carrying: undefined,
         currentStation: 'desk'
       });
@@ -88,13 +87,13 @@ export function usePtyParser(agentId: string) {
     const text = stripRef.current(chunk);
     if (!text.trim()) return;
 
-    // Passive context-limit sniffing from /context output (the gauge poll
-    // sends one probe per session; a manual /context works too). The limit
-    // only ever ratchets up — contextLimit is volatile across respawns.
+    // 从 /context 输出被动嗅探上下文上限（计量轮询每个会话探测一次，
+    // 手动 /context 同样有效）。所有引擎统一按 1M 窗口计；只有 CLI 真实
+    // 报告超过 1M 时才抬升上限，绝不把 1M 拉低到真实小窗口。
     const lim = CONTEXT_LIMIT_RE.exec(text);
     if (lim) {
       const value = parseFloat(lim[1]) * (lim[2].toLowerCase() === 'm' ? 1_000_000 : 1_000);
-      if (value >= 100_000) {
+      if (value > 1_000_000) {
         const agent = useStore.getState().agents.find((a) => a.id === agentId);
         if (agent && value > (agent.contextLimit ?? 0)) {
           updateAgent(agentId, { contextLimit: value });
@@ -102,7 +101,7 @@ export function usePtyParser(agentId: string) {
       }
     }
 
-    // The "esc to interrupt" footer is only shown while a turn is in progress.
+    // “esc to interrupt” 底栏只在回合进行中显示。
     const running = /esc to interrupt/i.test(text);
 
     let lastTool: string | null = null;
@@ -117,49 +116,49 @@ export function usePtyParser(agentId: string) {
     if (lastTool) {
       const station = TOOL_TO_STATION[lastTool] ?? 'desk';
       const carrying = TOOLKIND_BY_NAME[lastTool] ?? undefined;
-      // Collapse space runs: translated cursor-forwards (see ansiText) can
-      // stand for several columns, and the bubble shouldn't show the gaps.
+      // 压缩连续空格：翻译后的光标前移（见 ansiText）可能代表多个列宽，
+      // 气泡不应显示这些空隙。
       const summary = (lastArg ? `${lastTool.toLowerCase()} ${lastArg}` : lastTool.toLowerCase())
         .replace(/\s+/g, ' ');
-      // NOTE: `progress` deliberately untouched — it's the context gauge now
-      // (filled by the useHive context poll), not a per-task meter.
+      // 注意：`progress` 刻意保持不动——它现在是上下文计量表（由 useHive
+      // 的上下文轮询填充），不再是单任务进度条。
       updateAgent(agentId, {
         status: 'working',
         action: summary,
         currentStation: station,
         carrying
       });
-      // Mirror into the in-app feed so the mock terminal view shows it too if
-      // ever toggled — harmless for real ptys.
+      // 镜像写入应用内 feed，以便（若启用）模拟终端视图也能看到——
+      // 对真实 pty 无害。
       pushFeed(agentId, `\x1b[36m● ${lastTool}\x1b[0m ${lastArg ?? ''}`);
-      // Keep working while the spinner is up; otherwise allow the idle drift.
+      // 旋转动画在转时就保持 working；否则允许空闲漂移。
       if (running) cancelIdle(); else scheduleIdle();
       return;
     }
 
-    // Actively running but no fresh tool line (model is thinking / streaming
-    // prose) → keep the agent working at its desk, don't let it drift to idle.
+    // 正在运行但没有新的工具行（模型在思考 / 流式输出正文）→ 让 agent
+    // 继续在工位上保持 working，别让它漂移到 idle。
     if (running) {
       cancelIdle();
       updateAgent(agentId, { status: 'working' });
       return;
     }
 
-    // Not running → a genuine approval/question prompt is on screen.
+    // 不在运行 → 屏幕上是一个真正的审批/提问提示符。
     const recent = text.slice(-400);
     if (BLOCK_HINTS.some(re => re.test(recent))) {
-      // Only the god agent talks to the human, so only it is truly "blocked"
-      // (needs you). A sub-agent sitting at a prompt is autonomous — it reads as
-      // "waiting" and we don't raise a human-approval card for it.
+      // 只有 god agent 与人类对话，因此只有它会真正“被阻塞”（需要你）。
+      // 坐在提示符前的子 agent 是自主的——它记为 “waiting”，我们不会为它
+      // 弹人工审批卡片。
       const isGod = !!useStore.getState().agents.find((a) => a.id === agentId)?.isGod;
       if (isGod) {
         updateAgent(agentId, {
           status: 'blocked',
-          action: 'waiting on you',
+          action: '等你确认',
           currentStation: 'mailbox',
           blockReason: {
-            summary: 'Waiting for your reply',
-            detail: 'Claude is waiting for input. Check the terminal for the exact prompt.',
+            summary: '等待你的回复',
+            detail: 'Claude 正在等待输入。请查看终端以获取确切提示。',
             actions: [
               { label: 'Approve', kind: 'approve', send: 'y\r' },
               { label: 'Deny',    kind: 'deny',    send: 'n\r' }
@@ -169,7 +168,7 @@ export function usePtyParser(agentId: string) {
       } else {
         updateAgent(agentId, {
           status: 'waiting',
-          action: 'waiting on god',
+          action: '等 god 处理',
           currentStation: 'desk',
           blockReason: undefined
         });
@@ -177,7 +176,14 @@ export function usePtyParser(agentId: string) {
       return;
     }
 
-    // Turn finished, no prompt on screen → let it drift to idle.
+    // 回合结束、屏幕上没有提示符 → 让它漂移到空闲。
+    // qwen/kimi 等 proxy provider 没有 Claude 的 '● Tool' / 'esc to interrupt' 标记，
+    // 只要终端还在持续输出就先把状态置为 working（避免实际干活却恒显 idle），
+    // 静默 4s 后由 scheduleIdle 自动回落到 idle。blocked/waiting 不覆盖。
+    const agentNow = useStore.getState().agents.find((a) => a.id === agentId);
+    if (agentNow && agentNow.status !== 'blocked' && agentNow.status !== 'waiting') {
+      updateAgent(agentId, { status: 'working' });
+    }
     scheduleIdle();
   }, [agentId, updateAgent, pushFeed, scheduleIdle, cancelIdle]);
 }

--- a/src/renderer/src/hooks/useResolvedGodName.ts
+++ b/src/renderer/src/hooks/useResolvedGodName.ts
@@ -4,11 +4,10 @@ import { resolveGodName, DEFAULT_GOD_NAME } from '@shared/godIdentity';
 const GOD_ID = 'god';
 
 /**
- * God's persisted display name, for the boot screens shown BEFORE the store
- * has god's live agent object (so before `agent.name` exists anywhere to
- * read). Reads the registry directly, the same way useHive.ts's spawn effect
- * does, rather than assuming the default — otherwise a renamed god's own
- * "clocking in" screen would flash the wrong name every launch.
+ * god 的持久化显示名，用于 store 尚未拥有 god 活动 agent 对象的启动画面
+ * （也就是任何地方都还读不到 `agent.name` 之前）。直接读取注册表，与
+ * useHive.ts 的 spawn effect 方式相同，而不是假定默认名——否则被改名后的
+ * god 自己的“打卡上班”画面每次启动都会闪错名字。
  */
 export function useResolvedGodName(): string {
   const [godName, setGodName] = useState(DEFAULT_GOD_NAME);
@@ -16,7 +15,7 @@ export function useResolvedGodName(): string {
     let cancelled = false;
     void window.cth.hiveRegistry().then((reg) => {
       if (!cancelled) setGodName(resolveGodName(reg?.agents?.[GOD_ID]?.name));
-    }).catch(() => { /* keep the default while unknown */ });
+    }).catch(() => { /* 未知时保留默认名 */ });
     return () => { cancelled = true; };
   }, []);
   return godName;

--- a/src/renderer/src/hooks/useRestoreTeam.ts
+++ b/src/renderer/src/hooks/useRestoreTeam.ts
@@ -3,33 +3,29 @@ import { useStore, type Agent } from '@/store/store';
 import { buildSpawnCommand, inferAgentProvider, tokenizeCommand, type HarnessConfig } from '@/store/config';
 import { roleForHiveSpawn } from '@shared/agentRole';
 
-/** "Restore team" — respawn every worker from the previous session.
+/** “恢复团队” —— 从上一次会话重新拉起每个 worker。
  *
- *  Lives here rather than inside AgentStrip because the floor strip is hidden in
- *  fullscreen, which used to mean the restore button (and the list of restorable
- *  agents) simply vanished when you went fullscreen. Both mount points share the
- *  progress state below, so a restore kicked off from one view shows as running
- *  in the other and can't be double-started. */
+ *  放在这里而不是 AgentStrip 内部，是因为楼层条在全屏时会被隐藏，这曾经
+ *  意味着你进入全屏后，恢复按钮（以及可恢复 agent 的列表）就凭空消失了。
+ *  两个挂载点共享下面的进度状态，因此从一个视图发起的恢复会在另一个视图
+ *  中显示为运行中，并且不会被重复启动。 */
 
 let restoring = false;
 let note: string | null = null;
-/** True only while the AUTOMATIC boot restore is in flight, so the UI can say
- *  "this is happening on its own" rather than looking like a click you don't
- *  remember making. */
+/** 仅在“自动启动恢复”真正进行中时为 true，让 UI 显示“这是自动发生的”
+ *  而不是看起来像一次你不记得点的点击。 */
 let autoRestoring = false;
-/** Latched the moment the automatic restore starts. Module-level, not per
- *  component: `useRestoreTeam` is mounted from both the floor strip and the
- *  fullscreen rail, and without this each of them would kick off its own. */
+/** 在自动恢复启动的那一刻锁定。模块级而非组件级：`useRestoreTeam` 同时
+ *  挂在楼层条和全屏侧栏上，没有这个锁，两边会各自启动一次。 */
 let autoStarted = false;
 const listeners = new Set<() => void>();
 
-/** How long to wait after boot before restoring on our own.
+/** 启动后等待多久再自行恢复。
  *
- *  App.tsx reconciles the persisted roster against the PTYs actually alive in
- *  the main process, and that is an async round trip. Firing before it lands
- *  would read a restorable list that still contains agents whose terminals are
- *  already running, and try to spawn duplicates of them. The delay is also the
- *  window in which you can hit a dismiss ✕ if you don't want an agent back. */
+ *  App.tsx 会把持久化的名单与主进程中实际存活的 PTY 对账，而这是一次异步
+ *  往返。在它落地之前触发，读到的可恢复列表里仍包含终端已经在运行的
+ *  agent，会尝试把它们重复 spawn 一遍。这个延迟同时也是你不想恢复某个
+ *  agent 时点击 ✕ 关闭它的窗口期。 */
 export const AUTO_RESTORE_DELAY_MS = 2500;
 
 function emit(): void {
@@ -41,34 +37,34 @@ function subscribe(listener: () => void): () => void {
   return () => { listeners.delete(listener); };
 }
 
-// useSyncExternalStore requires a stable snapshot identity — returning a fresh
-// object each call would loop forever, so the two fields are read separately.
+// useSyncExternalStore 需要稳定的快照标识——每次调用返回新对象会无限循环，
+// 因此这两个字段分开读取。
 const getRestoring = (): boolean => restoring;
 const getNote = (): string | null => note;
 const getAutoRestoring = (): boolean => autoRestoring;
 
 export interface RestoreTeamState {
   restoring: boolean;
-  /** True when the run in flight was started automatically at boot, not by a
-   *  click. Drives the "restoring your team…" banner. */
+  /** 当进行中的这次运行是在启动时自动开始、而非点击触发时为 true。
+   *  驱动「正在恢复你的团队…」横幅。 */
   autoRestoring: boolean;
-  /** Outcome of the last run ("restored 3 · 1 failed — …"), or null. */
+  /** 上次运行的结果（"restored 3 · 1 failed — …"），或为 null。 */
   restoreNote: string | null;
   restoreTeam: () => Promise<void>;
 }
 
 /**
- * @param config used only to rebuild a spawn command for a restorable agent
- *        persisted before the `command` field existed.
+ * @param config 仅用于为在 `command` 字段出现之前持久化的可恢复 agent
+ *        重建 spawn 命令。
  */
 export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState {
   const isRestoring = useSyncExternalStore(subscribe, getRestoring, getRestoring);
   const restoreNote = useSyncExternalStore(subscribe, getNote, getNote);
   const isAutoRestoring = useSyncExternalStore(subscribe, getAutoRestoring, getAutoRestoring);
 
-  /** Respawn every worker from the previous session with its ORIGINAL agent id,
-   *  cwd, model and command — the hive workspace (memory.md, inbox, registry
-   *  entry) reattaches by itself, no memory transplant needed. */
+  /** 用其原始 agent id、cwd、model 与 command 从上一次会话重新拉起每个
+   *  worker —— hive 工作区（memory.md、inbox、注册表条目）会自行重新挂上，
+   *  无需移植记忆。 */
   const restoreTeam = async (): Promise<void> => {
     if (restoring) return;
     restoring = true;
@@ -76,49 +72,45 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
     emit();
     const prevSel = useStore.getState().selectedId;
     const restorableAgents = useStore.getState().restorableAgents;
-    // Tally every agent's outcome so the run ALWAYS leaves a visible trace — the
-    // original bug was that every failure path was console-only, so a click that
-    // couldn't spawn anything looked like a dead button.
+    // 汇总每个 agent 的结果，让运行 ALWAYS 留下可见痕迹——最初的 bug 就是
+    // 所有失败路径只写 console，导致一个什么都 spawn 不了的点击看起来像
+    // 个死按钮。
     let restored = 0;
     let alreadyLive = 0;
     const failures: string[] = [];
     try {
-      // Restore every agent CONCURRENTLY. Each spawn is keyed by its own ptyId and
-      // touches no cross-agent state in the renderer, and in the main process the
-      // whole `pty:spawn` handler (hive registry read-modify-write included) runs
-      // synchronously between awaits, so concurrent handlers can't interleave
-      // mid-update. Serially this cost the sum of every agent's git probe + spawn;
-      // a 6-agent team took ~6× one agent for no reason.
-      // Spawns run concurrently but agents are ADDED in roster order afterwards.
-      // Calling addAgent from inside each spawn made completion timing decide
-      // the roster order — and that order is persisted, so a slow provider or a
-      // slow git probe silently overwrote the sequence the user had dragged the
-      // cards into.
+      // 并发恢复每个 agent。每次 spawn 以各自的 ptyId 为键，不触碰渲染端
+      // 任何跨 agent 状态；而在主进程里，整个 `pty:spawn` 处理器（包括 hive
+      // 注册表的读-改-写）在每个 await 之间同步执行，所以并发处理器不可能
+      // 在更新中途交错。串行执行的成本是每个 agent 的 git 探测+spawn 之和；
+      // 一个 6-agent 团队为此白白付出约 6 倍单 agent 的时间。
+      // spawn 并发运行，但之后按名单顺序 ADD agent。在每次 spawn 内部调用
+      // addAgent 会让完成时序决定名单顺序——而该顺序会被持久化，于是慢的
+      // provider 或慢的 git 探测会静默覆盖用户拖拽好的卡片顺序。
       const restoredInOrder = await Promise.all([...restorableAgents].map(async (a): Promise<Agent | null> => {
-        // Per-agent guard: one agent's failure (or a rejected IPC call) must NEVER
-        // abort the others — an unhandled rejection here used to make the
-        // entire restore a silent no-op after the first bad agent.
+        // 单 agent 防护：一个 agent 的失败（或一次被拒绝的 IPC 调用）绝不能
+        // 中止其他 agent——这里曾经有一个未处理的 rejection，会让整个恢复
+        // 在第一个坏 agent 之后变成静默空操作。
         try {
           const provider = inferAgentProvider(a.command, a.provider);
           const command = (a.command ?? '').trim() || (config ? buildSpawnCommand(config, a.model, provider) : '');
           if (!command || !a.cwd) {
-            // No spawn recipe (an old entry persisted before `command`, with no
-            // config to rebuild one). Keep it restorable and SAY why rather than
-            // silently dropping it — silent removal read as "nothing happened".
+            // 没有 spawn 配方（在 `command` 之前持久化的旧条目，又没有可重建
+            // 的 config）。保留其可恢复状态并说明原因，而不是静默丢弃——
+            // 静默移除看起来像“什么都没发生”。
             failures.push(`${a.name}: no saved command`);
             return null;
           }
           const [exe, ...args] = tokenizeCommand(command);
           const ptyId = a.ptyId ?? `pty-${a.id}`;
-          // An isolated agent's worktree SURVIVES an app restart on disk (it's only
-          // torn down on per-tab close / mid-session exit, not on quit). So re-enter
-          // that exact worktree as the cwd rather than re-isolating — `git worktree
-          // add` would conflict with the existing path/branch, and re-isolating would
-          // also lose the worktree's uncommitted work. cwd = the worktree means
-          // resume + seedSessionTranscript land in the CORRECT checkout.
-          // But the user may have manually pruned/deleted the worktree between runs —
-          // gitIsRepo (git rev-parse) returns false for a missing/invalid dir, so
-          // fall back to the base repo cwd rather than spawning into a dead path.
+          // 隔离 agent 的工作树在应用重启后会残留在磁盘上（它只会在关闭
+          // 标签页/会话中途退出时被拆除，退出应用不会）。所以直接以那个工作树
+          // 作为 cwd 重新进入，而不是重新隔离——`git worktree add` 会与既有
+          // 路径/分支冲突，重新隔离还会丢失工作树的未提交改动。cwd = 工作树
+          // 意味着 resume + seedSessionTranscript 会落在正确的 checkout 上。
+          // 但用户可能在两次运行之间手动修剪/删除了工作树——gitIsRepo
+          // (git rev-parse) 对缺失/无效目录返回 false，因此回退到基础仓库的
+          // cwd，而不是 spawn 进一条死路径。
           let cwd = a.cwd;
           let worktreeGone = false;
           if (a.worktreePath) {
@@ -137,15 +129,14 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
             args,
             cols: 100,
             rows: 30,
-            // Worktree (if any) already exists on disk — cd into it, don't create a
-            // new one (re-isolating would conflict on the existing path/branch and
-            // lose its uncommitted work).
+            // 工作树（如果有）已在磁盘上——cd 进去，而不是新建一个
+            // （重新隔离会与既有路径/分支冲突并丢失未提交的改动）。
             isolate: false,
-            // Continue the worker's prior CLI session if one was recorded — the
-            // main process picks the provider's resume flag (Claude --resume,
-            // agy --conversation) and for Claude reattaches the transcript. The
-            // agent id is preserved across restart, so its registry entry,
-            // memory.md and inbox reattach by id. No-op without a recorded session.
+            // 如果记录了 worker 之前的 CLI 会话就继续它——主进程会选择
+            // provider 的 resume 标志（Claude --resume、agy --conversation），
+            // 对 Claude 会重新挂接 transcript。agent id 跨重启保持不变，
+            // 因此其注册表条目、memory.md 与 inbox 按 id 重新挂上。
+            // 没有记录的会话时该标志不生效。
             resume: true,
             hive: { id: a.id, name: a.name, provider, cwd, role: roleForHiveSpawn(a) }
           });
@@ -157,30 +148,29 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
                 ptyId,
                 archived: false,
                 status: 'idle',
-                // Surface the worktree fallback on the floor card; otherwise normal.
-                action: worktreeGone ? 'worktree gone — using base repo' : 'starting up',
-                // The worktree is no longer on disk — drop it so this agent is treated
-                // as a plain base-cwd agent going forward (a future restore won't keep
-                // re-probing a dead path).
+                // 在楼层卡片上体现工作树回退；否则显示正常。
+                action: worktreeGone ? '工作树已丢失——使用基础仓库' : '启动中',
+                // 工作树已不在磁盘上——去掉它，让该 agent 今后按普通
+                // base-cwd agent 处理（以后的恢复不会反复探测死路径）。
                 worktreePath: worktreeGone ? undefined : a.worktreePath,
-                // Crush spawns bare (no positional protocol) and hands the seed back
-                // here; useHive types it after boot. Re-seeding a resumed worker is
-                // idempotent (it just re-reads its inbox per protocol). (ondev-b)
+                // Crush 以裸方式 spawn（无位置协议）并把种子在这里交回；
+                // useHive 在启动后为其定型。对已恢复的 worker 重新播种是
+                // 幂等的（它只是按协议重读自己的 inbox）。(ondev-b)
                 seedPrompt: res.seedPrompt,
                 carrying: undefined,
                 currentStation: 'desk',
                 recentTextTs: Date.now()
             };
           } else if ((res.error ?? '').includes('already exists')) {
-            // A live PTY with this id is already running (e.g. respawned at boot or
-            // by another path) — the agent isn't actually missing, so retire it from
-            // the restorable list rather than reporting a phantom failure.
+            // 该 id 的活跃 PTY 已在运行（例如启动时已被拉起，或由其他路径
+            // 拉起）——agent 其实并不缺，因此把它从可恢复列表退役，而不是
+            // 报告一个幻影失败。
             alreadyLive++;
             useStore.getState().removeRestorableAgent(a.id);
           } else {
-            // Leave it restorable so the user can retry — but record WHY so the
-            // outcome is shown on the floor, not buried in the devtools console.
-            failures.push(`${a.name}: ${res.error ?? 'spawn failed'}`);
+            // 保留可恢复状态以允许用户重试——但记录原因，让结果显示在楼层上，
+            // 而不是埋在 devtools 控制台里。
+            failures.push(`${a.name}: ${res.error ?? '生成失败'}`);
             console.error('[restore] spawn failed for', a.id, res.error);
           }
         } catch (e) {
@@ -189,35 +179,33 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
         }
         return null;
       }));
-      // Add in the ORIGINAL roster order, not completion order.
+      // 按原始名单顺序添加，而不是完成顺序。
       for (const restoredAgent of restoredInOrder) {
         if (restoredAgent) useStore.getState().addAgent(restoredAgent);
       }
     } finally {
-      // addAgent auto-selects each spawn; put the user back where they were.
+      // addAgent 会自动选中每次 spawn；把用户放回原来的位置。
       const sel = useStore.getState();
       if (prevSel && sel.agents.some((x) => x.id === prevSel)) sel.select(prevSel);
       restoring = false;
-      // ALWAYS surface a result so the button can never look inert.
+      // ALWAYS 展示结果，让按钮永远不可能看起来呆滞。
       const parts: string[] = [];
-      if (restored) parts.push(`restored ${restored}`);
-      if (alreadyLive) parts.push(`${alreadyLive} already live`);
-      if (failures.length) parts.push(`${failures.length} failed — ${failures.join('; ')}`);
-      note = parts.length ? parts.join(' · ') : 'nothing to restore';
+      if (restored) parts.push(`已恢复 ${restored}`);
+      if (alreadyLive) parts.push(`${alreadyLive} 已在运行`);
+      if (failures.length) parts.push(`${failures.length} 个失败 — ${failures.join('; ')}`);
+      note = parts.length ? parts.join(' · ') : '无需恢复';
       emit();
     }
   };
 
-  // Restore the previous session's team on open, without waiting for a click.
+  // 打开应用时恢复上一会话的团队，无需等待点击。
   //
-  // Deliberately driven by a store SUBSCRIPTION rather than a plain timer: the
-  // restorable list is empty on the first render and only fills once App.tsx's
-  // PTY reconcile resolves, so a timer started at mount would look at an empty
-  // list, decide there was nothing to do, and never look again.
+  // 刻意用 store SUBSCRIPTION 驱动而不是普通定时器：可恢复列表在首次渲染时
+  // 为空，只有等 App.tsx 的 PTY 对账 resolve 之后才会填充，因此在挂载时
+  // 启动的定时器会看到一个空列表、断定无事可做、然后不再看第二眼。
   //
-  // Only ever fires for agents already on the restorable list — i.e. ones that
-  // had a terminal open when the app last quit. Archived agents (closed tabs)
-  // are never touched.
+  // 只对已经在可恢复列表上的 agent 生效——也就是上次退出应用时终端仍
+  // 打开的那些。已归档 agent（关闭的标签页）永远不会被触碰。
   useEffect(() => {
     if (autoStarted || !config?.onboardingComplete) return;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -229,8 +217,8 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
         timer = null;
         if (autoStarted || restoring) return;
         if (!useStore.getState().restorableAgents.length) return;
-        // Latch BEFORE the await so the other mount point's timer, which may
-        // fire in this same tick, sees it.
+        // 在 await 之前锁定，让另一个挂载点的定时器（可能在同一 tick 触发）
+        // 也能看到。
         autoStarted = true;
         autoRestoring = true;
         emit();
@@ -241,8 +229,8 @@ export function useRestoreTeam(config?: HarnessConfig | null): RestoreTeamState 
     check();
     const unsub = useStore.subscribe(check);
     return () => { unsub(); if (timer) clearTimeout(timer); };
-    // restoreTeam is rebuilt every render but only ever called from inside the
-    // timer, so it is read fresh at call time and does not belong in the deps.
+    // restoreTeam 每次渲染都会重建，但只会在定时器内部被调用，因此调用时
+    // 读取到的总是最新，不应列入依赖。
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config?.onboardingComplete]);
 

--- a/src/renderer/src/hooks/useTelemetry.ts
+++ b/src/renderer/src/hooks/useTelemetry.ts
@@ -1,16 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 
 /**
- * Renderer-side consumers of the live telemetry stream (#7B).
+ * 实时遥测流 (#7B) 的渲染端消费方。
  *
- * The main-process collector (telemetry.ts) pushes normalized, PII-free events
- * on `telemetry:event` and breaker state on `control:breakerState`. These hooks
- * subscribe + backfill from the cold-start snapshot, and shape the data for the
- * fleet grid (`useFleetTelemetry`) and the per-agent span waterfall
- * (`useAgentSpans`).
+ * 主进程采集器 (telemetry.ts) 通过 `telemetry:event` 推送规范化、去 PII 的
+ * 事件，通过 `control:breakerState` 推送熔断器状态。这些 hooks 订阅并在
+ * 冷启动快照上回填，再把数据整理成舰队网格 (`useFleetTelemetry`) 和单
+ * agent 的 span 瀑布图 (`useAgentSpans`)。
  *
- * Types mirror the LOCKED contract in src/main/telemetry.ts + src/preload (kept
- * in sync by hand, matching the codebase's local-redeclare pattern).
+ * 类型镜像 src/main/telemetry.ts + src/preload 中 LOCKED 合约（手工同步，
+ * 与代码库的本地重复声明模式保持一致）。
  */
 
 export interface AgentUsageSample {
@@ -48,20 +47,20 @@ type TelemetryEvent =
   | { kind: 'tool_result'; span: ToolSpan }
   | { kind: 'api_error'; agentId: string; sessionId: string; ts: number; error: string };
 
-/** Total tokens across all kinds — the sparkline/velocity basis. */
+/** 所有类型的 token 总和 —— 迷你走势图/速率的基础。 */
 export function totalTokens(s: AgentUsageSample): number {
   return s.input + s.output + s.cacheRead + s.cacheCreation;
 }
 
-/** How many tokens were fresh vs served from cache, as a 0–1 cache fraction. */
+/** 新鲜 token 与缓存命中 token 的比例，以 0–1 的缓存占比表示。 */
 export function cacheFraction(s: AgentUsageSample): number {
   const total = totalTokens(s);
   return total > 0 ? s.cacheRead / total : 0;
 }
 
-/** Per-agent rolling token deltas (for the sparkline) plus a simple tokens/min. */
+/** 每个 agent 的滚动 token 增量（供迷你走势图使用）外加简单的 tokens/min。 */
 interface Rate {
-  deltas: number[]; // most recent first-N token deltas between pushes
+  deltas: number[]; // 最近的前 N 次推送之间的 token 增量
   firstTs: number;
   firstTotal: number;
   lastTs: number;
@@ -72,19 +71,19 @@ const SPARK_LEN = 14;
 
 export interface FleetTelemetry {
   samples: Record<string, AgentUsageSample>;
-  /** sparkline series (token deltas between pushes), oldest→newest, per agent */
+  /** 迷你走势图序列（各次推送间的 token 增量），由旧到新，按 agent 分组 */
   spark: Record<string, number[]>;
-  /** tokens/min, derived per agent */
+  /** tokens/min，按 agent 推导 */
   rate: Record<string, number>;
-  /** last tool name seen per agent */
+  /** 每个 agent 最近一次看到的工具名 */
   lastTool: Record<string, string>;
-  /** latest breaker state per agent (drives the cost-meter color + ⚠) */
+  /** 每个 agent 最新的熔断器状态（驱动成本表颜色与 ⚠ 标记） */
   breakers: Record<string, BreakerState>;
 }
 
 /**
- * Subscribe to the whole fleet's live telemetry. One instance (the fleet grid).
- * Backfills from the snapshot on mount, then folds in live pushes.
+ * 订阅整个舰队的实时遥测。单实例（舰队网格）。
+ * 挂载时从快照回填，然后并入实时推送。
  */
 export function useFleetTelemetry(): FleetTelemetry {
   const [samples, setSamples] = useState<Record<string, AgentUsageSample>>({});
@@ -115,7 +114,7 @@ export function useFleetTelemetry(): FleetTelemetry {
       }
     };
 
-    // Backfill from the snapshot (we missed the pushes before mount).
+    // 从快照回填（我们错过了挂载前的推送）。
     window.cth.telemetrySnapshot?.().then((snap) => {
       if (!alive || !snap) return;
       for (const s of snap.usage ?? []) foldUsage(s as AgentUsageSample);
@@ -125,7 +124,7 @@ export function useFleetTelemetry(): FleetTelemetry {
         if (arr.length) tools[id] = arr[arr.length - 1].tool;
       }
       setLastTool((prev) => ({ ...tools, ...prev }));
-    }).catch(() => { /* collector not up — empty grid */ });
+    }).catch(() => { /* 采集器未启动 —— 网格为空 */ });
 
     const offEvent = window.cth.onTelemetryEvent?.((e: TelemetryEvent) => {
       if (e.kind === 'usage') foldUsage(e.sample);
@@ -142,8 +141,8 @@ export function useFleetTelemetry(): FleetTelemetry {
 }
 
 /**
- * Subscribe to ONE agent's tool spans for the waterfall. Backfills from the
- * collector on mount/agent-change, then appends live `tool_result` pushes.
+ * 订阅单个 agent 的工具 span，供瀑布图使用。挂载/切换 agent 时从采集器
+ * 回填，然后追加实时的 `tool_result` 推送。
  */
 export function useAgentSpans(agentId: string): ToolSpan[] {
   const [spans, setSpans] = useState<ToolSpan[]>([]);
@@ -153,7 +152,7 @@ export function useAgentSpans(agentId: string): ToolSpan[] {
     setSpans([]);
     window.cth.telemetrySpans?.(agentId).then((s) => {
       if (alive && Array.isArray(s)) setSpans(s as ToolSpan[]);
-    }).catch(() => { /* none yet */ });
+    }).catch(() => { /* 尚无记录 */ });
 
     const off = window.cth.onTelemetryEvent?.((e: TelemetryEvent) => {
       if (e.kind === 'tool_result' && e.span.agentId === agentId) {

--- a/src/renderer/src/hooks/useTypewriter.ts
+++ b/src/renderer/src/hooks/useTypewriter.ts
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Reveal `text` character by character.
- * `seed` resets the animation when it changes — pass a timestamp so identical
- * strings re-stream when the agent emits the same line twice.
+ * 逐字符展示 `text`。
+ * `seed` 变化时重置动画——传入时间戳，这样 agent 重复输出同一行时，
+ * 相同字符串也会重新播放。
  *
- * @param text  The full string to reveal.
- * @param seed  Any value; changing it restarts the typewriter.
- * @param cps   Characters per second. Default 90.
+ * @param text  要展示的完整字符串。
+ * @param seed  任意值；变化时重启打字机效果。
+ * @param cps   每秒字符数。默认 90。
  */
 export function useTypewriter(text: string, seed: unknown, cps = 90): {
   shown: string;

--- a/src/renderer/src/hooks/useWorkspaceImage.ts
+++ b/src/renderer/src/hooks/useWorkspaceImage.ts
@@ -1,28 +1,25 @@
 /**
- * Load a workspace image over IPC and hand back a `blob:` URL for it.
+ * 通过 IPC 加载工作区图片，并返回其 `blob:` URL。
  *
- * WHY A HOOK, AND WHY BLOB: the renderer cannot read the disk. The CSP is
- * `default-src 'self'` with `img-src 'self' data: blob:` and the app registers
- * no file protocol, so `<img src="file:///…">` fails silently — the classic
- * dead end for "why is my screenshot blank". Bytes therefore come over
- * `fs:readBinary` and get wrapped locally.
+ * 为什么用 HOOK 且为什么用 BLOB：渲染进程无法读取磁盘。CSP 是
+ * `default-src 'self'`，`img-src 'self' data: blob:`，且应用没有注册
+ * 文件协议，所以 `<img src="file:///…">` 会静默失败——“我的截图为什么是
+ * 空白”的经典死胡同就是它。因此字节通过 `fs:readBinary` 传过来并在本地包装。
  *
- * `blob:` over `data:`: a data URI base64-encodes the payload, inflating a 6 MB
- * screenshot to ~8 MB of JavaScript STRING that lives in the heap for as long as
- * the element does, and re-decodes on every render. A blob URL is a handle to
- * bytes the browser already holds, and it is cheap to pass around.
+ * `blob:` 而非 `data:`：data URI 会对载荷做 base64 编码，把一张 6 MB 的
+ * 截图膨胀成约 8 MB 的 JavaScript STRING，只要该元素存在就驻留在堆里，
+ * 而且每次渲染都要重新解码。blob URL 只是浏览器已持有的字节的句柄，
+ * 传递起来很便宜。
  *
- * The catch — and the reason every consumer must go through this hook — is that
- * a blob URL is a document-scoped registration that is NOT garbage collected
- * when the <img> disappears. The IDE opens and closes image tabs, and a markdown
- * report can hold a dozen screenshots; without an explicit revoke, every open
- * would strand its bytes for the lifetime of the window. The effect cleanup here
- * is the only revoke site, so "mounted" and "URL alive" are the same interval by
- * construction.
+ * 缺陷——也是每个消费方都必须经由这个 hook 的原因——在于 blob URL 是
+ * 文档作用域的注册项，当 <img> 消失时并不会被垃圾回收。IDE 会反复打开和
+ * 关闭图片标签页，一份 markdown 报告可能持有十几张截图；没有显式 revoke
+ * 的话，每次打开都会让字节滞留到窗口生命周期结束。这里的 effect 清理
+ * 是唯一的 revoke 位置，因此“已挂载”与“URL 存活”天然是同一个区间。
  *
- * SVG note: an SVG loaded through <img> renders in the browser's static secure
- * mode — no scripts, no external fetches — so agent-authored SVGs are safe to
- * display this way even though their source is executable-looking markup.
+ * SVG 说明：通过 <img> 加载的 SVG 运行在浏览器的静态安全模式下——无脚本、
+ * 无外部请求——因此 agent 生成的 SVG 即使源码看起来像可执行标记，也可以
+ * 安全地这样展示。
  */
 import { useEffect, useState } from 'react';
 
@@ -39,7 +36,7 @@ export function useWorkspaceImage(
 
   useEffect(() => {
     if (!root || !rel) {
-      setState({ status: 'error', error: 'no file' });
+      setState({ status: 'error', error: '无文件' });
       return;
     }
     let alive = true;
@@ -47,8 +44,8 @@ export function useWorkspaceImage(
     setState({ status: 'loading' });
 
     void window.cth.readBinary(root, rel).then((res) => {
-      // Bail BEFORE creating the URL when the consumer already unmounted — a URL
-      // created after cleanup has run would never be revoked by anyone.
+      // 在创建 URL 之前先检查：消费方已卸载时就放弃——清理之后创建的
+      // URL 永远不会被任何人 revoke。
       if (!alive) return;
       if (!res.ok) { setState({ status: 'error', error: res.error }); return; }
       created = URL.createObjectURL(new Blob([res.bytes], { type: res.mime }));

--- a/src/renderer/src/i18n/index.ts
+++ b/src/renderer/src/i18n/index.ts
@@ -1,19 +1,15 @@
 /**
- * i18n bootstrap — react-i18next with inline JSON resources.
+ * i18n 引导——基于内联 JSON 资源的 react-i18next。
  *
- * English is the default language (and the fallback for any missing key).
- * The user's choice is persisted in localStorage (`cth.language`). With nothing
- * saved the app starts in English, ALWAYS — it deliberately does not read
- * navigator.language. Auto-detect would change the UI out from under every
- * existing user on a non-English machine, who never asked for a translation and
- * may not want a partial one. Nothing moves until someone picks a language in
- * Settings.
+ * 英文是默认语言（也是任何缺失键的兜底）。用户的选择持久化在
+ * localStorage（`cth.language`）。没有任何保存值时，App 回退到操作系统语言：
+ * 中文系统以简体中文启动，其他系统以英文启动。每个人仍可在设置中
+ * 显式选择语言，且该选择从此永久生效。
  *
- * Adding a language: drop a `locales/<code>.json` with the exact same key
- * tree as `en.json`, register it in `resources` and `supportedLngs`, and add
- * an entry to `LANGUAGES` (Settings → General exposes the picker from that
- * list). Give it `dir: 'rtl'` if it is a right-to-left script. No other code
- * needs to change.
+ * 新增语言：放入一个键树与 `en.json` 完全一致的 `locales/<code>.json`，
+ * 在 `resources` 和 `supportedLngs` 里注册，并在 `LANGUAGES` 中加一条
+ * （设置 → 通用从该列表暴露选择器）。若为从右到左的文字，则给出
+ * `dir: 'rtl'`。其余代码无需改动。
  */
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
@@ -23,14 +19,13 @@ import zhCN from './locales/zh-CN.json';
 import ar from './locales/ar.json';
 
 /**
- * The languages the Settings picker offers, in display order.
+ * 设置选择器提供的语言，按显示顺序排列。
  *
- * `dir` is the language's WRITING DIRECTION, and it is the ONLY thing the app
- * keys right-to-left layout off. Not the OS locale, not the content of a
- * document, not a system font — the language the user picked here, and nothing
- * else. That is what makes RTL inert for everybody who has not picked an RTL
- * language: `dir` is 'ltr' for every one of them, so every `isRtl` branch in
- * the renderer takes the same path it took before Arabic existed.
+ * `dir` 是该语言的书写方向，是 App 决定从右到左布局时唯一依赖的东西。
+ * 不是 OS 语言、不是文档内容、不是系统字体——而是用户在此选择的语言，
+ * 仅此而已。正因如此，对每个未选择 RTL 语言的用户而言 RTL 都不起作用：
+ * 对他们每个 `dir` 都是 'ltr'，于是 renderer 中每个 `isRtl` 分支走的路径
+ * 与阿拉伯语出现之前完全一致。
  */
 export const LANGUAGES = [
   { code: 'en', label: 'English', dir: 'ltr' },
@@ -40,25 +35,24 @@ export const LANGUAGES = [
 
 export type LanguageCode = (typeof LANGUAGES)[number]['code'];
 
-/** Language codes that read right-to-left, derived from LANGUAGES itself so a
- *  new locale cannot be registered with a direction and then forgotten here. */
+/** 从右到左阅读的语言代码，直接从 LANGUAGES 推导而来，这样新语言环境
+ *  无法注册一个方向后在这里被遗忘。 */
 const RTL_CODES: ReadonlySet<string> = new Set(
   LANGUAGES.filter((l) => l.dir === 'rtl').map((l) => l.code)
 );
 
 /**
- * Does this language code read right-to-left?
+ * 这个语言代码是从右到左阅读的吗？
  *
- * Deliberately EXACT-MATCH on a registered code rather than a prefix or a
- * script guess. An unknown code is left-to-right, which is the direction every
- * user had before this shipped — an unrecognised value must never be able to
- * mirror somebody's UI.
+ * 刻意对已注册代码做「精确匹配」，而非前缀匹配或按文字猜测。
+ * 未知代码视为从左到右，这正是此功能发布前所有用户的方向——
+ * 一个无法识别的值绝不能去镜像某人的界面。
  */
 export function isRtlLanguage(lng: string | undefined | null): boolean {
   return !!lng && RTL_CODES.has(lng);
 }
 
-/** `'rtl'` or `'ltr'` for a language code, for a `dir` attribute. */
+/** 返回某个语言代码对应的 `'rtl'` 或 `'ltr'`，用于 `dir` 属性。 */
 export function directionFor(lng: string | undefined | null): 'rtl' | 'ltr' {
   return isRtlLanguage(lng) ? 'rtl' : 'ltr';
 }
@@ -68,15 +62,13 @@ const STORAGE_KEY = 'cth.language';
 const SUPPORTED: readonly string[] = LANGUAGES.map((l) => l.code);
 
 /**
- * The orchestrator's display name, for every string that talks about it.
+ * 编排者（god）的显示名，供所有提及它的字符串使用。
  *
- * The user can rename the god, and roughly forty strings mention it. Baking
- * "Michael" into the locale files would silently undo that rename everywhere at
- * once — a bug this codebase has already fixed three times in the spawn path.
- * So the locales say `{{godName}}` and the live name is supplied here as an
- * i18next DEFAULT VARIABLE, which means no call site has to pass it. A call site
- * that needs a variant (an upper-cased title, say) still overrides it by passing
- * `godName` explicitly.
+ * 用户可以重命名 god，而大约四十条字符串都提到它。把 "Michael" 硬编码进
+ * 语言文件会在所有地方同时静默撤销那次重命名——这是本代码库在 spawn 路径上
+ * 已经修过三次的 bug。因此语言文件写 `{{godName}}`，实际名字在此以
+ * i18next 默认变量提供，调用点无需传它。需要变体（比如大写的标题）的调用点
+ * 仍可显式传入 `godName` 覆盖。
  */
 export function setGodName(name: string | undefined | null): void {
   const next = name?.trim() || DEFAULT_GOD_NAME;
@@ -84,21 +76,29 @@ export function setGodName(name: string | undefined | null): void {
   const vars = interpolation.defaultVariables ?? (interpolation.defaultVariables = {});
   if (vars.godName === next) return;
   vars.godName = next;
-  // react-i18next re-renders on this event. Without it a rename would only
-  // reach strings that happened to re-render for some other reason.
+  // react-i18next 会在此事件上重新渲染。没有它，一次重命名只会
+  // 触及那些碰巧因其他原因重新渲染的字符串。
   i18n.emit('languageChanged', i18n.language);
 }
 
-/** The saved choice, or English. Never the OS locale — see the note above. */
+/** 已保存的选择，或操作系统语言（优先中文，否则英文）。 */
 function detectLanguage(): string {
   try {
     const saved = window.localStorage.getItem(STORAGE_KEY);
     if (saved && SUPPORTED.includes(saved as LanguageCode)) return saved;
   } catch { /* localStorage unavailable — English it is */ }
+  // 简体中文是当前唯一打包的 CJK 语言，因此任何 zh-* 代码
+  // （zh、zh-CN、zh-TW、zh-Hans …）都会解析到打包的 zh-CN 资源。
+  // 在 zh-TW 系统上的用户仍会看到 zh-CN 文本而非英文；
+  // 如果他们愿意，可以在设置里切到英文。
+  try {
+    const nav = window.navigator.language?.toLowerCase() ?? '';
+    if (nav.startsWith('zh')) return 'zh-CN';
+  } catch { /* navigator unavailable — English it is */ }
   return 'en';
 }
 
-/** Switch language now and persist the choice for next launch. */
+/** 立即切换语言，并在下次启动时保留该选择。 */
 export function setLanguage(lng: string): void {
   void i18n.changeLanguage(lng);
   try { window.localStorage.setItem(STORAGE_KEY, lng); } catch { /* best-effort */ }
@@ -115,12 +115,12 @@ void i18n
     lng: detectLanguage(),
     fallbackLng: 'en',
     supportedLngs: ['en', 'zh-CN', 'ar'],
-    // Resources are bundled inline, so nothing ever suspends — the string is
-    // there at init time. Keeping this false lets every component call
-    // useTranslation() without wrapping the tree in <Suspense>.
+    // 资源是内联打包的，因此永远不会挂起——字符串在初始化时就存在。
+    // 保持为 false 让每个组件都能直接调用 useTranslation()，
+    // 而无需用 <Suspense> 包裹整棵树。
     react: { useSuspense: false },
-    // `defaultVariables` is what lets every {{godName}} string resolve without
-    // its call site knowing god's name. setGodName() keeps it current.
+    // 正是 `defaultVariables` 让每个 {{godName}} 字符串无需调用点
+    // 知道 god 的名字即可解析。setGodName() 使其保持最新。
     interpolation: { escapeValue: false, defaultVariables: { godName: DEFAULT_GOD_NAME } },
     returnNull: false
   });

--- a/src/renderer/src/i18n/locales/ar.json
+++ b/src/renderer/src/i18n/locales/ar.json
@@ -141,6 +141,7 @@
     "barFailed": "{{tool}} · {{ms}} م.ث · فاشل"
   },
   "agentDetail": {
+    "editAria": "تحرير هذا الوكيل",
     "open": "فتح",
     "opening": "...",
     "ok": "تم",
@@ -157,7 +158,11 @@
     "openTerminalAria": "افتح طرفية نظام في مجلد هذا الوكيل"
   },
   "settingsHero": {
+    "brandName": "MUNDER DIFFLIN",
+    "downloadManualTitle": "نزّل برنامج التثبيت واستبدل التطبيق بنفسك. التحديث التلقائي في قسم «التحديثات» أدناه.",
+    "downloadVersion": "نزّل v{version}",
     "sponsoredBy": "برعاية",
+    "versionOut": "v{version} متاح الآن",
     "visit": "زيارة",
     "whatsNew": "ما الجديد",
     "whatsNewTitle": "اعرض ملاحظات إصدار التحديث الذي أُخبرت عنه آخر مرة",
@@ -272,6 +277,10 @@
       "budgetPlaceholder": "مثال: 1000000",
       "budgetEquals": "= {{value}} رمز",
       "budgetTotal": "إجمالي الرموز عبر الأرضية",
+      "meAndGod": "أنا و{godName}",
+      "onlyMe": "أنا فقط",
+      "onlyYouDesc": "أنت فقط. لا يزال {godName} يستطيع الطلب، ويبقى طلبه في قائمة الانتظار بدلًا من الفشل.",
+      "orchSpawnDesc": "{godName} يستطيع التوظيف بنفسه. كل وكيل يطلقه يستهلك رموزًا لم توافق عليها.",
       "velocity": "سرعة الرموز (رمز/دقيقة)",
       "velocityPlaceholder": "مثال: 200000",
       "repeatedLimit": "حدّ تكرار الأداة",
@@ -281,7 +290,8 @@
       "hardStopDesc": "عند التجاوز، أنهِ الوكيل بدل تقييده فقط. الإيقاف = التوجيه أولًا (موصى به).",
       "killOnTrip": "أنهِه عند التجاوز",
       "steerFirst": "وجِّه أولًا",
-      "saved": "حُفِظ"
+      "saved": "حُفِظ",
+      "whoCanAdd": "من يمكنه إضافة الوكلاء"
     },
     "memory": {
       "semanticMemory": "الذاكرة الدلالية",
@@ -654,10 +664,17 @@
       "note": "اعتبره \"مبنى البلدية\". تثبّت المنصّة حالة الوكلاء هناك ليمكن استئناف الجلسات بعد إعادة التشغيل."
     },
     "orchestrator": {
+      "badgeInstalled": "مثبّت",
+      "badgeInstallsFirstRun": "يُثبَّت عند أول تشغيل",
+      "badgeNotInstalled": "غير مثبّت",
+      "blockedMessage": "{label} غير مثبّت على هذا الجهاز ولا يملك التطبيق مُثبّتًا له، لذا تعذّر تشغيل {godName}. ثبّته أولًا ثم اضغط «تحقق مجددًا». أو اختر Claude Code، الذي يثبّت نفسه عند أول تشغيل.",
+      "checkAgain": "تحقق مجددًا",
+      "checking": "جارٍ التحقق...",
       "descPlain": "{{godName}} هو نسختك — يقرأ طلباتك، ويفكّكها إلى مهام، ويسلّمها إلى الوكيل المناسب. هو مدير الأرضية؛ وأنت ما زلت مديره. اختر محرّك الذكاء الاصطناعي الذي يشغّله.",
       "desc": "{{godName}} هو نسختك — مدير الأرضية الذي قابلته للتوّ. يفرز طلباتك، ويُسنِد المهام، ويُدير الفريق، ويُصعِّد كل ما يحتاجك فعلًا. اختر المحرّك والنموذج اللذين يشغّلانه؛ وأعطِه نموذجًا بسياق أطول وقدرة أعلى.",
       "cliAgentPlain": "<strong>وكيل الـCLI</strong> مساعد برمجة ذكي يعمل على حاسوبك — وأشهرها Claude Code (من Anthropic) وCodex (من OpenAI) وAntigravity (من Google Gemini). و<strong>نسختك</strong> هي الوكيل الدائم الذي يُدير مكتبك كله. ننصح بـClaude Code على Opus 4.8 (1M). ويمكنك إضافة الباقي أو التبديل إليها لاحقًا.",
       "cliAgent": "كل خيار هو <strong>محرّك CLI</strong> (Claude Code أو Codex أو Antigravity/Gemini أو وسيط محلي مثل Qwen). المحرّكات المعلَّمة بـINSTALLED موجودة على هذا الجهاز؛ وINSTALLS ON FIRST RUN يعني أن التطبيق يُعِدّها عند أول تشغيل لـ{{godName}}. و<strong>نسختك</strong> ({{godName}}) هي المحرّك الذي ينسّق الخلية كلها. الموصى به: Claude Code · Opus 4.8 · 1M. ويمكن ربط مزوّدين آخرين لكل وكيل لاحقًا.",
+      "installInstructions": "تعليمات التثبيت",
       "recommended": "موصى به",
       "model": "النموذج",
       "modelNote": "هذا يضبط محرّك {{godName}} فقط. ويمكنك تشغيل مزوّدين آخرين لكل وكيل لاحقًا."
@@ -1054,7 +1071,8 @@
   },
   "fileTree": {
     "loading": "جارٍ التحميل…",
-    "copyPathTitle": "نسخ المسار إلى الحافظة"
+    "copyPathTitle": "نسخ المسار إلى الحافظة",
+    "partial": "جزئي"
   },
   "fileEditor": {
     "file": "ملف",
@@ -1087,6 +1105,10 @@
     "copyPath": "نسخ المسار"
   },
   "fullscreenTerminal": {
+    "noNote": "لا ملاحظة",
+    "noteHint": "سطر واحد = نقطة واحدة · esc للإغلاق",
+    "privateNote": "ملاحظة خاصة",
+    "settingsTitle": "الإعدادات",
     "showAgentList": "أظهر قائمة الوكلاء",
     "hideAgentList": "أخفِ قائمة الوكلاء — طرفية بعرض كامل",
     "lightTheme": "التبديل إلى السِمة الفاتحة",
@@ -1167,6 +1189,7 @@
     "catalogUnreachable": "تعذّر الوصول إلى الفهرس"
   },
   "workersTab": {
+    "slack": "slack",
     "stopping": "يتوقّف",
     "working": "يعمل",
     "liveWorkers": "العمّال النشطون",
@@ -1292,6 +1315,7 @@
     "priority": "الأولوية {{level}}/5"
   },
   "queueComposer": {
+    "groqKeysLink": "console.groq.com/keys",
     "recording": "● يسجّل — انقر إيقاف للتفريغ النصي",
     "transcribing": "جارٍ التفريغ النصي…",
     "voice": "صوت",
@@ -1333,6 +1357,10 @@
     "ffHoldHint": "اضغط عليه وحده لحظةً للبدء؛ وأفلته ليُفرَّغ النص في المحرّر حيث يمكنك التعديل قبل الإرسال. يعمل أي من مفتاحَي Option، وتصل تركيبات Option+مفتاح إلى الطرفية كما هي."
   },
   "idePanel": {
+    "god": "المنسّق",
+    "nothingOpen": "لا شيء مفتوح",
+    "pickFileToEdit": "اختر ملفًا من الشجرة للتعديل، أو ملفًا تغيّر لمقارنته (diff).",
+    "spawnFirst": "ولّد وكيلًا أولًا — ستفتح IDE على مجلد عمله.",
     "workspace": "مساحة عمل {{name}}",
     "workspaceInferred": "لم يُسمَّ أي وكيل عند فتح بيئة التطوير — يُعرَض مساحة عمل {{name}} (التحديد الحالي)",
     "assumed": "مفترَض",
@@ -1393,6 +1421,8 @@
     "noDifferences": "لا فروقات"
   },
   "imagePreview": {
+    "copyAbsolutePath": "نسخ المسار المطلق",
+    "copyPath": "نسخ المسار",
     "fitTitle": "تصغير الصورة لتناسب اللوحة",
     "oneToOneTitle": "عرض كل بكسل بمقياس 1:1 (مرّر للتنقّل)",
     "fit": "ملاءمة",
@@ -1400,5 +1430,171 @@
     "viewSource": "عرض المصدر",
     "loading": "جارٍ تحميل الصورة…",
     "decodeFailed": "تعذّر فك ترميز هذه الصورة — قد يكون الملف تالفًا أو امتداده خاطئًا"
+  },
+  "hivePicker": {
+    "couldNotOpen": "تعذّر فتح هذا المجلد.",
+    "createNew": "إنشاء إعداد جديد…",
+    "current": "الحالي",
+    "desc": "إعداد النطاق <strong>harness config</strong> هو المجلد الذي يحتفظ فيه التطبيق بكل شيء لمساحة عمل واحدة — إعداداته، ووكلاؤك وذاكرتهم، والمهام والمشغلات والسجل. كل إعداد مستقل ومتكامل بذاته، لذا يمكنك تشغيل إعدادات مختلفة جنبًا إلى جنب. افتح الذي كنت تعمل فيه، أو بدّل إلى آخر، أو ابدأ واحدًا جديدًا.",
+    "open": "فتح",
+    "openExisting": "فتح إعداد موجود…",
+    "opening": "جارٍ فتح {name} — سيعيد التطبيق التحميل…",
+    "openingEllipsis": "جارٍ الفتح…",
+    "recent": "الأخيرة",
+    "switchArrow": "تبديل →",
+    "switchTo": "التبديل إلى {path} (سيعيد تحميل التطبيق)",
+    "title": "اختر إعداد النطاق (HARNESS CONFIG)"
+  },
+  "quitWarning": {
+    "cancelBack": "إلغاء — العودة إلى العمل",
+    "closeStartFail": "تعذّر بدء وقت الإغلاق.",
+    "closingTime": "وقت الإغلاق",
+    "closingTitle": "وقت الإغلاق",
+    "forceQuit": "أجهِز الخروج الآن",
+    "keepRunning": "أبقهم يعملون",
+    "killAllQuit": "أجهِز على الكل واخرج",
+    "killItQuit": "أجهِزه واخرج",
+    "killing": "جارٍ الإجهاز…",
+    "noWorkersWaiting": "لا يوجد عمال على النطاق — في انتظار المنسّق",
+    "quittingTitle": "هل تريد الخروج الآن؟",
+    "runningTitle": "{count} وكيل ما زال يعمل",
+    "runningTitlePlural": "{count} وكلاء ما زالوا يعملون",
+    "savedBody": "حفظ كل وكيل ذاكرته وأكّد المنسّق إيقاف التشغيل. سيغلق النطاق نفسه بعد لحظة.",
+    "savedTitle": "النطاق محفوظ — إلى اللقاء غدًا",
+    "terminateMany": "سيؤدي إغلاق النطاق إلى إنهاء جميع جلسات claude الـ{count} الجارية والتخلص من أي تقدم غير محفوظ كانت تحمله في ذاكرتها. يُفقد سجل المحادثة داخل كل جلسة عند خروج الطرفية (PTY).",
+    "terminateOne": "سيؤدي إغلاق النطاق إلى إنهاء جلسة claude الجارية والتخلص من أي تقدم غير محفوظ كانت تحمله في ذاكرتها. يُفقد سجل المحادثة داخل كل جلسة عند خروج الطرفية (PTY).",
+    "timeoutNote": "يستغرق هذا بعض الوقت (ربما يكون أحد الوكلاء في منتصف ضغط الذاكرة أو متعمقًا في استدعاء أداة). تابع الانتظار، أو أجهِز الخروج واقبل فقدان البيانات.",
+    "tip": "نصيحة: <strong>وقت الإغلاق</strong> هو الطريق الآمن للخروج — يطلب المنسّق من كل وكيل إيداع عمله وحفظ ذاكرته، ويغلق التطبيق نفسه بمجرد تأكيد النطاق بأكمله. لا فقدان للبيانات.",
+    "workersConfirmed": "{acked} / {total} من العمال أكّدوا",
+    "workersConfirmedWaiting": "{acked} / {total} من العمال أكّدوا — في انتظار المنسّق",
+    "wrappingBody": "أرسل المنسّق إعلان وقت الإغلاق. يوقف كل عامل عمله ويحفظ ذاكرته ويبلغ بالانتهاء — لا يُغلق التطبيق إلا بعد أن يؤكد المنسّق أنه لن يُفقد شيء.",
+    "wrappingStill": "ما زلنا نُنهي الأمور…",
+    "wrappingTitle": "إنهاء عمل النطاق"
+  },
+  "app": {
+    "addAgent": "إضافة وكيل",
+    "clockingIn": "{name} يسجّل دخوله.",
+    "darkTheme": "السمة الداكنة",
+    "emptyFloorDesc": "لا وكلاء على النطاق بعد. ولّد واحدًا لترى تدفق إخراج claude الحقيقي هنا.",
+    "emptyFloorTitle": "نطاق فارغ",
+    "exitFocusMode": "الخروج من وضع التركيز (Esc)",
+    "focusMode": "وضع التركيز",
+    "lightTheme": "السمة الفاتحة",
+    "noAgentSelected": "لم يُحدَّد أي وكيل",
+    "settingsAria": "الإعدادات",
+    "spawnFromStrip": "ولّد وكيلًا من الشريط أدناه.",
+    "terminalAndCmdBar": "ستحط هنا الطرفية وشريط الأوامر.",
+    "terminalWillLand": "ستحط الطرفية هنا بمجرد جلوسه.",
+    "toggleDarkMode": "تبديل الوضع الداكن",
+    "toggleFocusMode": "تبديل وضع التركيز",
+    "wakingTheFloor": "إيقاظ النطاق"
+  },
+  "michaelBooting": {
+    "clockingIn": "تسجيل الدخول"
+  },
+  "editAgent": {
+    "briefing": "الإحاطة",
+    "briefingHint": "الوصف · الهدف",
+    "cancel": "إلغاء",
+    "character": "الشخصية",
+    "color": "اللون",
+    "description": "الوصف",
+    "descriptionPlaceholder": "لأي غرض هذا الوكيل",
+    "directivePlaceholder": "توجيه طويل الأمد يُحقن في كل طلب",
+    "engine": "المحرك",
+    "engineHint": "المزوّد · الطراز · إعادة التشغيل التالية",
+    "identity": "الهوية",
+    "identityHint": "الاسم · الشخصية · اللون",
+    "model": "الطراز",
+    "name": "الاسم",
+    "namePlaceholder": "ستانلي",
+    "provider": "المزوّد",
+    "saveChanges": "حفظ التغييرات",
+    "title": "تحرير الوكيل"
+  },
+  "codeEditor": {
+    "copyAbsolutePath": "نسخ المسار المطلق",
+    "copyPath": "نسخ المسار",
+    "err": "خطأ",
+    "noFileOpen": "لا ملف مفتوح",
+    "openInIde": "فتح في IDE",
+    "openInIdeAria": "فتح في IDE",
+    "pickFileToView": "اختر ملفًا من الشجرة لعرضه هنا.",
+    "save": "حفظ",
+    "saveTitle": "حفظ (Cmd-S)",
+    "saved": "تم الحفظ"
+  },
+  "recentText": {
+    "recent": "الأخيرة"
+  },
+  "releaseDrop": {
+    "closeEsc": "إغلاق (Esc)",
+    "closeReleaseNotes": "إغلاق ملاحظات الإصدار",
+    "esc": "esc",
+    "loading": "جارٍ التحميل",
+    "releaseNotes": "/ ملاحظات الإصدار",
+    "whatsNew": "ما الجديد في Munder Difflin {version}"
+  },
+  "completionToast": {
+    "dismiss": "إغلاق"
+  },
+  "ptyTerminalView": {
+    "exitFocusMode": "الخروج من وضع التركيز (Esc)",
+    "resetZoom": "إعادة ضبط التكبير (Cmd 0)",
+    "zoomIn": "تكبير العرض (Cmd +)",
+    "zoomOut": "تصغير العرض (Cmd -)"
+  },
+  "sidebarSplitter": {
+    "dragToResize": "اسحب لتغيير الحجم · انقر نقرًا مزدوجًا لإعادة الضبط"
+  },
+  "updateToast": {
+    "availableTitle": "الإصدار v{version} متاح",
+    "downloadVersion": "تنزيل {version}",
+    "downloadedBody": "أعد تشغيل Munder Difflin متى شئت لتطبيقه — لا شيء يعيد التشغيل من تلقاء نفسه.",
+    "downloadedTitle": "تم تنزيل التحديث v{version}",
+    "later": "لاحقًا",
+    "manualBody": "لا يستطيع هذا التثبيت تحديث نفسه — احصل على البنية الجديدة من صفحة الإصدارات.",
+    "openReleases": "فتح صفحة الإصدارات",
+    "readMore": "اقرأ المزيد",
+    "restartToUpdate": "أعد التشغيل للتحديث",
+    "restarting": "جارٍ إعادة التشغيل…",
+    "starOnGitHub": "⭐ امنحنا نجمة على GitHub",
+    "whatsNew": "ما الجديد"
+  },
+  "updateBadge": {
+    "availableChip": "v{version} · تحديث",
+    "availableTitle": "جارٍ تنزيل v{version} في الخلفية؛ انقر لبدئه إن لم يبدأ",
+    "checkFailed": "فشل فحص التحديث",
+    "checking": "جارٍ الفحص…",
+    "checkingTitle": "جارٍ التحقق من التحديثات (أنت على v{v})",
+    "clickToDownload": "انقر لتنزيل v{pending}",
+    "downloadedChip": "v{version} · إعادة تشغيل",
+    "downloadedTitle": "انقر لإعادة التشغيل وتثبيت v{version}",
+    "downloading": "v{version} قيد التنزيل في متصفحك.",
+    "downloadingBody": "عند اكتماله، اخرج من هذا التطبيق وثبّت الإصدار الجديد فوق الإصدار الحالي. افتحه واختر نفس المشروع. ستبقى وكلاؤك وذاكرتك وإعداداتك كما هي.",
+    "downloadingChip": "جارٍ التنزيل {percent}%",
+    "downloadingTitle": "جارٍ تنزيل v{version}… {percent}%",
+    "errorTitle": "{message} — انقر للمحاولة مجددًا",
+    "gotIt": "فهمت",
+    "idleTitle": "v{v} — انقر للتحقق من التحديثات",
+    "installUpdateAria": "تثبيت التحديث",
+    "latest": "الأحدث",
+    "latestChecked": "v{version} هو أحدث إصدار. تم الفحص الآن.",
+    "latestTitle": "v{v} هو أحدث إصدار — انقر للفحص مجددًا",
+    "manualChip": "v{version} · تنزيل",
+    "manualTitle": "انقر لتنزيل v{version} ثم استبدل التطبيق الذي لديك",
+    "manualTitleReason": "انقر لتنزيل v{version} ثم استبدل التطبيق الذي لديك (تعذّر على هذا التثبيت تحديث نفسه: {reason})",
+    "onOs": "على {os}",
+    "preferSelfUpdate": "نزّل أحدث إصدار واستبدل التطبيق الذي لديك. هل تفضل أن يحدّث التطبيق نفسه؟",
+    "restartToUpdate": "أعد التشغيل للتحديث",
+    "restarting": "جارٍ إعادة التشغيل…",
+    "versionCheckAria": "الإصدار {version} — تحقق من التحديثات",
+    "youAreCurrent": "أنت على أحدث إصدار."
+  },
+  "agentNameEditor": {
+    "nameRequired": "الاسم مطلوب",
+    "renameAria": "إعادة تسمية {name}",
+    "renameFailed": "تعذّرت إعادة تسمية الوكيل",
+    "renameFailedPrefix": "تعذّرت إعادة تسمية الوكيل: {err}"
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -154,7 +154,8 @@
     "terminalTip": "Open your system terminal app in {{cwd}} — a normal shell in this agent's folder, separate from the agent's own terminal.",
     "openIde": "Open the IDE",
     "ide": "IDE",
-    "openTerminalAria": "Open a system terminal in this agent's folder"
+    "openTerminalAria": "Open a system terminal in this agent's folder",
+    "editAria": "Edit this agent"
   },
   "settingsHero": {
     "sponsoredBy": "Sponsored by",
@@ -171,7 +172,11 @@
     "foundersWallTitle": "On the Founders' Wall?",
     "foundersWallBody": "A month of Munder Difflin Pro free, then 50% off the annual plan. For the first 100 people on the wall.",
     "seeTheWall": "see the wall",
-    "joinDiscord": "join Discord"
+    "joinDiscord": "join Discord",
+    "downloadManualTitle": "Download the installer and replace the app yourself. Auto-update is in Updates below.",
+    "brandName": "MUNDER DIFFLIN",
+    "versionOut": "v{version} is out",
+    "downloadVersion": "download v{version}"
   },
   "officeTheme": {
     "title": "Office Theme",
@@ -281,7 +286,12 @@
       "hardStopDesc": "When tripped, KILL the agent instead of just constraining it. Off = steer-first (recommended).",
       "killOnTrip": "kill on trip",
       "steerFirst": "steer first",
-      "saved": "saved"
+      "saved": "saved",
+      "whoCanAdd": "Who can add agents",
+      "orchSpawnDesc": "{godName} can hire on his own. Every agent he starts spends tokens you did not approve.",
+      "onlyYouDesc": "Only you. {godName} can still ask, and his request waits in the queue instead of failing.",
+      "meAndGod": "me and {godName}",
+      "onlyMe": "only me"
     },
     "memory": {
       "semanticMemory": "Semantic memory",
@@ -660,7 +670,14 @@
       "cliAgent": "Each option is a <strong>CLI engine</strong> (Claude Code, Codex, Antigravity/Gemini, or a local proxy like Qwen). Engines marked INSTALLED are already on this machine; INSTALLS ON FIRST RUN means the app sets it up when {{godName}} first starts. <strong>Your clone</strong> ({{godName}}) is the engine that orchestrates the whole hive. Recommended: Claude Code · Opus 4.8 · 1M. Other providers can be wired per agent later.",
       "recommended": "RECOMMENDED",
       "model": "Model",
-      "modelNote": "This only sets {{godName}}'s engine. You can run other providers per agent later."
+      "modelNote": "This only sets {{godName}}'s engine. You can run other providers per agent later.",
+      "badgeInstalled": "INSTALLED",
+      "badgeInstallsFirstRun": "INSTALLS ON FIRST RUN",
+      "badgeNotInstalled": "NOT INSTALLED",
+      "blockedMessage": "{label} is not installed on this computer and the app has no installer for it, so {godName} could not start. Install it first, then press \"check again\". Or pick Claude Code, which installs itself on first run.",
+      "checking": "checking...",
+      "checkAgain": "check again",
+      "installInstructions": "install instructions"
     },
     "repos": {
       "descPlain": "Add your projects. A project is simply a folder — it can hold code, documents, notes, or any files you want your agents to work with. You can create a brand-new folder or pick an existing one, and add more anytime.",
@@ -1054,7 +1071,8 @@
   },
   "fileTree": {
     "loading": "loading…",
-    "copyPathTitle": "Copy path to clipboard"
+    "copyPathTitle": "Copy path to clipboard",
+    "partial": "Partial"
   },
   "fileEditor": {
     "file": "FILE",
@@ -1102,7 +1120,11 @@
     "ideTip": "Open the IDE: browse and edit files in {{name}}'s workspace, and see their uncommitted changes as a diff.",
     "openIdeAria": "Open the IDE",
     "openTerminalTip": "Open your system terminal app in {{cwd}} — a normal shell in this agent's folder, separate from the agent's own terminal.",
-    "openTerminalAria": "Open a system terminal in this agent's folder"
+    "openTerminalAria": "Open a system terminal in this agent's folder",
+    "noNote": "no note",
+    "privateNote": "PRIVATE NOTE",
+    "settingsTitle": "Settings",
+    "noteHint": "one line = one bullet · esc to close"
   },
   "memoryPanel": {
     "pill": "🧠 memory",
@@ -1188,7 +1210,8 @@
     "uncapped": "uncapped",
     "preserved": "Preserved worktrees ({{count}})",
     "preservedIntro": "Finished workers whose worktree held un-integrated work — kept (never auto-discarded) and auto-reclaimed once the work lands in its base branch.",
-    "keptAgo": "kept {{age}} ago"
+    "keptAgo": "kept {{age}} ago",
+    "slack": "slack"
   },
   "memoryGraph": {
     "topics": "topics",
@@ -1330,14 +1353,15 @@
     "ffCreateKey": "Create a free key at",
     "ffPasteKey": "Paste it into Settings → Voice → Groq API key",
     "ffClickOrHold": "Click voice, or hold the right Option key to talk",
-    "ffHoldHint": "Hold it ALONE for a moment to start; release to transcribe into the composer, where you can edit before sending. Either Option key works, and Option+key combos still reach the terminal untouched."
+    "ffHoldHint": "Hold it ALONE for a moment to start; release to transcribe into the composer, where you can edit before sending. Either Option key works, and Option+key combos still reach the terminal untouched.",
+    "groqKeysLink": "console.groq.com/keys"
   },
   "idePanel": {
     "workspace": "{{name}}'s workspace",
     "workspaceInferred": "No agent was named when the IDE opened — showing {{name}}'s workspace (the current selection)",
     "assumed": "assumed",
     "noAgent": "no agent",
-    "noWorkspace": "no workspace",
+    "noWorkspace": "No workspace available.",
     "closeIde": "Close IDE (Esc)",
     "expandGit": "Expand the git panel",
     "collapseGit": "Collapse the git panel — more room for the file tree",
@@ -1366,7 +1390,11 @@
     "copyPath": "copy path",
     "saveTitle": "Save (Cmd/Ctrl+S)",
     "saved": "saved",
-    "save": "save"
+    "save": "save",
+    "god": "god",
+    "nothingOpen": "nothing open",
+    "pickFileToEdit": "Pick a file from the tree to edit, or a changed file to diff.",
+    "spawnFirst": "Spawn an agent first — the IDE opens on its working directory."
   },
   "gitPanes": {
     "jumpConfirm": "Jump the repo to {{sha}} (\"{{subject}}\")?\n\nThis detaches HEAD. Blocked automatically if the tree is dirty or an agent is mid-run.",
@@ -1399,6 +1427,174 @@
     "viewSourceTitle": "Open the SVG markup in the editor",
     "viewSource": "view source",
     "loading": "loading image…",
-    "decodeFailed": "could not decode this image — the file may be corrupt or misnamed"
+    "decodeFailed": "could not decode this image — the file may be corrupt or misnamed",
+    "copyAbsolutePath": "Copy absolute path",
+    "copyPath": "copy path"
+  },
+  "hivePicker": {
+    "title": "SELECT A HARNESS CONFIG",
+    "desc": "A <strong>harness config</strong> is the folder where the app keeps everything for one workspace — its settings, your agents and their memory, tasks, triggers, and history. Each config is separate and self-contained, so you can run different setups side by side. Open the one you were working in, switch to another, or start a new one.",
+    "current": "CURRENT",
+    "open": "open",
+    "recent": "RECENT",
+    "switchTo": "Switch to {path} (reloads the app)",
+    "openingEllipsis": "opening…",
+    "switchArrow": "switch →",
+    "openExisting": "open existing config…",
+    "createNew": "create new config…",
+    "opening": "Opening {name} — the app will reload…",
+    "couldNotOpen": "Could not open that folder."
+  },
+  "quitWarning": {
+    "closingTitle": "CLOSING TIME",
+    "quittingTitle": "QUITTING NOW?",
+    "savedTitle": "FLOOR SAVED — SEE YOU TOMORROW",
+    "wrappingStill": "STILL WRAPPING UP…",
+    "wrappingTitle": "WRAPPING UP THE FLOOR",
+    "savedBody": "Every agent saved its memory and the orchestrator confirmed the shutdown. The harness closes itself in a moment.",
+    "wrappingBody": "The orchestrator broadcast closing time. Every worker parks its work, saves its memory, and reports back — the app closes only after the orchestrator confirms nothing will be lost.",
+    "workersConfirmed": "{acked} / {total} WORKERS CONFIRMED",
+    "workersConfirmedWaiting": "{acked} / {total} WORKERS CONFIRMED — WAITING FOR THE ORCHESTRATOR",
+    "noWorkersWaiting": "NO WORKERS ON THE FLOOR — WAITING FOR THE ORCHESTRATOR",
+    "timeoutNote": "This is taking a while (an agent may be mid-compaction or deep in a tool call). Keep waiting, or force quit and accept the data loss.",
+    "cancelBack": "cancel — back to work",
+    "forceQuit": "force quit now",
+    "killing": "killing...",
+    "keepRunning": "keep them running",
+    "closingTime": "closing time",
+    "runningTitle": "{count} AGENT STILL RUNNING",
+    "runningTitlePlural": "{count} AGENTS STILL RUNNING",
+    "terminateOne": "Closing the harness will terminate the running claude session and discard any unsaved progress they were holding in memory. The conversation history inside each session is lost when the PTY exits.",
+    "terminateMany": "Closing the harness will terminate all {count} running claude sessions and discard any unsaved progress they were holding in memory. The conversation history inside each session is lost when the PTY exits.",
+    "tip": "Tip: <strong>closing time</strong> is the safe way out — the orchestrator has every agent commit its work and save its memory, and the app closes itself once the whole floor has confirmed. No data loss.",
+    "closeStartFail": "Closing time could not start.",
+    "killItQuit": "kill it & quit",
+    "killAllQuit": "kill all & quit"
+  },
+  "app": {
+    "emptyFloorTitle": "EMPTY FLOOR",
+    "emptyFloorDesc": "No agents on the floor yet. Spawn one to see real claude output stream in here.",
+    "addAgent": "add agent",
+    "wakingTheFloor": "WAKING THE FLOOR",
+    "clockingIn": "{name} is clocking in.",
+    "terminalWillLand": "The terminal will land here once he's seated.",
+    "noAgentSelected": "NO AGENT SELECTED",
+    "spawnFromStrip": "Spawn an agent from the strip below.",
+    "terminalAndCmdBar": "The terminal and command bar will land here.",
+    "toggleDarkMode": "Toggle dark mode",
+    "toggleFocusMode": "Toggle focus mode",
+    "focusMode": "Focus mode",
+    "exitFocusMode": "Exit focus mode (Esc)",
+    "lightTheme": "Light theme",
+    "darkTheme": "Dark theme",
+    "settingsAria": "Settings"
+  },
+  "michaelBooting": {
+    "clockingIn": "CLOCKING IN"
+  },
+  "editAgent": {
+    "title": "EDIT AGENT",
+    "namePlaceholder": "Stanley",
+    "descriptionPlaceholder": "what is this agent for",
+    "directivePlaceholder": "long-running directive injected on every prompt",
+    "cancel": "cancel",
+    "saveChanges": "save changes",
+    "identity": "Identity",
+    "identityHint": "name · character · color",
+    "name": "Name",
+    "character": "Character",
+    "color": "Color",
+    "engine": "Engine",
+    "engineHint": "provider · model · next restart",
+    "provider": "Provider",
+    "model": "Model",
+    "briefing": "Briefing",
+    "briefingHint": "description · goal",
+    "description": "Description"
+  },
+  "codeEditor": {
+    "noFileOpen": "No file open",
+    "pickFileToView": "Pick a file from the tree to view it here.",
+    "copyPath": "copy path",
+    "copyAbsolutePath": "Copy absolute path",
+    "saveTitle": "Save (Cmd-S)",
+    "openInIde": "Open in the IDE",
+    "openInIdeAria": "Open in the IDE",
+    "saved": "saved",
+    "err": "err",
+    "save": "save"
+  },
+  "recentText": {
+    "recent": "recent"
+  },
+  "releaseDrop": {
+    "whatsNew": "What's new in Munder Difflin {version}",
+    "closeReleaseNotes": "Close release notes",
+    "closeEsc": "Close (Esc)",
+    "esc": "esc",
+    "loading": "Loading",
+    "releaseNotes": "/ release notes"
+  },
+  "completionToast": {
+    "dismiss": "Dismiss"
+  },
+  "ptyTerminalView": {
+    "zoomOut": "Zoom out (Cmd -)",
+    "resetZoom": "Reset zoom (Cmd 0)",
+    "zoomIn": "Zoom in (Cmd +)",
+    "exitFocusMode": "Exit focus mode (Esc)"
+  },
+  "sidebarSplitter": {
+    "dragToResize": "Drag to resize · double-click to reset"
+  },
+  "updateToast": {
+    "readMore": "Read more",
+    "later": "later",
+    "starOnGitHub": "⭐ Star us on GitHub",
+    "restarting": "restarting…",
+    "restartToUpdate": "restart to update",
+    "downloadedTitle": "Update v{version} downloaded",
+    "availableTitle": "v{version} is available",
+    "downloadedBody": "Restart Munder Difflin whenever you like to apply it — nothing restarts on its own.",
+    "manualBody": "This install can’t update itself — grab the new build from the releases page.",
+    "whatsNew": "What’s new",
+    "downloadVersion": "download {version}",
+    "openReleases": "open releases"
+  },
+  "updateBadge": {
+    "downloading": "v{version} is downloading in your browser.",
+    "downloadingBody": "When it lands, quit this app and install the new version over the current one. Open it and pick the same project. Your agents, memory and settings stay where they are.",
+    "gotIt": "got it",
+    "youAreCurrent": "You are on the latest version.",
+    "installUpdateAria": "Install the update",
+    "preferSelfUpdate": "Download the latest version and replace the app you have. Prefer the app to update itself?",
+    "clickToDownload": "Click to download v{pending}",
+    "onOs": "On {os}",
+    "restarting": "restarting…",
+    "restartToUpdate": "restart to update",
+    "latestChecked": "v{version} is the newest release. Checked just now.",
+    "downloadingChip": "downloading {percent}%",
+    "downloadingTitle": "Downloading v{version}… {percent}%",
+    "downloadedChip": "v{version} · restart",
+    "downloadedTitle": "Click to restart and install v{version}",
+    "availableChip": "v{version} · update",
+    "availableTitle": "Downloading v{version} in the background; click to start it if it has not begun",
+    "manualChip": "v{version} · download",
+    "manualTitle": "Click to download v{version}, then replace the app you have",
+    "manualTitleReason": "Click to download v{version}, then replace the app you have (this install could not update itself: {reason})",
+    "checking": "checking…",
+    "checkingTitle": "Checking for updates (you're on v{v})",
+    "checkFailed": "update check failed",
+    "errorTitle": "{message} — click to try again",
+    "latest": "latest",
+    "latestTitle": "v{v} is the latest version — click to check again",
+    "idleTitle": "v{v} — click to check for updates",
+    "versionCheckAria": "Version {version} — check for updates"
+  },
+  "agentNameEditor": {
+    "nameRequired": "Name is required",
+    "renameFailed": "Could not rename agent",
+    "renameFailedPrefix": "Could not rename agent: {err}",
+    "renameAria": "Rename {name}"
   }
 }

--- a/src/renderer/src/i18n/locales/zh-CN.json
+++ b/src/renderer/src/i18n/locales/zh-CN.json
@@ -154,7 +154,8 @@
     "terminalTip": "在 {{cwd}} 中打开你的系统终端应用 —— 位于该智能体文件夹中的普通 shell，与该智能体自己的终端相互独立。",
     "openIde": "打开 IDE",
     "ide": "IDE",
-    "openTerminalAria": "在该智能体的文件夹中打开系统终端"
+    "openTerminalAria": "在该智能体的文件夹中打开系统终端",
+    "editAria": "编辑此代理"
   },
   "settingsHero": {
     "sponsoredBy": "赞助方",
@@ -171,7 +172,11 @@
     "foundersWallTitle": "在 Founders' Wall 上吗？",
     "foundersWallBody": "免费获得一个月的 Munder Difflin Pro，此后年度套餐享 5 折。仅限前 100 位上榜用户。",
     "seeTheWall": "查看榜单",
-    "joinDiscord": "加入 Discord"
+    "joinDiscord": "加入 Discord",
+    "downloadManualTitle": "自行下载安装程序并替换应用。自动更新在下方「更新」部分。",
+    "brandName": "MUNDER DIFFLIN",
+    "versionOut": "v{version} 已发布",
+    "downloadVersion": "下载 v{version}"
   },
   "officeTheme": {
     "title": "办公室主题",
@@ -281,7 +286,12 @@
       "hardStopDesc": "触发时直接终止智能体，而不仅是约束。关闭 = 先引导（推荐）。",
       "killOnTrip": "触发即终止",
       "steerFirst": "先引导",
-      "saved": "已保存"
+      "saved": "已保存",
+      "whoCanAdd": "谁可以添加代理",
+      "orchSpawnDesc": "{godName} 可以自行雇佣。他启动的每个代理都会消耗你未批准的令牌。",
+      "onlyYouDesc": "只有你。{godName} 仍然可以请求，他的请求会排在队列中等待，而不是直接失败。",
+      "meAndGod": "我和 {godName}",
+      "onlyMe": "只有我"
     },
     "memory": {
       "semanticMemory": "语义记忆",
@@ -503,7 +513,7 @@
       }
     },
     "name": "名字",
-    "namePlaceholder": "Ada",
+    "namePlaceholder": "给新成员起个名字",
     "character": "角色",
     "color": "颜色",
     "project": "项目",
@@ -660,7 +670,14 @@
       "cliAgent": "每个选项都是一个<strong>CLI 引擎</strong>（Claude Code、Codex、Antigravity/Gemini，或本地代理如 Qwen）。标记为 INSTALLED 的引擎已在本机就绪；INSTALLS ON FIRST RUN 表示应用会在 {{godName}} 首次启动时进行安装。<strong>你的克隆体</strong>（{{godName}}）是统筹整个 hive 的引擎。推荐：Claude Code · Opus 4.8 · 1M。其他提供方之后可按智能体逐一接入。",
       "recommended": "推荐",
       "model": "模型",
-      "modelNote": "这只设置 {{godName}} 的引擎。之后你可以在每个智能体上运行其他提供商。"
+      "modelNote": "这只设置 {{godName}} 的引擎。之后你可以在每个智能体上运行其他提供商。",
+      "badgeInstalled": "已安装",
+      "badgeInstallsFirstRun": "首次运行自动安装",
+      "badgeNotInstalled": "未安装",
+      "blockedMessage": "{label} 未安装在这台电脑上，且应用没有它的安装程序，因此 {godName} 无法启动。请先安装它，然后点击「重新检查」。或者选择 Claude Code，它会在首次运行时自行安装。",
+      "checking": "检查中...",
+      "checkAgain": "重新检查",
+      "installInstructions": "安装说明"
     },
     "repos": {
       "descPlain": "添加你的项目。项目就是一个文件夹——可以放代码、文档、笔记，或任何你想让智能体处理的文件。你可以新建一个文件夹，也可以选现有的，随时还能再加。",
@@ -1054,7 +1071,8 @@
   },
   "fileTree": {
     "loading": "加载中…",
-    "copyPathTitle": "复制路径到剪贴板"
+    "copyPathTitle": "复制路径到剪贴板",
+    "partial": "部分"
   },
   "fileEditor": {
     "file": "文件",
@@ -1102,7 +1120,11 @@
     "ideTip": "打开 IDE：浏览并编辑 {{name}} 工作区中的文件，并将他们未提交的更改作为差异查看。",
     "openIdeAria": "打开 IDE",
     "openTerminalTip": "在 {{cwd}} 中打开你的系统终端应用 —— 位于该智能体文件夹中的普通 shell，与该智能体自己的终端相互独立。",
-    "openTerminalAria": "在该智能体的文件夹中打开系统终端"
+    "openTerminalAria": "在该智能体的文件夹中打开系统终端",
+    "noNote": "无备注",
+    "privateNote": "私密备注",
+    "settingsTitle": "设置",
+    "noteHint": "一行 = 一条要点 · esc 关闭"
   },
   "memoryPanel": {
     "pill": "🧠 记忆",
@@ -1188,7 +1210,8 @@
     "uncapped": "无上限",
     "preserved": "保留的工作树（{{count}}）",
     "preservedIntro": "已完成工人的工作树中保留着未整合的工作——保留（绝不自动丢弃），并在工作合入其基础分支后自动回收。",
-    "keptAgo": "{{age}} 前保留"
+    "keptAgo": "{{age}} 前保留",
+    "slack": "Slack"
   },
   "memoryGraph": {
     "topics": "主题",
@@ -1330,14 +1353,15 @@
     "ffCreateKey": "在以下地址免费创建密钥",
     "ffPasteKey": "粘贴到设置 → 语音 → Groq API 密钥",
     "ffClickOrHold": "点击「语音」，或按住右侧 Option 键说话",
-    "ffHoldHint": "单独按住一会儿即可开始；松开后转写到编辑器，发送前可修改。两个 Option 键都可以，Option+按键组合仍会原样到达终端。"
+    "ffHoldHint": "单独按住一会儿即可开始；松开后转写到编辑器，发送前可修改。两个 Option 键都可以，Option+按键组合仍会原样到达终端。",
+    "groqKeysLink": "console.groq.com/keys"
   },
   "idePanel": {
     "workspace": "{{name}} 的工作区",
     "workspaceInferred": "IDE 打开时未指定智能体——正在显示 {{name}} 的工作区（当前选中项）",
     "assumed": "推测",
     "noAgent": "无智能体",
-    "noWorkspace": "无工作区",
+    "noWorkspace": "没有可用的工作区。",
     "closeIde": "关闭 IDE（Esc）",
     "expandGit": "展开 git 面板",
     "collapseGit": "折叠 git 面板——为文件树腾出空间",
@@ -1366,7 +1390,11 @@
     "copyPath": "复制路径",
     "saveTitle": "保存（Cmd/Ctrl+S）",
     "saved": "已保存",
-    "save": "保存"
+    "save": "保存",
+    "god": "协调器",
+    "nothingOpen": "未打开任何内容",
+    "pickFileToEdit": "从文件树中选择一个文件编辑，或选择一个有改动的文件进行 diff。",
+    "spawnFirst": "请先生成一个代理——IDE 会打开到它的工作目录。"
   },
   "gitPanes": {
     "jumpConfirm": "把仓库跳转到 {{sha}}（\"{{subject}}\"）？\n\n这会脱离 HEAD。若工作区不干净或有智能体正在运行，将自动阻止。",
@@ -1399,6 +1427,174 @@
     "viewSourceTitle": "在编辑器中打开 SVG 标记",
     "viewSource": "查看源码",
     "loading": "正在加载图片…",
-    "decodeFailed": "无法解码此图片——文件可能已损坏或扩展名有误"
+    "decodeFailed": "无法解码此图片——文件可能已损坏或扩展名有误",
+    "copyAbsolutePath": "复制绝对路径",
+    "copyPath": "复制路径"
+  },
+  "hivePicker": {
+    "title": "选择工作区配置",
+    "desc": "<strong>工作区配置（harness config）</strong> 是应用为一个工作区保存所有内容的文件夹——包括其设置、你的代理及其记忆、任务、触发器和历史记录。每个配置相互独立且自包含，因此你可以并排运行不同的设置。打开你之前使用的那一个、切换到另一个，或新建一个。",
+    "current": "当前",
+    "open": "打开",
+    "recent": "最近使用",
+    "switchTo": "切换到 {path}（将重载应用）",
+    "openingEllipsis": "打开中…",
+    "switchArrow": "切换 →",
+    "openExisting": "打开已有配置…",
+    "createNew": "新建配置…",
+    "opening": "正在打开 {name}——应用将重新加载…",
+    "couldNotOpen": "无法打开该文件夹。"
+  },
+  "quitWarning": {
+    "closingTitle": "关闭时间",
+    "quittingTitle": "现在退出？",
+    "savedTitle": "楼层已保存——明天见",
+    "wrappingStill": "仍在收尾…",
+    "wrappingTitle": "正在收尾楼层",
+    "savedBody": "每个代理都已保存记忆，协调器确认关闭。应用片刻后将自行关闭。",
+    "wrappingBody": "协调器已广播关闭时间。每个员工都会停放其工作、保存记忆并回报——只有在协调器确认不会有任何丢失后，应用才会关闭。",
+    "workersConfirmed": "{acked} / {total} 名员工已确认",
+    "workersConfirmedWaiting": "{acked} / {total} 名员工已确认——等待协调器",
+    "noWorkersWaiting": "楼层上没有员工——等待协调器",
+    "timeoutNote": "这需要一段时间（某个代理可能正在进行压缩或深陷工具调用中）。可以继续等待，或强制退出并接受数据丢失。",
+    "cancelBack": "取消——回去工作",
+    "forceQuit": "立即强制退出",
+    "killing": "正在终止…",
+    "keepRunning": "让它们继续运行",
+    "closingTime": "关闭时间",
+    "runningTitle": "{count} 个代理仍在运行",
+    "runningTitlePlural": "{count} 个代理仍在运行",
+    "terminateOne": "关闭该 harness 将终止正在运行的 claude 会话，并丢弃其保存在内存中的任何未保存进度。会话内的对话历史会在 PTY 退出时丢失。",
+    "terminateMany": "关闭该 harness 将终止所有 {count} 个正在运行的 claude 会话，并丢弃其保存在内存中的任何未保存进度。会话内的对话历史会在 PTY 退出时丢失。",
+    "tip": "提示：<strong>关闭时间</strong> 是安全退出的方式——协调器会让每个代理提交其工作并保存记忆，且仅在整层楼确认后应用才会自行关闭。不会丢失数据。",
+    "closeStartFail": "无法启动关闭时间。",
+    "killItQuit": "终止它并退出",
+    "killAllQuit": "终止全部并退出"
+  },
+  "app": {
+    "emptyFloorTitle": "空楼层",
+    "emptyFloorDesc": "楼层上还没有代理。生成一个，即可在这里看到真实的 claude 输出流。",
+    "addAgent": "添加代理",
+    "wakingTheFloor": "正在唤醒楼层",
+    "clockingIn": "{name} 正在打卡上班。",
+    "terminalWillLand": "他入座后，终端将出现在这里。",
+    "noAgentSelected": "未选择代理",
+    "spawnFromStrip": "从下方的面板生成一个代理。",
+    "terminalAndCmdBar": "终端和命令栏将出现在这里。",
+    "toggleDarkMode": "切换深色模式",
+    "toggleFocusMode": "切换专注模式",
+    "focusMode": "专注模式",
+    "exitFocusMode": "退出专注模式 (Esc)",
+    "lightTheme": "浅色主题",
+    "darkTheme": "深色主题",
+    "settingsAria": "设置"
+  },
+  "michaelBooting": {
+    "clockingIn": "正在打卡"
+  },
+  "editAgent": {
+    "title": "编辑代理",
+    "namePlaceholder": "给代理起个名字",
+    "descriptionPlaceholder": "这个代理是做什么的",
+    "directivePlaceholder": "注入到每次提示中的长期指令",
+    "cancel": "取消",
+    "saveChanges": "保存更改",
+    "identity": "身份",
+    "identityHint": "名称 · 角色 · 颜色",
+    "name": "名称",
+    "character": "角色",
+    "color": "颜色",
+    "engine": "引擎",
+    "engineHint": "提供商 · 模型 · 下次重启",
+    "provider": "提供商",
+    "model": "模型",
+    "briefing": "任务简报",
+    "briefingHint": "描述 · 目标",
+    "description": "描述"
+  },
+  "codeEditor": {
+    "noFileOpen": "未打开文件",
+    "pickFileToView": "从文件树中选择一个文件在此查看。",
+    "copyPath": "复制路径",
+    "copyAbsolutePath": "复制绝对路径",
+    "saveTitle": "保存 (Cmd-S)",
+    "openInIde": "在 IDE 中打开",
+    "openInIdeAria": "在 IDE 中打开",
+    "saved": "已保存",
+    "err": "错误",
+    "save": "保存"
+  },
+  "recentText": {
+    "recent": "最近"
+  },
+  "releaseDrop": {
+    "whatsNew": "Munder Difflin {version} 的新功能",
+    "closeReleaseNotes": "关闭发行说明",
+    "closeEsc": "关闭 (Esc)",
+    "esc": "esc",
+    "loading": "加载中",
+    "releaseNotes": "/ 发行说明"
+  },
+  "completionToast": {
+    "dismiss": "关闭"
+  },
+  "ptyTerminalView": {
+    "zoomOut": "缩小 (Cmd -)",
+    "resetZoom": "重置缩放 (Cmd 0)",
+    "zoomIn": "放大 (Cmd +)",
+    "exitFocusMode": "退出专注模式 (Esc)"
+  },
+  "sidebarSplitter": {
+    "dragToResize": "拖动调整大小 · 双击重置"
+  },
+  "updateToast": {
+    "readMore": "了解更多",
+    "later": "稍后",
+    "starOnGitHub": "⭐ 在 GitHub 上给我们加星",
+    "restarting": "重启中…",
+    "restartToUpdate": "重启以更新",
+    "downloadedTitle": "更新 v{version} 已下载",
+    "availableTitle": "v{version} 可用",
+    "downloadedBody": "随时重启 Munder Difflin 即可应用更新——应用不会自行重启。",
+    "manualBody": "此安装无法自行更新——请从发行页面获取新版本。",
+    "whatsNew": "更新内容",
+    "downloadVersion": "下载 {version}",
+    "openReleases": "打开发行页"
+  },
+  "updateBadge": {
+    "downloading": "v{version} 正在你的浏览器中下载。",
+    "downloadingBody": "下载完成后，退出此应用并在当前版本之上安装新版本。打开后选择同一个项目。你的代理、记忆和设置都保持不变。",
+    "gotIt": "知道了",
+    "youAreCurrent": "你已是最新版本。",
+    "installUpdateAria": "安装更新",
+    "preferSelfUpdate": "下载最新版本并替换当前应用。更希望应用自行更新？",
+    "clickToDownload": "点击下载 v{pending}",
+    "onOs": "在 {os} 上",
+    "restarting": "重启中…",
+    "restartToUpdate": "重启以更新",
+    "latestChecked": "v{version} 是最新版本。刚刚检查过。",
+    "downloadingChip": "下载中 {percent}%",
+    "downloadingTitle": "正在下载 v{version}… {percent}%",
+    "downloadedChip": "v{version} · 重启",
+    "downloadedTitle": "点击重启并安装 v{version}",
+    "availableChip": "v{version} · 更新",
+    "availableTitle": "正在后台下载 v{version}；若尚未开始，请点击开始",
+    "manualChip": "v{version} · 下载",
+    "manualTitle": "点击下载 v{version}，然后替换当前应用",
+    "manualTitleReason": "点击下载 v{version}，然后替换当前应用（此安装无法自行更新：{reason}）",
+    "checking": "检查中…",
+    "checkingTitle": "正在检查更新（你当前在 v{v}）",
+    "checkFailed": "更新检查失败",
+    "errorTitle": "{message}——点击重试",
+    "latest": "最新",
+    "latestTitle": "v{v} 已是最新版本——点击重新检查",
+    "idleTitle": "v{v}——点击检查更新",
+    "versionCheckAria": "版本 {version}——检查更新"
+  },
+  "agentNameEditor": {
+    "nameRequired": "需要填写名称",
+    "renameFailed": "无法重命名代理",
+    "renameFailedPrefix": "无法重命名代理：{err}",
+    "renameAria": "重命名 {name}"
   }
 }

--- a/src/renderer/src/i18n/useDirection.ts
+++ b/src/renderer/src/i18n/useDirection.ts
@@ -3,38 +3,33 @@ import { useTranslation } from 'react-i18next';
 import { directionFor, isRtlLanguage } from './index';
 
 /**
- * The single gate for right-to-left layout.
+ * RTL 布局的唯一门控。
  *
- * `useRtl()` is what every component asks; `useDirectionSync()` is mounted once
- * near the root and stamps `dir`/`lang` on <html>. Both read ONE input — the
- * language the user picked in Settings. Not `navigator.language`, not the OS,
- * not the content on screen. A user who has not picked an RTL language gets
- * `dir="ltr"` and `useRtl() === false`, which is byte-for-byte the behaviour
- * they had before Arabic existed: no direction flip, no mirrored layout, no
- * different font, no different spacing.
+ * `useRtl()` 是每个组件都会问的；`useDirectionSync()` 在根附近挂载一次
+ * 并给 <html> 打上 `dir`/`lang`。两者都只读取一个输入 —— 用户在设置中选择的
+ * 语言。不是 `navigator.language`，不是 OS，不是屏幕上的内容。未选择 RTL
+ * 语言的用户会得到 `dir="ltr"` 和 `useRtl() === false`，行为与阿拉伯语存在前
+ * 完全一致：没有方向翻转、没有镜像布局、没有不同字体、没有不同间距。
  *
- * That gate is the condition the whole Arabic UI ships under, so it is one
- * function rather than a `language === 'ar'` check scattered across a dozen
- * components — a scattered check is a check somebody eventually forgets to
- * write, and each miss is a layout change for an English user.
+ * 这个门控是整个阿拉伯语 UI 交付的条件，因此它只是一个函数，而不是一句
+ *  `language === 'ar'` 的检查散落在十几个组件中 —— 散落的检查是某人最终会
+ *  忘记写的那类，每个遗漏都是 English 用户的布局变更。
  *
- * `dir` on <html> rather than on a React wrapper because portalled UI (modals,
- * tooltips, the fullscreen terminal) mounts outside the React tree and would
- * otherwise keep the document's direction while the rest of the app mirrored.
+ * 在 <html> 上设置 `dir` 而非 React 包装器，是因为 portalled UI（模态框、
+ *  提示框、全屏终端）挂载在 React 树之外，否则会在其余应用镜像时保持文档的方向。
  */
 
-/** True only when the user has selected a right-to-left app language. */
+/** 仅当用户选择了 RTL 应用语言时为 true。 */
 export function useRtl(): boolean {
   const { i18n } = useTranslation();
   return isRtlLanguage(i18n.language);
 }
 
 /**
- * Keep <html dir> and <html lang> pointed at the selected language.
+ * 让 <html dir> 和 <html lang> 指向所选语言。
  *
- * Mounted once, near the root. Restores `dir="ltr"`/`lang="en"` on the way
- * back out of an RTL language, so switching Arabic → English mirrors the UI
- * back rather than stranding it.
+ * 在根附近挂载一次。从 RTL 语言退出时恢复 `dir="ltr"`/`lang="en"`，
+ * 使得阿拉伯语 → 英语切换时 UI 镜像回去而不是卡住它。
  */
 export function useDirectionSync(): void {
   const { i18n } = useTranslation();

--- a/src/renderer/src/i18n/useGodNameSync.ts
+++ b/src/renderer/src/i18n/useGodNameSync.ts
@@ -3,12 +3,11 @@ import { useStore } from '@/store/store';
 import { setGodName } from './index';
 
 /**
- * Keep i18n's `{{godName}}` pointed at the orchestrator's real name.
+ * 让 i18n 的 `{{godName}}` 指向编排器的真实名称。
  *
- * Mounted once, near the root. Reads the live agent (which is what a rename
- * updates) and pushes it into i18next's default variables, so every string that
- * mentions the orchestrator follows the rename immediately, in both locales,
- * without any of those call sites knowing the name.
+ * 在根附近挂载一次。读取实时 agent（重命名会更新的正是这个）并将其推入
+ * i18next 的默认变量，因此所有提到编排器的字符串都会立即跟随重命名，
+ * 两种语言下都生效，且这些调用点无需知道该名称。
  */
 export function useGodNameSync(): void {
   const name = useStore((s) => s.agents.find((a) => a.isGod)?.name);

--- a/src/renderer/src/ide/GitPanes.tsx
+++ b/src/renderer/src/ide/GitPanes.tsx
@@ -1,16 +1,16 @@
 /**
- * v0.3.4 git visualization — the HISTORY and COMPARE panes of the IDE's left
- * rail. Both operate at the repository's MAIN root (mainRepoRoot), so every
- * agent worktree branch appears in one graph. All git access stays in the main
- * process; these panes only render what the IPC returns.
+ * v0.3.4 git 可视化 —— IDE 左侧栏的 HISTORY 和 COMPARE pane。
+ * 两者都在仓库的 MAIN 根（mainRepoRoot）上操作，因此所有
+ * agent worktree 分支都出现在一张图中。所有 git 访问都在 main
+ * 进程中完成；这些 pane 只渲染 IPC 返回的内容。
  */
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CommitGraph } from '@/components/git/CommitGraph';
 import { Icon } from '@/components/Icon';
 
-// Local mirrors of the main-side git shapes (renderer-local by convention —
-// importing the preload module would drag electron into the bundle).
+// 与 main 侧 git 形状对应的渲染器本地镜像（按惯例渲染器本地 ——
+// 导入 preload 模块会将 electron 拖入 bundle）。
 interface GitCommitRow {
   sha: string; shortSha: string; parents: string[];
   subject: string; author: string; time: number; refs: string[];
@@ -58,7 +58,7 @@ function FileRow({ f, onClick }: { f: GitFileChange; onClick: () => void }) {
 
 export function HistoryPane({ gitRoot, onOpenRevDiff }: {
   gitRoot: string;
-  /** Open a Monaco diff of `path` between `revA` (parent/base) and `revB`. */
+  /** 打开 `path` 在 `revA`（父/基）和 `revB` 之间的 Monaco diff。 */
   onOpenRevDiff: (revA: string, revB: string, path: string, label: string) => void;
 }) {
   const { t } = useTranslation();

--- a/src/renderer/src/ide/IdePanel.tsx
+++ b/src/renderer/src/ide/IdePanel.tsx
@@ -11,7 +11,7 @@ import { HistoryPane, ComparePane } from './GitPanes';
 import { isImagePath, isSvgPath } from '@shared/imageTypes';
 import { ideBarStyle, ideIconBtn as iconBtn, ideTextBtn as textBtn } from './chrome';
 
-// v0.3.4 markdown preview: per-md-tab view mode, defaulted from the last choice.
+// v0.3.4 文本预览：每个 md 标签页独立的查看模式，默认取上次的选择。
 type MdView = 'code' | 'split' | 'preview';
 const LS_MD_VIEW = 'cth.ide.mdView';
 const isMarkdown = (rel: string) => /\.(md|markdown)$/i.test(rel);
@@ -23,7 +23,7 @@ function defaultMdView(): MdView {
   return 'split';
 }
 
-/** Remembers the git rail collapse across IDE opens and app restarts. */
+/** 记住 Git 侧栏在 IDE 打开与 App 重启之间的折叠状态。 */
 const GIT_RAIL_COLLAPSED_KEY = 'cth.ide.gitRailCollapsed';
 
 // ─── Local mirrors of the main-side git shapes (kept renderer-local like GitTab) ──
@@ -63,26 +63,25 @@ function statusColor(code: string): string {
   return 'var(--cth-ink-500)';
 }
 
-/** Which agent's workspace the IDE is showing, and how confidently we know it. */
+/** IDE 正在显示哪个 agent 的工作区，以及我们对它的确信程度。 */
 interface IdeTarget {
   agent: Agent | null;
   root: string | null;
-  /** True when NOBODY told us which agent this is and we had to guess. The
-   *  guess is usually right, but the title says so rather than asserting a name
-   *  it cannot stand behind. */
+  /** 当没有任何人告诉我们这是哪个 agent、而我们只能猜测时为 true。
+   *  猜测通常是对的，但标题如实说明，而不是断言一个它无法担保的名字。 */
   inferred: boolean;
 }
 
-/** Snapshot the IDE's target once at mount. The IDE is a full-window overlay, so
- *  the user can't switch agents while it's open — a stable target is correct.
+/** 在挂载时快照一次 IDE 的目标。IDE 是全窗口浮层，因此打开期间用户无法
+ *  切换 agent——一个稳定的目标是正确的。
  *
- *  Preference order, most-trustworthy first:
- *   1. `ideAgentId` — the opener said exactly who this is for.
- *   2. the current selection — right for anything opened off the sidebar.
- *   3. the god agent, then the first agent — last resorts so the IDE still
- *      opens on *something* browsable instead of an empty shell.
- *  Everything past (1) is marked `inferred`, because those paths are exactly the
- *  ones that can disagree with what the user was actually looking at. */
+ *  偏好顺序，最可信者优先：
+ *   1. `ideAgentId`——打开者明确说了这是为谁打开的。
+ *   2. 当前选中项——适合任何从侧边栏打开的内容。
+ *   3. god agent，然后是第一个 agent——兜底方案，让 IDE 仍能在*某个*
+ *      可浏览的东西上打开，而不是一个空壳。
+ *  (1) 之后的一切都标记为 `inferred`，因为这些路径正是可能
+ *  与用户实际在看的东西不一致的那些。 */
 function pickIdeTarget(): IdeTarget {
   const s = useStore.getState();
   const byId = (id: string | null): Agent | null => (id ? s.agents.find((a) => a.id === id) ?? null : null);
@@ -107,18 +106,16 @@ export function IdePanel() {
   const [isRepo, setIsRepo] = useState<boolean | null>(null);
   const [status, setStatus] = useState<GitStatusT | null>(null);
   const [treeWidth, setTreeWidth] = useState(300);
-  // v0.3.4 git visualization: which rail pane is showing, and the repo's MAIN
-  // root (a worktree's history/compare must run against the shared repo).
+  // v0.3.4 Git 可视化：当前显示哪个侧栏面板，以及仓库的 MAIN
+  // 根（worktree 的历史/对比必须针对共享仓库运行）。
   const [railTab, setRailTab] = useState<'changes' | 'history' | 'compare'>('changes');
-  // Git rail collapse. COLLAPSED BY DEFAULT: the history graph is tall by
-  // nature and most IDE opens are "read this file", not "inspect the repo" —
-  // starting expanded spent the top 45% of the left column on a pane nobody
-  // asked for and pushed the file tree below the fold.
+  // Git 侧栏折叠。默认折叠：历史图天然很高，而大多数 IDE 打开是「读这个文件」，
+  // 不是「检查仓库」——一开始就展开会把左侧栏顶部 45% 花在没人要的面板上，
+  // 并把文件树挤到折线以下。
   //
-  // The stored value is still honoured in BOTH directions, so a user who opens
-  // the rail keeps it open across restarts. Note the test is `!== '0'` rather
-  // than `=== '1'`: with no stored value at all we must land on collapsed, and
-  // `=== '1'` would have made "never set" mean expanded.
+  // 存储的值在「两个方向」上都被尊重，所以打开了侧栏的用户在重启后仍保持打开。
+  // 注意判断是 `!== '0'` 而不是 `=== '1'`：完全没有存储值时必须落在折叠态，
+  // 而 `=== '1'` 会让「从未设置」被当成展开。
   const [gitCollapsed, setGitCollapsed] = useState<boolean>(() => {
     try { return localStorage.getItem(GIT_RAIL_COLLAPSED_KEY) !== '0'; } catch { return true; }
   });
@@ -136,15 +133,15 @@ export function IdePanel() {
     void window.cth.gitMainRepo(root).then((r) => { if (alive) setGitRoot(r ?? root); });
     return () => { alive = false; };
   }, [root]);
-  // Per-markdown-tab view mode (code | split | preview); changing it also
-  // updates the sticky default for the next markdown file.
+  // 每个 markdown 标签页的查看模式（code | split | preview）；修改它也会
+  // 更新下一个 markdown 文件的固定默认值。
   const [mdViews, setMdViews] = useState<Record<string, MdView>>({});
   const setMdView = useCallback((rel: string, v: MdView) => {
     setMdViews((p) => ({ ...p, [rel]: v }));
     try { window.localStorage.setItem(LS_MD_VIEW, v); } catch { /* noop */ }
   }, []);
 
-  // Refs so window/editor handlers always see current values without rebinding.
+  // 使用 Refs 让 window/editor 处理器始终读到当前值，而无需重新绑定。
   const tabsRef = useRef(tabs); tabsRef.current = tabs;
   const activeKeyRef = useRef(activeKey); activeKeyRef.current = activeKey;
   const editBuffersRef = useRef(editBuffers); editBuffersRef.current = editBuffers;
@@ -152,7 +149,7 @@ export function IdePanel() {
 
   const activeTab = useMemo(() => tabs.find((t) => t.key === activeKey) ?? null, [tabs, activeKey]);
 
-  // ─── Buffer / diff loaders ────────────────────────────────────────────────
+  // ─── 缓冲区 / diff 加载器 ────────────────────────────────────────────────
   const ensureEdit = useCallback((rel: string) => {
     if (!root || editBuffersRef.current[rel]) return;
     setEditBuffers((p) => ({ ...p, [rel]: { content: '', original: '', status: 'loading', saveState: 'idle' } }));
@@ -173,7 +170,7 @@ export function IdePanel() {
     setDiffData((p) => ({ ...p, [rel]: { status: 'loading', head: '', working: '' } }));
     window.cth.gitDiff(root, rel).then((res) => {
       if (!('ok' in res) || res.ok !== true) {
-        const error = 'error' in res && typeof res.error === 'string' ? res.error : 'diff failed';
+        const error = 'error' in res && typeof res.error === 'string' ? res.error : '差异失败';
         setDiffData((p) => ({ ...p, [rel]: { status: 'error', head: '', working: '', error } }));
         return;
       }
@@ -186,29 +183,27 @@ export function IdePanel() {
     });
   }, [root]);
 
-  // ─── Tab actions ──────────────────────────────────────────────────────────
+  // ─── 标签页操作 ──────────────────────────────────────────────────────────
   const openTab = useCallback((mode: TabMode, rel: string) => {
     const key = tabKey(mode, rel);
     setTabs((prev) => (prev.some((t) => t.key === key) ? prev : [...prev, { key, rel, mode }]));
     setActiveKey(key);
   }, []);
 
-  /** Force a file into Monaco regardless of type — the "view source" escape
-   *  hatch behind the image preview. */
+  /** 无论类型如何都把文件强制塞进 Monaco —— 图片预览背后的「查看源码」逃生门。 */
   const openSource = useCallback((rel: string) => { ensureEdit(rel); openTab('edit', rel); }, [ensureEdit, openTab]);
 
-  /** The default open. Images go to the preview instead of Monaco: routing them
-   *  through `ensureEdit` is what produced the old "binary file (not
-   *  displayable)" tab, since the text reader rejects anything with a null byte.
-   *  SVG has no null bytes and so used to open as unhighlighted plaintext — it
-   *  is a picture first here too, with `view source` one click away. */
+  /** 默认打开方式。图片进入预览而非 Monaco：把图片走 `ensureEdit` 正是产生旧版
+   *  「二进制文件（无法显示）」标签的原因，因为文本读取器会拒绝任何含空字节的内容。
+   *  SVG 没有空字节，所以过去会以无高亮的纯文本打开——在这里它同样是先当作图片，
+   *  而「查看源码」只差一次点击。 */
   const openEdit = useCallback((rel: string) => {
     if (isImagePath(rel)) { openTab('image', rel); return; }
     openSource(rel);
   }, [openSource, openTab]);
 
-  // v0.3.4: rev-pinned diff tabs (per-commit files + branch compare). Both
-  // sides load through the metadata-guarded git:showFile IPC at the MAIN root.
+  // v0.3.4：rev 固定的 diff 标签页（单提交文件 + 分支对比）。两侧都经由
+  // MAIN 根上带元数据保护的 git:showFile IPC 加载。
   const openRevDiff = useCallback((revA: string, revB: string, rel: string, revLabel: string) => {
     const repo = gitRoot ?? root;
     if (!repo) return;
@@ -224,7 +219,7 @@ export function IdePanel() {
       window.cth.gitShowFile(repo, revB, rel)
     ]).then(([a, b]) => {
       if (!a.ok || !b.ok) {
-        const error = (!a.ok ? a.error : !b.ok ? (b as { error: string }).error : 'diff failed');
+        const error = (!a.ok ? a.error : !b.ok ? (b as { error: string }).error : '差异失败');
         setDiffData((p) => ({ ...p, [key]: { status: 'error', head: '', working: '', error } }));
         return;
       }
@@ -236,9 +231,9 @@ export function IdePanel() {
     });
   }, [gitRoot, root]);
 
-  // Entry point from elsewhere in the app ("open in IDE" on the file overlay):
-  // consume the queued absolute path once the root is known, open it (preview
-  // for markdown), then clear the queue slot so a later IDE open starts fresh.
+  // 来自 App 其他位置的入口（文件浮层上的「在 IDE 中打开」）：一旦知道 root
+  // 就消费排队的绝对路径，打开它（markdown 走预览），然后清空队列槽，
+  // 以便后续的 IDE 打开重新开始。
   useEffect(() => {
     if (!root) return;
     const abs = useStore.getState().ideInitialFile;
@@ -247,8 +242,8 @@ export function IdePanel() {
     const prefix = root.endsWith('/') ? root : `${root}/`;
     if (!abs.startsWith(prefix)) return; // different workspace — tree still lets them browse
     const rel = abs.slice(prefix.length);
-    // Same routing as a tree click — an "open in IDE" on a screenshot must land
-    // on the preview, not on a tab that refuses to display it.
+    // 与点击文件树相同的路由——对截图「在 IDE 中打开」必须落到预览上，
+    // 而不是落到一个拒绝显示它的标签页上。
     openEdit(rel);
     if (isMarkdown(rel)) setMdViews((p) => ({ ...p, [rel]: 'preview' }));
   }, [root, openEdit]);
@@ -271,9 +266,9 @@ export function IdePanel() {
     setEditBuffers((p) => ({ ...p, [rel]: { ...p[rel], saveState: 'saving' } }));
     const res = await window.cth.writeFile(root, rel, buf.content);
     if (res.ok) {
-      // original ← the exact snapshot written (buf.content captured at save-start), NOT p[rel].content:
-      // if the user typed during the in-flight write, those keystrokes stay in content and remain dirty
-      // (content !== original) so they're persisted on the next save instead of being silently dropped.
+      // original ← 写入时的精确快照（保存开始时捕获的 buf.content），而不是 p[rel].content：
+      // 如果用户在进行中的写入期间继续输入，那些按键会留在 content 中并保持 dirty
+      // （content !== original），从而在下一次保存时被持久化，而不会被静默丢弃。
       setEditBuffers((p) => ({ ...p, [rel]: { ...p[rel], original: buf.content, saveState: 'saved' } }));
       setTimeout(() => setEditBuffers((p) => (p[rel] ? { ...p, [rel]: { ...p[rel], saveState: 'idle' } } : p)), 1200);
       void refreshStatus();
@@ -283,7 +278,7 @@ export function IdePanel() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [root]);
 
-  // ─── Git status (changed files) ───────────────────────────────────────────
+  // ─── Git 状态（已变更文件）──────────────────────────────────────────
   const refreshStatus = useCallback(async () => {
     if (!root) { setIsRepo(false); return; }
     const repo = await window.cth.gitIsRepo(root);
@@ -314,7 +309,7 @@ export function IdePanel() {
   );
   const anyDirtyRef = useRef(anyDirty); anyDirtyRef.current = anyDirty;
 
-  // ─── Keyboard: Cmd/Ctrl+S saves active edit tab; Esc closes (if nothing dirty) ──
+  // ─── 键盘：Cmd/Ctrl+S 保存当前编辑标签页；Esc 关闭（若无未保存内容）──
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && (e.key === 's' || e.key === 'S')) {
@@ -328,7 +323,7 @@ export function IdePanel() {
     return () => window.removeEventListener('keydown', onKey);
   }, [save, setIdeOpen]);
 
-  // ─── Left splitter drag ───────────────────────────────────────────────────
+  // ─── 左侧分隔条拖拽 ───────────────────────────────────────────────────
   const startDrag = (e: React.MouseEvent) => {
     const startX = e.clientX; const startW = treeWidth;
     const onMove = (ev: MouseEvent) => setTreeWidth(Math.min(520, Math.max(200, startW + (ev.clientX - startX))));
@@ -347,8 +342,8 @@ export function IdePanel() {
     if (root) navigator.clipboard.writeText(rel ? `${root}/${rel}` : root).catch(() => { /* noop */ });
   };
 
-  // Image tabs highlight in the tree too — the tree's job is "what am I looking
-  // at", and an image is as much "open" as a text file is.
+  // 图片标签页同样在文件树中高亮——文件树的作用是「我正在看什么」，
+  // 而一张图片和文本文件一样是「打开」状态。
   const activeEditRel = activeTab && (activeTab.mode === 'edit' || activeTab.mode === 'image')
     ? activeTab.rel
     : undefined;
@@ -377,12 +372,10 @@ export function IdePanel() {
         }}>
           MUNDER DIFFLIN · IDE
         </span>
-        {/* WHOSE workspace this is. The folder name alone was ambiguous the
-            moment two agents shared a repo (worktrees named for the branch, not
-            the agent) or an agent worked in a generically-named directory —
-            "src" tells you nothing about which of eight agents you are editing
-            under. Name first, directory second: the name is the identity, the
-            path is the detail. */}
+        {/* 这是谁的工作区。两个 agent 共享一个仓库（worktree 以分支而非 agent 命名）
+            或某个 agent 在一个通用命名的目录里工作时，单凭文件夹名就变得含糊——
+            「src」完全无法告诉你此刻在哪个 agent（八个之一）底下编辑。
+            名字在前、目录在后：名字是身份，路径只是细节。 */}
         {target.agent ? (
           <span style={{ display: 'inline-flex', alignItems: 'baseline', gap: 6, minWidth: 0 }}>
             <span
@@ -399,11 +392,11 @@ export function IdePanel() {
               <span style={{
                 fontFamily: 'var(--cth-font-display)', fontSize: 7, padding: '1px 3px',
                 background: 'var(--cth-lilac-light)', color: 'var(--cth-ink-900)'
-              }}>god</span>
+              }}>{t('idePanel.god')}</span>
             )}
             {target.inferred && (
-              // Never assert a name we had to guess at. One quiet word is enough
-              // to stop someone trusting the wrong agent's directory.
+              // 绝不武断断言一个我们只能猜测的名字。一个不起眼的词就足以
+              // 阻止别人误信了错误 agent 的目录。
               <span style={{ fontFamily: 'var(--cth-font-ui)', fontSize: 11, color: 'var(--cth-ink-500)' }}>
                 ({t('idePanel.assumed')})
               </span>
@@ -444,7 +437,7 @@ export function IdePanel() {
           flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
           textAlign: 'center', color: 'var(--cth-ink-500)', fontFamily: 'var(--cth-font-ui)', fontSize: 16
         }}>
-          No workspace available.<br />Spawn an agent first — the IDE opens on its working directory.
+          {t('idePanel.noWorkspace')}<br />{t('idePanel.spawnFirst')}
         </div>
       ) : (
         <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
@@ -454,8 +447,8 @@ export function IdePanel() {
             display: 'flex', flexDirection: 'column',
             borderRight: '1px solid var(--cth-ink-700)', background: 'var(--cth-cream-50)'
           }}>
-            {/* Git rail: CHANGES · HISTORY · COMPARE (v0.3.4). History/compare
-                run at the repo's MAIN root so worktree branches all appear. */}
+            {/* Git 侧栏：CHANGES · HISTORY · COMPARE（v0.3.4）。历史/对比
+                针对仓库的 MAIN 根运行，这样 worktree 的所有分支都会出现。 */}
             <div style={{
               flexShrink: 0, display: 'flex', gap: 2, padding: '6px 10px 4px',
               background: 'var(--cth-cream-50)', borderBottom: '1px solid var(--cth-ink-100)'
@@ -467,13 +460,10 @@ export function IdePanel() {
                 aria-expanded={!gitCollapsed}
                 style={{
                   ...iconBtn,
-                  // Mark + caret in ONE control rather than a decorative logo
-                  // beside a separate toggle: a git mark that does nothing when
-                  // clicked is a dead spot exactly where the eye lands first.
-                  // The mark names the section (it is collapsed by default, so
-                  // the tab labels are the only other clue), the caret says it
-                  // folds, and together they are a bigger hit target than the
-                  // caret alone was.
+                  // 把标记 + 箭头放进「一个」控件，而不是装饰性 logo 旁再放一个
+                  // 独立开关：一个点击毫无反应的 git 标记，正是目光最先落下的死区。
+                  // 标记指明该分区（它默认折叠，所以标签文字是唯一线索），箭头表示
+                  // 可折叠，两者合起来比单独的箭头拥有更大的点击目标。
                   display: 'flex', alignItems: 'center', gap: 3, width: 'auto', padding: '0 3px',
                   fontFamily: 'var(--cth-font-mono)', fontSize: 10, lineHeight: '14px',
                   color: 'var(--cth-ink-700)'
@@ -485,8 +475,8 @@ export function IdePanel() {
               {(['changes', 'history', 'compare'] as const).map((k) => (
                 <button
                   key={k}
-                  // Picking a tab while collapsed means "show me this" — expanding
-                  // is the only reading of that click that isn't a dead end.
+                  // 折叠时点某个标签意味着「给我看这个」——展开是那次点击
+                  // 唯一不算死路的解读。
                   onClick={() => { setRailTab(k); if (gitCollapsed) toggleGitRail(); }}
                   style={{
                     padding: '1px 8px', border: 'none', cursor: 'pointer',
@@ -506,11 +496,10 @@ export function IdePanel() {
             </div>
             {railTab === 'changes' && !gitCollapsed && (
             <div style={{ flexShrink: 0, maxHeight: '45%', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-              {/* `flex: 1` is what makes this scroll. Without it the scroller's
-                  height is its CONTENT height (flex-basis auto), so it grew past
-                  the parent's maxHeight and simply overflowed instead of ever
-                  reaching its own scroll threshold — a long changed-file list ran
-                  off the bottom with no way to reach the end. */}
+              {/* `flex: 1` 才让它能滚动。没有它时滚动器的高度等于其内容高度
+                  （flex-basis auto），于是它超出父级 maxHeight 直接溢出，
+                  永远达不到自己的滚动阈值——一长串变更文件列表在底部被截断，
+                  没有任何办法滚到末尾。 */}
               <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
                 {isRepo === false && (
                   <div style={{ padding: '6px 12px', fontSize: 12, color: 'var(--cth-ink-500)' }}>{t('gitTab.notARepo')}</div>
@@ -623,9 +612,9 @@ export function IdePanel() {
                   <div style={{
                     fontFamily: 'var(--cth-font-display)', fontSize: 8, textTransform: 'uppercase',
                     letterSpacing: 1, color: 'var(--cth-ink-700)'
-                  }}>nothing open</div>
+                  }}>{t('idePanel.nothingOpen')}</div>
                   <div style={{ fontFamily: 'var(--cth-font-ui)', fontSize: 13 }}>
-                    Pick a file from the tree to edit, or a changed file to diff.
+                    {t('idePanel.pickFileToEdit')}
                   </div>
                   <ShortcutHint />
                 </div>
@@ -633,8 +622,8 @@ export function IdePanel() {
 
               {activeTab?.mode === 'image' && root && (
                 <ImagePreview
-                  // Keyed by path so switching image tabs tears the previous
-                  // preview down — that unmount is what revokes its blob URL.
+                  // 以路径为 key，这样切换图片标签会拆除上一个预览——
+                  // 正是那次卸载撤销了它的 blob URL。
                   key={activeTab.key}
                   root={root}
                   rel={activeTab.rel}
@@ -659,7 +648,7 @@ export function IdePanel() {
                       onCopy={() => copyAbs(activeTab.rel)}
                       mdView={md ? view : undefined}
                       onMdView={md ? (v) => setMdView(activeTab.rel, v) : undefined}
-                      // The return leg of the SVG round trip: source ⇄ picture.
+                      // SVG 往返的返回段：源码 ⇄ 图片。
                       onViewImage={isImagePath(activeTab.rel) ? () => openTab('image', activeTab.rel) : undefined}
                     />
                     <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
@@ -769,9 +758,9 @@ function SectionHeader({ title, right }: { title: string; right?: React.ReactNod
 
 function EditorBar({ rel, dirty, saveState, onSave, onCopy, mdView, onMdView, onViewImage }: {
   rel: string; dirty: boolean; saveState: EditBuffer['saveState']; onSave: () => void; onCopy: () => void;
-  /** Set only for markdown files — renders the code|split|preview switch. */
+  /** 仅对 markdown 文件设置——渲染 code|split|preview 切换开关。 */
   mdView?: MdView; onMdView?: (v: MdView) => void;
-  /** Set only for files that are ALSO images (SVG) — jumps back to the picture. */
+  /** 仅对同时也是图片的文件（SVG）设置——跳回图片视图。 */
   onViewImage?: () => void;
 }) {
   const { t } = useTranslation();
@@ -809,9 +798,8 @@ function EditorBar({ rel, dirty, saveState, onSave, onCopy, mdView, onMdView, on
   );
 }
 
-/** Markdown preview pane — renders the LIVE edit buffer (deferred so fast typing
- *  never blocks the editor). In split view it takes the right half behind a
- *  hairline divider; in preview view it fills the body. */
+/** Markdown 预览面板——渲染「实时」编辑缓冲（延迟处理，快速输入永不阻塞编辑器）。
+ *  分屏视图里它占据细分割线后的右半部分；预览视图里它填满主体。 */
 function MdPane({ rel, root, source, split, onOpenMarkdownLink }: {
   rel: string; root: string; source: string; split: boolean; onOpenMarkdownLink: (rel: string) => void;
 }) {
@@ -822,26 +810,22 @@ function MdPane({ rel, root, source, split, onOpenMarkdownLink }: {
       background: 'var(--cth-paper-100)',
       borderLeft: split ? '1px solid var(--cth-ink-100)' : 'none'
     }}>
-      {/* `root` is what lets a report's screenshots render inline instead of
-          collapsing to placeholder chips. */}
+      {/* `root` 正是让报告里的截图能内联渲染、而不是塌缩成占位小片的原因。 */}
       <MarkdownPreview source={deferred} baseRel={rel} root={root} onOpenMarkdownLink={onOpenMarkdownLink} />
     </div>
   );
 }
 
 /**
- * The IDE's empty state doubles as the only place these capabilities are
- * advertised.
+ * IDE 的空状态兼作这些能力的唯一宣传位。
  *
- * Monaco ships find/replace, a command palette and go-to-line/symbol, all of
- * which have worked here since the editor landed — and essentially nobody knew,
- * because the panel never mentioned them and there is no menu bar to discover
- * them from. People asked for "search in the IDE" while ⌘F was already bound.
- * (Repo-wide search is genuinely absent; this hint deliberately promises only
- * what exists.)
+ * Monaco 自带查找/替换、命令面板和跳转到行/符号，这些自编辑器落地起就能用——
+ * 但几乎没人知道，因为面板从未提过它们，也没有菜单栏可供发现。
+ * 用户一边问「在 IDE 里搜索」，一边 ⌘F 早已绑定。（仓库级搜索确实没有；
+ * 这个提示刻意只承诺真实存在的东西。）
  *
- * Kept as a muted list under the empty state rather than a banner: it is the one
- * moment the pane has nothing to say, and it must not compete with an open file.
+ * 以空状态下的低调列表而非横幅呈现：这是面板唯一无话可说的时刻，
+ * 它不能和打开的文件抢注意力。
  */
 function ShortcutHint() {
   return (
@@ -859,25 +843,25 @@ function ShortcutHint() {
   );
 }
 
-/** Electron reports the host platform in the UA; there is no platform helper in
- *  the renderer, and printing ⌘ to a Linux user would be worse than useless. */
+/** Electron 在 UA 里报告宿主平台；renderer 中没有平台辅助函数，
+ *  给 Linux 用户印出 ⌘ 会比毫无用处更糟。 */
 const IS_MAC = typeof navigator !== 'undefined' && /mac/i.test(navigator.userAgent);
 
-/** Monaco's own default bindings — do not invent entries here. */
+/** Monaco 自身的默认快捷键——不要在这里编造条目。 */
 const EDITOR_SHORTCUTS: ReadonlyArray<readonly [string, string]> = IS_MAC
   ? [
-      ['⌘F', 'find in file'],
-      ['⌥⌘F', 'replace'],
-      ['F1', 'command palette'],
-      ['⌃G', 'go to line'],
-      ['⇧⌘O', 'go to symbol']
+      ['⌘F', '在文件中查找'],
+      ['⌥⌘F', '替换'],
+      ['F1', '命令面板'],
+      ['⌃G', '转到行'],
+      ['⇧⌘O', '转到符号']
     ]
   : [
-      ['Ctrl+F', 'find in file'],
-      ['Ctrl+H', 'replace'],
-      ['F1', 'command palette'],
-      ['Ctrl+G', 'go to line'],
-      ['Ctrl+Shift+O', 'go to symbol']
+      ['Ctrl+F', '在文件中查找'],
+      ['Ctrl+H', '替换'],
+      ['F1', '命令面板'],
+      ['Ctrl+G', '转到行'],
+      ['Ctrl+Shift+O', '转到符号']
     ];
 
 function Centered({ children, tone }: { children: React.ReactNode; tone?: 'error' }) {

--- a/src/renderer/src/ide/ImagePreview.tsx
+++ b/src/renderer/src/ide/ImagePreview.tsx
@@ -1,18 +1,17 @@
 /**
- * Image tab body for the IDE.
+ * IDE 的图片标签页主体。
  *
- * Replaces the dead end this app used to have: opening a .png in the IDE created
- * a tab whose entire content was the red text "binary file (not displayable)",
- * because the only file reader available refused anything with a null byte. That
- * made screenshots — the single most common non-text artefact an agent writes —
- * invisible inside the product that produced them.
+ * 取代了这个 App 过去存在的死胡同：在 IDE 中打开 .png 会创建一个标签，
+ * 其全部内容只是红字「binary file (not displayable)」，因为唯一可用的
+ * 文件读取器拒绝任何含空字节的内容。这使截图——agent 写出的最常见的
+ * 非文本产物——在产生它的产品内部反而不可见。
  *
- * The bytes arrive over IPC and are held as a `blob:` URL by useWorkspaceImage,
- * which owns revocation (see the note there: blob URLs outlive the elements that
- * reference them, and IDE tabs open and close all day).
+ * 字节经 IPC 到达，并由 useWorkspaceImage 以 `blob:` URL 持有，
+ * 后者负责撤销（见那里的说明：blob URL 比引用它的元素活得久，
+ * 而 IDE 标签整天开开关关）。
  *
- * The bar deliberately mirrors the editor's bar minus Save — nothing here is
- * editable — so the tab strip reads as one surface rather than two.
+ * 工具条刻意镜像编辑器工具条并去掉保存——这里没有任何可编辑内容——
+ * 这样标签条读起来像一个整体而不是两个。
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,23 +21,22 @@ import { formatBytes, isSvgPath } from '@shared/imageTypes';
 import { ideBarStyle, ideTextBtn } from './chrome';
 
 export interface ImagePreviewProps {
-  /** Absolute workspace root the path is confined to. */
+  /** 路径被限制在其中的绝对工作区根。 */
   root: string;
-  /** Workspace-relative path of the image. */
+  /** 图片相对于工作区的路径。 */
   rel: string;
-  /** Copy the absolute path (same affordance as the editor bar). */
+  /** 复制绝对路径（与编辑器栏相同的交互方式）。 */
   onCopyPath: () => void;
-  /** Open this file in Monaco instead. Present for SVG, whose source is
-   *  hand-edited often enough that a read-only preview would be a regression. */
+  /** 改为在 Monaco 中打开该文件。针对 SVG 提供，其源码常被手改，
+   *  只读预览反而是一种退化。 */
   onViewSource?: () => void;
 }
 
 export function ImagePreview({ root, rel, onCopyPath, onViewSource }: ImagePreviewProps) {
   const { t } = useTranslation();
   const img = useWorkspaceImage(root, rel);
-  // Fit is the default because the common case is a full-screen screenshot that
-  // is far wider than the pane; showing it at 1:1 first would open every tab
-  // scrolled into the top-left corner of a picture nobody can see the shape of.
+  // 默认「适应窗口」，因为常见场景是比面板宽得多的全屏截图；
+  // 先以 1:1 显示会让每个标签页都滚动到一张看不出全貌的图片左上角。
   const [fit, setFit] = useState(true);
   const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
   const [decodeFailed, setDecodeFailed] = useState(false);
@@ -52,9 +50,8 @@ export function ImagePreview({ root, rel, onCopyPath, onViewSource }: ImagePrevi
           title={rel}
         >{rel}</span>
 
-        {/* Facts about the file, in the same muted register as the diff bar's
-            HEAD → working tree label. Dimensions only exist once the image has
-            actually decoded, so this stays honest about what is known. */}
+        {/* 关于文件的事实，与 diff 栏「HEAD → 工作区」标签同样克制的风格。
+            尺寸只在图片真正解码后才存在，因此这里如实反映已知信息。 */}
         <span style={{ fontFamily: 'var(--cth-font-mono)', fontSize: 11, color: 'var(--cth-ink-500)', whiteSpace: 'nowrap' }}>
           {dims ? `${dims.w}×${dims.h}` : '—'}
           {img.status === 'ready' ? ` · ${formatBytes(img.size)}` : ''}
@@ -80,18 +77,17 @@ export function ImagePreview({ root, rel, onCopyPath, onViewSource }: ImagePrevi
             {t('imagePreview.viewSource')}
           </button>
         )}
-        <button onClick={onCopyPath} title="Copy absolute path" style={ideTextBtn}>copy path</button>
+        <button onClick={onCopyPath} title={t('imagePreview.copyAbsolutePath')} style={ideTextBtn}>{t('imagePreview.copyPath')}</button>
       </div>
 
       <div style={{
         flex: 1, minHeight: 0, overflow: 'auto',
         display: 'flex', alignItems: fit ? 'center' : 'flex-start', justifyContent: fit ? 'center' : 'flex-start',
         padding: 16,
-        // A checkerboard, not a flat fill: transparent PNGs are everywhere in
-        // agent output (icons, cropped screenshots) and on a plain background a
-        // transparent region is indistinguishable from a white or black one.
-        // Both tones are tokens, so the board inverts with the theme instead of
-        // glowing white in dark mode.
+        // 用棋盘格而非纯色填充：透明 PNG 在 agent 输出中随处可见（图标、裁剪的截图），
+        // 而在纯色背景上，透明区域与白色或黑色无法区分。
+        // 两种色调都是 token，因此棋盘会随主题反色，
+        // 而不是在深色模式下泛着刺眼的白。
         backgroundColor: 'var(--cth-paper-100)',
         backgroundImage: `
           linear-gradient(45deg, var(--cth-cream-200) 25%, transparent 25%),
@@ -115,13 +111,11 @@ export function ImagePreview({ root, rel, onCopyPath, onViewSource }: ImagePrevi
             onLoad={(e) => setDims({ w: e.currentTarget.naturalWidth, h: e.currentTarget.naturalHeight })}
             onError={() => setDecodeFailed(true)}
             style={fit
-              // `maxWidth/maxHeight: 100%` only shrinks — a 32px favicon is not
-              // blown up into a blurry poster, it just sits there at 32px.
+              // `maxWidth/maxHeight: 100%` 只会缩小——32px 的 favicon 不会
+              // 被放大成模糊的海报，它只是以 32px 静静待在原地。
               ? { maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }
-              // 1:1 must NOT be allowed to shrink: it is inside a flex row, and
-              // flex's default `min-width: auto` would squeeze the image back
-              // down to the pane — which is precisely the state the user just
-              // clicked away from.
+              // 1:1 绝不能被允许缩小：它位于 flex 行内，而 flex 默认的
+              // `min-width: auto` 会把图片重新压缩回面板——这正是用户刚点走的那个状态。
               : { flexShrink: 0 }}
           />
         )}

--- a/src/renderer/src/ide/MonacoDiff.tsx
+++ b/src/renderer/src/ide/MonacoDiff.tsx
@@ -4,16 +4,16 @@ import { setupMonaco, CTH_MONACO_THEME, languageForPath } from './monaco';
 setupMonaco();
 
 export interface MonacoDiffProps {
-  /** File path — drives syntax language only. */
+  /** 文件路径 —— 仅驱动语法高亮语言。 */
   path: string;
-  /** Left side (committed HEAD content). */
+  /** 左侧（已提交的 HEAD 内容）。 */
   original: string;
-  /** Right side (current working-tree content). */
+  /** 右侧（当前工作树内容）。 */
   modified: string;
 }
 
-/** Read-only side-by-side diff (working tree vs HEAD) backed by Monaco's
- *  built-in DiffEditor — the same dependency as the editor, no extra view layer. */
+/** 只读并排 diff（工作树 vs HEAD），由 Monaco 内置的
+ *  DiffEditor 驱动 —— 与编辑器相同的依赖，无额外视图层。 */
 export function MonacoDiff({ path, original, modified }: MonacoDiffProps) {
   return (
     <DiffEditor

--- a/src/renderer/src/ide/MonacoEditor.tsx
+++ b/src/renderer/src/ide/MonacoEditor.tsx
@@ -2,23 +2,23 @@ import { useRef } from 'react';
 import Editor, { type OnMount } from '@monaco-editor/react';
 import { setupMonaco, CTH_MONACO_THEME, languageForPath } from './monaco';
 
-// Pin @monaco-editor/react to the bundled monaco + register themes at module load,
-// before any <Editor/> mounts (avoids a CDN fetch / unthemed first paint).
+// 将 @monaco-editor/react 固定到打包的 monaco + 在模块加载时注册主题，
+// 在任何 <Editor/> 挂载之前（避免 CDN 获取 / 无主题的首次绘制）。
 setupMonaco();
 
 export interface MonacoEditorProps {
-  /** File path — drives syntax language only. */
+  /** 文件路径 —— 仅驱动语法高亮语言。 */
   path: string;
   value: string;
   onChange: (value: string) => void;
-  /** Invoked on Cmd/Ctrl+S while the editor has focus. */
+  /** 编辑器获得焦点时 Cmd/Ctrl+S 触发。 */
   onSave?: () => void;
   readOnly?: boolean;
 }
 
 export function MonacoEditor({ path, value, onChange, onSave, readOnly }: MonacoEditorProps) {
-  // Keep the latest onSave in a ref so the editor command (bound once at mount)
-  // always calls the current handler without rebinding.
+  // 在 ref 中保存最新的 onSave，使得编辑器命令（挂载时绑定一次）
+  // 始终调用当前处理器而无需重新绑定。
   const onSaveRef = useRef(onSave);
   onSaveRef.current = onSave;
 

--- a/src/renderer/src/ide/chrome.ts
+++ b/src/renderer/src/ide/chrome.ts
@@ -1,34 +1,33 @@
 /**
- * The IDE's shared bar chrome.
+ * IDE 共享的栏 chrome。
  *
- * These three style objects were previously private to IdePanel, which was fine
- * while IdePanel rendered every pane itself. The image preview renders its own
- * bar, and a second copy of "padding 3px 8px, cream-200, ink-700 hairline" would
- * drift the moment either file was touched — the two bars sit directly on top of
- * each other in the same tab strip, so any drift is immediately visible. One
- * definition, imported by both.
+ * 这三个样式对象之前是 IdePanel 私有的，这没问题
+ * 因为 IdePanel 自己渲染每个 pane。图片预览渲染自己的
+ * 栏，而第二份 "padding 3px 8px、cream-200、ink-700 细线" 会在
+ * 任一文件被改动时立即产生偏差 —— 两个栏在同一个标签页栏中
+ * 直接叠在一起，任何偏差都立即可见。一个定义，两者共用。
  *
- * Every colour is a token, never a literal: the app ships a light AND a dark
- * theme that swap by redefining these variables, so a hardcoded hex here would
- * look correct in exactly one of them.
+ * 每个颜色都是 token，绝非字面量：应用同时提供浅色和深色
+ * 主题，通过重新定义这些变量来切换，因此此处的硬编码 hex
+ * 只在其中一个主题下看起来正确。
  */
 import type { CSSProperties } from 'react';
 
-/** The horizontal bar above an editor / preview body. */
+/** 编辑器 / 预览主体上方的水平栏。 */
 export const ideBarStyle: CSSProperties = {
   display: 'flex', alignItems: 'center', gap: 6, padding: '3px 8px',
   background: 'var(--cth-cream-200)', borderBottom: '1px solid var(--cth-ink-700)',
   fontFamily: 'var(--cth-font-ui)', fontSize: 12, color: 'var(--cth-ink-700)'
 };
 
-/** Square, borderless button that holds only an icon. */
+/** 方形、无边框、仅含图标的按钮。 */
 export const ideIconBtn: CSSProperties = {
   display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
   padding: 0, width: 18, height: 18, background: 'transparent', border: 'none',
   cursor: 'pointer', color: 'var(--cth-ink-500)'
 };
 
-/** Small labelled button used for bar actions (save, copy path, view toggles). */
+/** 带标签的小按钮，用于栏操作（保存、复制路径、视图切换）。 */
 export const ideTextBtn: CSSProperties = {
   padding: '0 6px', height: 20, fontFamily: 'var(--cth-font-ui)', fontSize: 12,
   color: 'var(--cth-ink-900)', background: 'var(--cth-cream-100)', border: 'none',

--- a/src/renderer/src/ide/monaco.ts
+++ b/src/renderer/src/ide/monaco.ts
@@ -1,21 +1,21 @@
 /**
- * Monaco bootstrap for the Electron renderer (electron-vite / Vite).
+ * Electron 渲染器的 Monaco 初始化（electron-vite / Vite）。
  *
- * Two things have to be true for Monaco to work in a bundled Electron app:
+ * 要让 Monaco 在打包的 Electron 应用中工作，必须满足两件事：
  *
- *  1. Workers must be SELF-HOSTED, not fetched from a CDN. We import each
- *     language worker through Vite's `?worker` suffix, which emits a real
- *     bundled worker chunk and a constructor. `MonacoEnvironment.getWorker`
- *     hands Monaco the right one per language. This is the electron-vite-safe
- *     equivalent of the classic `getWorkerUrl` CDN dance — it works offline and
- *     inside the packaged `app.asar` because the worker URL is resolved by Vite
- *     at build time (relative `base: './'`).
+ *  1. Worker 必须是自托管的，不能从 CDN 获取。我们通过 Vite 的
+ *     `?worker` 后缀导入每种语言 worker，它生成一个真实的
+ *     打包 worker chunk 和构造函数。`MonacoEnvironment.getWorker`
+ *     为每种语言向 Monaco 提供对应的 worker。这是 electron-vite 安全的
+ *     经典 `getWorkerUrl` CDN 方案等价物 —— 离线可用，且在
+ *     打包的 `app.asar` 内部也能工作，因为 worker URL 在构建时由 Vite 解析
+ *     （相对 `base: './'`）。
  *
- *  2. `@monaco-editor/react` must use THIS bundled `monaco` instance rather than
- *     its default behaviour of lazy-loading monaco from a CDN via AMD. We pin it
- *     with `loader.config({ monaco })`.
+ *  2. `@monaco-editor/react` 必须使用这个打包的 `monaco` 实例，而不是
+ *     它默认通过 AMD 从 CDN 懒加载 monaco 的行为。我们用
+ *     `loader.config({ monaco })` 将其固定。
  *
- * Import this module once (for its side effects) before any editor mounts.
+ * 在任何 editor 挂载之前，只导入此模块一次（利用其副作用）。
  */
 import * as monaco from 'monaco-editor';
 import { loader } from '@monaco-editor/react';
@@ -51,7 +51,7 @@ import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 
 let themesDefined = false;
 
-/** Register the CTH light/dark Monaco themes (idempotent). */
+/** 注册 CTH 浅色/深色 Monaco 主题（幂等）。 */
 function defineThemes(m: typeof monaco): void {
   if (themesDefined) return;
   themesDefined = true;
@@ -90,7 +90,7 @@ function defineThemes(m: typeof monaco): void {
 
 let configured = false;
 
-/** Pin @monaco-editor/react to the bundled monaco + register themes. Idempotent. */
+/** 将 @monaco-editor/react 固定到打包的 monaco + 注册主题。幂等。 */
 export function setupMonaco(): typeof monaco {
   if (!configured) {
     configured = true;
@@ -102,7 +102,7 @@ export function setupMonaco(): typeof monaco {
 
 export const CTH_MONACO_THEME = 'cth-light';
 
-/** Map a filename to a Monaco language id (used to set the model language). */
+/** 将文件名映射为 Monaco language id（用于设置模型语言）。 */
 export function languageForPath(path: string): string {
   const name = path.split(/[\\/]/).pop() ?? path;
   const ext = name.includes('.') ? name.split('.').pop()!.toLowerCase() : '';

--- a/src/renderer/src/integrations/registryClient.ts
+++ b/src/renderer/src/integrations/registryClient.ts
@@ -1,26 +1,25 @@
-// Integrations registry client — the renderer's single doorway to the
-// integrations registry + secret broker.
+// 集成注册表客户端 —— 渲染器的集成注册表 + 密钥代理的唯一入口。
 //
-// CONFORMED to Jim's spec v1 (hive/docs/integrations-spec.md): the types are the
-// CANONICAL ones from `@shared/integrations` (Jim's src/shared/integrations.ts),
-// and the client maps 1:1 to the §6 IPC surface — whose handlers already exist in
-// src/main/index.ts (integrations:list / templates / upsert / setSecret / remove /
-// test). The real path calls window.cth.* (Jim's preload bridge).
+// 遵循 Jim 的 spec v1（hive/docs/integrations-spec.md）：类型来自
+// `@shared/integrations`（Jim 的 src/shared/integrations.ts）的规范定义，
+// 客户端与 §6 IPC 接口 1:1 映射 —— 其处理器已存在于
+// src/main/index.ts（integrations:list / templates / upsert / setSecret / remove /
+// test）。真实路径调用 window.cth.*（Jim 的 preload bridge）。
 //
-// ⚠️ The preload bridge is NOT landed yet (Jim owns it — god relays when it's in).
-// Until then this falls back to an in-memory mock so the UI is fully usable in dev.
-// The real path is FEATURE-DETECTED: the moment Jim's preload methods appear it
-// activates with NO change here. Two coordination notes:
-//   1. The bridge method NAMES below (integrationsList, …) follow the existing
-//      preload camelCase→colon-channel convention (getConfig→'config:get', etc.).
-//      Jim: expose exactly these (or tell me the names) so the detect matches.
-//   2. The catalog served by `integrations:templates` is Jim's `INTEGRATION_TEMPLATES`
-//      (the 2 v1 reference templates). Dwight's richer src/shared/integrationTemplates.ts
-//      is a SEPARATE, currently-unwired file — reconciliation is a god/Jim/Dwight call.
+// ⚠️ preload bridge 尚未落地（Jim 负责 —— god 会在落地后通知）。
+// 在此之前回退到内存 mock，使 UI 在 dev 下完全可用。
+// 真实路径是 FEATURE-DETECTED 的：Jim 的 preload 方法出现的瞬间即激活，
+// 此处无需改动。两个协调要点：
+//   1. 下面的桥接方法名称（integrationsList、…）遵循现有
+//      preload camelCase→冒号通道约定（getConfig→'config:get' 等）。
+//      Jim：暴露这些（或告诉我名称）以便检测匹配。
+//   2. `integrations:templates` 提供的是 Jim 的 `INTEGRATION_TEMPLATES`
+//      （2 个 v1 参考模板）。Dwight 的 src/shared/integrationTemplates.ts
+//      是独立的、尚未接线的文件 —— 协调是 god/Jim/Dwight 的工作。
 //
-// SECURITY INVARIANT (matches §2): a secret value flows ONE WAY — from the form
-// into save()'s setSecret call and onward to the encrypted store. It is NEVER read
-// back. list() returns records with secretRef redacted to hasSecret:boolean.
+// 安全不变式（匹配 §2）：密钥值单向流动 —— 从表单
+// 进入 save() 的 setSecret 调用并继续到加密存储。绝不回读。
+// list() 返回的记录中 secretRef 被脱敏为 hasSecret:boolean。
 
 import {
   INTEGRATION_TEMPLATES,
@@ -34,11 +33,11 @@ import {
 export type { IntegrationRecord, IntegrationTemplate } from '@shared/integrations';
 export type { IntegrationKind, IntegrationAuthType } from '@shared/integrations';
 
-/** The renderer-visible record: secretRef is redacted to a presence boolean.
- *  Matches main `integrations.listRecordsRedacted()`. */
+/** 渲染器可见的记录：secretRef 被脱敏为存在性布尔值。
+ *  匹配 main 侧的 `integrations.listRecordsRedacted()`。 */
 export type IntegrationRecordView = Omit<IntegrationRecord, 'secretRef'> & { hasSecret: boolean };
 
-/** Result of a §6 `integrations:test` probe. */
+/** §6 `integrations:test` 探测的结果。 */
 export interface TestResult {
   ok: boolean;
   status?: number;
@@ -50,14 +49,14 @@ type UpsertResult = { ok: true; record: IntegrationRecord } | { ok: false; error
 export interface IntegrationsClient {
   listTemplates(): Promise<IntegrationTemplate[]>;
   list(): Promise<IntegrationRecordView[]>;
-  /** §6 upsert (metadata, no secret) + §6 setSecret when a new secret was typed. */
+  /** §6 upsert（元数据，无密钥）+ §6 setSecret（当用户输入了新密钥时）。 */
   save(record: IntegrationRecord, secret?: string): Promise<{ ok: boolean; error?: string }>;
   remove(id: string): Promise<{ ok: boolean }>;
   test(id: string): Promise<TestResult>;
 }
 
-// The preload bridge Jim exposes (Deliverable 2). Channels are fixed by §6;
-// accessed via a tolerant cast so this compiles before the bridge exists.
+// Jim 暴露的 preload bridge（Deliverable 2）。通道由 §6 固定；
+// 通过宽容类型转换来访问，以便 bridge 不存在时也能编译。
 interface IntegrationsBridge {
   integrationsList(): Promise<IntegrationRecordView[]>;
   integrationsTemplates(): Promise<IntegrationTemplate[]>;
@@ -73,12 +72,12 @@ function liveBridge(): IntegrationsBridge | undefined {
   return b && typeof b.integrationsList === 'function' ? (b as IntegrationsBridge) : undefined;
 }
 
-// ───────────────────────── PROVISIONAL mock (dev fallback only) ─────────────────────────
-// Serves Jim's canonical INTEGRATION_TEMPLATES and validates upserts with Jim's
-// real validateIntegrationRecord, so the mock behaves like the wired backend.
+// ───────────────────────── 临时 mock（仅 dev 回退）────────────────────────
+// 提供 Jim 的规范 INTEGRATION_TEMPLATES 并用 Jim 的真实
+// validateIntegrationRecord 验证 upsert，使 mock 行为与有线后端一致。
 
 let mockRecords: IntegrationRecord[] = [];
-const mockSecret = new Set<string>(); // secretRef membership only — never values
+const mockSecret = new Set<string>(); // 仅 secretRef 成员 —— 不含实际值
 
 function redact(r: IntegrationRecord): IntegrationRecordView {
   const { secretRef, ...rest } = r;
@@ -107,16 +106,16 @@ const mockClient: IntegrationsClient = {
   },
   test: (id) => {
     const r = mockRecords.find((x) => x.id === id);
-    if (!r) return Promise.resolve({ ok: false, error: 'unknown integration' });
-    if (!r.enabled) return Promise.resolve({ ok: false, error: 'integration is disabled' });
+    if (!r) return Promise.resolve({ ok: false, error: '未知集成' });
+    if (!r.enabled) return Promise.resolve({ ok: false, error: '集成已禁用' });
     if (authTypeNeedsSecret(r.authType) && !(r.secretRef && mockSecret.has(r.secretRef))) {
-      return Promise.resolve({ ok: false, status: 503, error: 'no secret set' });
+      return Promise.resolve({ ok: false, status: 503, error: '未设置密钥' });
     }
     return Promise.resolve({ ok: true, status: 200 });
   }
 };
 
-// ───────────────────────── exported client (real → mock fallback) ─────────────────────────
+// ───────────────────────── 导出的客户端（真实 → mock 回退）────────────────────────
 
 export const integrationsClient: IntegrationsClient = {
   listTemplates: () => {
@@ -148,9 +147,9 @@ export const integrationsClient: IntegrationsClient = {
   }
 };
 
-// ───────────────────────── small UI helper ─────────────────────────
+// ───────────────────────── 小型 UI 辅助函数 ─────────────────────────
 
-/** Best-effort slug from a label (server-side validateIntegrationRecord is authoritative). */
+/** 从标签生成 slug（服务端 validateIntegrationRecord 为准）。 */
 export function slugify(label: string): string {
   const base = label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40).replace(/-+$/g, '');
   return base.length >= 2 ? base : `${base || 'api'}-x`;

--- a/src/renderer/src/markdown/MarkdownPreview.tsx
+++ b/src/renderer/src/markdown/MarkdownPreview.tsx
@@ -1,17 +1,17 @@
 /**
- * Rendered markdown view (v0.3.4) — the shared preview used by the IDE's
- * split/preview modes, the fullscreen file overlay, and (via those) the
- * terminal ⌘-click flow. The `card` variant renders agent-written markdown
- * inside another surface: the ASK ME question and the task detail's Q&A trail.
+ * 渲染后的 markdown 视图（v0.3.4）—— IDE 的
+ *  分屏/预览模式、全屏文件覆盖层，以及（通过它们）终端 ⌘-click 流程
+ *  共用的预览。`card` 变体在另一个表面内渲染 agent 编写的
+ *  markdown：ASK ME 问题和任务详情的 Q&A 跟踪。
  *
- * SECURITY: agent-generated markdown is untrusted. react-markdown WITHOUT
- * rehype-raw renders to React elements only — no HTML sink exists, raw HTML in
- * the source is shown as text, and the default urlTransform already drops
- * javascript: URIs. Keep it that way: never add rehype-raw here.
+ * 安全：agent 生成的 markdown 不可信。react-markdown 不带
+ *  rehype-raw 只渲染为 React 元素 —— 不存在 HTML sink，源中的
+ *  原始 HTML 显示为文本，默认 urlTransform 已丢弃
+ *  javascript: URI。保持这样：此处绝不调用 rehype-raw。
  *
- * Links never navigate the window: http(s)/mailto go through the main-process
- * opener; relative *.md links surface through onOpenMarkdownLink so the host
- * (IDE tab / overlay) opens them in context; everything else is inert.
+ * 链接从不导航窗口：http(s)/mailto 走 main-process 打开器；
+ * 相对 *.md 链接通过 onOpenMarkdownLink 浮出，由宿主
+ * （IDE 标签页 / 覆盖层）在上下文中打开它们；其余保持惰性。
  */
 import { memo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -22,35 +22,35 @@ import { remarkSoftBreaks } from './remarkSoftBreaks';
 import { rehypeAutoDir } from './rehypeAutoDir';
 import { useRtl } from '@/i18n/useDirection';
 
-/** How the rendered markdown sits in its host.
- *  - `document` (default): a page — its own type scale, 72ch measure, page padding.
- *  - `card`: markdown INSIDE another surface (an ASK ME question, a Q&A entry).
- *    Inherits the host's font and size, drops the page chrome, and keeps a single
- *    newline as a line break the way the plain-text block it replaced did. */
+/** 渲染后的 markdown 如何嵌入其宿主。
+ *  - `document`（默认）：页面 —— 拥有自己的类型比例、72ch 度量、页面内边距。
+ *  - `card`：markdown 在另一个表面内部（ASK ME 问题、Q&A 条目）。
+ *    继承宿主字体和大小，去除页面 chrome，并保留单个
+ *    换行作为换行，与它替换的纯文本块行为一致。 */
 export type MarkdownVariant = 'document' | 'card';
 
-// Hoisted: a fresh array on every render would make react-markdown re-run the
-// whole pipeline even when nothing about the source changed.
+// 提升：每次渲染都新建数组会让 react-markdown 即使
+// 源未变化也重跑整条管线。
 const DOC_PLUGINS = [remarkGfm];
 const CARD_PLUGINS = [remarkGfm, remarkSoftBreaks];
 
-/** Per-block `dir="auto"`, for an RTL app language only — see the note at the
- *  `useRtl()` call site below. Frozen module constants so the prop identity is
- *  stable and react-markdown does not re-run the pipeline on every render. */
+/** 每块 `dir="auto"`，仅对 RTL 应用语言 —— 见下方
+ *  `useRtl()` 调用点的说明。冻结的模块常量，使 prop 身份稳定，
+ *  react-markdown 不会在每次渲染时重跑管线。 */
 const AUTO_DIR_PLUGINS = [rehypeAutoDir];
 const NO_PLUGINS: never[] = [];
 
 export interface MarkdownPreviewProps {
   source: string;
-  /** Repo-relative path of the file being previewed (for resolving relative links). */
+  /** 正在预览的文件的工作区相对路径（用于解析相对链接）。 */
   baseRel?: string;
-  /** Absolute workspace root. Supplying it turns LOCAL images from placeholder
-   *  chips into actual pictures (read through the root-confined fs IPC); without
-   *  it every image stays a chip, because there is nothing to resolve against. */
+  /** 绝对工作区根目录。提供它可将本地图片从占位符
+   *  芯片渲染为真实图片（通过限制到根目录的 fs IPC 读取）；
+   *  不提供时每张图片保持为芯片，因为没有可解析的基准。 */
   root?: string;
-  /** Open a sibling markdown file (repo-relative path) in the host's context. */
+  /** 在宿主上下文中打开兄弟 markdown 文件（工作区相对路径）。 */
   onOpenMarkdownLink?: (rel: string) => void;
-  /** Page vs in-card rendering. Defaults to `document`. */
+  /** 页面 vs 卡片内渲染。默认为 `document`。 */
   variant?: MarkdownVariant;
 }
 
@@ -58,14 +58,13 @@ export const MarkdownPreview = memo(function MarkdownPreview({
   source, baseRel, root, onOpenMarkdownLink, variant = 'document'
 }: MarkdownPreviewProps) {
   const card = variant === 'card';
-  // Per-block direction, gated on the APP LANGUAGE rather than on the text.
+  // 每块方向，以 APP 语言为门控，而非以文本本身。
   //
-  // The plugin stamps `dir="auto"`, which resolves from each block's first
-  // strong character — so ungated it fires for an English user the moment an
-  // agent quotes a line of Arabic, and mirrors a block of their UI over
-  // something they never turned on. Keying it to the chosen language instead
-  // means an English user's markdown renders through exactly the pipeline it
-  // rendered through before this existed, whatever the agent writes into it.
+  // 该插件对每块打上 `dir="auto"`，从其第一个强字符解析 ——
+  // 若不加门控，在英文用户看到 agent 引用阿拉伯语行的瞬间就会触发，
+  // 并将他们的 UI 镜像覆盖到他们从未开启的内容上。
+  // 绑定到所选语言意味着英文用户的 markdown 渲染与
+  // 此功能存在之前完全一致的管线，不论 agent 在其中写入什么。
   const rtl = useRtl();
   return (
     <div className={card ? 'cth-md-preview cth-md-card' : 'cth-md-preview'}>
@@ -81,7 +80,7 @@ export const MarkdownPreview = memo(function MarkdownPreview({
               if (isRelativeMd(h) && onOpenMarkdownLink) {
                 onOpenMarkdownLink(resolveRel(baseRel, h.replace(/#.*$/, '')));
               }
-              // anything else (file:, anchors into self, unknown schemes): inert
+              // 其余（file:、自身锚点、未知协议）：惰性
             };
             const clickable = isExternal(h) || (isRelativeMd(h) && !!onOpenMarkdownLink);
             return (
@@ -95,11 +94,11 @@ export const MarkdownPreview = memo(function MarkdownPreview({
               </a>
             );
           },
-          // Images. LOCAL ones render for real (bytes via the root-confined fs
-          // IPC → blob URL); remote ones stay a placeholder chip. Until now
-          // every image was a chip, which meant an agent's report saying "see
-          // the screenshot below" showed a pill reading "🖼 screenshot" and the
-          // evidence was unviewable anywhere in the app.
+          // 图片。本地图片真实渲染（字节通过限制到根目录的 fs
+          // IPC → blob URL）；远程图片保持为占位符芯片。
+          // 此前每张图片都是芯片，这意味着 agent 报告说 "见下方截图" 时
+          // 显示的是写着 "🖼 screenshot" 的药丸，证据在应用中
+          // 任何地方都不可见。
           img: ({ alt, src }) => {
             const s = typeof src === 'string' ? src : undefined;
             const rel = root ? resolveLocalImageRel(baseRel, s) : null;
@@ -114,8 +113,8 @@ export const MarkdownPreview = memo(function MarkdownPreview({
   );
 });
 
-/** Fallback for anything we won't (or can't) load: remote URLs, non-images,
- *  and local files that turned out to be missing or undecodable. */
+/** 我们无法（或不能）加载的 fallback：远程 URL、非图片、
+ *  以及被发现缺失或无法解码的本地文件。 */
 function ImageChip({ alt, src, note }: { alt?: string; src?: string; note?: string }) {
   return (
     <span className="cth-md-img" title={src}>
@@ -124,15 +123,15 @@ function ImageChip({ alt, src, note }: { alt?: string; src?: string; note?: stri
   );
 }
 
-/** A local image inside rendered markdown. Falls back to the chip on any
- *  failure so a stale path in a report degrades to the old behaviour instead of
- *  a broken-image glyph. Blob lifetime (create AND revoke) belongs to the hook. */
+/** 渲染 markdown 中的本地图片。任何失败时 fallback 到芯片，
+ *  使报告中的过期路径退化为旧行为而非破碎图片图标。
+ *  Blob 生命周期（创建 AND 撤销）属于该 hook。 */
 function MdImage({ root, rel, alt, src }: { root: string; rel: string; alt?: string; src?: string }) {
   const img = useWorkspaceImage(root, rel);
   const [decodeFailed, setDecodeFailed] = useState(false);
   if (img.status === 'loading') return <ImageChip alt={alt} src={src} note="loading" />;
   if (img.status === 'error') return <ImageChip alt={alt} src={src} note={img.error} />;
-  if (decodeFailed) return <ImageChip alt={alt} src={src} note="could not decode" />;
+  if (decodeFailed) return <ImageChip alt={alt} src={src} note="无法解码" />;
   return (
     <img
       className="cth-md-image"

--- a/src/renderer/src/markdown/mdLinks.ts
+++ b/src/renderer/src/markdown/mdLinks.ts
@@ -1,20 +1,20 @@
 /**
- * Pure link/path logic for the markdown preview.
+ * markdown 预览的纯链接/路径逻辑。
  *
- * Extracted from MarkdownPreview.tsx so it can be unit-tested: these are the
- * functions that decide what a rendered document is allowed to REACH, and a
- * `.tsx` file cannot be loaded by the `node --test` harness. The component keeps
- * only the rendering.
+ * 从 MarkdownPreview.tsx 中提取，以便可以进行单元测试：
+ * 这些函数决定渲染后的文档可以触及什么，而
+ * `.tsx` 文件无法被 `node --test` 加载。组件仅保留
+ * 渲染部分。
  */
 import { isImagePath } from '@shared/imageTypes';
 
-/** Resolve `href` against the directory of `baseRel` ('' when unknown).
+/** 以 `baseRel` 的目录为基准解析 `href`（未知时为 ''）。
  *
- *  Note that `..` can only ever pop segments that this function itself pushed —
- *  once `parts` is empty a `..` is dropped — so the result is always a path
- *  UNDER the workspace root, never a sibling of it. That is a convenience, not
- *  the security boundary: the real containment check is `safeJoin` in the main
- *  process, which every read goes through. */
+ *  注意 `..` 只能弹出本函数自己推入的段 ——
+ *  `parts` 为空后 `..` 会被丢弃 —— 因此结果始终是工作区根目录
+ *  下的路径，而非其兄弟。这是一个便利，并非
+ *  安全边界：真实的安全边界是 main
+ *  进程中的 `safeJoin`，所有读取都经过它。 */
 export function resolveRel(baseRel: string | undefined, href: string): string {
   const baseDir = (baseRel ?? '').split('/').slice(0, -1);
   const parts = [...baseDir];
@@ -30,7 +30,7 @@ export function isExternal(href: string): boolean {
   return /^(https?:|mailto:)/i.test(href);
 }
 
-/** True when `href` carries any URI scheme (http:, data:, file:, javascript:…). */
+/** 当 `href` 带有 URI 协议（http:、data:、file:、javascript:…）时为 true。 */
 function hasScheme(href: string): boolean {
   return /^[a-z][a-z0-9+.-]*:/i.test(href);
 }
@@ -40,28 +40,28 @@ export function isRelativeMd(href: string): boolean {
 }
 
 /**
- * Workspace-relative path for a markdown `<img src>`, or null when the source is
- * not a local image we may load.
+ * markdown `<img src>` 的工作区相对路径，或当源不是
+ * 我们可以加载的本地图片时为 null。
  *
- * WHY THIS EXISTS: the preview used to replace EVERY image with a placeholder
- * chip, so an agent-written report containing screenshots rendered as a row of
- * "🖼 screenshot" pills — the report's evidence was invisible everywhere in the
- * app. Local images can now be resolved and read through the same root-confined
- * IPC as everything else.
+ * 为什么需要这个：预览之前会将每张图片替换为占位符
+ * 芯片，因此包含截图的 agent 报告渲染为一行
+ * "🖼 screenshot" 药丸 —— 报告的证据在应用中
+ * 任何地方都不可见。现在可以通过与一切相同的
+ * 限制到根目录的 IPC 解析和读取本地图片。
  *
- * What is refused, and why:
- *  - anything with a SCHEME (http:, https:, data:, file:, javascript:). Remote
- *    URLs are already dead under the CSP (`img-src 'self' data: blob:`), and
- *    silently proxying them through the main process would turn a rendered
- *    document into a network beacon that leaks "this user opened this file" to
- *    whoever authored the markdown. Agent-generated markdown is untrusted.
- *  - anything whose extension is not a known image type — there is no reason for
- *    an <img> to pull an arbitrary file's bytes into the renderer.
+ * 拒绝什么，以及原因：
+ *  - 带协议的（http:、https:、data:、file:、javascript:）。远程
+ *    URL 在 CSP（`img-src 'self' data: blob:`）下已失效，且
+ *    静默通过 main 进程代理它们会使渲染文档变成网络信标，
+ *    向 markdown 的作者泄漏 "这个用户打开了这个文件"。
+ *    Agent 生成的 markdown 不可信。
+ *  - 扩展名不是已知图片类型的 —— <img> 没有理由将任意文件的
+ *    字节拉入渲染器。
  *
- * A leading `/` is read as workspace-root-relative rather than as a filesystem
- * absolute path; the leading slashes are stripped and the rest resolves from the
- * root, so `/etc/passwd` becomes the (harmless, nonexistent) `etc/passwd` inside
- * the workspace instead of escaping to the real one.
+ * 前导 `/` 被读为工作区根相对而非文件系统
+ * 绝对路径；前导斜杠被剥离，其余从根目录解析，
+ * 因此 `/etc/passwd` 变为工作区内的（无害、不存在的）`etc/passwd`
+ * 而非逃逸到真实的。
  */
 export function resolveLocalImageRel(baseRel: string | undefined, src: string | undefined): string | null {
   if (typeof src !== 'string') return null;
@@ -69,7 +69,7 @@ export function resolveLocalImageRel(baseRel: string | undefined, src: string | 
   if (!raw) return null;
   if (hasScheme(raw)) return null;
   if (!isImagePath(raw)) return null;
-  // Strip the query/hash before resolving — they are cache-busters, not path.
+  // 解析前剥离查询/哈希 —— 它们是缓存破坏器，不是路径。
   const clean = raw.split('#')[0].split('?')[0];
   const rooted = clean.startsWith('/');
   const rel = resolveRel(rooted ? undefined : baseRel, clean);

--- a/src/renderer/src/markdown/rehypeAutoDir.ts
+++ b/src/renderer/src/markdown/rehypeAutoDir.ts
@@ -1,40 +1,38 @@
 /**
- * rehype plugin: stamp `dir="auto"` on every block-level element of rendered
- * markdown, so each block picks its own reading direction from its first strong
- * character.
+ * rehype 插件：给渲染后 markdown 的每个块级元素打上 `dir="auto"`，
+ * 使每块从其第一个强字符中自主选择阅读方向。
  *
- * WHY a plugin and not CSS: `unicode-bidi: plaintext` resolves the *bidi* order
- * of a block but leaves the `direction` property alone — so an Arabic list item
- * would read right-to-left while its bullet stayed pinned on the left, and
- * `text-align: start` would still resolve against the container's LTR. `dir`
- * sets the real base direction, which markers, alignment and trailing
- * punctuation all follow. Doing it here rather than in `components` covers every
- * block element in one pass, including ones nobody has overridden yet.
+ * 为什么用插件而非 CSS：`unicode-bidi: plaintext` 解析块的 *双向* 顺序，
+ * 但会忽略 `direction` 属性 —— 因此阿拉伯语列表项会右到左阅读，
+ * 而其项目符号仍固定在左侧，`text-align: start` 仍会相对于
+ * 容器的 LTR 解析。`dir` 设置真实的基础方向，标记、对齐和尾部
+ * 标点都遵循它。在此处而非 `components` 中做，一次覆盖所有
+ * 块级元素，包括那些尚未被覆盖的。
  *
- * Applied per BLOCK, never to the root: a document with English headings and
- * Arabic prose (the common case for agent output) gets each block right, where a
- * single `dir` on the wrapper would have to be wrong for one of them.
+ * 按块应用，从不应用于根：一篇带有英文标题和阿拉伯语正文的文档
+ * （agent 输出的常见情况）每块都正确，而在包装器上设单一 `dir`
+ * 则必有一方错误。
  *
- * `pre`/`code` are skipped deliberately — code is LTR regardless of the language
- * of the comments inside it, and reordering a shell command would be a bug.
+ * `pre`/`code` 被刻意跳过 —— 代码无论其内部注释的语言如何都是 LTR，
+ * 重新排列 shell 命令会是 bug。
  */
 import type { Root, Element } from 'hast';
 
-/** Block elements whose text is prose, so direction should follow content. */
+/** 文本为散文的块级元素，因此方向应跟随内容。 */
 const AUTO_DIR = new Set([
   'p', 'li', 'blockquote', 'td', 'th', 'dd', 'dt', 'figcaption', 'summary',
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-  // The list CONTAINER too, not just its items: `dir` on a `ul` resolves from
-  // the first strong character in its subtree, which is the first item's text.
-  // Without it the container stays LTR and an Arabic item reads right-to-left
-  // with its bullet stranded on the left, over the container's left padding.
-  // `table` is left out on purpose — there `dir` would reverse COLUMN order,
-  // which is a bigger claim than "this text is Arabic"; the per-cell `td`/`th`
-  // entries above already give each cell the right alignment.
+  // 列表 CONTAINER 本身，而非只是其项目：`dir` 在 `ul` 上从其
+  // 子树中的第一个强字符解析，即第一个项目的文本。
+  // 没有它容器保持 LTR，阿拉伯语项目右到左阅读，
+  // 其项目符号滞留在左侧，位于容器左边距之上。
+  // `table` 被刻意排除 —— 那里 `dir` 会反转列顺序，
+  // 这是一个比 "这段文本是阿拉伯语" 更大的主张；
+  // 上面的每个单元格 `td`/`th` 条目已经给每个单元格正确的对齐。
   'ul', 'ol'
 ]);
 
-/** Subtrees to leave strictly LTR (code keeps its own order). */
+/** 保持严格 LTR 的子树（代码保留自己的顺序）。 */
 const SKIP = new Set(['pre', 'code']);
 
 export function rehypeAutoDir() {

--- a/src/renderer/src/markdown/remarkSoftBreaks.ts
+++ b/src/renderer/src/markdown/remarkSoftBreaks.ts
@@ -1,20 +1,19 @@
 /**
- * Treat a single newline as a line break.
+ * 将单个换行视为换行符。
  *
- * CommonMark folds a soft break into a space, so a question written as
+ * CommonMark 将软断行折叠为空格，因此写成如下形式的提问
  *
- *     Do X first.
- *     Then tell me about Y.
+ *     先做 X。
+ *     然后告诉我关于 Y。
  *
- * renders as one run-on line. That is correct for a document, and wrong for a
- * card that used to be a `white-space: pre-wrap` block — the ASK ME question
- * and the task detail's Q&A trail both read as messages, not as prose files.
- * So the card variant of MarkdownPreview runs this and the document variant
- * does not.
+ * 会渲染为一条连在一起的行。这对文档是正确的，但对曾经
+ * 是 `white-space: pre-wrap` 块的卡片是错误的 —— ASK ME 问题
+ * 和任务详情的 Q&A 跟踪都读作消息，而非散文文件。
+ * 因此 MarkdownPreview 的 card 变体运行此插件，document 变体不运行。
  *
- * The walk only rewrites `text` nodes. Fenced and indented code are `code`
- * nodes carrying a raw `value` with no children, and inline code is
- * `inlineCode` — neither is touched, so newlines inside code survive as-is.
+ * walk 只重写 `text` 节点。围栏和缩进代码是携带原始 `value`
+ * 且无子节点的 `code` 节点，行内代码是 `inlineCode` —— 都不碰，
+ * 因此代码内的换行原样保留。
  */
 
 interface MdNode {

--- a/src/renderer/src/realtime/CompletionToast.tsx
+++ b/src/renderer/src/realtime/CompletionToast.tsx
@@ -1,27 +1,27 @@
 /**
- * Realtime Michael — completion toast (card rt-12, Phase 2, the visual half of
- * "respond when done").
+ * Realtime Michael —— 完成提示（卡片 rt-12，第二阶段，“完成时响应”的视觉半）。
  *
- * When voice-Michael dispatches work fire-and-notify, main detects completion (see
- * src/main/realtimeCompletionWatcher.ts) and — while a session is live — pushes the
- * event to the renderer over the `realtime:completion` channel. Michael SPEAKS it; this
- * component shows a brief matching TOAST so the human has a glanceable record (handy when
- * audio is missed or several finish at once).
+ * 当语音 Michael 派发 fire-and-notify 工作时，main 检测完成（见
+ * src/main/realtimeCompletionWatcher.ts），并在会话活跃期间通过
+ * `realtime:completion` 通道把事件推给渲染端。Michael 把它说出来；这个组件
+ * 显示一条简短匹配的 TOAST，让人有一份可瞥见的记录（漏听音频或同时完成
+ * 多条时很有用）。
  *
- * Self-contained + self-subscribing: it listens on `window.cth.onRealtimeCompletion`,
- * stacks recent completions, auto-dismisses each, and renders nothing when empty. It owns
- * no realtime/session state — it's a pure consumer of Kevin's push channel (rt-12 seam).
- * Mount it ONCE anywhere in the renderer tree (Kevin wires the one-line mount near the
- * voice UI); positioning is a fixed bottom-right overlay so it's layout-independent.
+ * 自包含 + 自订阅：它监听 `window.cth.onRealtimeCompletion`、堆叠最近的完成
+ * 事件、自动逐条消失，并在为空时不渲染任何东西。它不持有 realtime/session
+ * 状态——纯粹是 Kevin 推送通道（rt-12 seam）的消费者。在渲染树里任意位置
+ * 挂载一次即可（Kevin 在语音 UI 附近接上这一行挂载）；定位是固定右下角
+ * 覆盖层，与布局无关。
  *
- * Branch feat/realtime-michael. See board.md "🎙 REALTIME MICHAEL".
+ * 分支 feat/realtime-michael。见 board.md “🎙 REALTIME MICHAEL”。
  */
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Icon } from '@/components/Icon';
 import { useStore } from '@/store/store';
 
-/** Mirrors the `window.cth.onRealtimeCompletion` payload (preload). `summary` is the
- *  human-speakable line Michael relays; the rest is context for this toast. */
+/** 镜像 `window.cth.onRealtimeCompletion` 载荷（preload）。`summary` 是
+ *  Michael 转述的、人类可说的行；其余是这条 toast 的上下文。 */
 export interface RealtimeCompletionToastData {
   correlationId: string;
   kind: string;
@@ -33,19 +33,20 @@ export interface RealtimeCompletionToastData {
 }
 
 interface ActiveToast extends RealtimeCompletionToastData {
-  /** Stable key for React + dismissal. */
+  /** React 渲染 + 消失用的稳定 key。 */
   key: string;
 }
 
-/** How long each toast lingers before auto-dismiss. */
+/** 每条 toast 自动消失前停留多久。 */
 const AUTO_DISMISS_MS = 9000;
-/** Cap on simultaneously-visible toasts (oldest drop off). */
+/** 同时可见 toast 的上限（最老的先掉出）。 */
 const MAX_VISIBLE = 4;
 
 export function CompletionToast(): JSX.Element | null {
+  const { t } = useTranslation();
   const godName = useStore((s) => s.agents.find((a) => a.isGod)?.name) ?? 'the orchestrator';
   const [toasts, setToasts] = useState<ActiveToast[]>([]);
-  // Stable across renders so the subscription's closures always see live timers.
+  // 跨渲染稳定，让订阅的闭包总能看到实时定时器。
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   const dismiss = (key: string): void => {
@@ -77,8 +78,8 @@ export function CompletionToast(): JSX.Element | null {
       for (const tm of timersAtMount.values()) clearTimeout(tm);
       timersAtMount.clear();
     };
-    // Mount-once: the subscription + dismissal use refs + functional setState, so they
-    // never need to re-bind on re-render.
+    // 只挂载一次：订阅 + 消失使用 refs + 函数式 setState，所以重渲染时
+    // 永不需要重新绑定。
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -98,9 +99,9 @@ export function CompletionToast(): JSX.Element | null {
         pointerEvents: 'none'
       }}
     >
-      {toasts.map((t) => (
+      {toasts.map((toast) => (
         <div
-          key={t.key}
+          key={toast.key}
           role="status"
           style={{
             pointerEvents: 'auto',
@@ -127,8 +128,8 @@ export function CompletionToast(): JSX.Element | null {
             <Icon name="bell" /> {godName} · completed
             <button
               type="button"
-              onClick={() => dismiss(t.key)}
-              aria-label="Dismiss"
+              onClick={() => dismiss(toast.key)}
+              aria-label={t('completionToast.dismiss')}
               style={{
                 marginLeft: 'auto',
                 border: 'none',
@@ -152,11 +153,11 @@ export function CompletionToast(): JSX.Element | null {
               color: 'var(--cth-ink-900)'
             }}
           >
-            {t.summary}
+            {toast.summary}
           </div>
-          {t.objective && (
+          {toast.objective && (
             <div style={{ fontSize: 12, lineHeight: '17px', color: 'var(--cth-ink-700)' }}>
-              {t.objective}
+              {toast.objective}
             </div>
           )}
         </div>

--- a/src/renderer/src/realtime/CostHud.tsx
+++ b/src/renderer/src/realtime/CostHud.tsx
@@ -1,21 +1,20 @@
 /**
- * Realtime Michael — voice session cost HUD (card rt-9, cost-guard).
+ * Realtime Michael —— 语音会话成本 HUD（卡片 rt-9，成本守卫）。
  *
- * A compact meter for the live voice session's spend. Reads the cost store
- * (costStore.ts), which Kevin's session feeds via resetRealtimeCost() on connect
- * and recordRealtimeUsage() on each usage delta. Self-contained: mount it once
- * near the voice toggle (Michael's card / fullscreen header) — it renders its own
- * state and needs no props.
+ * 一个紧凑的实时语音会话支出计量表。读取成本 store（costStore.ts），
+ * Kevin 的会话通过 connect 时 resetRealtimeCost() 和每个用量增量上的
+ * recordRealtimeUsage() 喂给它。自包含：在语音开关附近挂载一次
+ * （Michael 的卡片 / 全屏头部）——它渲染自己的状态，无需 props。
  *
- * Shows:
- *  • a spend cap control (always) — set a USD ceiling for the session;
- *  • the running $ + token counts while a session is metering;
- *  • an amber "approaching cap" cue at ≥80% and a red "over cap" warning at 100%,
- *    so the user (and Michael, who can read get_cost) knows to wrap up. The actual
- *    auto-stop / mic-off-when-idle action lives in the session (it owns the mic);
- *    this HUD surfaces the signal + the cap the session reads.
+ * 显示：
+ *  • 支出上限控件（始终）——为会话设置一个美元上限；
+ *  • 会话计量期间的运行中 $ + token 数；
+ *  • ≥80% 时的琥珀色“接近上限”提示，100% 时的红色“超上限”警告，
+ *    让用户（和能读 get_cost 的 Michael）知道该收尾了。真正的自动停止 /
+ *    麦克风空闲关闭动作在会话里（它拥有麦克风）；这个 HUD 只表面化信号 +
+ *    会话读取的上限。
  *
- * Branch feat/realtime-michael. See board.md "🎙 REALTIME MICHAEL".
+ * 分支 feat/realtime-michael。见 board.md “🎙 REALTIME MICHAEL”。
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -51,20 +50,19 @@ const capInputStyle: React.CSSProperties = {
 };
 
 export interface CostHudProps {
-  /** Compact inline readout (sits next to the voice toggle): just the live $,
-   *  colored by cap status, and only while a session is metering — renders
-   *  nothing when off, so it never clutters the toggle row. The full form (cap
-   *  control + token breakdown) is the default, for a roomy spot like Settings. */
+  /** 紧凑行内读数（挨着语音开关）：只显示实时的 $，按上限状态着色，且只在
+   *  会话计量期间——关闭时渲染为空，绝不弄乱开关行。完整表单（上限控件 +
+   *  token 明细）是默认，用于设置页这类宽敞处。 */
   compact?: boolean;
 }
 
 export function CostHud({ compact = false }: CostHudProps): React.ReactElement | null {
   const { t } = useTranslation();
   const { usd, inputTokens, outputTokens, capUsd, overCap, startedTs, setCap } = useRealtimeCost();
-  // Local text state so the field can be cleared/typed without fighting the store.
+  // 本地文本状态，让字段可以清空/输入而不跟 store 打架。
   const [capText, setCapText] = useState(capUsd != null ? String(capUsd) : '');
 
-  // Keep the input in sync if the cap is changed elsewhere (e.g. reset).
+  // 若上限在别处被改（例如重置），让输入保持同步。
   useEffect(() => {
     setCapText(capUsd != null ? String(capUsd) : '');
   }, [capUsd]);
@@ -79,10 +77,9 @@ export function CostHud({ compact = false }: CostHudProps): React.ReactElement |
   const near = capUsd != null && !overCap && ratio >= WARN_RATIO;
   const meterColor = overCap ? 'var(--cth-danger, #c0392b)' : near ? 'var(--cth-warn, #b8860b)' : 'var(--cth-ink-900)';
 
-  // Compact: a glanceable TOKEN chip next to the voice toggle, only while a session
-  // runs. Money is intentionally NOT surfaced in the agent chrome — the spend cap
-  // still fires silently (see the cost guard in session.ts); the agent chrome shows
-  // token usage only.
+  // 紧凑版：语音开关旁一个可瞥见的 TOKEN 芯片，只在会话运行期间显示。
+  // 刻意不在 agent 界面里露出钱——支出上限仍会静默触发（见 session.ts 的
+  // 成本守卫）；agent 界面只显示 token 用量。
   if (compact) {
     if (!live) return null;
     const totalTok = inputTokens + outputTokens;

--- a/src/renderer/src/realtime/DevicePicker.tsx
+++ b/src/renderer/src/realtime/DevicePicker.tsx
@@ -1,20 +1,19 @@
 /**
- * Realtime Michael — microphone & speaker device picker (card rt-8, Phase 1).
+ * Realtime Michael —— 麦克风 & 扬声器设备选择器（卡片 rt-8，第一阶段）。
  *
- * Lets the user choose WHICH microphone the voice loop captures and WHICH speaker
- * it plays Michael's voice through. Selections are held in the realtime session
- * store via `setDeviceId()` / `setOutputDeviceId()` (see session.ts): the mic is
- * applied on the next connect() (getUserMedia `{ deviceId: { exact } }`), the
- * speaker is applied immediately to the live `<audio>` sink via `setSinkId()` (and
- * re-applied at connect). Both fall back to the system default if a stored id is
- * stale.
+ * 让用户选择语音循环采集哪个麦克风、通过哪个扬声器播放 Michael 的声音。
+ * 选择保存在实时会话 store 里，经 `setDeviceId()` / `setOutputDeviceId()`
+ * （见 session.ts）：麦克风在下次 connect() 时应用（getUserMedia
+ * `{ deviceId: { exact } }`），扬声器立即应用到活跃的 `<audio>` 输出端
+ * （经 `setSinkId()`，并在 connect 时重新应用）。存储的 id 过期时两者都
+ * 回退到系统默认。
  *
- * `enumerateDevices()` only returns device LABELS once the page has been granted
- * mic access at least once (our main-process gate opens while a voice session or
- * Free Flow is live — see src/main/index.ts). Before that we show generic
- * "Microphone N" / "Speaker N" names and a hint, so the picker is usable cold.
+ * `enumerateDevices()` 只在页面至少被授予过一次麦克风访问后才返回设备
+ * LABEL（我们的主进程闸在语音会话或 Free Flow 活跃时打开——见
+ * src/main/index.ts）。在此之前我们显示通用的「麦克风 N」/「扬声器 N」
+ * 名称和一个提示，让选择器冷启动即可用。
  *
- * Branch feat/realtime-michael. See board.md "🎙 REALTIME MICHAEL".
+ * 分支 feat/realtime-michael。见 board.md “🎙 REALTIME MICHAEL”。
  */
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,14 +25,14 @@ interface AudioDevice {
   label: string;
 }
 
-/** Whether this runtime can route audio output to a chosen sink (Chromium/Electron
- *  expose HTMLMediaElement.setSinkId; some lib.dom targets don't). When false we
- *  hide the speaker picker rather than show an inert control. */
+/** 此运行时能否把音频输出路由到选定的输出端（Chromium/Electron 暴露
+ *  HTMLMediaElement.setSinkId；某些 lib.dom 目标没有）。为 false 时我们隐藏
+ *  扬声器选择器，而不是显示一个无效控件。 */
 const CAN_PICK_SPEAKER =
   typeof HTMLMediaElement !== 'undefined' && 'setSinkId' in HTMLMediaElement.prototype;
 
-/** Enumerate audio devices of one kind, with a generic fallback label when the
- *  real label is hidden (no mic permission granted yet this session). */
+/** 枚举某一种类的音频设备；真实标签被隐藏时（本会话还没授予麦克风权限）
+ *  提供一个通用回退标签。 */
 async function listDevices(kind: 'audioinput' | 'audiooutput'): Promise<AudioDevice[]> {
   if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) return [];
   const fallback = kind === 'audioinput' ? 'Microphone' : 'Speaker';
@@ -65,7 +64,7 @@ export function RealtimeDevicePicker(): React.ReactElement {
   const godName = useStore((s) => s.agents.find((a) => a.isGod)?.name) ?? 'the orchestrator';
   const [mics, setMics] = useState<AudioDevice[]>([]);
   const [speakers, setSpeakers] = useState<AudioDevice[]>([]);
-  /** True once at least one device exposes a real label ⇒ mic permission granted. */
+  /** 一旦至少一个设备暴露真实标签即为 true ⇒ 麦克风权限已授予。 */
   const [labelled, setLabelled] = useState(false);
 
   const refresh = useCallback(async () => {
@@ -80,7 +79,7 @@ export function RealtimeDevicePicker(): React.ReactElement {
 
   useEffect(() => {
     void refresh();
-    // Hot-plug / unplug a device, or a permission grant that reveals labels → re-list.
+    // 热插拔设备，或揭示标签的权限授予 → 重新枚举。
     const md = typeof navigator !== 'undefined' ? navigator.mediaDevices : undefined;
     if (!md) return;
     const onChange = (): void => void refresh();

--- a/src/renderer/src/realtime/actions.ts
+++ b/src/renderer/src/realtime/actions.ts
@@ -1,22 +1,21 @@
 /**
- * Realtime Michael — voice ACTION tools (card rt-5, Phase 2).
+ * Realtime Michael —— 语音动作工具（卡片 rt-5，第二阶段）。
  *
- * The write-side function-tools that turn voice-Michael into an orchestrator: ping
- * / dispatch / steer / task CRUD / spawn-hire / kill / pause / halt / edit-schedule.
- * These are THIN — every tool just forwards a {verb, ...args} to the main process
- * (src/main/realtimeActions.ts), which owns the entire safety spine: the soft-vs-
- * destructive tiering, the two-step verbal echo-back confirm, the distinct-token
- * rule, the hard allowlist (kill-god / mass-ops forbidden), and the michael-voice
- * attribution. The renderer is the untrusted side, so it holds NO policy — it only
- * speaks back what main returns (`res.spoken`).
+ * 把语音 Michael 变成编排者的写侧函数工具：ping / dispatch / steer /
+ * task CRUD / spawn-hire / kill / pause / halt / edit-schedule。这些是
+ * THIN 的——每个工具只把一条 {verb, ...args} 转发给主进程
+ * （src/main/realtimeActions.ts），后者拥有整套安全主干：软 vs 破坏性
+ * 分级、两步口头回显确认、独立 token 规则、硬性白名单（禁 kill-god /
+ * 批量操作）、以及 michael-voice 归因。渲染端是不可信侧，所以它不持有
+ * 任何策略——只回显 main 返回的内容（`res.spoken`）。
  *
- * Confirm flow: a destructive tool returns an echo-back ("…say 'confirm' or 'kill'")
- * and main stages a single pending action. The model then calls `confirm_action`
- * with the user's spoken phrase to commit, or `cancel_action` to drop it. Because
- * each tool call mutes the mic (session.ts agent_tool_start), the commit inside
- * confirm_action happens mic-idle — no stray audio can inject consent.
+ * 确认流程：破坏性工具返回一段回显（"…say 'confirm' or 'kill'"），main
+ * 暂存一条待处理动作。模型随后用用户说出的短语调用 `confirm_action` 来
+ * 提交，或用 `cancel_action` 丢弃它。因为每次工具调用都会静音麦克风
+ * （session.ts agent_tool_start），confirm_action 内的提交发生在麦克风
+ * 空闲时——不会有杂音音频混入同意。
  *
- * Registered alongside the read-tools: session.ts uses
+ * 与只读工具一起注册：session.ts 使用
  *   tools: [...realtimeReadTools(), ...realtimeActionTools()]
  */
 import { tool } from '@openai/agents-realtime';
@@ -25,39 +24,39 @@ const obj = (x: unknown): Record<string, unknown> =>
   x && typeof x === 'object' ? (x as Record<string, unknown>) : {};
 const str = (x: unknown): string => (typeof x === 'string' ? x : '');
 
-/** Forward a verb + args to the main action spine and return its spoken result.
- *  Instrumented for the rt-5 live-bug: any failure is logged to the (human-visible)
- *  renderer console with the verb + raw args so the next repro is self-diagnosing. */
+/** 把一条 verb + args 转发给主动作主干并返回其口头结果。
+ *  针对 rt-5 线上 bug 埋点：任何失败都会把 verb + 原始 args 记到（人类
+ *  可见的）渲染端控制台，让下一次复现可以自我诊断。 */
 async function act(verb: string, input: unknown): Promise<string> {
-  // Graceful guard: if the preload bridge is missing (e.g. a dev hot-reload left the
-  // renderer ahead of a stale preload), say so instead of throwing an opaque error.
+  // 优雅守卫：若 preload 桥缺失（例如 dev 热重载让渲染端领先于过期的
+  // preload），说明原因而不是抛出晦涩错误。
   if (typeof window.cth?.realtimeAction !== 'function') {
     console.error('[realtime-action] window.cth.realtimeAction is not available — restart the app to load the rt-5 preload.', { verb });
-    return 'Voice actions are not available in this build yet — try restarting the app.';
+    return '此版本尚不支持语音操作——请尝试重启应用。';
   }
   try {
     const res = await window.cth.realtimeAction({ verb, ...obj(input) });
     if (!res?.ok) console.warn('[realtime-action] verb=%s rejected: %s', verb, res?.spoken, { input });
-    return res?.spoken || 'Done.';
+    return res?.spoken || '完成。';
   } catch (e) {
     console.error('[realtime-action] verb=%s threw:', verb, e, { input });
     const msg = e instanceof Error ? e.message : 'an unknown error';
-    return `I couldn't do that (${msg}).`;
+    return `我无法完成该操作（${msg}）。`;
   }
 }
 
 export function realtimeActionTools(): ReturnType<typeof tool>[] {
   return [
-    // ── soft writes (execute immediately) ─────────────────────────────────
+    // ── 软写入（立即执行）─────────────────────────────────
     tool({
       name: 'ping_agent',
       description:
-        'Send a short message to one agent (a nudge or note). Soft action — runs immediately, no confirm. Use for "tell Oscar X" or "check in with Jim".',
+        '给单个 agent 发送一条简短消息（提醒或便条）。软操作——立即执行，无需确认。用于「告诉 Oscar X」或「跟 Jim 打个招呼」。',
       parameters: {
         type: 'object',
         properties: {
-          agentId: { type: 'string', description: 'Agent name or id to message.' },
-          message: { type: 'string', description: 'What to say to them.' }
+          agentId: { type: 'string', description: '要发送消息的 agent 名称或 id。' },
+          message: { type: 'string', description: '想对他们说的话。' }
         },
         required: ['agentId', 'message'],
         additionalProperties: false
@@ -67,15 +66,15 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'dispatch_agent',
       description:
-        'Give an agent a task as a structured 4-part work order (objective, context, constraints, done-when) delivered to their inbox. Soft action — runs immediately. Use for "have Jim build X" or "ask Oscar to investigate Y".',
+        '以结构化的四部分工单（目标、背景、约束、完成标准）将任务下发给某个 agent 的收件箱。软操作——立即执行。用于「让 Jim 构建 X」或「让 Oscar 调查 Y」。',
       parameters: {
         type: 'object',
         properties: {
-          agentId: { type: 'string', description: 'Agent name or id to dispatch to.' },
-          objective: { type: 'string', description: 'The goal — what they should accomplish.' },
-          context: { type: 'string', description: 'Optional. Background they need.' },
-          constraints: { type: 'string', description: 'Optional. Limits / guardrails to respect.' },
-          doneWhen: { type: 'string', description: 'Optional. The definition of done.' }
+          agentId: { type: 'string', description: '要下发的 agent 名称或 id。' },
+          objective: { type: 'string', description: '目标——他们应该完成什么。' },
+          context: { type: 'string', description: '可选。他们需要的背景。' },
+          constraints: { type: 'string', description: '可选。需要遵守的限制/护栏。' },
+          doneWhen: { type: 'string', description: '可选。完成标准。' }
         },
         required: ['agentId', 'objective'],
         additionalProperties: false
@@ -85,12 +84,12 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'steer_agent',
       description:
-        'Inject live guidance into a running agent to redirect it without stopping it. Soft action — runs immediately. This is the priority verb: "tell Jim to focus on the bug first", "steer Oscar away from that approach".',
+        '向运行中的 agent 注入实时引导，在不停止它的前提下重新定向。软操作——立即执行。这是优先动词：「让 Jim 先专注这个 bug」「引导 Oscar 避开那个方案」。',
       parameters: {
         type: 'object',
         properties: {
-          agentId: { type: 'string', description: 'Agent name or id to steer.' },
-          text: { type: 'string', description: 'The steering guidance to inject.' }
+          agentId: { type: 'string', description: '要引导的 agent 名称或 id。' },
+          text: { type: 'string', description: '要注入的引导内容。' }
         },
         required: ['agentId', 'text'],
         additionalProperties: false
@@ -100,14 +99,14 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'create_task',
       description:
-        'Add a new card to the task board. Soft action — runs immediately. Use for "make a task to X", optionally assigned to someone.',
+        '向任务看板添加一张新卡片。软操作——立即执行。用于「创建一个 X 任务」，可选指派给某人。',
       parameters: {
         type: 'object',
         properties: {
-          title: { type: 'string', description: 'The task title.' },
-          description: { type: 'string', description: 'Optional. More detail.' },
-          assignee: { type: 'string', description: 'Optional. Agent id/name to own it.' },
-          priority: { type: 'number', description: 'Optional. 1 (highest) to 10.' }
+          title: { type: 'string', description: '任务标题。' },
+          description: { type: 'string', description: '可选。更多详情。' },
+          assignee: { type: 'string', description: '可选。负责它的 agent id/名称。' },
+          priority: { type: 'number', description: '可选。1（最高）到 10。' }
         },
         required: ['title'],
         additionalProperties: false
@@ -116,12 +115,12 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     }),
     tool({
       name: 'assign_task',
-      description: 'Assign an existing task to an agent. Soft action — runs immediately.',
+      description: '将现有任务指派给某个 agent。软操作——立即执行。',
       parameters: {
         type: 'object',
         properties: {
-          taskId: { type: 'string', description: 'Task id or title to assign.' },
-          assignee: { type: 'string', description: 'Agent id/name to own it.' }
+          taskId: { type: 'string', description: '要指派的任务 id 或标题。' },
+          assignee: { type: 'string', description: '负责它的 agent id/名称。' }
         },
         required: ['taskId', 'assignee'],
         additionalProperties: false
@@ -131,14 +130,14 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'update_task',
       description:
-        'Change an existing task: its status (todo/doing/blocked/done), result note, or assignee. Soft action — runs immediately.',
+        '修改现有任务：其状态（todo/doing/blocked/done）、结果备注或负责人。软操作——立即执行。',
       parameters: {
         type: 'object',
         properties: {
-          taskId: { type: 'string', description: 'Task id or title to update.' },
-          status: { type: 'string', enum: ['todo', 'doing', 'blocked', 'done'], description: 'Optional new status.' },
-          result: { type: 'string', description: 'Optional outcome note.' },
-          assignee: { type: 'string', description: 'Optional new owner.' }
+          taskId: { type: 'string', description: '要更新的任务 id 或标题。' },
+          status: { type: 'string', enum: ['todo', 'doing', 'blocked', 'done'], description: '可选的新状态。' },
+          result: { type: 'string', description: '可选的结果备注。' },
+          assignee: { type: 'string', description: '可选的新负责人。' }
         },
         required: ['taskId'],
         additionalProperties: false
@@ -146,16 +145,16 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
       execute: (input) => act('update_task', input)
     }),
 
-    // ── wait for a dispatched task to finish (rt-12 await-in-session) ──────
+    // ── 等待派发任务完成（rt-12 会话内等待）────────────────
     tool({
       name: 'wait_for',
       description:
-        'Wait until a task you dispatched completes, then report it. Use for "tell me when X is done" or "let me know once that finishes". Bounded by a timeout. (For fire-and-forget you do not need this — completions are announced automatically.)',
+        '等待你下发的任务完成，然后汇报结果。用于「告诉我 X 什么时候完成」或「完成后告诉我」。受超时限制。（发完即忘则不需要它——完成会自动播报。）',
       parameters: {
         type: 'object',
         properties: {
-          taskId: { type: 'string', description: 'The task id (or dispatch correlation id) to wait on.' },
-          timeoutSeconds: { type: 'number', description: 'Optional max wait in seconds (default 120, max 600).' }
+          taskId: { type: 'string', description: '要等待的任务 id（或下发关联 id）。' },
+          timeoutSeconds: { type: 'number', description: '可选的最长等待秒数（默认 120，最大 600）。' }
         },
         required: ['taskId'],
         additionalProperties: false
@@ -164,33 +163,33 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
         try {
           const a = obj(input);
           const taskId = str(a.taskId);
-          if (!taskId) return 'I need a task id to wait on.';
+          if (!taskId) return '我需要一个任务 id 才能等待。';
           const secs = typeof a.timeoutSeconds === 'number' && a.timeoutSeconds > 0 ? Math.min(a.timeoutSeconds, 600) : 120;
           const res = await window.cth.realtimeWaitFor(taskId, secs * 1000);
           if (res && 'timedOut' in res && res.timedOut) {
-            return `That one's still running after the wait — I'll let you know the moment it finishes.`;
+            return `等待之后它仍在运行——它一完成我就会通知你。`;
           }
-          return (res && 'summary' in res && res.summary) || 'That task completed.';
+          return (res && 'summary' in res && res.summary) || '该任务已完成。';
         } catch (e) {
           console.error('[realtime-action] wait_for threw:', e);
           const msg = e instanceof Error ? e.message : 'an unknown error';
-          return `I couldn't wait on that (${msg}).`;
+          return `我无法等待该任务（${msg}）。`;
         }
       }
     }),
 
-    // ── destructive / expensive (echo-back confirm required) ──────────────
+    // ── 破坏性 / 高代价（需要回显确认）─────────────────────
     tool({
       name: 'spawn_agent',
       description:
-        'Hire a NEW agent worker (provider engine + optional role). This does NOT run immediately; it asks for verbal confirmation first. After the user confirms, call confirm_action.',
+        '聘用一个新的 agent 工作者（provider 引擎 + 可选角色）。这不是立即执行的；会先请求口头确认。用户确认后，调用 confirm_action。',
       parameters: {
         type: 'object',
         properties: {
-          provider: { type: 'string', description: 'Engine: claude (default), codex, gemini, opencode, crush, pi, qwen, copilot, cursor.' },
-          role: { type: 'string', description: 'Optional. The role/job for the new agent.' },
-          name: { type: 'string', description: 'Optional. A name for the agent.' },
-          cwd: { type: 'string', description: 'Optional. Working directory; defaults to the hive root.' }
+          provider: { type: 'string', description: '引擎：claude（默认）、codex、gemini、opencode、crush、pi、qwen、copilot、cursor。' },
+          role: { type: 'string', description: '可选。新 agent 的角色/职责。' },
+          name: { type: 'string', description: '可选。该 agent 的名称。' },
+          cwd: { type: 'string', description: '可选。工作目录；默认为 hive 根目录。' }
         },
         required: [],
         additionalProperties: false
@@ -200,10 +199,10 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'kill_agent',
       description:
-        'Terminate a running agent (closes its terminal, archives it). DESTRUCTIVE — does NOT run immediately; returns an echo-back and asks for verbal confirmation. After the user confirms, call confirm_action. Killing the god orchestrator or all agents at once is forbidden.',
+        '终止一个运行中的 agent（关闭其终端并归档）。破坏性操作——不会立即执行；会返回回显并要求口头确认。用户确认后，调用 confirm_action。禁止杀死 god 编排器或一次性终止所有 agent。',
       parameters: {
         type: 'object',
-        properties: { agentId: { type: 'string', description: 'Agent name or id to kill.' } },
+        properties: { agentId: { type: 'string', description: '要终止的 agent 名称或 id。' } },
         required: ['agentId'],
         additionalProperties: false
       },
@@ -212,10 +211,10 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'pause_agent',
       description:
-        'Pause a running agent (it stops acting until resumed). DESTRUCTIVE — does NOT run immediately; returns an echo-back and asks for verbal confirmation. After the user confirms, call confirm_action.',
+        '暂停一个运行中的 agent（暂停期间不再行动，直到恢复）。破坏性操作——不会立即执行；会返回回显并要求口头确认。用户确认后，调用 confirm_action。',
       parameters: {
         type: 'object',
-        properties: { agentId: { type: 'string', description: 'Agent name or id to pause.' } },
+        properties: { agentId: { type: 'string', description: '要暂停的 agent 名称或 id。' } },
         required: ['agentId'],
         additionalProperties: false
       },
@@ -224,10 +223,10 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'halt_agent',
       description:
-        'Halt a running agent (a hard stop of its current work). DESTRUCTIVE — does NOT run immediately; returns an echo-back and asks for verbal confirmation. After the user confirms, call confirm_action.',
+        '让运行中的 agent 停止（强制停止其当前工作）。破坏性操作——不会立即执行；会返回回显并要求口头确认。用户确认后，调用 confirm_action。',
       parameters: {
         type: 'object',
-        properties: { agentId: { type: 'string', description: 'Agent name or id to halt.' } },
+        properties: { agentId: { type: 'string', description: '要停止的 agent 名称或 id。' } },
         required: ['agentId'],
         additionalProperties: false
       },
@@ -236,12 +235,12 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'edit_schedule',
       description:
-        'Enable, disable, or delete a recurring scheduled mission. DESTRUCTIVE — does NOT run immediately; returns an echo-back and asks for verbal confirmation. After the user confirms, call confirm_action.',
+        '启用、禁用或删除一个循环调度的任务。破坏性操作——不会立即执行；会返回回显并要求口头确认。用户确认后，调用 confirm_action。',
       parameters: {
         type: 'object',
         properties: {
-          missionId: { type: 'string', description: 'The schedule id or label to edit.' },
-          action: { type: 'string', enum: ['enable', 'disable', 'delete'], description: 'What to do to it.' }
+          missionId: { type: 'string', description: '要编辑的调度 id 或标签。' },
+          action: { type: 'string', enum: ['enable', 'disable', 'delete'], description: '要对它做什么。' }
         },
         required: ['missionId', 'action'],
         additionalProperties: false
@@ -249,14 +248,14 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
       execute: (input) => act('edit_schedule', input)
     }),
 
-    // ── v0.3.4 full-control verbs ─────────────────────────────────────────
+    // ── v0.3.4 全控制动词 ─────────────────────────────────
     tool({
       name: 'resume_agent',
       description:
-        'Resume a paused or halted agent so its tools flow again. Soft action — runs immediately. The undo for pause_agent / halt_agent.',
+        '恢复一个已暂停或已停止的 agent，让其工具重新运作。软操作——立即执行。这是对 pause_agent / halt_agent 的撤销操作。',
       parameters: {
         type: 'object',
-        properties: { agentId: { type: 'string', description: 'Agent name or id to resume.' } },
+        properties: { agentId: { type: 'string', description: '要恢复的 agent 名称或 id。' } },
         required: ['agentId'],
         additionalProperties: false
       },
@@ -265,12 +264,12 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'set_auto_delivery',
       description:
-        'Pause or resume automatic message-queue delivery to one agent. Paused = queued messages wait until resumed. Soft action — runs immediately.',
+        '暂停或恢复向某个 agent 的自动消息队列投递。暂停 = 队列中的消息会一直等待直到恢复。软操作——立即执行。',
       parameters: {
         type: 'object',
         properties: {
-          agentId: { type: 'string', description: 'Agent name or id.' },
-          state: { type: 'string', enum: ['pause', 'resume'], description: 'pause holds the queue; resume lets it flow.' }
+          agentId: { type: 'string', description: 'agent 名称或 id。' },
+          state: { type: 'string', enum: ['pause', 'resume'], description: 'pause 保持队列挂起；resume 让它继续流动。' }
         },
         required: ['agentId', 'state'],
         additionalProperties: false
@@ -280,13 +279,13 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'gate_tool',
       description:
-        'Block (gate) or unblock one named tool for one agent — e.g. gate Bash for Jim. Soft action — runs immediately.',
+        '为某个 agent 封锁（gate）或解除封锁一个指定的工具——例如为 Jim gate Bash。软操作——立即执行。',
       parameters: {
         type: 'object',
         properties: {
-          agentId: { type: 'string', description: 'Agent name or id.' },
-          tool: { type: 'string', description: 'Exact tool name, e.g. Bash, WebFetch, Edit.' },
-          state: { type: 'string', enum: ['gate', 'allow'], description: 'gate blocks it; allow removes the block.' }
+          agentId: { type: 'string', description: 'agent 名称或 id。' },
+          tool: { type: 'string', description: '确切的工具名称，例如 Bash、WebFetch、Edit。' },
+          state: { type: 'string', enum: ['gate', 'allow'], description: 'gate 封锁它；allow 移除封锁。' }
         },
         required: ['agentId', 'tool', 'state'],
         additionalProperties: false
@@ -296,10 +295,10 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'delete_task',
       description:
-        'Delete one task card from the board by title or id. Soft action — runs immediately (recreate it if wrong).',
+        '按标题或 id 从看板上删除一张任务卡片。软操作——立即执行（若弄错了可重建）。',
       parameters: {
         type: 'object',
-        properties: { taskId: { type: 'string', description: 'Task title or id to delete.' } },
+        properties: { taskId: { type: 'string', description: '要删除的任务标题或 id。' } },
         required: ['taskId'],
         additionalProperties: false
       },
@@ -307,10 +306,10 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     }),
     tool({
       name: 'unarchive_agent',
-      description: 'Bring an archived agent back onto the roster. Soft action — runs immediately.',
+      description: '把已归档的 agent 重新带回花名册。软操作——立即执行。',
       parameters: {
         type: 'object',
-        properties: { agentId: { type: 'string', description: 'Archived agent name or id.' } },
+        properties: { agentId: { type: 'string', description: '已归档的 agent 名称或 id。' } },
         required: ['agentId'],
         additionalProperties: false
       },
@@ -319,10 +318,10 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'clear_agent_context',
       description:
-        "Queue a context clear (/clear) for one agent — wipes its working memory of the current conversation; delivery waits until the agent is idle. DESTRUCTIVE — returns an echo-back and asks for verbal confirmation ('clear' or 'confirm'). After the user confirms, call confirm_action. Allowed on the god orchestrator too (it can resume its session).",
+        "为某个 agent 排队一次上下文清除（/clear）——抹除其对当前会话的工作记忆；投递会等待该 agent 空闲。破坏性操作——会返回回显并要求口头确认（'clear' 或 'confirm'）。用户确认后，调用 confirm_action。对 god 编排器也允许（它可以恢复其会话）。",
       parameters: {
         type: 'object',
-        properties: { agentId: { type: 'string', description: 'Agent name or id whose context to clear.' } },
+        properties: { agentId: { type: 'string', description: '要清除上下文的 agent 名称或 id。' } },
         required: ['agentId'],
         additionalProperties: false
       },
@@ -331,10 +330,10 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'archive_agent',
       description:
-        'Archive an agent — takes it off the floor, history kept (unarchive brings it back). DESTRUCTIVE — returns an echo-back and asks for verbal confirmation. After the user confirms, call confirm_action.',
+        '归档一个 agent——将其移出战场，历史保留（unarchive 可将其找回）。破坏性操作——会返回回显并要求口头确认。用户确认后，调用 confirm_action。',
       parameters: {
         type: 'object',
-        properties: { agentId: { type: 'string', description: 'Agent name or id to archive.' } },
+        properties: { agentId: { type: 'string', description: '要归档的 agent 名称或 id。' } },
         required: ['agentId'],
         additionalProperties: false
       },
@@ -343,14 +342,14 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'create_schedule',
       description:
-        'Create a NEW recurring schedule that messages an agent on an interval. DESTRUCTIVE — returns an echo-back and asks for verbal confirmation. After the user confirms, call confirm_action.',
+        '创建一个新的循环调度，按固定间隔向某个 agent 发送消息。破坏性操作——会返回回显并要求口头确认。用户确认后，调用 confirm_action。',
       parameters: {
         type: 'object',
         properties: {
-          label: { type: 'string', description: 'Short name for the schedule.' },
-          prompt: { type: 'string', description: 'The message the agent receives each time it fires.' },
-          intervalMinutes: { type: 'number', description: 'How often it fires, in minutes (min 5). Default 60.' },
-          to: { type: 'string', description: 'Target agent name or id. Default: the god orchestrator.' }
+          label: { type: 'string', description: '该调度的简短名称。' },
+          prompt: { type: 'string', description: '每次触发时 agent 收到的消息。' },
+          intervalMinutes: { type: 'number', description: '触发频率，以分钟计（最小 5）。默认 60。' },
+          to: { type: 'string', description: '目标 agent 名称或 id。默认：god 编排器。' }
         },
         required: ['label', 'prompt'],
         additionalProperties: false
@@ -360,12 +359,12 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'update_setting',
       description:
-        "Change one app setting from the voice-allowed list. Cosmetic/low-risk keys (notifications, officeTheme, terminalTheme, freeflowEnabled, strongKeepalive, autoUpdate, tvShowOffices, realtimeIdleDisconnectMs) apply immediately; behavior-changing keys (autoMode, defaultModel, godProvider, godModel, maxConcurrentWorkers, costCapTokens, maxTurns, slackEnabled, webhookEnabled, semanticMemory, multiWindow) return an echo-back with old→new and need verbal confirmation ('setting' or 'confirm') — then call confirm_action. Secrets, folders and anything not listed are refused.",
+        "从允许语音修改的设置列表中修改一个应用设置。外观/低风险键（notifications、officeTheme、terminalTheme、freeflowEnabled、strongKeepalive、autoUpdate、tvShowOffices、realtimeIdleDisconnectMs）立即生效；改变行为的键（autoMode、defaultModel、godProvider、godModel、maxConcurrentWorkers、costCapTokens、maxTurns、slackEnabled、webhookEnabled、semanticMemory、multiWindow）会返回带旧值→新值的回显，需要口头确认（'setting' 或 'confirm'）——然后调用 confirm_action。密钥、文件夹以及任何未列出项都会被拒绝。",
       parameters: {
         type: 'object',
         properties: {
-          key: { type: 'string', description: 'The exact setting key, e.g. autoMode or notifications.' },
-          value: { type: 'string', description: 'The new value: true/false, a number, or the option name.' }
+          key: { type: 'string', description: '确切的设置键，例如 autoMode 或 notifications。' },
+          value: { type: 'string', description: '新值：true/false、数字或选项名称。' }
         },
         required: ['key', 'value'],
         additionalProperties: false
@@ -373,44 +372,44 @@ export function realtimeActionTools(): ReturnType<typeof tool>[] {
       execute: (input) => act('update_setting', input)
     }),
 
-    // ── confirm / cancel (drive the two-phase commit) ─────────────────────
+    // ── 确认 / 取消（驱动两阶段提交）───────────────────────
     tool({
       name: 'confirm_action',
       description:
-        'Commit the destructive action that is currently awaiting confirmation, using the EXACT words the user just spoke. Only call this right after a destructive tool returned an echo-back and the user verbally confirmed. Main rejects a bare "yes" — pass the user\'s real phrase.',
+        '提交当前等待确认的破坏性操作，使用用户刚刚说出的确切措辞。仅在破坏性工具返回回显且用户口头确认之后调用。Main 会拒绝一句单纯的「是的」——请传入用户真实说的话。',
       parameters: {
         type: 'object',
-        properties: { phrase: { type: 'string', description: 'The confirmation words the user actually said.' } },
+        properties: { phrase: { type: 'string', description: '用户实际说出的确认措辞。' } },
         required: ['phrase'],
         additionalProperties: false
       },
       execute: async (input) => {
         if (typeof window.cth?.realtimeActionConfirm !== 'function') {
           console.error('[realtime-action] window.cth.realtimeActionConfirm is not available — restart the app.');
-          return 'Voice actions are not available in this build yet — try restarting the app.';
+          return '此版本尚不支持语音操作——请尝试重启应用。';
         }
         try {
           const res = await window.cth.realtimeActionConfirm({ phrase: str(obj(input).phrase) });
           if (!res?.ok) console.warn('[realtime-action] confirm rejected: %s', res?.spoken, { input });
-          return res?.spoken || 'Done.';
+          return res?.spoken || '完成。';
         } catch (e) {
           console.error('[realtime-action] confirm threw:', e, { input });
           const msg = e instanceof Error ? e.message : 'an unknown error';
-          return `I couldn't confirm that (${msg}).`;
+          return `我无法确认该操作（${msg}）。`;
         }
       }
     }),
     tool({
       name: 'cancel_action',
-      description: 'Cancel the destructive action that is awaiting confirmation. Call this when the user declines or changes their mind.',
+      description: '取消当前等待确认的破坏性操作。当用户拒绝或改变主意时调用。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: async () => {
         try {
           const res = await window.cth?.realtimeActionCancel?.();
-          return res?.spoken || 'Cancelled.';
+          return res?.spoken || '已取消。';
         } catch (e) {
           console.error('[realtime-action] cancel threw:', e);
-          return 'Cancelled.';
+          return '已取消。';
         }
       }
     })

--- a/src/renderer/src/realtime/costStore.ts
+++ b/src/renderer/src/realtime/costStore.ts
@@ -1,35 +1,33 @@
 /**
- * Realtime Michael — renderer cost store (card rt-9, cost-guard).
+ * Realtime Michael —— 渲染端成本 store（卡片 rt-9，成本守卫）。
  *
- * A tiny external store (same useSyncExternalStore shape as session.ts) that
- * tracks the LIVE cost of the current voice session: it accumulates usage deltas,
- * prices them via the shared audio rates, and exposes a running dollar figure +
- * token counts, an optional spend cap, and an idle signal for mic-off-when-idle.
+ * 一个微型外部 store（与 session.ts 相同的 useSyncExternalStore 形态），
+ * 跟踪当前语音会话的实时成本：累加用量增量、用共享音频费率计价，并暴露
+ * 一个运行中的美元数字 + token 计数、一个可选的支出上限、以及一个供
+ * 麦克风空闲时关闭的空闲信号。
  *
- * Net-new + disjoint by design: I own this file + the HUD that reads it. Kevin's
- * session (session.ts) feeds it through TWO one-line calls (the integration points
- * god assigned to him):
- *   • on connect():            resetRealtimeCost()
- *   • on each usage delta:     recordRealtimeUsage(usage)
- * and may read getRealtimeCostSnapshot()/isRealtimeIdle()/the overCap flag to
- * auto-disconnect on cap or after idle (the mic-off action lives in the session,
- * which this store does not own).
+ * 全新且刻意不重叠：我拥有这个文件 + 读取它的 HUD。Kevin 的会话
+ * （session.ts）通过两处单行调用喂给它（god 指派给他的集成点）：
+ *   • connect() 时:            resetRealtimeCost()
+ *   • 每个用量增量时:     recordRealtimeUsage(usage)
+ * 并可读取 getRealtimeCostSnapshot()/isRealtimeIdle()/overCap 标志，以便
+ * 在触顶或空闲后自动断开（麦克风关闭动作在会话里，这个 store 不拥有它）。
  */
 import { useSyncExternalStore } from 'react';
 import { computeRealtimeUsd, normalizeRealtimeUsage, type RealtimeUsage } from '@shared/realtimePricing';
 
 export interface RealtimeCostState {
-  /** Running session cost in USD (conservative upper bound — see realtimePricing). */
+  /** 会话运行中的美元成本（保守上界——见 realtimePricing）。 */
   usd: number;
   inputTokens: number;
   outputTokens: number;
-  /** Optional spend cap in USD; null = no cap. */
+  /** 可选的美元支出上限；null = 无上限。 */
   capUsd: number | null;
-  /** True once usd >= capUsd (cap set). The session should warn / auto-stop. */
+  /** 一旦 usd >= capUsd（已设上限）即为 true。会话应警告 / 自动停止。 */
   overCap: boolean;
-  /** Epoch ms of the last usage delta (proxy for last voice activity), or null. */
+  /** 最后一次用量增量的 epoch 毫秒（作为最后一次语音活动的代理），或 null。 */
   lastActivityTs: number | null;
-  /** Epoch ms the current session's metering began, or null when off. */
+  /** 当前会话计量开始的 epoch 毫秒，关闭时为 null。 */
   startedTs: number | null;
 }
 
@@ -57,8 +55,8 @@ function recomputeOverCap(usd: number, capUsd: number | null): boolean {
   return capUsd != null && capUsd > 0 && usd >= capUsd;
 }
 
-/** Begin metering a fresh session (Kevin: call from session connect()). Preserves
- *  the user's chosen cap across sessions; zeroes the running totals. */
+/** 开始计量一个新会话（Kevin：从 session connect() 调用）。跨会话保留
+ *  用户选择的上限；清零运行中的总计。 */
 export function resetRealtimeCost(startedAtMs: number): void {
   setState({
     usd: 0,
@@ -70,12 +68,12 @@ export function resetRealtimeCost(startedAtMs: number): void {
   });
 }
 
-/** Stop metering (session off). Keeps the final figure visible until next reset. */
+/** 停止计量（会话关闭）。保持最终数值可见直到下次 reset。 */
 export function endRealtimeCost(): void {
   setState({ startedTs: null });
 }
 
-/** Accumulate one usage delta (Kevin: call on each realtime usage event). */
+/** 累加一次用量增量（Kevin：在每个 realtime 用量事件上调用）。 */
 export function recordRealtimeUsage(usage: RealtimeUsage, nowMs: number): void {
   const { inputTokens, outputTokens } = normalizeRealtimeUsage(usage);
   if (inputTokens === 0 && outputTokens === 0) return;
@@ -89,14 +87,14 @@ export function recordRealtimeUsage(usage: RealtimeUsage, nowMs: number): void {
   });
 }
 
-/** Set (or clear, with null) the session spend cap. */
+/** 设置（或用 null 清除）会话支出上限。 */
 export function setRealtimeCap(capUsd: number | null): void {
   const cap = capUsd != null && capUsd > 0 ? capUsd : null;
   setState({ capUsd: cap, overCap: recomputeOverCap(state.usd, cap) });
 }
 
-/** True when no usage delta has arrived for `thresholdMs` while a session is live —
- *  the cue for mic-off-when-idle (the session decides whether to disconnect). */
+/** 当会话活跃时，若超过 `thresholdMs` 没有新的用量增量到达则为 true——
+ *  这是麦克风空闲关闭的提示（是否断开由会话决定）。 */
 export function isRealtimeIdle(thresholdMs: number, nowMs: number): boolean {
   if (state.startedTs == null) return false;
   const since = state.lastActivityTs ?? state.startedTs;
@@ -112,7 +110,7 @@ function subscribe(cb: () => void): () => void {
   return () => listeners.delete(cb);
 }
 
-/** React binding for the cost HUD + the cap control. */
+/** 成本 HUD + 上限控件的 React 绑定。 */
 export function useRealtimeCost(): RealtimeCostState & { setCap: (capUsd: number | null) => void } {
   const snap = useSyncExternalStore(subscribe, getRealtimeCostSnapshot);
   return { ...snap, setCap: setRealtimeCap };

--- a/src/renderer/src/realtime/session.ts
+++ b/src/renderer/src/realtime/session.ts
@@ -1,27 +1,27 @@
 /**
- * Realtime Michael — renderer voice session (card rt-2, Phase 1 = READ-ONLY voice).
+ * Realtime Michael —— 渲染端语音会话（卡片 rt-2，第一阶段 = 只读语音）。
  *
- * The voice orchestrator runs IN THE RENDERER over WebRTC, talking speech-to-speech
- * to OpenAI `gpt-realtime-2`. The renderer never holds the real OpenAI key: it asks
- * MAIN to mint a short-lived EPHEMERAL client secret (`realtime:mintToken`, see
- * src/main/realtime.ts) and connects with THAT.
+ * 语音编排者在 RENDERER 里跑在 WebRTC 之上，与 OpenAI `gpt-realtime-2`
+ * 做语音到语音对话。渲染端从不持有真实 OpenAI 密钥：它请 MAIN 铸造一个
+ * 短期的 EPHEMERAL 客户端密钥（`realtime:mintToken`，见
+ * src/main/realtime.ts），并用它连接。
  *
- * We drive a CUSTOM `OpenAIRealtimeWebRTC` transport (not the bare `'webrtc'` string)
- * so we can: (a) open the mic ourselves with echo-cancellation + noise-suppression +
- * auto-gain (and honor the device the user picked — Oscar's rt-8 seam), and (b) own
- * the <audio> sink for playback. Turn-taking uses semantic VAD with barge-in (the
- * model truncates when the user talks over it).
+ * 我们驱动一个 CUSTOM `OpenAIRealtimeWebRTC` 传输（不是裸 `'webrtc'`
+ * 字符串），以便：(a) 自己打开麦克风，带回声消除 + 噪声抑制 + 自动增益
+ * （并尊重用户选择的设备——Oscar 的 rt-8 seam），(b) 拥有回放的 <audio>
+ * 输出端。轮转使用带插话的语义 VAD（用户打断时模型会截断自己的话）。
  *
- * Phase 1 is a read-only connect→listen→respond round-trip. The agent runs Kevin's
- * rt-4 READ-ONLY tools (get_fleet_status / get_tasks / get_cost / get_triggers /
- * get_config / get_memory / get_activity) and god's rt-6 "Michael" persona, so the
- * agent_tool_start/agent_tool_end lifecycle fires and the mic goes idle during a tool
- * call and resumes — a Phase-1 acceptance criterion. NO hive action-tools yet (rt-5, held).
+ * 第一阶段是只读的 connect→listen→respond 往返。agent 运行 Kevin 的 rt-4
+ * 只读工具（get_fleet_status / get_tasks / get_cost / get_triggers /
+ * get_config / get_memory / get_activity）和 god 的 rt-6 “Michael” 人设，
+ * 因此 agent_tool_start/agent_tool_end 生命周期会触发，麦克风在工具调用
+ * 期间静音并在其返回后恢复——这是第一阶段的验收条件。还没有 hive
+ * 动作工具（rt-5，暂缓）。
  *
- * Shape mirrors freeflow/recorder.ts: a single module-level session (only ONE voice
- * loop at a time) exposed through a `useRealtimeMichael()` hook via useSyncExternalStore.
+ * 形态镜像 freeflow/recorder.ts：单一模块级会话（同一时刻只有一条语音
+ * 循环），通过 `useRealtimeMichael()` hook 经 useSyncExternalStore 暴露。
  *
- * Branch feat/realtime-michael. See board.md "🎙 REALTIME MICHAEL".
+ * 分支 feat/realtime-michael。见 board.md “🎙 REALTIME MICHAEL”。
  */
 import { useSyncExternalStore } from 'react';
 import { RealtimeAgent, RealtimeSession, OpenAIRealtimeWebRTC } from '@openai/agents-realtime';
@@ -30,51 +30,50 @@ import { realtimeActionTools } from './actions';
 import { resetRealtimeCost, recordRealtimeUsage, endRealtimeCost, isRealtimeIdle, getRealtimeCostSnapshot } from './costStore';
 
 /**
- * Voice-loop state machine:
- *   off        — no session (initial / after disconnect / fatal error)
- *   connecting — minting token + opening the WebRTC connection
- *   listening  — connected, mic live, waiting for / hearing the user
- *   responding — the model is generating / speaking audio back
- *   working    — a tool call is in flight; mic is muted until it returns
+ * 语音循环状态机：
+ *   off        — 无会话（初始 / 断开后 / 致命错误）
+ *   connecting — 铸造 token + 打开 WebRTC 连接
+ *   listening  — 已连接，麦克风活跃，等待 / 聆听用户
+ *   responding — 模型正在生成 / 播放语音回复
+ *   working    — 工具调用进行中；麦克风静音直到它返回
  */
 export type RealtimeStatus = 'off' | 'connecting' | 'listening' | 'responding' | 'working';
 
 export interface RealtimeMichaelState {
   status: RealtimeStatus;
-  /** Last error (no key, mint failure, mic denied, transport error…). Cleared on connect. */
+  /** 最后一个错误（无密钥、铸造失败、麦克风被拒、传输错误…）。connect 时清除。 */
   error: string | null;
-  /** Whether the mic is currently muted (true while `working`). */
+  /** 麦克风当前是否静音（`working` 期间为 true）。 */
   muted: boolean;
-  /** The realtime model actually in use (from the mint's sessionConfig). */
+  /** 实际使用的实时模型（来自铸造结果的 sessionConfig）。 */
   model: string | null;
-  /** Unix-seconds expiry of the ephemeral token, if main reported one. */
+  /** 临时 token 的 Unix 秒级过期时间，若 main 报告了的话。 */
   expiresAt: number | null;
-  /** Selected input device (Oscar's device picker, rt-8). null = system default. */
+  /** 选定的输入设备（Oscar 的设备选择器，rt-8）。null = 系统默认。 */
   deviceId: string | null;
-  /** Selected output/speaker device (Oscar's speaker picker, rt-8). null = system default. */
+  /** 选定的输出/扬声器设备（Oscar 的扬声器选择器，rt-8）。null = 系统默认。 */
   outputDeviceId: string | null;
 }
 
-/** Voices for gpt-realtime-2 (board: Cedar / Marin). god finalizes in rt-6. */
+/** gpt-realtime-2 的声音（看板：Cedar / Marin）。god 在 rt-6 定稿。 */
 const REALTIME_VOICE = 'cedar';
 
-/** Warm openers Michael leads with the moment a voice session connects, so he
- *  greets the user instead of sitting in silence waiting for them to speak. One
- *  is picked at random per connect so the greeting varies. Hardcoded constants
- *  (never user/external text) — safe to speak verbatim, no sanitization needed. */
+/** Michael 在语音会话连接时率先说出的暖场白，让他主动问候用户而不是坐在
+ *  沉默里等对方开口。每次连接随机挑一个，让问候有所变化。硬编码常量
+ *  （绝非用户/外部文本）——安全原样说出，无需净化。 */
 const GREETINGS = [
-  "Hi, what's up?",
-  "Hey, how's it going?",
-  "Hello, how can I help you?",
-  "Hey there, Michael here — what can I do for you?",
-  "Hi! What are we working on today?",
-  "Hey, good to hear you. What's on your mind?",
-  "Hello! What do you need?",
-  "Hey, I'm all ears — what's going on?"
+  "嗨，最近怎么样？",
+  "嘿，还好吗？",
+  "你好，我能帮你什么？",
+  "嘿，我是 Michael——有什么能帮你的？",
+  "嗨！今天咱们忙什么？",
+  "嘿，很高兴听到你。在想什么？",
+  "你好！你需要什么？",
+  "嘿，我洗耳恭听——出什么事了？"
 ];
 
-/** Michael's voice persona (rt-6 — the final Phase-1 instructions, authored by god). Michael
- *  is READ-ONLY: he reports on the hive via the rt-4 read-tools but takes no actions yet. */
+/** Michael 的语音人设（rt-6 —— 最终的第一阶段指令，由 god 撰写）。Michael
+ *  是只读的：他通过 rt-4 只读工具汇报 hive，但还不采取任何行动。 */
 const MICHAEL_PERSONA =
   `You are Michael — the voice of the orchestrator ("god") of a hive of autonomous Claude coding agents. The person you're talking to is the human who runs the hive; treat them as the boss you're briefing.
 
@@ -120,32 +119,31 @@ let state: RealtimeMichaelState = {
 };
 const listeners = new Set<() => void>();
 
-/** The single live session (only one voice loop at a time, like freeflow's recorder). */
+/** 唯一条活跃会话（同一时刻只有一条语音循环，与 freeflow 的录音器相同）。 */
 let session: RealtimeSession | null = null;
-/** The mic stream we opened (so we can stop its tracks on teardown). */
+/** 我们打开的麦克风流（以便拆除时停止其轨道）。 */
 let stream: MediaStream | null = null;
-/** The <audio> sink for Michael's voice. */
+/** Michael 声音的 <audio> 输出端。 */
 let audioEl: HTMLAudioElement | null = null;
-/** Guards against overlapping connect() calls racing the async mint/connect. */
+/** 防止重叠的 connect() 调用竞争异步 mint/connect。 */
 let connecting = false;
-/** rt-12: unsubscribe handle for the completion push, active only while a session is live. */
+/** rt-12：完成推送的退订句柄，仅在会话活跃期间启用。 */
 let offCompletion: (() => void) | null = null;
 let offFloorDelta: (() => void) | null = null;
-/** rt-9 cost guard: periodic tick that auto-disconnects on hard cost cap or after an
- *  idle open mic (curbs runaway audio spend on a forgotten session). */
+/** rt-9 成本守卫：周期 tick，在硬性成本上限到达、或空闲麦克风挂起过久时
+ *  自动断开（遏制被遗忘会话的失控音频开销）。 */
 let costGuardTimer: ReturnType<typeof setInterval> | null = null;
-/** Default idle auto-disconnect window (ms) when config has none. Raised from the
- *  original 45s to 3 min so a normal thinking/reading pause no longer drops the
- *  call; the user tunes it (or turns it off) via config.realtimeIdleDisconnectMs. */
+/** 配置缺省时的默认空闲自动断开窗口（毫秒）。从最初的 45 秒提高到 3 分钟，
+ *  让正常的思考/阅读停顿不再掉线；用户经 config.realtimeIdleDisconnectMs
+ *  调整（或关闭）。 */
 const DEFAULT_IDLE_DISCONNECT_MS = 180_000;
 const COST_GUARD_TICK_MS = 10_000;
 
-/** N3-seam (rt-10 hardening): a completion summary carries dispatch objective text.
- *  It CANNOT escalate — MAIN independently gates every destructive/forbidden op
- *  (Pam confirmed) — but neutralize it before injecting into the model as a system
- *  notification (defense in depth): collapse newlines, strip the parens that frame
- *  my notification, drop role markers + classic prompt-injection lead-ins, and cap
- *  length. Jim does the matching watcher-side half on the summary it emits. */
+/** N3-seam（rt-10 加固）：完成摘要携带派发目标文本。它 CANNOT 越权——
+ *  MAIN 独立门控每个破坏性/禁止操作（Pam 已确认）——但在把它作为系统通知
+ *  注入模型之前先中和它（纵深防御）：折叠换行、去掉框住我通知的括号、
+ *  移除角色标记 + 经典提示注入开场、并限制长度。Jim 在其发出的摘要上做
+ *  匹配的 watcher 侧半边。 */
 function sanitizeForVoice(s: string): string {
   return (s || '')
     .replace(/[\r\n]+/g, ' ')
@@ -164,34 +162,33 @@ function setState(patch: Partial<RealtimeMichaelState>): void {
   for (const l of listeners) l();
 }
 
-/** Wire the session lifecycle events onto our state machine. */
+/** 把会话生命周期事件挂到我们的状态机上。 */
 function wire(s: RealtimeSession): void {
-  // Model started / stopped speaking audio back to the user.
+  // 模型开始 / 停止向用户播放语音。
   s.on('audio_start', () => {
     if (state.status !== 'working') setState({ status: 'responding' });
   });
   s.on('audio_stopped', () => {
-    // Only fall back to listening if we aren't mid tool-call.
+    // 只有不在工具调用中途时才回退到 listening。
     if (state.status !== 'working') setState({ status: 'listening' });
   });
-  // User talked over the model (barge-in) — semantic_vad with interruptResponse
-  // truncates the assistant turn automatically; we just reflect it.
+  // 用户盖过模型说话（插话）——semantic_vad 配 interruptResponse 会自动
+  // 截断助手回合；我们只反映它。
   s.on('audio_interrupted', () => {
     if (state.status !== 'working') setState({ status: 'listening' });
   });
-  // A turn fully ended — safety reset to listening (no-op if already there).
+  // 回合完全结束——安全重置为 listening（已在则无操作）。
   s.on('agent_end', () => {
     if (state.status !== 'working') setState({ status: 'listening' });
   });
 
-  // Tool-call lifecycle: mute the mic while a tool runs so the user doesn't talk over
-  // a side effect, then resume. (Phase 1 runs the rt-4 read-tools; rt-5 action-tools
-  // inherit this for free.)
+  // 工具调用生命周期：工具运行期间静音麦克风，避免用户盖过副作用，然后
+  // 恢复。（第一阶段运行 rt-4 只读工具；rt-5 动作工具自动继承这一点。）
   s.on('agent_tool_start', () => {
     try {
       s.mute(true);
     } catch {
-      /* mute is best-effort */
+      /* 静音是尽力而为 */
     }
     setState({ status: 'working', muted: true });
   });
@@ -199,22 +196,22 @@ function wire(s: RealtimeSession): void {
     try {
       s.mute(false);
     } catch {
-      /* best-effort */
+      /* 尽力而为 */
     }
     setState({ status: 'listening', muted: false });
   });
 
-  // Transport / model errors. Surface the message; stay connected (the session can
-  // recover from a transient error). A hard transport drop is handled by disconnect().
+  // 传输/模型错误。显示消息；保持连接（会话能从瞬时错误恢复）。硬性
+  // 传输掉线由 disconnect() 处理。
   s.on('error', (err) => {
     const e = (err as { error?: unknown })?.error;
-    const msg = e instanceof Error ? e.message : typeof e === 'string' ? e : 'realtime session error';
+    const msg = e instanceof Error ? e.message : typeof e === 'string' ? e : '语音会话出错';
     setState({ error: msg });
   });
 
-  // rt-9 cost meter: each completed response reports token usage on the raw transport
-  // `response.done` event. Hand it straight to Oscar's cost store (its normalizer
-  // tolerates camel/snake-case + missing fields). Best-effort — never break the loop.
+  // rt-9 成本表：每次完成的响应在原始传输的 `response.done` 事件上报
+  // token 用量。直接交给 Oscar 的成本 store（其规范化器容忍 camel/snake
+  // 大小写 + 缺失字段）。尽力而为——绝不弄断循环。
   s.on('transport_event', (event) => {
     try {
       const ev = event as { type?: string; response?: { usage?: unknown } };
@@ -222,12 +219,12 @@ function wire(s: RealtimeSession): void {
         recordRealtimeUsage(ev.response.usage as Parameters<typeof recordRealtimeUsage>[0], Date.now());
       }
     } catch {
-      /* metering is best-effort */
+      /* 计量是尽力而为 */
     }
   });
 }
 
-/** Stop the mic + release the audio sink. Safe to call repeatedly. */
+/** 停止麦克风 + 释放音频输出端。可安全重复调用。 */
 function teardownMedia(): void {
   if (stream) {
     for (const t of stream.getTracks()) {
@@ -250,7 +247,7 @@ function teardownMedia(): void {
   audioEl = null;
 }
 
-/** Make a getUserMedia failure legible. */
+/** 让 getUserMedia 失败变得可读。 */
 function micFriendly(msg: string): string {
   const m = msg.toLowerCase();
   if (m.includes('permission') || m.includes('notallowed') || m.includes('denied'))
@@ -261,27 +258,26 @@ function micFriendly(msg: string): string {
 }
 
 /**
- * Open/close the main-process mic permission gate for the realtime session (Oscar's
- * rt-8 gate, src/main/index.ts). That gate grants getUserMedia only while
- * `freeflowEnabled || realtimeVoiceEnabled` is true, and the check is SYNCHRONOUS — so
- * we must flip `realtimeVoiceEnabled` true and let it settle BEFORE opening the mic, then
- * false again on teardown/error. (We deliberately do NOT gate on key-presence: the
- * OpenAI key is shared with the CLI engines, so that would open the mic for CLI-only
- * users — a guardrail regression.)
+ * 为实时会话打开/关闭主进程麦克风权限闸（Oscar 的 rt-8 闸，
+ * src/main/index.ts）。该闸只在 `freeflowEnabled || realtimeVoiceEnabled`
+ * 为 true 时授予 getUserMedia，且检查是 SYNCHRONOUS——所以我们必须先把
+ * `realtimeVoiceEnabled` 翻成 true 并让它落地，再打开麦克风，然后在拆除/
+ * 出错时再翻回 false。（我们刻意不按密钥存在性做闸：OpenAI 密钥与 CLI
+ * 引擎共享，那样会给仅 CLI 用户打开麦克风——一个护栏回归。）
  */
 async function setMicGate(on: boolean): Promise<void> {
   try {
     await window.cth.updateConfig({ realtimeVoiceEnabled: on });
   } catch {
-    /* if the config write fails, getUserMedia will surface the denial below */
+    /* 若配置写入失败，getUserMedia 会在下面浮出拒绝 */
   }
 }
 
 /**
- * Apply the chosen output device to our <audio> sink (Oscar's speaker picker, rt-8).
- * `setSinkId` is Chromium/Electron-only and not in every lib.dom, so we feature-detect +
- * cast narrowly. Best-effort: if the device is gone or unsupported we stay on the default
- * sink (passing '' selects the system default).
+ * 把选定的输出设备应用到我们的 <audio> 输出端（Oscar 的扬声器选择器，
+ * rt-8）。`setSinkId` 仅 Chromium/Electron 有、不在每个 lib.dom 里，所以
+ * 我们做特性检测 + 收窄类型转换。尽力而为：设备消失或不受支持时停在默认
+ * 输出端（传 '' 选择系统默认）。
  */
 async function applyOutputSink(el: HTMLAudioElement, deviceId: string | null): Promise<void> {
   const sink = el as HTMLAudioElement & { setSinkId?: (id: string) => Promise<void> };
@@ -289,14 +285,14 @@ async function applyOutputSink(el: HTMLAudioElement, deviceId: string | null): P
   try {
     await sink.setSinkId(deviceId ?? '');
   } catch {
-    /* device unavailable / unsupported — fall back to the default sink */
+    /* 设备不可用 / 不受支持——回退到默认输出端 */
   }
 }
 
 /**
- * Connect the voice loop: mint an ephemeral token, open the mic (EC/NS/AGC), open a
- * WebRTC RealtimeSession with semantic-VAD turn-taking, and start listening.
- * Idempotent — a no-op if already connecting/connected.
+ * 连接语音循环：铸造临时 token、打开麦克风（EC/NS/AGC）、打开带语义 VAD
+ * 轮转的 WebRTC RealtimeSession，并开始聆听。幂等——已在连接/已连接时为
+ * no-op。
  */
 export async function connect(): Promise<void> {
   if (connecting || (session && state.status !== 'off')) return;
@@ -309,13 +305,13 @@ export async function connect(): Promise<void> {
       return;
     }
 
-    // Open the main-process mic gate BEFORE getUserMedia. Oscar's rt-8 permission check
-    // is synchronous, so `realtimeVoiceEnabled` must already be true when the mic opens;
-    // we close it again on teardown/error.
+    // 在 getUserMedia 之前打开主进程麦克风闸。Oscar 的 rt-8 权限检查是
+    // 同步的，所以麦克风打开时 `realtimeVoiceEnabled` 必须已是 true；
+    // 拆除/出错时再把它关闭。
     await setMicGate(true);
 
-    // Mic with echo-cancellation + noise-suppression + auto-gain, honoring the device
-    // the user picked (Oscar's rt-8 picker). getUserMedia surfaces permission denials.
+    // 带回声消除 + 噪声抑制 + 自动增益的麦克风，尊重用户选择的设备
+    // （Oscar 的 rt-8 选择器）。getUserMedia 会浮出权限拒绝。
     const audioConstraints: MediaTrackConstraints = {
       echoCancellation: true,
       noiseSuppression: true,
@@ -324,17 +320,18 @@ export async function connect(): Promise<void> {
     if (state.deviceId) audioConstraints.deviceId = { exact: state.deviceId };
     stream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
 
-    // Our own <audio> sink for Michael's voice, routed to the chosen speaker (rt-8).
+    // 我们自己的 Michael 声音 <audio> 输出端，路由到选定的扬声器（rt-8）。
     audioEl = new Audio();
     audioEl.autoplay = true;
     await applyOutputSink(audioEl, state.outputDeviceId);
 
     const transport = new OpenAIRealtimeWebRTC({ mediaStream: stream, audioElement: audioEl });
-    // Warm-start: a short, best-effort hive snapshot so Michael's first answer is grounded
-    // without a tool round-trip (rt-4 realtimeSessionSummary). Returns '' on failure / never throws.
+    // 热启动：一段简短、尽力而为的 hive 快照，让 Michael 的第一个回答无需
+    // 工具往返即有据可依（rt-4 realtimeSessionSummary）。失败返回 '' / 绝不
+    // 抛错。
     let warmStart = await realtimeSessionSummary().catch(() => '');
-    // rt-12: catch up on completions that finished while no session was open, so Michael
-    // can mention them as a "since we last talked" warm-start (the closed-session queue).
+    // rt-12：补上会话未打开期间完成的完成项，让 Michael 能像“我们上次
+    // 通话以来”那样在热启动里提到它们（关闭会话队列）。
     try {
       const queued = await window.cth.realtimeDrainCompletions();
       if (Array.isArray(queued) && queued.length) {
@@ -342,12 +339,11 @@ export async function connect(): Promise<void> {
         if (lines) warmStart = `${warmStart}\nCompletions since you last spoke: ${lines} Mention these to the user when it's natural.`.trim();
       }
     } catch {
-      /* warm-start catch-up is best-effort */
+      /* 热启动补尽是尽力而为 */
     }
-    // v0.3.4: the snapshot is NOT baked into instructions any more — a byte-stable
-    // persona+tools prefix stays fully prompt-cached across turns and sessions
-    // (cached input is ~99% cheaper). The snapshot goes in as the FIRST
-    // conversation item below, and the floor watcher appends deltas mid-call.
+    // v0.3.4：快照不再烘焙进指令——一个字节稳定的人设+工具前缀能在回合和
+    // 会话间完全命中提示缓存（缓存输入便宜约 99%）。快照作为下面的第一个
+    // conversation item 进入，楼层观察者在通话中追加增量。
     const agent = new RealtimeAgent({
       name: 'Michael',
       instructions: MICHAEL_PERSONA,
@@ -361,7 +357,7 @@ export async function connect(): Promise<void> {
         voice: REALTIME_VOICE,
         audio: {
           input: {
-            // Natural turn boundaries + automatic barge-in (truncate on interrupt).
+            // 自然的回合边界 + 自动插话（被打断时截断）。
             turnDetection: {
               type: 'semantic_vad',
               eagerness: 'medium',
@@ -375,16 +371,15 @@ export async function connect(): Promise<void> {
     });
     wire(s);
 
-    // The ephemeral client secret is the apiKey for this connect; the real OpenAI key
-    // never reaches the renderer.
+    // 这个临时客户端密钥就是本次连接的 apiKey；真实 OpenAI 密钥永远到不了
+    // 渲染端。
     await s.connect({ apiKey: mint.token, model: mint.sessionConfig.model });
 
     session = s;
-    resetRealtimeCost(Date.now()); // rt-9: start the live session cost meter
-    // v0.3.4: SILENT context injection — a raw conversation.item.create with no
-    // response.create, so the model absorbs the item without speaking. (This SDK
-    // version's sendMessage always triggers a response, so we go one level down
-    // to the transport for the silent path.)
+    resetRealtimeCost(Date.now()); // rt-9：启动实时会话成本表
+    // v0.3.4：静默上下文注入——裸 conversation.item.create，不带
+    // response.create，让模型吸收该项而不开口。（此 SDK 版本的 sendMessage
+    // 总会触发响应，所以我们下探到传输层走静默路径。）
     const injectSilent = (text: string): void => {
       try {
         s.transport.sendEvent({
@@ -395,38 +390,37 @@ export async function connect(): Promise<void> {
             content: [{ type: 'input_text', text }]
           }
         } as never);
-      } catch { /* injection is best-effort */ }
+      } catch { /* 注入是尽力而为 */ }
     };
-    // The connect snapshot goes in as the FIRST conversation item (the greeting
-    // below opens the conversation; this just grounds it).
+    // 连接快照作为第一个 conversation item 进入（下面的问候开启对话；
+    // 这只是一个立足点）。
     if (warmStart) {
       injectSilent(`(Floor snapshot at connect — orientation only, call your tools for detail: ${sanitizeForVoice(warmStart)})`);
     }
-    // Floor deltas — silent appends that keep Michael's picture live without
-    // touching the cached instructions prefix.
+    // 楼层增量——保持 Michael 画面实时的静默追加，不触碰缓存的指令前缀。
     offFloorDelta = window.cth.onRealtimeFloorDelta?.((d) => {
       if (session !== s) return;
       injectSilent(`(Floor update: ${sanitizeForVoice(d.text)}. Mention it only when relevant — don't interrupt.)`);
     }) ?? null;
-    // rt-12: mark the session live (main now pushes completions instead of queuing) and
-    // subscribe so a detected completion makes Michael speak it unprompted.
+    // rt-12：把会话标记为活跃（main 现在改为推送完成项而不是排队），并
+    // 订阅，让检测到的完成项让 Michael 不请自来说出来。
     void window.cth.realtimeSetSessionLive(true);
     offCompletion = window.cth.onRealtimeCompletion((c) => {
       try {
-        // Feed it as a system-framed notification so the model relays it rather than
-        // treating it as a user request; semantic_vad won't interrupt an active turn.
-        // N3-seam: sanitize the summary before injection (defense in depth).
+        // 作为系统框定的通知喂给它，让模型转述而不是当作用户请求；
+        // semantic_vad 不会打断一个活跃回合。N3-seam：注入前净化摘要
+        // （纵深防御）。
         session?.sendMessage(
           `(System notification — a task you dispatched just finished: ${sanitizeForVoice(c.summary)}) Briefly let the user know, and offer details if they want them.`
         );
       } catch {
-        /* session may be tearing down */
+        /* 会话可能正在拆除 */
       }
     });
-    // rt-9 cost guard: periodically stop the session if the hard cap is hit, or after an
-    // idle open mic, so a forgotten session doesn't bleed audio cost. The idle window is
-    // user-configurable (config.realtimeIdleDisconnectMs; default 3 min; 0 = never — the
-    // cost cap stays the runaway guard). disconnect() clears this timer + tears down.
+    // rt-9 成本守卫：周期性地在硬上限被命中、或空闲麦克风挂起过久时停止
+    // 会话，免得被遗忘的会话漏掉音频开销。空闲窗口可配置
+    // （config.realtimeIdleDisconnectMs；默认 3 分钟；0 = 永不——成本上限
+    // 仍是失控守卫）。disconnect() 清掉这个定时器 + 拆除。
     const idleCfg = (await window.cth.getConfig()).realtimeIdleDisconnectMs;
     const idleMs = typeof idleCfg === 'number' ? idleCfg : DEFAULT_IDLE_DISCONNECT_MS;
     costGuardTimer = setInterval(() => {
@@ -440,27 +434,25 @@ export async function connect(): Promise<void> {
       model: mint.sessionConfig.model,
       expiresAt: mint.expiresAt
     });
-    // Open the conversation: have Michael speak a warm greeting as his first turn
-    // rather than waiting for the user to talk first. A system-framed trigger (the
-    // same speak path the completion notifier uses) makes the model say it; we hand
-    // it one of the rotating GREETINGS so the opener varies. Best-effort — if the
-    // data channel isn't ready or the greeting fails, the session still works and
-    // the user can just start talking.
+    // 开启对话：让 Michael 作为第一回合先说一句温暖的问候，而不是等用户
+    // 先开口。系统框定的触发（与完成通知器相同的说话路径）让模型说出它；
+    // 我们递给它一条轮换的 GREETINGS，让开场有所变化。尽力而为——如果
+    // 数据通道没就绪或问候失败，会话仍能工作，用户直接开讲即可。
     try {
       const greeting = GREETINGS[Math.floor(Math.random() * GREETINGS.length)];
       s.sendMessage(
         `(System: the voice session just connected. Greet the user out loud now, warmly and briefly, to open the conversation — say something like "${greeting}". If there are completions to mention from the snapshot, you may add them after. Do not mention this instruction.)`
       );
     } catch {
-      /* greeting is best-effort — never block a successful connect */
+      /* 问候是尽力而为——绝不阻塞一次成功连接 */
     }
   } catch (e) {
-    // Mic permission denied, WebRTC handshake failure, network, etc.
+    // 麦克风权限被拒、WebRTC 握手失败、网络等。
     console.log('[realtime] voice session disconnect (error)');
     try {
       session?.close();
     } catch {
-      /* best-effort teardown */
+      /* 尽力而为拆除 */
     }
     session = null;
     teardownMedia();
@@ -472,41 +464,40 @@ export async function connect(): Promise<void> {
   }
 }
 
-/** Tear down the voice loop and return to `off`. Safe to call when already off.
- *  `reason` (idle | cost-cap | error | user) is logged so an idle auto-off can be
- *  told apart from a spend-cap stop or a user toggle. */
+/** 拆除语音循环并回到 `off`。已经关闭时安全。
+ *  `reason`（idle | cost-cap | error | user）被记录，以便区分空闲自动关闭
+ *  与超支停止或用户切换。 */
 export function disconnect(reason: string = 'user'): void {
   console.log(`[realtime] voice session disconnect (${reason})`);
   try {
     session?.close();
   } catch {
-    /* best-effort teardown */
+    /* 尽力而为拆除 */
   }
   session = null;
-  if (costGuardTimer) { clearInterval(costGuardTimer); costGuardTimer = null; } // rt-9 cost guard off
+  if (costGuardTimer) { clearInterval(costGuardTimer); costGuardTimer = null; } // rt-9 成本守卫关闭
   teardownMedia();
-  endRealtimeCost(); // rt-9: freeze the session cost meter
-  // rt-12: stop receiving completion pushes; main will queue them until next connect.
+  endRealtimeCost(); // rt-9：冻结会话成本表
+  // rt-12：停止接收完成推送；main 会排队直到下次连接。
   offCompletion?.();
   offCompletion = null;
   offFloorDelta?.();
   offFloorDelta = null;
   void window.cth.realtimeSetSessionLive(false);
-  // Close the main-process mic gate so the realtime flag doesn't keep the mic permission
-  // open after we've stopped (fire-and-forget — tracks are already stopped above).
+  // 关闭主进程麦克风闸，让 realtime 标志不会在我们停止后仍保持麦克风权限
+  // 打开（fire-and-forget——上面的轨道已经停止）。
   void setMicGate(false);
   setState({ status: 'off', muted: false });
 }
 
-/** Select the microphone (Oscar's device picker, rt-8). Applied on the next connect(). */
+/** 选择麦克风（Oscar 的设备选择器，rt-8）。下次 connect() 时应用。 */
 export function setDeviceId(deviceId: string | null): void {
   setState({ deviceId });
 }
 
 /**
- * Select the speaker/output device (Oscar's speaker picker, rt-8). Stores the choice and,
- * if a session is live, re-routes the current <audio> sink immediately; otherwise it's
- * applied on the next connect().
+ * 选择扬声器/输出设备（Oscar 的扬声器选择器，rt-8）。存储选择，如果会话
+ * 活跃则立即重新路由当前 <audio> 输出端；否则下次 connect() 时应用。
  */
 export function setOutputDeviceId(deviceId: string | null): void {
   setState({ outputDeviceId: deviceId });
@@ -523,9 +514,9 @@ function getSnapshot(): RealtimeMichaelState {
 }
 
 /**
- * React binding for the Realtime Michael voice loop. Returns the current state plus
- * `connect()` / `disconnect()` / `setDeviceId()`. A single session is shared across the
- * whole renderer, so every consumer sees the same status.
+ * Realtime Michael 语音循环的 React 绑定。返回当前状态加 `connect()` /
+ * `disconnect()` / `setDeviceId()`。整个渲染端共享同一条会话，所以每个
+ * 消费方看到的状态一致。
  */
 export function useRealtimeMichael(): RealtimeMichaelState & {
   connect: () => Promise<void>;

--- a/src/renderer/src/realtime/tools.ts
+++ b/src/renderer/src/realtime/tools.ts
@@ -1,81 +1,78 @@
 /**
- * Realtime Michael — read-tools (rt-4, Realtime Michael Phase 1).
+ * Realtime Michael —— 只读工具（rt-4，Realtime Michael 第一阶段）。
  *
- * The real function-tools that replace rt-2's placeholder no-op. Each one is a
- * thin, READ-ONLY wrapper over a window.cth bridge that already powers the office
- * floor UI, formatted as short spoken prose — a TTS voice reads these aloud, so
- * there is no markdown, no bullet characters, and no asterisks. Phase 1 is
- * read-only by construction: there is not a single mutating call in this file
- * (action-tools are rt-5, held).
+ * 替代 rt-2 占位 no-op 的真实函数工具。每个都是对已驱动办公室楼层 UI 的
+ * window.cth 桥的薄、只读包装，格式化为简短的口语散文——TTS 语音会把这些
+ * 读出来，所以不能有 markdown、项目符号字符、星号。第一阶段在结构上就是
+ * 只读的：这个文件里没有一个变更调用（动作工具是 rt-5，暂缓）。
  *
- * SECURITY: tools run in the RENDERER and only touch already-exposed read IPC.
- * The real OpenAI key never appears here (rt-1's mint keeps it main-only). And
- * get_config NEVER dumps HarnessConfig — that object carries secrets
- * (groqApiKey, slack/webhook tokens); we surface a hand-picked, non-sensitive
- * allowlist only.
+ * 安全：工具在 RENDERER 中运行，只触碰已暴露的只读 IPC。真实 OpenAI 密钥
+ * 绝不在此出现（rt-1 的 mint 让它只留在 main）。而且 get_config 绝不转储
+ * HarnessConfig——那个对象携带机密（groqApiKey、slack/webhook tokens）；
+ * 我们只暴露一份手工挑选的非敏感白名单。
  *
- * INTEGRATION (rt-2's src/renderer/src/realtime/session.ts — Jim's file):
+ * 集成（rt-2 的 src/renderer/src/realtime/session.ts —— Jim 的文件）：
  *   import { realtimeReadTools, realtimeSessionSummary } from './tools';
  *   ...
- *   tools: realtimeReadTools()            // swap for placeholderTools() at the `tools:` field
- * and optionally prepend `await realtimeSessionSummary()` to the agent instructions
- * for a warm-start orientation. The agent_tool_start / agent_tool_end mic-idle
- * lifecycle in session.ts is tool-agnostic, so it survives the swap unchanged.
+ *   tools: realtimeReadTools()            // 在 `tools:` 字段处替换 placeholderTools()
+ * 并且可选地把 `await realtimeSessionSummary()` 前置拼到 agent 指令上，
+ * 作为热启动导向。session.ts 里的 agent_tool_start / agent_tool_end
+ * 麦克风空闲生命周期与工具无关，所以换用后原样存活。
  */
 import { tool } from '@openai/agents-realtime';
 
-// ─── spoken-prose formatting helpers ────────────────────────────────────────
+// ─── 口语散文格式化辅助 ──────────────────────────────────────
 
-/** Relative "x ago" for a unix-ms timestamp; voice-safe and defensive. */
+/** 相对“x 前”的 unix-毫秒时间戳；语音安全且防御性。 */
 function ago(ts: unknown): string {
-  if (typeof ts !== 'number' || !isFinite(ts) || ts <= 0) return 'an unknown time ago';
+  if (typeof ts !== 'number' || !isFinite(ts) || ts <= 0) return '未知时间';
   const ms = Date.now() - ts;
-  if (ms < 5_000) return 'just now';
+  if (ms < 5_000) return '刚刚';
   const s = Math.round(ms / 1000);
-  if (s < 60) return `${s} seconds ago`;
+  if (s < 60) return `${s} 秒前`;
   const m = Math.round(s / 60);
-  if (m < 60) return `${m} minute${m === 1 ? '' : 's'} ago`;
+  if (m < 60) return `${m} 分钟前`;
   const h = Math.round(m / 60);
-  if (h < 24) return `${h} hour${h === 1 ? '' : 's'} ago`;
+  if (h < 24) return `${h} 小时前`;
   const d = Math.round(h / 24);
-  return `${d} day${d === 1 ? '' : 's'} ago`;
+  return `${d} 天前`;
 }
 
-/** Humanize an interval in ms into spoken cadence ("every 5 minutes"). */
+/** 把毫秒间隔人性化成口语节奏（“每 5 分钟”）。 */
 function every(ms: unknown): string {
-  if (typeof ms !== 'number' || !isFinite(ms) || ms <= 0) return 'on an unknown cadence';
+  if (typeof ms !== 'number' || !isFinite(ms) || ms <= 0) return '节奏未知';
   const m = Math.round(ms / 60_000);
-  if (m < 1) return 'every minute or less';
-  if (m < 60) return `every ${m} minute${m === 1 ? '' : 's'}`;
+  if (m < 1) return '每分钟或更频繁';
+  if (m < 60) return `每 ${m} 分钟`;
   const h = Math.round(m / 60);
-  return `every ${h} hour${h === 1 ? '' : 's'}`;
+  return `每 ${h} 小时`;
 }
 
-function plural(n: number, one: string, many = one + 's'): string {
+function plural(n: number, one: string, many = one): string {
   return `${n} ${n === 1 ? one : many}`;
 }
 
-/** Compact a big number for speech (1.2 thousand / 3.4 million). */
+/** 把大数字压缩成语音表达（1.2 千 / 3.4 百万）。 */
 function tokens(n: unknown): string {
   const v = typeof n === 'number' && isFinite(n) ? n : 0;
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)} million`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)} thousand`;
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)} 百万`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)} 千`;
   return `${Math.round(v)}`;
 }
 
 function clip(s: string, n: number): string {
-  return s.length > n ? s.slice(0, n).trimEnd() + ' (truncated)' : s;
+  return s.length > n ? s.slice(0, n).trimEnd() + '（已截断）' : s;
 }
 
-/** The trailing folder name of a path — speech-friendly (the persona avoids
- *  reading full file paths aloud unless asked). e.g. /a/b/cth-voice-tools → cth-voice-tools. */
+/** 路径的尾端文件夹名——对语音友好（人设除非被要求，否则避免完整读文件
+ *  路径）。例如 /a/b/cth-voice-tools → cth-voice-tools。 */
 function shortDir(p: string): string {
   const parts = (p || '').replace(/\/+$/, '').split('/').filter(Boolean);
   return parts.length ? parts[parts.length - 1] : p;
 }
 
-/** Strip markdown to plain speakable prose (headers, emphasis, bullets, links,
- *  code fences) and collapse whitespace. */
+/** 把 markdown 剥成纯口语散文（标题、强调、项目符号、链接、代码围栏）并
+ *  折叠空白。 */
 function despan(md: string): string {
   return (md || '')
     .replace(/```[\s\S]*?```/g, ' ')
@@ -91,23 +88,22 @@ const obj = (x: unknown): Record<string, unknown> =>
 
 const str = (x: unknown): string => (typeof x === 'string' ? x : '');
 
-/** Wrap a tool body so a read failure degrades to a spoken sentence rather than
- *  rejecting the model's tool call. */
+/** 包装一个工具体，让读取失败降级为口语句子而不是拒绝模型的工具调用。 */
 async function spoken(fn: () => Promise<string>, what: string): Promise<string> {
   try {
     const out = (await fn()).trim();
-    return out || `I could not find any ${what} right now.`;
+    return out || `现在没有找到任何${what}。`;
   } catch (e) {
-    const msg = e instanceof Error ? e.message : 'an unknown error';
-    return `I could not read the ${what} just now (${msg}).`;
+    const msg = e instanceof Error ? e.message : '未知错误';
+    return `刚才无法读取${what}（${msg}）。`;
   }
 }
 
-// ─── the read-tools ──────────────────────────────────────────────────────────
+// ─── 只读工具 ──────────────────────────────────────────────────────────
 
 /**
- * The real Phase-1 read-tools. Returned as an array so rt-2's session can pass it
- * straight to `tools:` in place of placeholderTools().
+ * 真正的第一阶段只读工具。返回数组，让 rt-2 的会话能直接传给 `tools:`，
+ * 替换 placeholderTools()。
  */
 export function realtimeReadTools(): ReturnType<typeof tool>[] {
   return [
@@ -115,13 +111,13 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
     tool({
       name: 'get_fleet_status',
       description:
-        'Who is in the agent hive right now: how many agents, which are active versus archived, who the god orchestrator is, and each active agent name, role, and engine. Call this when the user asks who is working, who is on the floor, or for a roster.',
+        '当前 agent hive 里都有谁：多少 agent、哪些活跃哪些已归档、god 调度器是谁，以及每个活跃 agent 的名称、角色和引擎。当用户问谁在工作、谁在楼层上、或要一份名单时调用此工具。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: () =>
         spoken(async () => {
           const reg = await window.cth.hiveRegistry();
           const entries = Object.entries(obj(reg.agents));
-          if (!entries.length) return 'The hive has no registered agents yet.';
+          if (!entries.length) return 'hive 还没有注册任何 agent。';
           const active = entries.filter(([, a]) => !obj(a).archived);
           const archived = entries.length - active.length;
           const godId = reg.godId;
@@ -130,33 +126,33 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
             .filter(([id]) => id !== godId)
             .map(([, a]) => {
               const m = obj(a);
-              const name = str(m.name) || 'an unnamed agent';
+              const name = str(m.name) || '未命名 agent';
               const role = str(m.role);
               const provider = str(m.provider) || 'claude';
-              const status = str(m.status) || 'unknown';
-              return `${name}${role ? `, the ${role},` : ''} on ${provider} (${status})`;
+              const status = str(m.status) || '未知';
+              return `${name}${role ? `，角色 ${role}` : ''}，引擎 ${provider}（${status}）`;
             });
-          const head = `There ${active.length === 1 ? 'is' : 'are'} ${plural(active.length, 'agent')} active${
-            archived ? ` and ${plural(archived, 'archived agent')}` : ''
-          }.`;
-          const god = godName ? ` ${godName} is the god orchestrator.` : '';
-          const roster = lines.length ? ` Active workers: ${lines.join('; ')}.` : '';
+          const head = `Hive 里有 ${plural(active.length, '个活跃 agent')}${
+            archived ? `，另有 ${plural(archived, '个已归档 agent')}` : ''
+          }。`;
+          const god = godName ? ` ${godName} 是 god 调度器。` : '';
+          const roster = lines.length ? ` 当前活跃成员：${lines.join('；')}。` : '';
           return head + god + roster;
-        }, 'fleet status')
+        }, '舰队状态')
     }),
 
     // ── get_tasks ─────────────────────────────────────────────────────────
     tool({
       name: 'get_tasks',
       description:
-        'The current task board: how many tasks are todo, in progress, blocked, and done, plus the titles and owners of the in-progress and blocked ones. Optionally filter by a single status. Call this when the user asks what the team is working on, what is blocked, or about progress.',
+        '当前任务看板：多少任务处于待办、进行中、阻塞和完成状态，以及进行中和阻塞任务的标题与负责人。可按单个状态过滤。当用户问团队在做什么、什么被阻塞了、或进度如何时调用此工具。',
       parameters: {
         type: 'object',
         properties: {
           status: {
             type: 'string',
             enum: ['todo', 'doing', 'blocked', 'done'],
-            description: 'Optional. Restrict the answer to one status.'
+            description: '可选。把答案限定为某一种状态。'
           }
         },
         required: [],
@@ -168,47 +164,45 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
           const filter = typeof a.status === 'string' ? a.status : null;
           const raw = await window.cth.hiveTasks();
           const list = Array.isArray(obj(raw).tasks) ? (obj(raw).tasks as unknown[]) : [];
-          if (!list.length) return 'The task board is empty.';
+          if (!list.length) return '任务看板是空的。';
           const tasks = list.map(obj);
           const by = (s: string): Record<string, unknown>[] => tasks.filter((t) => str(t.status) === s);
-          const counts = `${plural(by('todo').length, 'to do')}, ${by('doing').length} in progress, ${plural(
+          const counts = `${plural(by('todo').length, '个待办')}、${by('doing').length} 个进行中、${plural(
             by('blocked').length,
-            'blocked'
-          )}, and ${by('done').length} done`;
+            '个阻塞'
+          )}、${by('done').length} 个已完成`;
           const describe = (t: Record<string, unknown>): string => {
             const who = str(t.assignee);
-            return `"${clip(str(t.title) || str(t.id) || 'untitled', 90)}"${who ? ` (${who})` : ''}`;
+            return `「${clip(str(t.title) || str(t.id) || '未命名', 90)}」${who ? `（${who}）` : ''}`;
           };
           if (filter) {
             const sel = by(filter);
-            if (!sel.length) return `Nothing is ${filter} right now. Overall: ${counts}.`;
-            return `${plural(sel.length, 'task')} ${filter}: ${sel.slice(0, 12).map(describe).join('; ')}.`;
+            if (!sel.length) return `目前没有处于 ${filter} 状态的任务。总体：${counts}。`;
+            return `${plural(sel.length, '个任务')} 处于 ${filter}：${sel.slice(0, 12).map(describe).join('；')}。`;
           }
           const doing = by('doing');
           const blocked = by('blocked');
           const detail = [
-            doing.length ? `In progress: ${doing.slice(0, 8).map(describe).join('; ')}.` : '',
-            blocked.length ? `Blocked: ${blocked.slice(0, 8).map(describe).join('; ')}.` : ''
+            doing.length ? `进行中：${doing.slice(0, 8).map(describe).join('；')}。` : '',
+            blocked.length ? `阻塞：${blocked.slice(0, 8).map(describe).join('；')}。` : ''
           ]
             .filter(Boolean)
             .join(' ');
-          return `There ${tasks.length === 1 ? 'is' : 'are'} ${plural(tasks.length, 'task')}: ${counts}.${
-            detail ? ' ' + detail : ''
-          }`;
-        }, 'task board')
+          return `共有 ${plural(tasks.length, '个任务')}：${counts}。${detail ? ' ' + detail : ''}`;
+        }, '任务看板')
     }),
 
     // ── get_cost ──────────────────────────────────────────────────────────
     tool({
       name: 'get_cost',
       description:
-        'How much the hive is USING this session: total tokens across all agents, plus the top users. Reported in tokens (no dollar figures). Call this when the user asks about usage or token consumption.',
+        '本会话 hive 的用量：所有 agent 的 token 总数，以及用量最高的几个。仅以 token 报告（不涉及金额）。当用户问及用量或 token 消耗时调用此工具。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: () =>
         spoken(async () => {
           const snap = await window.cth.telemetrySnapshot();
           const usage = Array.isArray(snap.usage) ? snap.usage : [];
-          if (!usage.length) return 'No token usage has been recorded this session yet.';
+          if (!usage.length) return '本会话还没有记录到任何 token 用量。';
           let totIn = 0;
           let totOut = 0;
           const perAgent = new Map<string, number>();
@@ -218,98 +212,95 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
             const outTok = typeof m.output === 'number' ? m.output : 0;
             totIn += inTok;
             totOut += outTok;
-            const id = str(m.agentId) || 'unknown';
+            const id = str(m.agentId) || '未知';
             perAgent.set(id, (perAgent.get(id) ?? 0) + inTok + outTok);
           }
           const top = [...perAgent.entries()]
             .sort((x, y) => y[1] - x[1])
             .slice(0, 3)
-            .map(([id, tok]) => `${id} at ${tokens(tok)} tokens`);
-          return `So far this session the hive has used ${tokens(totIn)} input and ${tokens(totOut)} output tokens across ${plural(
+            .map(([id, tok]) => `${id} 用了 ${tokens(tok)} token`);
+          return `本会话至今 hive 共用了 ${tokens(totIn)} 输入、${tokens(totOut)} 输出 token，涉及 ${plural(
             perAgent.size,
-            'agent'
-          )}.${top.length ? ` Top users: ${top.join(', ')}.` : ''}`;
-        }, 'token usage')
+            '个 agent'
+          )}。${top.length ? ` 用量最高：${top.join('、')}。` : ''}`;
+        }, 'token 用量')
     }),
 
     // ── get_triggers ──────────────────────────────────────────────────────
     tool({
       name: 'get_triggers',
       description:
-        'The triggers that fire the hive without a human typing. Today this reports the schedules: the recurring missions the hive runs on a timer, with their labels, cadence, recipient, and when each last fired. The other trigger types — webhooks and inbound organization messages — are configured elsewhere and are not listed here. Call this when the user asks about triggers, schedules, recurring jobs, heartbeats, or automations.',
+        '无需人工输入即可触发 hive 的触发器。目前它报告的是定时计划：hive 按定时器运行的周期性任务，包括标签、节奏、接收者，以及各自上次触发时间。其他触发器类型——webhook 和入站组织消息——在其他地方配置，不在此列出。当用户问及触发器、定时计划、周期任务、心跳或自动化时调用此工具。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: () =>
         spoken(async () => {
           const missions = await window.cth.listMissions();
           const list = Array.isArray(missions) ? missions : [];
-          if (!list.length) return 'There are no scheduled missions configured.';
+          if (!list.length) return '当前没有配置任何定时任务。';
           const enabled = list.filter((m) => obj(m).enabled);
-          if (!enabled.length) return `There are ${plural(list.length, 'scheduled mission')}, but all are disabled.`;
+          if (!enabled.length) return `共有 ${plural(list.length, '个定时任务')}，但全部处于停用状态。`;
           const lines = enabled.slice(0, 8).map((m) => {
             const o = obj(m);
-            const label = str(o.label) || 'a mission';
+            const label = str(o.label) || '一个任务';
             const to = str(o.to);
-            const last = o.lastFiredAt ? `, last fired ${ago(o.lastFiredAt)}` : ', not fired yet';
-            return `${label} ${every(o.intervalMs)}${to ? ` to ${to}` : ''}${last}`;
+            const last = o.lastFiredAt ? `，上次触发于 ${ago(o.lastFiredAt)}` : '，尚未触发过';
+            return `${label} ${every(o.intervalMs)}${to ? `，发给 ${to}` : ''}${last}`;
           });
-          return `There ${enabled.length === 1 ? 'is' : 'are'} ${plural(
-            enabled.length,
-            'active scheduled mission'
-          )}: ${lines.join('; ')}.`;
-        }, 'schedules')
+          return `共有 ${plural(enabled.length, '个启用的定时任务')}：${lines.join('；')}。`;
+        }, '定时计划')
     }),
 
     // ── get_config ────────────────────────────────────────────────────────
     tool({
       name: 'get_config',
       description:
-        'The non-sensitive hive settings: autonomy mode, the default model and god engine, budget caps, worker limits, the circuit breaker, and which features are on. Never returns secrets or API keys. Call this when the user asks how the hive is configured, what the limits or budgets are, or whether a feature is enabled.',
+        'hive 的非敏感设置：自主模式、默认模型与 god 引擎、预算上限、worker 数量上限、熔断器，以及哪些功能处于开启状态。绝不返回机密或 API 密钥。当用户问 hive 如何配置、上限或预算是多少、或某个功能是否启用时调用此工具。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: () =>
         spoken(async () => {
           const c = await window.cth.getConfig();
-          // Hand-picked NON-SENSITIVE allowlist. Never iterate the object — it
-          // carries groqApiKey, slack/webhook tokens, and signing secrets. Read
-          // through obj() so the renderer's HarnessConfig mirror can lag the main
-          // one (it is hand-mirrored across three files) without breaking us.
+          // 手工挑选的非敏感白名单。绝不遍历整个对象——它携带
+          // groqApiKey、slack/webhook tokens 和签名机密。通过 obj() 读取，
+          // 这样渲染端的 HarnessConfig 镜像可以滞后于 main 的那份（它在三个
+          // 文件间手工镜像）而不会弄坏我们。
           const cc = obj(c);
           const parts: string[] = [];
-          parts.push(`Autonomy mode is ${c.autoMode ? 'on' : 'off'}.`);
-          if (c.defaultModel) parts.push(`The default model is ${c.defaultModel}.`);
+          parts.push(`自主模式：${c.autoMode ? '开启' : '关闭'}。`);
+          if (c.defaultModel) parts.push(`默认模型为 ${c.defaultModel}。`);
           if (c.godProvider || c.godModel)
-            parts.push(`The god orchestrator runs ${[c.godProvider, c.godModel].filter(Boolean).join(' ')}.`);
+            parts.push(`god 调度器运行 ${[c.godProvider, c.godModel].filter(Boolean).join(' ')}。`);
           if (typeof cc.maxConcurrentWorkers === 'number')
-            parts.push(`Up to ${plural(cc.maxConcurrentWorkers, 'worker')} run concurrently.`);
-          // De-monetized: report only the token cap (no dollar cap), and avoid
-          // money words. The $ runaway guard still exists + fires; it just isn't spoken.
+            parts.push(`最多 ${plural(cc.maxConcurrentWorkers, '个 worker')} 并发运行。`);
+          // 去除金钱化：只报告 token 上限（不报美元上限），并避开金钱字眼。
+          // $ 失控守卫仍然存在并会触发；只是不说出来。
           if (typeof c.costCapTokens === 'number' && c.costCapTokens > 0)
-            parts.push(`Token cap: ${tokens(c.costCapTokens)} tokens.`);
+            parts.push(`token 上限：${tokens(c.costCapTokens)}。`);
           const breakerOn = obj(c.circuitBreaker).enabled;
-          parts.push(`The circuit breaker is ${breakerOn ? 'enabled' : 'off'}.`);
-          parts.push(`Desktop notifications are ${c.notifications ? 'on' : 'off'}.`);
+          parts.push(`熔断器：${breakerOn ? '已启用' : '关闭'}。`);
+          parts.push(`桌面通知：${c.notifications ? '开启' : '关闭'}。`);
           const features = [
             c.slackEnabled && 'Slack',
-            c.webhookEnabled && 'webhooks',
-            c.freeflowEnabled && 'Free Flow voice',
-            c.realtimeVoiceEnabled && 'realtime voice (this session)',
-            c.semanticMemory && 'semantic memory',
-            obj(c.knowledgeGraph).enabled && 'the knowledge graph'
+            c.webhookEnabled && 'webhook',
+            c.freeflowEnabled && 'Free Flow 语音',
+            c.realtimeVoiceEnabled && '实时语音（本会话）',
+            c.semanticMemory && '语义记忆',
+            obj(c.knowledgeGraph).enabled && '知识图谱'
           ].filter(Boolean);
-          if (features.length) parts.push(`Enabled features: ${features.join(', ')}.`);
+          if (features.length) parts.push(`已启用功能：${features.join('、')}。`);
           return parts.join(' ');
-        }, 'configuration')
+        }, '配置信息')
     }),
 
     // ── get_memory ────────────────────────────────────────────────────────
     tool({
       name: 'get_memory',
       description:
-        "Read the team's memory. You can ALWAYS answer with this — it never dead-ends. Pass a query to search everything the hive has learned; pass an agentId to read ONE agent's notes (works for any agent, active OR archived); pass BOTH to search within that one agent's notes; pass neither for memory status. Semantic search is used when available, otherwise a direct text search across every agent's memory file. Call this whenever the user asks what the team learned, remembered, decided, or noted.",
+        "读取团队的记忆。你随时都可以用它作答——它绝不会走进死胡同。传入 query 可搜索 hive 学到的一切；传入 agentId 可读取某一个 agent 的笔记（对任何 agent 都有效，无论活跃还是已归档）；两者都传则在该 agent 的笔记内搜索；都不传则返回记忆状态。可用时使用语义搜索，否则对所有 agent 的记忆文件做直接文本搜索。当用户问团队学到了什么、记住了什么、决定了什么或记录了什么时候调用此工具。",
       parameters: {
         type: 'object',
         properties: {
-          query: { type: 'string', description: "Optional. What to search for across the team's memory." },
-          agentId: { type: 'string', description: "Optional. An agent id to read or scope the search to — any agent, active or archived." }
+          query: { type: 'string', description: '可选。要在团队记忆中搜索什么。' },
+          agentId: { type: 'string', description: '可选。要读取或限定搜索范围的 agent id——任何 agent，无论活跃还是已归档。' }
         },
         required: [],
         additionalProperties: false
@@ -320,9 +311,9 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
           const query = str(a.query).trim();
           const agentId = str(a.agentId).trim();
 
-          // Direct text fallback across every agent's memory.md (INCLUDING archived
-          // agents), the board, and tasks — works with or without the semantic
-          // memory CLI, so a query can never dead-end. Optionally narrow to one agent.
+          // 跨每个 agent 的 memory.md（包括已归档的）、看板与任务做直接文本
+          // 回退——有或没有语义记忆 CLI 都能工作，所以查询绝不会走进死胡同。
+          // 可选地收窄到单个 agent。
           const textFallback = async (q: string, onlyAgent?: string): Promise<string> => {
             const res = await window.cth.textSearch(q);
             if (!res.ok || !res.results.length) return '';
@@ -335,11 +326,11 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
               if (!bySource.has(who)) bySource.set(who, []);
               bySource.get(who)!.push(r.excerpt);
             }
-            const lines = [...bySource.entries()].slice(0, 6).map(([who, ex]) => `${who} noted ${ex.slice(0, 2).join('; ')}`);
-            return `From the team's notes — ${lines.join('. ')}.`;
+            const lines = [...bySource.entries()].slice(0, 6).map(([who, ex]) => `${who} 记录：${ex.slice(0, 2).join('；')}`);
+            return `来自团队的笔记——${lines.join('。')}。`;
           };
 
-          // query + agentId → search WITHIN one agent (semantic wing first, then text).
+          // query + agentId → 在单个 agent 内搜索（先语义分支，再文本）。
           if (query && agentId) {
             const res = await window.cth.searchMemory(query, agentId);
             if (res.ok && res.output.trim()) return clip(res.output.trim(), 1600);
@@ -348,47 +339,47 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
             const mem = await window.cth.hiveMemory(agentId);
             const ql = query.toLowerCase();
             const matched = mem.split('\n').map((l) => l.trim()).filter((l) => l.toLowerCase().includes(ql)).slice(0, 8);
-            if (matched.length) return clip(`From ${agentId}'s memory — ${matched.join(' ')}`, 1600);
+            if (matched.length) return clip(`来自 ${agentId} 的记忆——${matched.join(' ')}`, 1600);
             return mem.trim()
-              ? `I read ${agentId}'s memory but found nothing about "${query}".`
-              : `${agentId} has not recorded any memory yet.`;
+              ? `我读了 ${agentId} 的记忆，但没有找到与「${query}」相关的内容。`
+              : `${agentId} 还没有记录任何记忆。`;
           }
 
-          // query alone → semantic across the whole palace, then text fallback across all agents.
+          // 仅 query → 先跨整个宫庭做语义搜索，再回退到所有 agent 的文本。
           if (query) {
             const res = await window.cth.searchMemory(query);
             if (res.ok && res.output.trim()) return clip(res.output.trim(), 1600);
             const tf = await textFallback(query);
             if (tf) return clip(tf, 1600);
-            return `I searched the team's memory but found nothing about "${query}".`;
+            return `我搜索了团队的记忆，但没有找到与「${query}」相关的内容。`;
           }
 
-          // agentId alone → read that agent's notes directly (any agent, active OR archived).
+          // 仅 agentId → 直接读取该 agent 的笔记（任何 agent，活跃或已归档）。
           if (agentId) {
             const mem = await window.cth.hiveMemory(agentId);
-            return mem.trim() ? clip(mem.trim(), 1600) : `${agentId} has not recorded any memory yet.`;
+            return mem.trim() ? clip(mem.trim(), 1600) : `${agentId} 还没有记录任何记忆。`;
           }
 
-          // neither → status, but make clear search always works.
+          // 都没有 → 状态，但要讲清楚搜索永远可用。
           const status = await window.cth.memoryStatus();
           const sem = status.active
-            ? 'Semantic memory is active'
+            ? '语义记忆处于启用状态'
             : status.available
-            ? 'Semantic memory is enabled but idle'
-            : 'Semantic memory is offline';
-          return `${sem} — but I can always text-search every agent's notes, active or archived. Ask me to search a topic, or name an agent to read their memory.`;
-        }, 'memory')
+            ? '语义记忆已启用但处于空闲'
+            : '语义记忆当前离线';
+          return `${sem}——但我随时都可以全文搜索每个 agent 的笔记，无论活跃还是已归档。你可以让我搜索某个主题，或点名某个 agent 读取其记忆。`;
+        }, '记忆')
     }),
 
     // ── get_activity ──────────────────────────────────────────────────────
     tool({
       name: 'get_activity',
       description:
-        'The most recent hive activity log: spawns, archives, messages, and other lifecycle events, newest first. Call this when the user asks what just happened, for recent activity, or for a play-by-play.',
+        '最近的 hive 活动日志：生成、归档、消息等生命周期事件，最新的在前。当用户问刚才发生了什么、要最近活动、或要逐条回顾时调用此工具。',
       parameters: {
         type: 'object',
         properties: {
-          limit: { type: 'number', description: 'Optional. How many recent events to summarize (default 12, max 40).' }
+          limit: { type: 'number', description: '可选。汇总多少条最近事件（默认 12，最多 40）。' }
         },
         required: [],
         additionalProperties: false
@@ -399,32 +390,32 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
           const want = typeof a.limit === 'number' && isFinite(a.limit) ? Math.max(1, Math.min(40, Math.round(a.limit))) : 12;
           const log = await window.cth.hiveLog(want);
           const list = Array.isArray(log) ? log : [];
-          if (!list.length) return 'There is no recorded hive activity yet.';
+          if (!list.length) return '目前还没有记录到任何 hive 活动。';
           const lines = list
             .slice(-want)
             .reverse()
             .map((e) => {
               const o = obj(e);
-              const kind = str(o.kind) || str(o.event) || 'event';
+              const kind = str(o.kind) || str(o.event) || '事件';
               const who = str(o.agentId) || str(o.name) || str(o.from);
               const when = ago(o.ts);
-              return `${kind}${who ? ` by ${who}` : ''} ${when}`;
+              return `${kind}${who ? `，由 ${who}` : ''} ${when}`;
             });
-          return `Most recent activity: ${lines.join('; ')}.`;
-        }, 'activity log')
+          return `最近活动：${lines.join('；')}。`;
+        }, '活动日志')
     }),
 
     // ── get_messages ──────────────────────────────────────────────────────
     tool({
       name: 'get_messages',
       description:
-        "Read the actual CONTENT of hive messages — what agents have said to each other in their inboxes and outboxes, not just that an event happened. Use this when the user wants to know what a message SAID, what someone asked or reported, or to catch up on the latest traffic. Pass an agentId to focus on one agent's mailbox, pass a messageId to read one specific message in full, or pass neither for the most recent messages across the whole floor. Secrets and keys are always stripped before you see them, so quote bodies freely.",
+        "读取 hive 消息的实际内容——agent 们在收件箱和发件箱里对彼此说了什么，而不只是发生了某个事件。当用户想知道某条消息说了什么、某人问了或报告了什么、或要跟上最新动态时使用此工具。传入 agentId 聚焦某个 agent 的邮箱，传入 messageId 完整读取某一条消息，或都不传以读取整个楼层的最近消息。机密和密钥在到达你之前总会先被剥离，所以可以放心引用正文。",
       parameters: {
         type: 'object',
         properties: {
-          agentId: { type: 'string', description: "Optional. Focus on one agent's inbox and outbox (id or, if you have it, the exact id)." },
-          messageId: { type: 'string', description: 'Optional. Read one specific message in full by its id.' },
-          limit: { type: 'number', description: 'Optional. How many recent messages to summarize (default 8, max 40).' }
+          agentId: { type: 'string', description: '可选。聚焦某个 agent 的收件箱和发件箱（id，或你手上有的准确 id）。' },
+          messageId: { type: 'string', description: '可选。按 id 完整读取某一条消息。' },
+          limit: { type: 'number', description: '可选。汇总多少条最近消息（默认 8，最多 40）。' }
         },
         required: [],
         additionalProperties: false
@@ -436,39 +427,39 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
           const messageId = str(a.messageId).trim();
           const limit = typeof a.limit === 'number' && isFinite(a.limit) ? Math.max(1, Math.min(40, Math.round(a.limit))) : 8;
 
-          // Speak one message's body relative to a perspective. from→to + subject + body.
+          // 相对视角说出一条消息正文。from→to + subject + body。
           const speakOne = (m: { from: string; to: string; subject: string; body: string; created_at: string; requires_reply: boolean }, full: boolean): string => {
             const subj = str(m.subject).trim();
             const body = despan(str(m.body)).trim();
-            const head = `${str(m.from) || 'someone'} to ${str(m.to) || 'someone'}${subj ? ` about "${clip(subj, 80)}"` : ''} ${ago(Date.parse(m.created_at))}`;
-            if (!body) return `${head}, with no body.`;
-            return `${head}: ${clip(body, full ? 700 : 220)}${m.requires_reply ? ' (a reply was requested)' : ''}`;
+            const head = `${str(m.from) || '某人'} 发给 ${str(m.to) || '某人'}${subj ? `，主题「${clip(subj, 80)}」` : ''} ${ago(Date.parse(m.created_at))}`;
+            if (!body) return `${head}，没有正文。`;
+            return `${head}：${clip(body, full ? 700 : 220)}${m.requires_reply ? '（对方请求了回复）' : ''}`;
           };
 
           if (messageId) {
             const found = await window.cth.hiveMessages({ id: messageId });
-            if (!found.length) return `I couldn't find a message with id ${messageId}.`;
-            return `That message — ${speakOne(found[0], true)}.`;
+            if (!found.length) return `找不到 id 为 ${messageId} 的消息。`;
+            return `这条消息——${speakOne(found[0], true)}。`;
           }
 
           const msgs = await window.cth.hiveMessages(agentId ? { agentId, limit } : { limit });
           if (!msgs.length)
-            return agentId ? `I don't see any messages in ${agentId}'s mailbox.` : 'There are no hive messages to read yet.';
-          const scope = agentId ? `${agentId}'s mailbox` : 'the floor';
+            return agentId ? `在 ${agentId} 的邮箱里没有看到任何消息。` : '目前还没有可读取的 hive 消息。';
+          const scope = agentId ? `${agentId} 的邮箱` : '整个楼层';
           const lines = msgs.slice(0, limit).map((m) => speakOne(m, false));
-          return `${plural(lines.length, 'recent message')} from ${scope}: ${lines.join('. ')}.`;
-        }, 'messages')
+          return `来自${scope}的${plural(lines.length, '条最近消息')}：${lines.join('。')}。`;
+        }, '消息')
     }),
 
     // ── get_agent_detail ──────────────────────────────────────────────────
     tool({
       name: 'get_agent_detail',
       description:
-        'Everything known about ONE agent: name, role, the engine and model it runs, its working directory, whether it is active or archived, its live status, how full its context window is, how many tokens it has used, its circuit-breaker state, what it last did, and whether it has recorded memory. Call this when the user asks about a specific agent — where it is working, which directory it is in, how it is doing, or for its full status. Accepts an id or a name.',
+        '关于某一个 agent 的全部已知信息：名称、角色、运行引擎与模型、工作目录、活跃还是已归档、实时状态、上下文窗口占用、累计 token 用量、熔断器状态、最近做了什么，以及是否已记录记忆。当用户问某个具体 agent——在哪里工作、在哪个目录、状态如何、或要完整状态时调用此工具。接受 id 或名称。',
       parameters: {
         type: 'object',
         properties: {
-          agentId: { type: 'string', description: 'The agent id or friendly name to look up (e.g. "kevin-mqpbq43v" or "Kevin").' }
+          agentId: { type: 'string', description: '要查询的 agent id 或友好名称（例如 "kevin-mqpbq43v" 或 "Kevin"）。' }
         },
         required: ['agentId'],
         additionalProperties: false
@@ -477,44 +468,44 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
         spoken(async () => {
           const a = obj(input);
           const want = str(a.agentId).trim().toLowerCase();
-          if (!want) return 'Tell me which agent you mean.';
+          if (!want) return '请告诉我你指的是哪个 agent。';
           const dir = await window.cth.hiveAgentDirectory();
           const list = Array.isArray(dir.agents) ? dir.agents : [];
           const e =
             list.find((x) => x.id.toLowerCase() === want) ??
             list.find((x) => x.name.toLowerCase() === want) ??
             list.find((x) => x.id.toLowerCase().startsWith(want) || x.name.toLowerCase().startsWith(want));
-          if (!e) return `I don't see an agent matching "${str(a.agentId)}".`;
+          if (!e) return `没有找到与「${str(a.agentId)}」匹配的 agent。`;
           const parts: string[] = [];
-          const role = e.role ? `, the ${e.role},` : '';
+          const role = e.role ? `，角色 ${e.role}` : '';
           const where = e.archived
-            ? 'archived — its terminal is closed, but its working directory and memory are still here'
-            : `active and ${e.status}`;
-          parts.push(`${e.name}${role} runs on ${e.provider}${e.model ? ` with model ${e.model}` : ''}, ${where}.`);
+            ? '已归档——其终端已关闭，但工作目录和记忆都还在'
+            : `活跃，状态为 ${e.status}`;
+          parts.push(`${e.name}${role}，运行引擎 ${e.provider}${e.model ? `，模型 ${e.model}` : ''}，${where}。`);
           if (e.cwd)
             parts.push(
-              `Working directory: ${e.cwd}${e.cwdValid === false ? ', which is not a valid directory — spawning there would fail' : ''}.`
+              `工作目录：${e.cwd}${e.cwdValid === false ? '，这不是一个有效目录——在那里生成 agent 会失败' : ''}。`
             );
-          if (typeof e.contextPct === 'number') parts.push(`Its context window is ${e.contextPct} percent full.`);
-          else if (typeof e.contextTokens === 'number') parts.push(`It is carrying ${tokens(e.contextTokens)} tokens of context.`);
-          if (e.tokens) parts.push(`It has used ${tokens(e.tokens)} tokens so far.`);
-          parts.push(`Circuit breaker: ${e.breaker}.`);
-          if (e.lastTool) parts.push(`Last tool was ${e.lastTool}${typeof e.lastActiveSecAgo === 'number' ? `, ${ago(Date.now() - e.lastActiveSecAgo * 1000)}` : ''}.`);
-          if (e.inboxBacklog) parts.push(`${plural(e.inboxBacklog, 'message')} waiting in its inbox.`);
-          parts.push(e.hasMemory ? "It has recorded memory — ask me to read it." : 'It has not recorded much memory yet.');
+          if (typeof e.contextPct === 'number') parts.push(`其上下文窗口已使用 ${e.contextPct}%。`);
+          else if (typeof e.contextTokens === 'number') parts.push(`其上下文约 ${tokens(e.contextTokens)} token。`);
+          if (e.tokens) parts.push(`它累计使用了 ${tokens(e.tokens)} token。`);
+          parts.push(`熔断器：${e.breaker}。`);
+          if (e.lastTool) parts.push(`最近使用的工具是 ${e.lastTool}${typeof e.lastActiveSecAgo === 'number' ? `，${ago(Date.now() - e.lastActiveSecAgo * 1000)}` : ''}。`);
+          if (e.inboxBacklog) parts.push(`收件箱里还有 ${plural(e.inboxBacklog, '条消息')} 待处理。`);
+          parts.push(e.hasMemory ? '它已记录记忆——可以让我读取。' : '它还没有记录多少记忆。');
           return parts.join(' ');
-        }, 'agent detail')
+        }, 'agent 详情')
     }),
 
     // ── list_agents ───────────────────────────────────────────────────────
     tool({
       name: 'list_agents',
       description:
-        'The FULL roster, including archived (inactive) agents: each one\'s name, engine, active-or-archived state, working directory, context fill, and breaker state. Use this to enumerate EVERYONE (including inactive agents), or to answer "where is X working", "who is archived", or "who is near their context limit". For live workers only, get_fleet_status is lighter.',
+        '完整名单，包括已归档（非活跃）agent：每个人的名称、引擎、活跃或已归档状态、工作目录、上下文占用和熔断器状态。用它枚举所有人（包括非活跃 agent），或回答「X 在哪里工作」「谁已归档」「谁接近上下文上限」。若只要当前活跃的 worker，get_fleet_status 更轻量。',
       parameters: {
         type: 'object',
         properties: {
-          includeArchived: { type: 'boolean', description: 'Default true. Set false to list only active agents.' }
+          includeArchived: { type: 'boolean', description: '默认为 true。设为 false 则只列出活跃 agent。' }
         },
         required: [],
         additionalProperties: false
@@ -525,53 +516,53 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
           const includeArchived = a.includeArchived !== false;
           const dir = await window.cth.hiveAgentDirectory();
           const all = Array.isArray(dir.agents) ? dir.agents : [];
-          if (!all.length) return 'The hive has no registered agents.';
+          if (!all.length) return 'hive 中还没有注册任何 agent。';
           const active = all.filter((e) => !e.archived);
           const archived = all.filter((e) => e.archived);
           const near = active
             .filter((e) => typeof e.contextPct === 'number' && e.contextPct >= 70)
-            .map((e) => `${e.name} at ${e.contextPct} percent`);
+            .map((e) => `${e.name} 已用 ${e.contextPct}%`);
           const describe = (e: typeof all[number]): string =>
-            `${e.name} on ${e.provider}${e.cwd ? ` in ${shortDir(e.cwd)}` : ''}${
-              typeof e.contextPct === 'number' ? `, context ${e.contextPct} percent` : ''
+            `${e.name}，引擎 ${e.provider}${e.cwd ? `，位于 ${shortDir(e.cwd)}` : ''}${
+              typeof e.contextPct === 'number' ? `，上下文已用 ${e.contextPct}%` : ''
             }`;
           const parts: string[] = [];
           parts.push(
-            `${plural(active.length, 'active agent')}${archived.length ? ` and ${plural(archived.length, 'archived agent')}` : ''}.`
+            `${plural(active.length, '个活跃 agent')}${archived.length ? `，另有 ${plural(archived.length, '个已归档 agent')}` : ''}。`
           );
-          if (active.length) parts.push(`Active: ${active.slice(0, 12).map(describe).join('; ')}.`);
+          if (active.length) parts.push(`活跃：${active.slice(0, 12).map(describe).join('；')}。`);
           if (includeArchived && archived.length)
             parts.push(
-              `Archived: ${archived
+              `已归档：${archived
                 .slice(0, 12)
-                .map((e) => `${e.name}${e.cwd ? ` (last in ${shortDir(e.cwd)})` : ''}`)
-                .join('; ')}.`
+                .map((e) => `${e.name}${e.cwd ? `（最后位于 ${shortDir(e.cwd)}）` : ''}`)
+                .join('；')}。`
             );
-          if (near.length) parts.push(`Near their context limit: ${near.join(', ')}.`);
+          if (near.length) parts.push(`接近上下文上限：${near.join('、')}。`);
           return parts.join(' ');
-        }, 'agent roster')
+        }, 'agent 名单')
     }),
 
     // ── get_board ─────────────────────────────────────────────────────────
     tool({
       name: 'get_board',
       description:
-        'The hive plan narrative — the human-readable board the orchestrator keeps in prose (the current plan, priorities, and notes). Call this when the user asks about the plan, the strategy, the roadmap, or what the board says.',
+        'hive 的计划叙事——调度器用散文形式维护的、人类可读的看板（当前计划、优先级和备注）。当用户问计划、策略、路线图、或看板上写了什么时调用此工具。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: () =>
         spoken(async () => {
           const board = await window.cth.hiveBoard();
           const text = despan(board || '');
-          if (!text) return 'The board is empty right now.';
+          if (!text) return '当前看板是空的。';
           return clip(text, 1800);
-        }, 'board')
+        }, '看板')
     }),
 
     // ── get_floor_state (v0.3.4) ──────────────────────────────────────────
     tool({
       name: 'get_floor_state',
       description:
-        'The LIVE floor in one call: every active agent with its current status, context fill, breaker state and inbox backlog, plus in-flight tasks. Returns compact JSON plus a one-line spoken summary. Prefer this for "what is everyone doing" style questions.',
+        '一次调用拿到实时楼层：每个活跃 agent 的当前状态、上下文占用、熔断器状态和收件箱积压，外加进行中的任务。返回紧凑 JSON 加一行口语总结。适合「大家都在做什么」这类问题。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: () =>
         spoken(async () => {
@@ -583,7 +574,7 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
             .filter((a) => !a.archived)
             .map((a) => ({
               name: str(a.name) || str(a.id),
-              status: str(a.status) || 'unknown',
+              status: str(a.status) || '未知',
               engine: str(a.provider) || undefined,
               contextPct: typeof a.contextPct === 'number' ? a.contextPct : undefined,
               breaker: str(a.breaker) && str(a.breaker) !== 'healthy' ? str(a.breaker) : undefined,
@@ -591,41 +582,39 @@ export function realtimeReadTools(): ReturnType<typeof tool>[] {
             }));
           const doing = tasks.filter((t) => str(t.status) === 'doing').map((t) => ({ title: str(t.title), owner: str(t.assignee) || undefined }));
           const blocked = tasks.filter((t) => str(t.status) === 'blocked').map((t) => ({ title: str(t.title), owner: str(t.assignee) || undefined }));
-          const summary = `${plural(rows.length, 'agent')} on the floor, ${doing.length} in progress, ${blocked.length} blocked.`;
-          // Flagged JSON per the Realtime prompting guidance: precise fields the
-          // model can quote verbatim, with the spoken line separate.
+          const summary = `楼层上有 ${plural(rows.length, '个 agent')}，${doing.length} 个进行中，${blocked.length} 个阻塞。`;
+          // 按 Realtime 提示指引标记的 JSON：模型可直接逐字引用的精确字段，
+          // 口语行则单独给出。
           return `${summary} DATA: ${JSON.stringify({ agents: rows, doing, blocked })}`;
-        }, 'floor state')
+        }, '楼层状态')
     }),
 
     // ── get_app_info (v0.3.4) ─────────────────────────────────────────────
     tool({
       name: 'get_app_info',
       description:
-        'About the Munder Difflin app itself: the running version and the latest release notes (changelog). Use for "what version is this" or "what is new in this release".',
+        '关于 Munder Difflin 应用本身：当前运行的版本和最新的发布说明（更新日志）。用于回答「这是什么版本」或「这个版本有什么新功能」。',
       parameters: { type: 'object', properties: {}, required: [], additionalProperties: false },
       execute: () =>
         spoken(async () => {
           const info = await window.cth.appInfo();
           const notes = despan(info.changelog || '');
-          return `This is Munder Difflin version ${info.version}. ${notes ? `Latest release notes: ${clip(notes, 1600)}` : 'No release notes are bundled with this build.'}`;
-        }, 'app info')
+          return `这是 Munder Difflin ${info.version} 版本。${notes ? `最新发布说明：${clip(notes, 1600)}` : '该版本未附带发布说明。'}`;
+        }, '应用信息')
     })
   ];
 }
 
 /**
- * A short, preloaded orientation Michael can open the session with — the hive
- * size, who god is, and how many tasks are in flight — so the first answer is
- * grounded without a tool round-trip. Best-effort: returns '' if reads fail, so
- * the caller can safely concatenate it onto the agent instructions.
+ * Michael 打开会话时可携带的一段简短、预加载的导向——hive 规模、god 是谁、
+ * 有多少任务在进行中——让第一个回答无需工具往返即有据可依。尽力而为：
+ * 读取失败返回 ''，调用方可以安全地把它拼到 agent 指令上。
  */
 export async function realtimeSessionSummary(): Promise<string> {
   try {
-    // v0.3.4: a COMPACT PER-AGENT TABLE, not just counts — most "what's
-    // happening" questions should be answerable from this alone, with zero
-    // tool round-trips. Injected as the FIRST CONVERSATION ITEM (not into the
-    // instructions), so the cached prompt prefix stays byte-stable.
+    // v0.3.4：一张紧凑的 PER-AGENT 表格，而不只是计数——大多数“发生了什么”
+    // 类问题仅凭它就该能回答，零工具往返。作为第一个对话项注入（不是注入
+    // 指令），让缓存的提示前缀保持字节稳定。
     const [dir, tasksRaw] = await Promise.all([
       window.cth.hiveAgentDirectory(),
       window.cth.hiveTasks()
@@ -634,30 +623,30 @@ export async function realtimeSessionSummary(): Promise<string> {
     const godRow = rows.find((a) => a.isGod === true);
     const lines = rows.slice(0, 20).map((a) => {
       const bits = [
-        `${str(a.name) || str(a.id)} is ${str(a.status) || 'in an unknown state'}`,
-        str(a.provider) ? `on ${str(a.provider)}` : '',
-        typeof a.contextPct === 'number' ? `context ${Math.round(a.contextPct as number)} percent full` : '',
-        str(a.breaker) && str(a.breaker) !== 'healthy' ? `breaker ${str(a.breaker)}` : '',
-        typeof a.inboxBacklog === 'number' && (a.inboxBacklog as number) > 0 ? `${a.inboxBacklog} unread` : ''
+        `${str(a.name) || str(a.id)} 状态：${str(a.status) || '未知'}`,
+        str(a.provider) ? `引擎 ${str(a.provider)}` : '',
+        typeof a.contextPct === 'number' ? `上下文已用 ${Math.round(a.contextPct as number)}%` : '',
+        str(a.breaker) && str(a.breaker) !== 'healthy' ? `熔断器 ${str(a.breaker)}` : '',
+        typeof a.inboxBacklog === 'number' && (a.inboxBacklog as number) > 0 ? `${a.inboxBacklog} 条未读` : ''
       ].filter(Boolean);
-      return bits.join(', ');
+      return bits.join('，');
     });
     const list = Array.isArray(obj(tasksRaw).tasks) ? (obj(tasksRaw).tasks as unknown[]).map(obj) : [];
     const doing = list.filter((t) => str(t.status) === 'doing');
     const blocked = list.filter((t) => str(t.status) === 'blocked');
     const taskLine = [
       doing.length
-        ? `In progress: ${doing.slice(0, 5).map((t) => `"${str(t.title)}"${str(t.assignee) ? ` with ${str(t.assignee)}` : ''}`).join('; ')}.`
-        : 'Nothing is in progress on the board.',
-      blocked.length ? `Blocked: ${blocked.slice(0, 4).map((t) => `"${str(t.title)}"`).join('; ')}.` : ''
+        ? `进行中：${doing.slice(0, 5).map((t) => `「${str(t.title)}」${str(t.assignee) ? `，负责 ${str(t.assignee)}` : ''}`).join('；')}。`
+        : '看板上没有进行中的任务。',
+      blocked.length ? `阻塞：${blocked.slice(0, 4).map((t) => `「${str(t.title)}」`).join('；')}。` : ''
     ].filter(Boolean).join(' ');
     return (
-      `Floor at connect — ${plural(rows.length, 'agent')} active` +
-      `${godRow ? `, ${str(godRow.name)} orchestrating alongside you` : ''}. ` +
-      `Per agent: ${lines.join(' | ') || 'none'}. ` +
+      `连接时的楼层快照——${plural(rows.length, '个活跃 agent')}` +
+      `${godRow ? `，${str(godRow.name)} 与你一同调度` : ''}。 ` +
+      `逐个 agent：${lines.join(' | ') || '无'}。 ` +
       taskLine +
-      ` You will also receive short "(Floor update: …)" notes as things change mid-call — trust those over this snapshot.` +
-      ` You share the floor with god (the typing orchestrator); the board is the single source of truth.`
+      ` 通话过程中情况变化时，你还会收到简短的 "(Floor update: …)"（楼层更新）提示——请以它们为准，优先于这份快照。` +
+      ` 你和 god（打字端调度器）共享整个楼层；任务看板是唯一的事实来源。`
     );
   } catch {
     return '';

--- a/src/renderer/src/scene/office/Camera.ts
+++ b/src/renderer/src/scene/office/Camera.ts
@@ -1,9 +1,9 @@
 import { Container } from 'pixi.js';
 
-// Simplified port of shahar061/the-office (office/engine/camera.ts).
-// Phase targeting is dropped (we have no project phases); kept: fit-to-screen,
-// map-edge clamping, smooth lerp, a manual focus(), and nudgeToward() used to
-// pan toward the selected agent.
+// shahar061/the-office 的简化移植（office/engine/camera.ts）。
+// 阶段定位被去掉（我们没有项目阶段）；保留：适配屏幕、
+// 地图边缘钳制、平滑插值、手动 focus()，以及用于向所选 agent
+// 平移的 nudgeToward()。
 
 const LERP_SPEED = 0.08;
 
@@ -47,7 +47,7 @@ export class Camera {
     return Math.min(this.viewWidth / this.mapWidth, this.viewHeight / this.mapHeight);
   }
 
-  /** Fit the whole map to the viewport, centered. */
+  /** 把整个地图适配到视口，居中。 */
   fitToScreen(): void {
     this.manualOverride = false;
     this.targetX = this.mapWidth / 2;
@@ -55,7 +55,7 @@ export class Camera {
     this.targetZoom = this.getMinZoom();
   }
 
-  /** Pan/zoom toward a world point (used when an agent is selected). */
+  /** 朝某个世界点平移/缩放（选中的 agent 时使用）。 */
   focusOn(worldX: number, worldY: number, zoom?: number): void {
     this.manualOverride = true;
     this.targetX = worldX;
@@ -63,7 +63,7 @@ export class Camera {
     this.targetZoom = Math.max(this.getMinZoom(), Math.min(4, zoom ?? this.currentZoom));
   }
 
-  /** A gentle, decaying pan toward a world point without taking manual control. */
+  /** 温和、衰减地朝某个世界点平移，而不接管手动控制。 */
   nudgeToward(worldX: number, worldY: number, duration = 1200): void {
     if (this.manualOverride) return;
     this.nudgeOffsetX = (worldX - this.targetX) * this.nudgeStrength;

--- a/src/renderer/src/scene/office/Character.ts
+++ b/src/renderer/src/scene/office/Character.ts
@@ -4,11 +4,10 @@ import { findPath } from './pathfinding';
 import type { TiledMapRenderer } from './TiledMapRenderer';
 import { ThoughtBubble } from './ThoughtBubble';
 
-// Adapted from shahar061/the-office (office/characters/Character.ts).
-// Differences: keyed by our dynamic agentId (not a fixed role); seat tile +
-// glow color are injected (we seat agents from a pool); CSS-theme halo pulse
-// replaced with constants; added blocked "!" + success sparkle overlays to
-// cover our status model.
+// 改编自 shahar061/the-office（office/characters/Character.ts）。
+// 差异：按我们的动态 agentId 索引（不是固定角色）；座位瓦片 + 光晕颜色是
+// 注入的（我们从池子里给 agent 分配座位）；CSS 主题光晕脉冲换成常量；新增
+// 阻塞“!” + 成功闪光覆盖层，以覆盖我们的状态模型。
 
 export type CharacterAnimation = 'idle' | 'walk' | 'type' | 'read';
 export type StatusGlyph = 'none' | 'blocked' | 'success' | 'compacting' | 'looping';
@@ -18,10 +17,9 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * tt;
 }
 
-/** A tiny coffee mug (white body, yellow stripe, handle) at (x, y) = its
- *  bottom-left. Same silhouette as the mug the tileset used to bake onto
- *  every desk — now it only exists where an agent actually put one down.
- *  Shared with the scene (the clean-cup sideboard renders its stock with it). */
+/** 一个小咖啡马克杯（白身、黄条、把手），(x, y) = 它的左下角。与 tileset
+ *  曾经烘在每张桌子上的马克杯同轮廓——现在它只存在于 agent 真的放下一个的
+ *  地方。与场景共享（干净杯具餐边柜用它渲染库存）。 */
 export function paintCup(g: Graphics, x: number, y: number): void {
   g.rect(x, y - 4, 5, 4).fill(0xf2ede2);
   g.rect(x, y - 2, 5, 1).fill(0xe8c14d);
@@ -29,29 +27,24 @@ export function paintCup(g: Graphics, x: number, y: number): void {
   g.rect(x, y - 4, 5, 1).fill(0xffffff);
 }
 
-const SPEED = 48; // pixels/sec (tileSize=16)
-// Slide the sprite when seated so it reads as "sitting on the chair" rather than
-// standing on the tile. The chair tile holds the chair/barrel, with the desk in
-// the tile the agent faces. The feet are anchored at the seat tile's bottom and
-// the body is ~2 tiles tall, so without a nudge the head overshoots past the far
-// desk edge and the chair below looks empty. We push the body toward the viewer
-// (down, for up/side seats; the desk is behind them) so the head settles at the
-// monitor and the torso rests on the chair. Down-facing agents (desk in front)
-// are pushed into the desk instead.
+const SPEED = 48; // 像素/秒（tileSize=16）
+// 坐下时滑动精灵，让它读起来是“坐在椅子上”而不是站在瓦片上。椅子瓦片放
+// 着椅子/桶，agent 面对的那块瓦片是桌子。脚锚在座位瓦片底部、身体约 2 个
+// 瓦片高，所以没有推挤的话头会越到远处桌沿外、下面的椅子看起来空着。我们把
+// 身体朝观看者推（向下，用于上/侧向座位；桌子在它们后面），让头落在显示器
+// 处、躯干坐在椅子上。面向下的 agent（桌子在前）被推进桌子。
 const SIT_OFFSET = 5;
 const SIT_OFFSET_DOWN = 12;
-const SIT_OFFSET_UP = 5;   // up-facing: drop the body down onto the chair
-const SIT_OFFSET_SIDE = 4; // left/right: a smaller drop plus the sideways tuck
-// Pixels cropped off the bottom of the 32px sprite while seated. Up/side seats
-// trim just the feet so most of the torso shows and fills the chair seat; the
-// down-facing crop is larger so the legs tuck under the desk in front.
+const SIT_OFFSET_UP = 5;   // 面向向上：把身体放低到椅子上
+const SIT_OFFSET_SIDE = 4; // 左/右：小一点的落差 + 侧向收拢
+// 坐姿时从 32px 精灵底部裁掉的像素。上/侧向座位只裁脚，让大部分躯干露出并
+// 填满椅面；面向下的裁剪更大，让腿收进前面的桌子下面。
 const SEAT_LEG_CROP = 8;
 const SEAT_BACK_CROP = 2;
 
-// Idle 30/30 loop: between tasks an agent alternates roaming the floor with
-// resting at its own desk — for every IDLE_LINGER_SECONDS it spends lingering it
-// then sits at its desk for DESK_REST_SECONDS, and repeats. Working agents skip
-// this entirely (they stay seated via sitAtDesk).
+// 空闲 30/30 循环：任务之间 agent 在地板上游荡与在自己桌前休息交替——
+// 每闲逛 IDLE_LINGER_SECONDS 秒就在桌前坐 DESK_REST_SECONDS 秒，如此反复。
+// 工作中的 agent 完全跳过它（他们经 sitAtDesk 保持坐着）。
 const IDLE_LINGER_SECONDS = 30;
 const DESK_REST_SECONDS = 30;
 
@@ -60,10 +53,10 @@ interface CharacterOptions {
   mapRenderer: TiledMapRenderer;
   frames: Texture[][];
   seatTile: { x: number; y: number };
-  /** Where the avatar first appears (the office door). Defaults to seatTile. */
+  /** 头像首次出现的位置（办公室门）。默认 seatTile。 */
   spawnTile?: { x: number; y: number };
   glowColor: number;
-  /** Direction faced while seated. Default 'down' so the face is toward the user. */
+  /** 坐姿时朝向。默认 'down'，让脸朝向用户。 */
   seatDirection?: Direction;
   onClick?: (agentId: string) => void;
 }
@@ -85,7 +78,7 @@ export class Character {
   private wandering = false;
   private idleTimer = 0;
   private idleWanderDelay = 1 + Math.random() * 3;
-  // Idle 30/30 loop state (see constants above). Active only between tasks.
+  // 空闲 30/30 循环状态（见上方常量）。仅在任务之间激活。
   private idleLoop = false;
   private idleLoopPhase: 'linger' | 'toDesk' | 'resting' = 'linger';
   private idleLoopTimer = 0;
@@ -108,22 +101,21 @@ export class Character {
   private glyphElapsed = 0;
   private onClick?: (agentId: string) => void;
 
-  // ── Office-life effects (cheer / coffee / watering) ────────────────────────
-  /** Effect layer riding on the sprite: confetti, the carried cup, droplets. */
+  // ── 办公室生活特效（欢呼 / 咖啡 / 浇水）────────────────────────────
+  /** 挂在精灵上的特效层：彩纸、手持的杯子、水滴。 */
   private fx: Graphics;
-  private fxDirty = false;            // fx drew last frame → needs a clear when idle
-  private cheerT = -1;                // -1 = not cheering
+  private fxDirty = false;            // fx 上一帧画过 → 空闲时需要清除
+  private cheerT = -1;                // -1 = 未在欢呼
   private confetti: Array<{ x: number; y: number; vx: number; vy: number; c: number }> = [];
   private carryingCup = false;
-  /** The cup parked on this agent's desk (world-positioned, lives in the char
-   *  layer so it survives the agent walking away). */
+  /** 停在该 agent 桌子上的杯子（世界坐标定位，活在角色层里，agent 走开也还在）。 */
   private deskCup: Graphics;
   private deskCupOn = false;
   private cupSpot: { x: number; y: number } | null = null;
-  private waterT = -1;                // -1 = not watering
+  private waterT = -1;                // -1 = 未在浇水
   private waterDur = 0;
   private onWaterDone: (() => void) | null = null;
-  private smokeT = -1;                // -1 = not smoking (the boss's cigar)
+  private smokeT = -1;                // -1 = 未在抽烟（老板的雪茄）
   private smokeDur = 0;
   private onSmokeDone: (() => void) | null = null;
 
@@ -135,7 +127,7 @@ export class Character {
     this.seatDirection = options.seatDirection ?? 'down';
     this.onClick = options.onClick;
 
-    // Appear at the spawn tile (the door) and walk in from there.
+    // 出现在出生瓦片（门）处，然后从这里走进来。
     const start = options.spawnTile ?? this.deskTile;
     const pos = this.mapRenderer.tileToPixel(start.x, start.y);
     this.px = pos.x + this.mapRenderer.tileSize / 2;
@@ -143,8 +135,8 @@ export class Character {
     this.sprite.setPosition(this.px, this.py);
 
     this.thoughtBubble = new ThoughtBubble();
-    // Keep the cloud inside the world — Michael's corner office would
-    // otherwise push his bubble off the top/left map edge.
+    // 让气泡留在世界内——否则 Michael 的角落办公室会把他的气泡
+    // 挤出地图上/左边缘。
     this.thoughtBubble.setBounds(
       this.mapRenderer.width * this.mapRenderer.tileSize,
       this.mapRenderer.height * this.mapRenderer.tileSize
@@ -178,8 +170,8 @@ export class Character {
   moveTo(tile: { x: number; y: number }): void {
     const path = findPath(this.mapRenderer, this.getTilePosition(), tile);
     if (path && path.length > 0) {
-      this.sitting = false; // stand up before walking (clears the sit offset)
-      this.sprite.setSeatedCrop(0); // show legs again while standing/walking
+      this.sitting = false; // 走路前先站起来（清掉坐姿偏移）
+      this.sprite.setSeatedCrop(0); // 站立/走路时重新露出腿
       this.path = path;
       this.state = 'walk';
       this.sprite.setAnimation('walk', this.direction);
@@ -187,28 +179,28 @@ export class Character {
   }
 
   walkToAndThen(tile: { x: number; y: number }, callback: () => void): void {
-    this.idleLoop = false; // a directed walk-and-do (e.g. a café break) owns the avatar
+    this.idleLoop = false; // 定向“走过去然后做某事”（如咖啡休息）占据头像
     this.arrivalCallback = callback;
     this.moveTo(tile);
     if (this.state !== 'walk') {
-      // No path produced. If we're already on the tile, fire the callback now;
-      // otherwise it's unreachable — drop it so we don't "arrive" somewhere else.
+      // 没有生成路径。如果已经在这块瓦片上，现在就触发回调；
+      // 否则不可达——丢掉它，免得“到达”别的地方。
       this.arrivalCallback = null;
       const t = this.getTilePosition();
       if (t.x === tile.x && t.y === tile.y) callback();
     }
   }
 
-  /** Sit at the assigned desk, facing the monitor. Walks there first if away.
-   *  `working` toggles the pulsing focus halo. This is the default pose — agents
-   *  stay seated unless blocked. */
+  /** 坐在分配的桌子前，面向显示器。若不在则先走过去。
+   *  `working` 切换脉冲式专注光晕。这是默认姿态——agent
+   *  除非被阻塞，否则保持坐着。 */
   sitAtDesk(working: boolean): void {
-    this.idleLoop = false;     // an explicit desk command ends the idle loop
+    this.idleLoop = false;     // 显式的坐桌命令结束空闲循环
     this.walkToDeskAndSit(working);
   }
 
-  /** Walk to the home desk (if away) and sit. `working` toggles the focus halo.
-   *  Shared by sitAtDesk (real work/wait) and the idle-loop rest. */
+  /** 走到家桌（若不在）并坐下。`working` 切换专注光晕。
+   *  由 sitAtDesk（真正的工作/等待）和空闲循环休息共用。 */
   private walkToDeskAndSit(working: boolean): void {
     this.glowOn = working;
     this.wandering = false;
@@ -219,17 +211,17 @@ export class Character {
       this.pendingSit = true;
       this.pendingWork = null;
       this.arrivalCallback = null;
-      this.moveTo(this.deskTile); // updateWalk() sits on arrival
+      this.moveTo(this.deskTile); // updateWalk() 到达时坐下
     }
   }
 
-  /** Snap into the seated pose at the current (desk) tile. */
+  /** 在当前（桌子）瓦片上瞬间进入坐姿。 */
   private applySit(): void {
     this.applySitPose(this.seatDirection);
   }
 
-  /** Snap into a seated pose facing `dir` at the current tile. Shared by the
-   *  home desk (applySit) and any café seat (sitInPlace). */
+  /** 在当前瓦片上瞬间进入面向 `dir` 的坐姿。由
+   *  家桌（applySit）和任意咖啡座（sitInPlace）共用。 */
   private applySitPose(dir: Direction): void {
     this.state = 'idle';
     this.pendingWork = null;
@@ -238,8 +230,8 @@ export class Character {
     this.sitting = true;
     this.direction = dir;
     this.sprite.setAnimation('idle', dir);
-    // Slide toward the desk so the agent tucks in instead of floating in the
-    // aisle, then crop the legs so they read as seated (no standing legs).
+    // 朝桌子滑动，让 agent 收进去而不是飘在过道里，再裁掉腿，
+    // 让它们读起来是坐着的（没有站立的腿）。
     let dx = 0, dy = 0;
     switch (dir) {
       case 'down':  dy = SIT_OFFSET_DOWN; break;
@@ -251,10 +243,9 @@ export class Character {
     this.sprite.setSeatedCrop(dir === 'down' ? SEAT_LEG_CROP : SEAT_BACK_CROP);
   }
 
-  /** Sit on a café seat at the CURRENT tile, facing `dir`. The agent must have
-   *  already walked onto the seat tile (drive this from walkToAndThen). Unlike
-   *  sitAtDesk this leaves the agent's home desk untouched and never lights the
-   *  focus halo — it's a break, not work. */
+  /** 坐在当前瓦片上的咖啡座，面向 `dir`。agent 必须先已经
+   *  走到座位瓦片上（用 walkToAndThen 驱动）。与 sitAtDesk 不同，
+   *  这不动 agent 的家桌，也从不点亮专注光晕——这是休息，不是工作。 */
   sitInPlace(dir: Direction): void {
     this.idleLoop = false;
     this.wandering = false;
@@ -263,13 +254,13 @@ export class Character {
     this.applySitPose(dir);
   }
 
-  /** True while the avatar is parked in a seated pose (desk or café). */
+  /** 头像是否停在坐姿（桌子或咖啡座）。 */
   isSitting(): boolean {
     return this.sitting;
   }
 
-  /** Turn a standing/idle avatar to face `dir` (e.g. toward the coffee machine
-   *  while taking a standing break). No-op mid-walk or while seated. */
+  /** 让站立/空闲的头像面向 `dir`（例如站着休息时面朝咖啡机）。
+   *  走路中途或坐着时无操作。 */
   faceDirection(dir: Direction): void {
     this.direction = dir;
     if (!this.sitting && this.state !== 'walk') {
@@ -291,19 +282,19 @@ export class Character {
     this.sprite.setPosition(this.px, this.py);
   }
 
-  /** Roam the office between tasks. Picks random walkable tiles and strolls
-   *  to them until the agent is given work again. */
+  /** 任务之间在办公室里闲逛。挑随机的可行走瓦片一直溜达，
+   *  直到 agent 再次被派活。 */
   startWandering(): void {
-    if (this.idleLoop && this.wandering) return; // already in the linger phase
-    // (Re)enter the idle loop at its linger phase, then begin roaming.
+    if (this.idleLoop && this.wandering) return; // 已经在闲逛阶段
+    // （重新）从闲逛阶段进入空闲循环，然后开始游荡。
     this.idleLoop = true;
     this.idleLoopPhase = 'linger';
     this.idleLoopTimer = 0;
     this.beginWander();
   }
 
-  /** Low-level: start roaming the floor now. Drives the linger phase of the
-   *  idle loop (and is reused when a rest ends). Does not touch the loop state. */
+  /** 底层：现在就起步在地板上游荡。驱动空闲循环的
+   *  闲逛阶段（休息结束时也会复用）。不改循环状态。 */
   private beginWander(): void {
     if (this.wandering) return;
     this.glowOn = false;
@@ -317,11 +308,11 @@ export class Character {
     if (this.state !== 'walk') {
       this.state = 'idle';
       this.sprite.setAnimation('idle', this.direction);
-      this.sprite.setPosition(this.px, this.py); // clear any sit offset
+      this.sprite.setPosition(this.px, this.py); // 清掉坐姿偏移
     }
   }
 
-  /** Walk to an arbitrary tile (e.g. the waiting area when blocked); stands on arrival. */
+  /** 走到任意瓦片（如阻塞时去等候区）；到达后站着。 */
   walkToTile(tile: { x: number; y: number }): void {
     this.idleLoop = false;
     this.pendingWork = null;
@@ -340,30 +331,30 @@ export class Character {
     this.sprite.setPosition(this.px, this.py);
   }
 
-  /** Show what the agent is doing right now in the thought cloud above its head.
-   *  Empty text renders an animated "…" (thinking); `tool` adds a small glyph. */
+  /** 在头像头顶的气泡里显示它此刻在做什么。空文本渲染一个
+   *  动画“…”（思考中）；`tool` 加一个小图标。 */
   showThought(text: string, tool?: string): void {
     this.thoughtBubble.show(text, tool);
   }
 
-  /** Fade the thought cloud out after a short linger — the agent went quiet. */
+  /** 短暂停留后让气泡淡出——agent 安静下来了。 */
   hideThought(): void {
     this.thoughtBubble.startLinger();
   }
 
-  /** The thought cloud's current base screen rect (no lift), or null if hidden.
-   *  The scene uses this to detect and resolve overlapping bubbles. */
+  /** 气泡当前的基础屏幕矩形（无抬升），或隐藏时为 null。
+   *  场景用它检测并消解重叠的气泡。 */
   getThoughtLayout(): { x: number; y: number; w: number; h: number } | null {
     return this.thoughtBubble.getLayout(this.px, this.py);
   }
 
-  /** Shift this avatar's thought cloud up by `px` so it clears a nearby one. */
+  /** 把该头像的气泡向上移 `px`，让它避开附近的一个。 */
   setThoughtLift(px: number): void {
     this.thoughtBubble.setLift(px);
   }
 
-  /** Forward the camera zoom so the thought cloud can counter-scale and keep
-   *  its on-screen text size when the window (and thus the world) shrinks. */
+  /** 转发相机缩放，让气泡可以反向缩放，在窗口（以及整个世界）缩小时
+   *  保持其屏幕上的文字大小不变。 */
   setBubbleZoom(z: number): void {
     this.thoughtBubble.setZoom(z);
   }
@@ -375,14 +366,14 @@ export class Character {
     if (glyph === 'none') this.overlay.clear();
   }
 
-  // ── Cheer ──────────────────────────────────────────────────────────────────
+  // ── 欢呼 ────────────────────────────────────────────────────────────────
 
-  /** Celebrate finished work: a couple of happy hops under a confetti burst.
-   *  Movement (wander / idle loop) is held for the duration so the jump reads
-   *  on the spot; whatever the avatar was told to do resumes right after. */
+  /** 庆祝完成的工作：在一阵彩纸爆开下蹦跳几下。
+   *  期间暂停移动（游荡/空闲循环），让跳跃在当场可读；
+   *  之后头像原本被吩咐做的事立即恢复。 */
   cheer(): void {
-    if (this.sitting) return; // seated cheer would fight the sit offset/crop
-    // Stop in place so the hops read on the spot; roaming resumes right after.
+    if (this.sitting) return; // 坐姿欢呼会跟坐姿偏移/裁剪打架
+    // 原地停下，让跳跃在当场可读；随后继续游荡。
     this.path = [];
     if (this.state === 'walk') {
       this.state = 'idle';
@@ -402,15 +393,15 @@ export class Character {
     }
   }
 
-  /** True while the cheer animation holds the avatar in place. */
+  /** 欢呼动画是否正把头像按在原地。 */
   isCheering(): boolean {
     return this.cheerT >= 0;
   }
 
-  // ── Coffee cup ─────────────────────────────────────────────────────────────
+  // ── 咖啡杯 ─────────────────────────────────────────────────────────────
 
-  /** Where this agent's cup rests when parked on its desk (world pixels).
-   *  Typically beside the monitor — where the old baked-in tileset mug sat. */
+  /** 该 agent 的杯子停在桌上时的位置（世界像素）。
+   *  通常在显示器旁边——旧 tileset 烘烤的马克杯所在处。 */
   setCupSpot(spot: { x: number; y: number } | null): void {
     this.cupSpot = spot;
     if (spot) {
@@ -419,12 +410,12 @@ export class Character {
     }
   }
 
-  /** Show/hide the cup in the avatar's hand (walking it to/from the café). */
+  /** 显示/隐藏 avatar 手里的杯子（端去/端回咖啡馆时）。 */
   setCarryingCup(carrying: boolean): void {
     this.carryingCup = carrying;
   }
 
-  /** Park the carried cup on the desk / pick it back up. No-op without a spot. */
+  /** 把端着的杯子放到桌上 / 再拿起来。没有放置点时无操作。 */
   setCupOnDesk(on: boolean): void {
     if (!this.cupSpot) return;
     this.deskCupOn = on;
@@ -441,10 +432,10 @@ export class Character {
     return this.carryingCup;
   }
 
-  // ── Watering ───────────────────────────────────────────────────────────────
+  // ── 浇水 ───────────────────────────────────────────────────────────────
 
-  /** Water the plant the avatar is facing: a held watering can + a steady arc
-   *  of droplets for `seconds`, then `onDone` (resume wandering etc.). */
+  /** 给 avatar 面前的那盆植物浇水：手持喷壶 + 持续 `seconds` 的
+   *  稳定水滴弧线，然后触发 `onDone`（恢复游荡等）。 */
   startWatering(seconds: number, onDone?: () => void): void {
     this.waterT = 0;
     this.waterDur = seconds;
@@ -455,17 +446,17 @@ export class Character {
     return this.waterT >= 0;
   }
 
-  /** Abort a watering in progress (real work arrived). The callback is dropped. */
+  /** 中止进行中的浇水（来了真正的活）。回调被丢弃。 */
   stopWatering(): void {
     this.waterT = -1;
     this.onWaterDone = null;
   }
 
-  // ── The boss's cigar ───────────────────────────────────────────────────────
+  // ── 老板的雪茄 ────────────────────────────────────────────────────────
 
-  /** Light a cigar for `seconds`: a glowing stub in hand and smoke puffs
-   *  drifting up. Pure boss energy; pair it with a window for plausible
-   *  deniability. `onDone` fires when it's been smoked down. */
+  /** 点上雪茄持续 `seconds`：手里一根发光的烟头，烟雾袅袅
+   *  飘起。纯粹的老板气质；配一扇窗户即可合理自辩。
+   *  `onDone` 在抽完时触发。 */
   startSmoking(seconds: number, onDone?: () => void): void {
     this.smokeT = 0;
     this.smokeDur = seconds;
@@ -476,7 +467,7 @@ export class Character {
     return this.smokeT >= 0;
   }
 
-  /** Stub the cigar out early (real work arrived). The callback is dropped. */
+  /** 提前掐灭雪茄（来了真正的活）。回调被丢弃。 */
   stopSmoking(): void {
     this.smokeT = -1;
     this.onSmokeDone = null;
@@ -543,7 +534,7 @@ export class Character {
         }
       }
     } else if (this.isVisible) {
-      // ease sprite alpha toward target (for ghost dimming)
+      // 把精灵 alpha 缓动到目标值（用于幽灵变暗）
       const a = this.sprite.container.alpha;
       if (Math.abs(a - this.targetAlpha) > 0.01) {
         this.sprite.setAlpha(lerp(a, this.targetAlpha, Math.min(1, dt / 0.2)));
@@ -553,8 +544,8 @@ export class Character {
     this.thoughtBubble.update(dt);
     if (!this.isVisible) return;
 
-    // Working agents stay seated; between tasks they wander the office.
-    // A cheer, a watering or a cigar holds roaming so the effect plays in place.
+    // 工作中的 agent 保持坐着；任务之间他们在办公室里游荡。
+    // 欢呼、浇水或雪茄会暂停游荡，让特效原地播放。
     const heldByFx = this.cheerT >= 0 || this.waterT >= 0 || this.smokeT >= 0;
     if (this.state === 'walk') this.updateWalk(dt);
     else if (this.wandering && !heldByFx) this.updateWander(dt);
@@ -563,7 +554,7 @@ export class Character {
     this.sprite.container.zIndex = this.py;
     this.thoughtBubble.setPosition(this.px, this.py);
 
-    // work glow
+    // 工作光晕
     const ts = this.mapRenderer.tileSize;
     this.workGlow.x = this.px;
     this.workGlow.y = this.py - ts / 2;
@@ -582,16 +573,16 @@ export class Character {
     this.updateFx(dt);
   }
 
-  /** True while parked in the seated pose at the HOME desk (not a café seat). */
+  /** 是否以坐姿停在家桌（而非咖啡座）。 */
   isSittingAtDesk(): boolean {
     if (!this.sitting) return false;
     const t = this.getTilePosition();
     return t.x === this.deskTile.x && t.y === this.deskTile.y;
   }
 
-  // ── Effect rendering (cheer confetti, carried cup, watering, cup steam) ────
+  // ── 特效渲染（欢呼彩纸、手持杯子、浇水、杯上蒸汽）────────────────
 
-  /** Carried-cup offset from the feet anchor, per facing direction. */
+  /** 手持杯子相对脚锚点的偏移，按朝向分。 */
   private carryOffset(): { x: number; y: number } {
     switch (this.direction) {
       case 'left':  return { x: -7, y: -9 };
@@ -601,7 +592,7 @@ export class Character {
     }
   }
 
-  /** Hand position while watering, per facing direction. */
+  /** 浇水时手的位置，按朝向分。 */
   private handOffset(): { x: number; y: number } {
     switch (this.direction) {
       case 'left':  return { x: -6, y: -9 };
@@ -620,11 +611,11 @@ export class Character {
   private updateFx(dt: number): void {
     this.steamT += dt;
 
-    // ── Desk cup (world-anchored, persists while the agent roams) ───────────
+    // ── 桌上杯子（世界锚定，agent 游荡时也持续存在）───────────────
     if (this.deskCupOn && this.cupSpot) {
       this.deskCup.clear();
       this.drawCup(this.deskCup, 0, 0);
-      // two staggered steam pixels drifting up and fading
+      // 两缕错开的蒸汽像素，向上飘并淡出
       for (let i = 0; i < 2; i++) {
         const ph = (this.steamT * 0.7 + i * 0.5) % 1;
         this.deskCup.rect(1 + i * 2, -5 - Math.round(ph * 5), 1, 1)
@@ -632,7 +623,7 @@ export class Character {
       }
     }
 
-    // ── Sprite-riding effects ────────────────────────────────────────────────
+    // ── 跟随精灵的特效 ──────────────────────────────────────────────────
     const active = this.cheerT >= 0 || this.waterT >= 0 || this.smokeT >= 0 || this.carryingCup;
     if (!active) {
       if (this.fxDirty) { this.fx.clear(); this.fxDirty = false; }
@@ -641,14 +632,14 @@ export class Character {
     this.fx.clear();
     this.fxDirty = true;
 
-    // Cheer: happy hops + a confetti burst, ~1.6s, then back to whatever the
-    // avatar was doing (movement is held meanwhile — see update()).
+    // 欢呼：快乐的蹦跳 + 一阵彩纸，约 1.6 秒，然后回到
+    // avatar 原本在做的事（期间移动被按住——见 update()）。
     if (this.cheerT >= 0) {
       this.cheerT += dt;
       const t = this.cheerT;
       if (t >= 1.6) {
         this.cheerT = -1;
-        this.sprite.setPosition(this.px, this.py); // land the final hop
+        this.sprite.setPosition(this.px, this.py); // 落定最后一跳
       } else {
         const decay = 1 - t / 1.6;
         const hop = Math.abs(Math.sin(t * Math.PI * 2.2)) * 5 * decay;
@@ -663,7 +654,7 @@ export class Character {
       }
     }
 
-    // Carried cup, riding in the hand on the facing side (+ steam).
+    // 手持杯子，在朝向侧的手里（+ 蒸汽）。
     if (this.carryingCup) {
       const o = this.carryOffset();
       this.drawCup(this.fx, o.x, o.y);
@@ -672,8 +663,8 @@ export class Character {
         .fill({ color: 0xffffff, alpha: 0.5 * (1 - ph) });
     }
 
-    // The cigar: a stub in hand with a glowing ember, smoke puffs rising and
-    // drifting as they fade. Pure boss energy.
+    // 雪茄：手里一根烟头带发光的余烬，烟圈升起、
+    // 一边飘一边淡出。纯粹的老板气质。
     if (this.smokeT >= 0) {
       this.smokeT += dt;
       if (this.smokeT >= this.smokeDur) {
@@ -685,12 +676,12 @@ export class Character {
         const h = this.handOffset();
         const dirX = this.direction === 'left' ? -1 : this.direction === 'right' ? 1 : 0;
         const tipX = h.x + (dirX >= 0 ? 4 : -4);
-        // cigar body + band + pulsing ember at the tip
+        // 烟身 + 烟箍 + 烟头处脉冲发光的余烬
         this.fx.rect(Math.min(h.x, tipX), h.y - 1, 4, 1).fill(0x6b4a33);
         this.fx.rect(h.x + (dirX >= 0 ? 1 : -2), h.y - 1, 1, 1).fill(0xd9a04a);
         const ember = 0.5 + 0.5 * Math.sin(this.smokeT * 5);
         this.fx.rect(tipX, h.y - 1, 1, 1).fill({ color: 0xff7a3c, alpha: 0.55 + 0.45 * ember });
-        // three staggered puffs rising from the tip, drifting and fading
+        // 三缕错开的烟圈从烟头升起，一边飘一边淡出
         for (let i = 0; i < 3; i++) {
           const ph = (this.smokeT * 0.45 + i / 3) % 1;
           const px2 = tipX + Math.sin((this.smokeT + i * 2) * 1.7) * 2 + ph * 2 * (dirX || 1);
@@ -701,8 +692,8 @@ export class Character {
       }
     }
 
-    // Watering: a little can in the hand and an arc of droplets falling onto
-    // the plant in front, until the duration elapses → onDone (resume idling).
+    // 浇水：手里一个小喷壶，一串水滴弧线落在
+    // 面前的植物上，直到时长耗尽 → onDone（恢复空闲）。
     if (this.waterT >= 0) {
       this.waterT += dt;
       if (this.waterT >= this.waterDur) {
@@ -714,7 +705,7 @@ export class Character {
         const h = this.handOffset();
         const dirX = this.direction === 'left' ? -1 : this.direction === 'right' ? 1 : 0;
         const dirY = this.direction === 'up' ? -1 : this.direction === 'down' ? 1 : 0;
-        // can body + spout toward the plant
+        // 壶身 + 壶嘴朝植物
         this.fx.rect(h.x - 2, h.y - 2, 5, 3).fill(0x9aa7b0);
         this.fx.rect(h.x + (dirX >= 0 ? 3 : -4), h.y - 2, 2, 1).fill(0x9aa7b0);
         for (let i = 0; i < 4; i++) {
@@ -735,27 +726,27 @@ export class Character {
     this.glyphElapsed += dt;
     const g = this.overlay;
     g.clear();
-    const yTop = -34; // just above the 32px sprite
+    const yTop = -34; // 刚好在 32px 精灵上方
     if (this.statusGlyph === 'blocked') {
-      // pulsing "!" — blink ~2.5Hz
+      // 脉冲“!”——约 2.5Hz 闪烁
       if (Math.floor(this.glyphElapsed / 0.4) % 2 === 0) {
         g.rect(-1, yTop, 2, 5).fill(0xff6b6b);
         g.rect(-1, yTop + 6, 2, 2).fill(0xff6b6b);
       }
     } else if (this.statusGlyph === 'success') {
-      // brief 4-point sparkle, auto-clears after 0.9s
+      // 短暂的四点闪光，0.9 秒后自动清除
       const p = (Math.sin(this.glyphElapsed * 18) + 1) / 2;
       const s = 2 + p * 2;
       g.rect(-0.5, yTop - s, 1, s * 2).fill(0xffd93d);
       g.rect(-s, yTop - 0.5, s * 2, 1).fill(0xffd93d);
       if (this.glyphElapsed > 0.9) this.setStatusGlyph('none');
     } else if (this.statusGlyph === 'compacting') {
-      // #5C — violet box that rhythmically "packs down" (boxing up context).
+      // #5C — 紫色方块，节奏性地“打包压实”（把上下文装箱）。
       const p = (Math.sin(this.glyphElapsed * 6) + 1) / 2; // 0..1
       const s = 2 + p * 3;
       g.rect(-s, yTop - s, s * 2, s * 2).fill(0x9b7ede);
     } else if (this.statusGlyph === 'looping') {
-      // #5C — orange 4-dot warning ring with one lit dot spinning around it.
+      // #5C — 橙色四点警告环，一个亮点绕环旋转。
       const idx = Math.floor(this.glyphElapsed * 8) % 4;
       const pts: [number, number][] = [[-3, yTop - 3], [3, yTop - 3], [3, yTop + 3], [-3, yTop + 3]];
       for (let i = 0; i < 4; i++) {
@@ -774,7 +765,7 @@ export class Character {
         this.pendingWork = null;
         this.sprite.setAnimation(this.state as AnimState, this.seatDirection);
       } else if (this.wandering) {
-        // Reached a wander waypoint — pause, idle, then pick another later.
+        // 到达一个游荡路点——停一下，发呆，之后另挑一个。
         this.state = 'idle';
         this.idleTimer = 0;
         this.idleWanderDelay = 1 + Math.random() * 3;
@@ -813,22 +804,22 @@ export class Character {
     this.sprite.setPosition(this.px, this.py);
   }
 
-  /** Drive the idle 30/30 loop: linger on the floor, then rest at the desk,
-   *  then linger again — independent of the low-level walk/wander animation. */
+  /** 驱动空闲 30/30 循环：在地板上闲逛，然后在桌前休息，
+   *  再闲逛——独立于底层的走/游荡动画。 */
   private updateIdleLoop(dt: number): void {
     switch (this.idleLoopPhase) {
       case 'linger':
-        // Roaming (beginWander) handles the motion; we just time the phase.
+        // 游荡（beginWander）负责动作；我们只计算阶段时长。
         this.idleLoopTimer += dt;
         if (this.idleLoopTimer >= IDLE_LINGER_SECONDS) {
           this.idleLoopPhase = 'toDesk';
           this.idleLoopTimer = 0;
-          this.walkToDeskAndSit(false); // head home and sit (no focus halo)
+          this.walkToDeskAndSit(false); // 回桌并坐下（无专注光晕）
         }
         break;
       case 'toDesk':
-        // Wait until we've actually arrived and sat down, then start the rest
-        // clock. Watchdog: if the desk is somehow unreachable, resume lingering.
+        // 等到真正到达并坐下，再开始休息计时。看门狗：
+        // 如果桌子不知何故不可达，恢复闲逛。
         this.idleLoopTimer += dt;
         if (this.sitting) {
           this.idleLoopPhase = 'resting';
@@ -844,7 +835,7 @@ export class Character {
         if (this.idleLoopTimer >= DESK_REST_SECONDS) {
           this.idleLoopPhase = 'linger';
           this.idleLoopTimer = 0;
-          this.beginWander(); // stand up and roam again
+          this.beginWander(); // 站起来再游荡
         }
         break;
     }
@@ -855,7 +846,7 @@ export class Character {
     if (this.idleTimer < this.idleWanderDelay) return;
     this.idleTimer = 0;
     this.idleWanderDelay = 1 + Math.random() * 3;
-    // Pick a nearby walkable tile and stroll to it.
+    // 挑一块附近可行的瓦片溜达过去。
     const cur = this.getTilePosition();
     const range = 6;
     for (let attempt = 0; attempt < 14; attempt++) {
@@ -863,8 +854,8 @@ export class Character {
       const ty = cur.y + Math.floor(Math.random() * range * 2) - range;
       if ((tx !== cur.x || ty !== cur.y) && this.mapRenderer.isWalkable(tx, ty)) {
         const wasWandering = this.wandering;
-        this.moveTo({ x: tx, y: ty });   // moveTo() leaves state='walk'
-        this.wandering = wasWandering;   // keep wandering through the walk
+        this.moveTo({ x: tx, y: ty });   // moveTo() 会把 state 设为 'walk'
+        this.wandering = wasWandering;   // 走路过程中保持游荡
         return;
       }
     }

--- a/src/renderer/src/scene/office/CharacterSprite.ts
+++ b/src/renderer/src/scene/office/CharacterSprite.ts
@@ -3,7 +3,7 @@ import { AnimatedSprite, Container, Graphics, Texture } from 'pixi.js';
 export type Direction = 'down' | 'up' | 'right' | 'left';
 export type AnimState = 'walk' | 'type' | 'read' | 'idle';
 
-// Output rows from SpriteAdapter: down=0, up=1, right=2 (left = flipped right)
+// SpriteAdapter 输出的行：down=0, up=1, right=2（left = 翻转的 right）
 const DIRECTION_ROW: Record<Direction, number> = {
   down: 0,
   up: 1,
@@ -18,12 +18,11 @@ const ANIM_FRAMES: Record<AnimState, number[]> = {
   idle: [0],
 };
 
-// Render characters a bit larger than their native 18×32 so heads/faces read
-// clearly on the floor. Applied to the container so the leg-crop mask (a child)
-// scales with the sprite and stays aligned.
+// 把角色渲染得比原生 18×32 稍大一些，让头/脸在地板上更清晰。
+// 应用于容器，让腿部裁剪遮罩（子元素）随精灵一起缩放并保持对齐。
 const CHAR_SCALE = 1.08;
 
-/** Ported from shahar061/the-office (office/characters/CharacterSprite.ts). */
+/** 从 shahar061/the-office 移植（office/characters/CharacterSprite.ts）。 */
 export class CharacterSprite {
   readonly container: Container;
   private sprite: AnimatedSprite;
@@ -44,8 +43,8 @@ export class CharacterSprite {
     this.sprite.anchor.set(0.5, 1);
     this.sprite.animationSpeed = this.frameSpeed;
     this.sprite.play();
-    // Anchor is (0.5, 1): in container space the sprite spans x∈[-w/2, w/2],
-    // y∈[-h, 0] (feet at the origin). Used by the seated leg-crop mask.
+    // 锚点是 (0.5, 1)：在容器空间里精灵横跨 x∈[-w/2, w/2]，
+    // y∈[-h, 0]（脚在原点）。供坐姿腿部裁剪遮罩使用。
     this.frameW = this.sprite.texture.frame.width || this.sprite.width || 16;
     this.frameH = this.sprite.texture.frame.height || this.sprite.height || 32;
 
@@ -54,10 +53,9 @@ export class CharacterSprite {
   }
 
   /**
-   * Crop `cropPx` off the bottom of the sprite (the legs) so a seated agent
-   * reads as tucked under the desk instead of standing on top of it. Pass 0 to
-   * clear the crop (standing / walking). The mask only covers the sprite, so
-   * status glyphs / bubbles parented elsewhere are unaffected.
+   * 从精灵底部裁掉 `cropPx`（腿部），让坐姿 agent 看起来是收在桌下而不是
+   * 站在桌上。传 0 清除裁剪（站立 / 行走）。遮罩只覆盖精灵，所以挂在别处的
+   * 状态符号 / 气泡不受影响。
    */
   setSeatedCrop(cropPx: number): void {
     if (cropPx <= 0) {
@@ -74,8 +72,7 @@ export class CharacterSprite {
     const w = this.frameW;
     const h = this.frameH;
     this.cropMask.clear();
-    // Keep the top (h - cropPx) of the sprite; reveal whatever (the desk) is
-    // behind where the legs were.
+    // 保留精灵顶部 (h - cropPx)；露出腿部原先挡住的（桌子）。
     this.cropMask
       .rect(-w / 2 - 2, -h - 2, w + 4, h - cropPx + 2)
       .fill(0xffffff);

--- a/src/renderer/src/scene/office/DeskScreen.ts
+++ b/src/renderer/src/scene/office/DeskScreen.ts
@@ -2,26 +2,25 @@ import { Container, Graphics, Sprite } from 'pixi.js';
 import type { TiledMapRenderer } from './TiledMapRenderer';
 import type { MonitorConfig } from './themeRegistry';
 
-// The office tileset ships every desk PC twice: a dark, switched-off monitor
-// (gids 365/366 + 381/382 — what the map paints) and the SAME monitor with a
-// lit blue desktop (367/368 + 383/384). DeskScreen overlays the lit variant on
-// a desk's monitor block while its agent is seated, plus a tiny screen-life
-// animation (scrolling lines + a blinking cursor) so the PC visibly works when
-// its owner does. Hidden, the map's off art shows through — no state to undo.
+// 办公室 tileset 把每台桌机画了两遍：深色关机的显示器（gids 365/366 +
+// 381/382 —— 地图画的就是它）和同一台点亮蓝色桌面的显示器（367/368 +
+// 383/384）。DeskScreen 在 agent 坐下时把点亮变体叠到桌子的显示器块上，
+// 再加一段微小的屏幕活跃动画（滚动行 + 闪烁光标），让电脑在主人工作时
+// 明显在运行。隐藏时地图的关机美术透出——没有需要撤销的状态。
 
-/** gid of the OFF monitor block's top-left tile, as painted in the office map.
- *  Default for the office theme; a theme supplies its own via MonitorConfig. */
+/** OFF 显示器块的左上瓦片 gid，按办公室地图所画。办公室主题的默认值；
+ *  主题可通过自己的 MonitorConfig 提供。 */
 export const MONITOR_OFF_TOPLEFT_GID = 365;
-/** Matching ON tiles for the office theme, laid out 2×2 directly right of the
- *  off block — used when no per-theme MonitorConfig is passed. */
+/** 办公室主题匹配的 ON 瓦片，直接铺在 OFF 块右侧 2×2 处——在没传
+ *  每主题 MonitorConfig 时使用。 */
 const DEFAULT_ON_GIDS: ReadonlyArray<readonly [number, number, number]> = [
-  // [gid, dx, dy] in tiles relative to the block's top-left
+  // [gid, dx, dy] 以瓦片为单位，相对块左上角
   [367, 0, 0], [368, 1, 0],
   [383, 0, 1], [384, 1, 1]
 ];
 
-/** Screen interior of the 2×2 (32×32px) block, in local pixels — where the
- *  blue desktop is drawn in the tile art. The animation stays inside it. */
+/** 2×2（32×32px）块的屏幕内部，以本地像素计——瓦片美术里蓝色桌面的
+ *  绘制处。动画保持在它内部。 */
 const SCREEN = { x: 3, y: 5, w: 25, h: 12 };
 
 export class DeskScreen {
@@ -45,15 +44,14 @@ export class DeskScreen {
     this.container.addChild(this.anim);
     this.container.x = topLeft.x * ts;
     this.container.y = topLeft.y * ts;
-    // Sort with the characters: the block's bottom edge sits above the seated
-    // agent's anchor row, so the avatar's head draws over the keyboard, not
-    // under it — same painter's order the map art implies.
+    // 与角色一起排序：块的底边位于坐姿 agent 的锚点行上方，所以头像画在
+    // 键盘之上、而不是之下——与地图美术暗示的画家顺序一致。
     this.container.zIndex = (topLeft.y + 2) * ts - 1;
     this.container.visible = false;
     this.container.eventMode = 'none';
   }
 
-  /** Light the screen (agent sat down) or cut it (stood up / left). */
+  /** 点亮屏幕（agent 坐下）或熄灭（站起 / 离开）。 */
   setOn(on: boolean): void {
     if (on === this.on) return;
     this.on = on;
@@ -66,8 +64,8 @@ export class DeskScreen {
     this.t += dt;
     const g = this.anim;
     g.clear();
-    // Two faint "output" lines scrolling up the desktop, wrapping around —
-    // the eternal build log — plus a cursor blinking in the lower left.
+    // 两行微弱的“输出”行在桌面上向上滚动、循环往复——
+    // 永恒的构建日志——加上左下角闪烁的光标。
     for (let i = 0; i < 2; i++) {
       const phase = (this.t * 3.2 + i * (SCREEN.h / 2)) % SCREEN.h;
       const y = SCREEN.y + SCREEN.h - 1 - phase;

--- a/src/renderer/src/scene/office/MessageEnvelope.ts
+++ b/src/renderer/src/scene/office/MessageEnvelope.ts
@@ -1,19 +1,18 @@
 import { Container, Graphics } from 'pixi.js';
 import { colors } from '@/design/tokens';
 
-/** Hive speech-acts (mirrors HiveMessage['act'] in the main process). */
+/** Hive 言语行为（镜像主进程里的 HiveMessage['act']）。 */
 export type MessageAct = 'request' | 'inform' | 'propose' | 'query' | 'agree' | 'refuse' | 'done';
 
-// A little pixel-art envelope that flies from a sender's desk to a recipient's
-// desk when the hive routes a message, then pops a small arrival burst. Lives in
-// world space on the character layer so the camera transforms it like everything
-// else. Fully self-contained: spawn it, tick it, and drop it when done() is true.
+// 一个小像素画信封：hive 路由消息时从发件人的桌子飞向收件人的桌子，然后
+// 迸出一小圈到达光点。活在角色层的世界空间里，所以相机像对待其它一切一样
+// 变换它。完全自包含：生成它、tick 它、done() 为 true 时丢弃它。
 //
-// Aesthetic per DESIGN.md — hard edges, integer pixels, no border-radius, ink
-// outline, status colour by speech-act so a glance reads "who's asking whom".
+// 美感遵循 DESIGN.md——硬边、整像素、无圆角、墨线轮廓、按言语行为取状态色，
+// 一眼读出“谁在问谁”。
 
-/** Speech-act → envelope tint. Mirrors the floor's status palette intent:
- *  asks are cool, answers are warm/positive, refusals are red. */
+/** 言语行为 → 信封色调。镜像楼层的状态调色板意图：
+ *  请求是冷色、回答是暖/正色、拒绝是红色。 */
 const ACT_COLOR: Record<MessageAct, number> = {
   request: colors.accent.sky,
   query:   colors.accent.lilac,
@@ -25,16 +24,16 @@ const ACT_COLOR: Record<MessageAct, number> = {
 };
 
 const OUTLINE = colors.ink[900];
-const HUMAN_COLOR = colors.accent.coral; // escalations to the human
+const HUMAN_COLOR = colors.accent.coral; // 升级给人类的消息
 
-const FLY_HEIGHT = 22;       // px above the feet anchor the envelope rides at
-const ARC_LIFT = 38;         // peak of the travel arc (negative y)
-const SPEED = 230;           // px/sec — duration derives from travel distance
+const FLY_HEIGHT = 22;       // 信封骑乘在足部锚点上方的 px
+const ARC_LIFT = 38;         // 飞行弧线的峰高（负 y）
+const SPEED = 230;           // px/秒 —— 时长由飞行距离推导
 const MIN_DURATION = 0.8;
 const MAX_DURATION = 2.0;
 const FADE_IN = 0.14;
 const FADE_OUT = 0.22;
-const BURST_DURATION = 0.34; // arrival sparkle ring
+const BURST_DURATION = 0.34; // 到达闪光环
 
 function easeInOut(t: number): number {
   return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
@@ -53,7 +52,7 @@ export class MessageEnvelope {
   private burstElapsed = 0;
   private finished = false;
 
-  /** start/end are world-pixel feet anchors of sender & recipient. */
+  /** start/end 是发件人与收件人的世界像素足部锚点。 */
   constructor(
     start: { x: number; y: number },
     end: { x: number; y: number },
@@ -68,16 +67,16 @@ export class MessageEnvelope {
     const fill = needsHuman ? HUMAN_COLOR : (ACT_COLOR[act] ?? colors.cream[200]);
 
     this.container = new Container();
-    this.container.zIndex = 1_000_000; // always above the cast
+    this.container.zIndex = 1_000_000; // 永远在角色群之上
     this.container.eventMode = 'none';
     this.container.alpha = 0;
 
-    // Envelope: a 14×10 rect with an ink outline and a "flap" chevron. Drawn
-    // centered so rotation/scale pivot at the middle.
+    // 信封：带墨线轮廓和“封盖”山形折线的 14×10 矩形。居中绘制，让旋转/
+    // 缩放以中心为支点。
     this.body = new Graphics();
     const w = 14, h = 10;
     this.body.rect(-w / 2, -h / 2, w, h).fill({ color: fill }).stroke({ color: OUTLINE, width: 1 });
-    // flap — two lines from the top corners meeting at the centre
+    // 封盖——从两个顶角汇聚到中心的两条线
     this.body.moveTo(-w / 2, -h / 2).lineTo(0, h / 2 - 3).lineTo(w / 2, -h / 2)
       .stroke({ color: OUTLINE, width: 1 });
     this.container.addChild(this.body);
@@ -94,7 +93,7 @@ export class MessageEnvelope {
     this.container.y = Math.round(y);
   }
 
-  /** Advance the animation. Returns true once it has fully played out. */
+  /** 推进动画。完全播完时返回 true。 */
   update(dt: number): boolean {
     if (this.finished) return true;
 
@@ -102,13 +101,13 @@ export class MessageEnvelope {
       this.elapsed += dt;
       const t = Math.min(this.elapsed / this.duration, 1);
       const e = easeInOut(t);
-      // quadratic arc: lerp the endpoints, lift the midpoint
+      // 二次曲线弧：插值端点，抬高中点
       const x = this.sx + (this.ex - this.sx) * e;
       const lift = -ARC_LIFT * Math.sin(Math.PI * e);
       const y = this.sy + (this.ey - this.sy) * e + lift;
       this.setPos(x, y);
 
-      // fade in at the start, out near the end; gentle bob rotation
+      // 开头淡入、临近结尾淡出；轻微钟摆旋转
       const fadeIn = Math.min(this.elapsed / FADE_IN, 1);
       const fadeOut = t > 1 - FADE_OUT / this.duration
         ? Math.max(0, (1 - t) / (FADE_OUT / this.duration))
@@ -126,7 +125,7 @@ export class MessageEnvelope {
       return false;
     }
 
-    // arrival burst — an expanding ink ring that fades out
+    // 到达光点——一圈扩张并淡出的墨环
     this.burstElapsed += dt;
     const bt = Math.min(this.burstElapsed / BURST_DURATION, 1);
     const r = 3 + bt * 12;

--- a/src/renderer/src/scene/office/OfficeFloor.tsx
+++ b/src/renderer/src/scene/office/OfficeFloor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Application, Container, Graphics, Ticker, Texture } from 'pixi.js';
-// PixiJS uses new Function() internally, blocked by Electron CSP — this patches it.
+// PixiJS 内部使用 new Function()，被 Electron CSP 阻止——此补丁修复它。
 import 'pixi.js/unsafe-eval';
 import { useStore, type Agent } from '@/store/store';
 import { TiledMapRenderer } from './TiledMapRenderer';
@@ -18,13 +18,13 @@ import {
 } from './glRecovery';
 import type { Tile, Facing, ErrandKind, ErrandSpot } from './themeRegistry';
 
-// The map, tileset atlases, desk-claim order, errand spots, coffee-economy
-// tiles, prop anchors, monitor gids and palette all come from the active
-// ThemeConfig now (see themeRegistry.ts / themeLoader.ts). Phase 0 ships the
-// existing office unchanged as `theme: 'office'`.
+// 地图、图块集图集、工位认领顺序、跑腿点、咖啡经济
+// 图块、道具锚点、显示器 gid 和调色板均来自活跃
+// ThemeConfig 现在（见 themeRegistry.ts / themeLoader.ts）。Phase 0 以
+// 现有的办公室原样发货，`theme: 'office'`。
 
-/** A cafeteria break in progress for one agent — set by the coffee-break
- *  director, cleared when the agent leaves or gets pulled back to work. */
+/** 一位代理正在进行的咖啡休息——由咖啡休息
+ * 导演设置，代理离开或拉回工作时清除。 */
 interface CafeChat {
   lines: readonly string[];        // alternating beats: even = initiator, odd = partner
   partnerId: string;
@@ -41,15 +41,15 @@ interface CafeBreak {
   chattingWith?: string;           // set on the partner: stays put & stays quiet
 }
 
-/** An idle errand in progress for one agent. */
+/** 一位代理正在进行的空闲跑腿。 */
 interface ErrandRun {
   phase: 'walking' | 'doing';
   timer: number;
   idx: number; // into ERRAND_SPOTS
 }
 
-/** One leg of the coffee economy: fetch a clean mug from the sideboard, brew
- *  at the counter machine, (later) wash at the sink and rack the mug again. */
+/** 咖啡经济的一个 leg：从边柜取一个干净杯子，在
+ * 柜台机器处冲泡，（之后）在水槽清洗并将杯子放回架子。 */
 interface CoffeeRun {
   phase: 'toTray' | 'taking' | 'toMachine' | 'brewing' | 'toSink' | 'washing' | 'toTrayBack' | 'placing';
   timer: number;
@@ -66,24 +66,24 @@ interface Runtime {
   prevCarrying?: string;
   prevPrompt?: string;
   brk?: CafeBreak;
-  /** This desk's monitor overlay — lit while its agent is seated. */
+   /** 此桌的显示器覆盖层——代理就座时点亮。 */
   screen?: DeskScreen;
-  /** Walking a fresh coffee from the break room home to the desk. */
+   /** 从休息室步行回家喝咖啡。 */
   cupCarryHome?: boolean;
   err?: ErrandRun;
   run?: CoffeeRun;
-  /** When the current busy stretch (working/thinking/compacting) began. */
+   /** 当前忙碌时段（工作/思考/压缩）开始的时间。 */
   busySince?: number;
 }
 
-/** Only a busy stretch at least this long earns a cheer on finishing. Short
- *  turns (an inbox nudge, a heartbeat reply) end quietly — otherwise idle
- *  agents "celebrate" every few minutes over nothing, and the "done!" bubble
- *  reads like real work completed when none did. */
+/** 只有持续时间至少这么长的忙碌时段值得在结束时欢呼。短暂
+ * 任务（收件箱提示、心跳回复）安静结束——否则空闲
+ * 代理会"庆祝"每几分钟无事可做，"完成！"气泡
+ * 读起来像真实完成的工作但实际上没有。 */
 const CHEER_MIN_BUSY_MS = 60_000;
 
-/** What an avatar mutters per errand, picked at random. i18n keys into
- *  `office.errand.*`. */
+/** 代理每次跑腿随机嘟囔的话。i18n 键指向
+ * `office.errand.*`。 */
 const ERRAND_THOUGHTS: Record<ErrandKind, readonly string[]> = {
   water:     ['office.errand.water.0', 'office.errand.water.1', 'office.errand.water.2'],
   window:    ['office.errand.window.0', 'office.errand.window.1', 'office.errand.window.2'],
@@ -94,8 +94,8 @@ const ERRAND_THOUGHTS: Record<ErrandKind, readonly string[]> = {
   smoke:     ['office.errand.smoke.0', 'office.errand.smoke.1', 'office.errand.smoke.2', 'office.errand.smoke.3']
 };
 
-/** What workers blurt out when the boss walks by — performative excellence.
- *  `{{done}}` interpolates that worker's REAL done-task count. */
+/** 老板走过时 workers 脱口而出的话——表演性卓越。
+ *  `{{done}}` 插值该 worker 的真实完成任务数。 */
 const SUCK_UP_KEYS = [
   'office.suckUp.0',
   'office.suckUp.1',
@@ -106,7 +106,7 @@ const SUCK_UP_KEYS = [
   'office.suckUp.6'
 ] as const;
 
-/** What they actually say once he's out of earshot. */
+/** 他离开可听范围后他们实际说的话。 */
 const GOSSIP_KEYS = [
   'office.gossip.0',
   'office.gossip.1',
@@ -117,7 +117,7 @@ const GOSSIP_KEYS = [
   'office.gossip.6'
 ] as const;
 
-/** Lines an avatar throws over its shoulder right after finishing a task. */
+/** 代理完成任务后立即抛出的话。 */
 const CHEER_KEYS = [
   'office.cheer.0',
   'office.cheer.1',
@@ -128,9 +128,9 @@ const CHEER_KEYS = [
   'office.cheer.6'
 ] as const;
 
-/** Load a texture via an <img> element. Unlike Pixi's Assets.load(), this
- *  handles extension-less data: URLs (Vite inlines small assets like the a5
- *  tileset as base64), which the Assets resolver fails to type-detect. */
+/** 通过 <img> 元素加载纹理。与 Pixi 的 Assets.load() 不同，此
+ * 处理无扩展名的数据：URL（Vite 将小资产如 a5
+ * 图块集内联为 base64），Assets 解析器无法类型检测。 */
 function loadTexture(url: string): Promise<Texture> {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -144,17 +144,16 @@ function loadTexture(url: string): Promise<Texture> {
   });
 }
 
-/** What the agent is doing right now, for the thought cloud. Prefer the live
- *  `action` (e.g. "edit App.tsx", "bash npm test"), fall back to the prompt we
- *  gave it, then to a caller-supplied generic. Returns '' for the working state
- *  with nothing concrete yet — the bubble renders an animated "…" for that. */
+/** 代理当前正在做的事情，用于思想云。优先使用实时
+ * `action`（如"编辑 App.tsx"、"bash npm test"），回退到我们给它的
+ * 提示，然后到调用方提供的通用提示。对于尚未有具体内容的工作状态返回 ''--气泡会渲染一个动画的 "..."。 */
 function liveActivity(agent: Agent, fallback = ''): string {
   const action = (agent.action || '').trim();
   if (action) return action;
   return firstWords(agent.lastPrompt) || fallback;
 }
 
-/** First few words of the last user prompt, for the desk card. */
+/** 用户最后提示的前几个字，用于桌面卡片。 */
 function firstWords(prompt: string | undefined, maxWords = 6, maxChars = 42): string {
   if (!prompt) return '';
   const words = prompt.trim().split(/\s+/);
@@ -170,42 +169,42 @@ export function OfficeFloor() {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const appRef = useRef<Application | null>(null);
   const mountIdRef = useRef(0);
-  // Bumped when the WebGL context is evicted; a dep of the effect below, so the
-  // whole scene is torn down and rebuilt through the existing mount path rather
-  // than through a second, parallel recovery routine.
+  // 当 WebGL 上下文被驱逐时递增；下面效果的依赖，因此
+  // 整个场景通过现有的安装路径拆除并重建，而不是
+  // 通过第二个并行恢复例程。
   const [glGeneration, setGlGeneration] = useState(0);
-  // Retries spent on an init that could not GET a context (see glRecovery.ts).
-  // A ref, not state: the budget has to survive the rebuilds it schedules, which
-  // re-run the effect below and would reset anything scoped to it.
+  // 无法获取上下文的初始化重试次数（见 glRecovery.ts）。
+  // 一个 ref，不是 state：预算必须存活它安排的重新构建，这些
+  // 重新运行下面的效果并会重置任何作用域其中的内容。
   const initRetriesRef = useRef(0);
-  // The active office theme (store mirror of config.officeTheme). Changing it
-  // tears down and rebuilds the whole scene on the new map/cast (see deps below).
+  // 活跃的办公室主题（config.officeTheme 的存储镜像）。更改它
+  // 会在新的 map/cast 上拆除并重建整个场景（见下方依赖）。
   const officeTheme = useStore((s) => s.officeTheme);
 
-  // Is the floor actually on screen? A fullscreen terminal or file editor covers
-  // it completely, and a hidden window shows nothing at all — but the Pixi ticker
-  // went on running the whole scene regardless: every character, thought cloud,
-  // coffee run and envelope animating, and the renderer drawing every frame, into
-  // pixels nobody can see. On a floor of twenty agents that is the app's single
-  // largest continuous cost, and users who live in the fullscreen terminal (the
-  // normal way to work with one agent) paid it 100% of the time.
+  // 地板实际上在屏幕上吗？全屏终端或文件编辑器完全覆盖
+  // 它，隐藏窗口显示无任何内容——但 Pixi ticker
+  // 无论是否可见都持续运行整个场景：每个角色、思想云、
+  // 咖啡行程和信封动画，渲染器每帧绘制到
+  // 无人可见的像素。在二十个代理的地板上，这是应用的最大
+  // 持续成本，而在全屏终端中生活的用户（与一个
+  // 代理协作的正常方式）支付了 100% 的时间。
   //
-  // Stop the ticker instead of unmounting: the WebGL context, textures and the
-  // whole scene graph stay alive, so coming back out of fullscreen is instant
-  // rather than a full theme reload.
+  // 停止 ticker 而不是卸载：WebGL 上下文、纹理和整个
+  // 场景图保持存活，因此从全屏退出是即时的
+  // 而不是完整的主题重新加载。
   //
-  // A paused floor resumes where it left off. Two things make that true, and it is
-  // worth being precise because the obvious claim — "nothing here reads wall-clock
-  // time" — is FALSE: Date.now() is read for the aura/coffee timers and for the
-  // busy/cheer thresholds. The first sits inside onTick, so a stopped ticker freezes
-  // it along with everything else. The second runs in applyState, a store
-  // subscription that keeps firing while paused — but it only mutates sprite state
-  // that is redrawn on resume, so the worst case is a cosmetic cheer reflecting
-  // genuinely-elapsed busy time, invisible while hidden anyway.
+  // 暂停的地板从它离开的地方恢复。两件事使这成为可能，并且精确地
+  // 指出很重要因为显而易见的主张——"这里没有读取墙钟
+  // 时间"——是错误的：Date.now() 用于 aura/咖啡计时器和 busy/
+  // cheer 阈值。第一个在 onTick 内部，所以停止的 ticker 冻结
+  // 它与所有其他内容。第二个在 applyState 中运行，这是一个
+  // 订阅在暂停时保持触发——但它只变异精灵状态
+  // 在恢复时重绘，所以最坏的情况是 cosmetic cheer 反映
+  // 真正经过的繁忙时间，在隐藏时不可见。
   //
-  // The frame delta is safe by construction: Pixi clamps elapsedMS to minFPS on
-  // start(), so a floor paused for an hour advances a few frames on resume rather
-  // than teleporting every character across the map.
+  // 帧增量是安全构建的：Pixi 在 start() 上将 elapsedMS 钳制到 minFPS，
+  // 所以暂停一小时的地板在恢复时前进几帧而不是
+  // 让每个角色穿越地图传送。
   const fullscreenAgentId = useStore((s) => s.fullscreenAgentId);
   const ideOpen = useStore((s) => s.ideOpen);
   const [docHidden, setDocHidden] = useState(() => document.hidden);
@@ -215,8 +214,8 @@ export function OfficeFloor() {
     return () => document.removeEventListener('visibilitychange', onVis);
   }, []);
   const paused = !!fullscreenAgentId || ideOpen || docHidden;
-  // Read inside init(), which finishes asynchronously and would otherwise start a
-  // ticker the effect below had already been asked to stop.
+  // 在 init() 内部读取，它异步完成否则会启动一个
+  // 下面的效果已被要求停止的 ticker。
   const pausedRef = useRef(paused);
   useEffect(() => {
     pausedRef.current = paused;
@@ -236,24 +235,24 @@ export function OfficeFloor() {
 
     const runtimes = new Map<string, Runtime>();
     const seatClaims = new Set<number>();
-    // In-flight message envelopes (sender desk → recipient desk). Capped so a
-    // broadcast doesn't bury the floor in paper.
+    // 飞行中的消息信封（发送者桌面 → 接收者桌面）。限制数量以便
+    // 广播不会将地板埋在纸张中。
     const envelopes: MessageEnvelope[] = [];
     const MAX_ENVELOPES = 16;
 
     const init = async () => {
-      // Load the active theme bundle (falls back to 'office' on a bad/absent bundle).
+      // 加载活跃主题包（在坏/缺失包时回退到 'office'）。
       const theme = await loadTheme(officeTheme);
       await app.init({
         background: hexNum(theme.palette.background),
         antialias: false,
         roundPixels: true,
-        // resolution: 1 let the OS/browser upscale the canvas on scaled and
-        // HiDPI displays (125–150% is the Windows laptop default), blurring
-        // everything — worst of all the bubble text, which is small to begin
-        // with. Render at the real device pixel density instead, floored at 2
-        // so the half-scale-supersampled bubble text stays legible even at
-        // 100% scaling. autoDensity keeps the canvas CSS size in logical px.
+        // resolution: 1 让操作系统/浏览器在缩放和
+        // HiDPI 显示器上放大画布（125–150% 是 Windows 笔记本电脑默认），模糊
+        // 一切——最糟糕的是气泡文本，它一开始就很小。
+        // 改为在真实设备像素密度下渲染，下限为 2
+        // 这样半比例超采样的气泡文本即使在
+        // 100% 缩放下仍可辨认。autoDensity 保持画布 CSS 尺寸为逻辑 px。
         resolution: Math.max(window.devicePixelRatio || 1, 2),
         autoDensity: true,
         width: host.clientWidth || 800,
@@ -263,11 +262,11 @@ export function OfficeFloor() {
       while (host.firstChild) host.removeChild(host.firstChild);
       host.appendChild(app.canvas);
 
-      // This canvas holds the OLDEST WebGL context in the process (it is built at
-      // startup), so it is the one Chromium evicts once enough xterm terminals —
-      // each of which takes a context via @xterm/addon-webgl — are open. Pixi
-      // reports nothing when that happens: the floor just goes blank forever.
-      // Rebuild instead. See glRecovery.ts.
+      // 此画布持有进程中最新的 WebGL 上下文（它在
+      // 启动时构建），因此它是 Chromium 驱逐的那个一旦足够多的 xterm 终端——
+      // 每个都通过 @xterm/addon-webgl 获取上下文——打开后。Pixi
+      // 在此发生时报告 nothing：地板永远变空白。
+      // 重新构建。见 glRecovery.ts。
       (app as any).__glRecovery = installContextLossRecovery(app.canvas, {
         onRebuild: () => { if (mountIdRef.current === mountId) setGlGeneration((n) => n + 1); },
         onGiveUp: () => {
@@ -276,7 +275,7 @@ export function OfficeFloor() {
         }
       });
 
-      // Load tilesets in theme order (texture[i] lines up with map tilesets[i]).
+      // 按主题顺序加载图块集（texture[i] 与 map tilesets[i] 对齐）。
       const tilesetTextures = await Promise.all(
         themeTilesetUrls(theme).map(loadTexture),
       );
@@ -297,10 +296,10 @@ export function OfficeFloor() {
       camera.setViewSize(app.screen.width, app.screen.height);
       camera.fitToScreen();
 
-      // ─── The boss's wall calendar → TRIGGERS ───────────────────────────────
-      // A little tear-off month page hangs on the CEO office wall. Clicking it
-      // selects Michael (the god) and opens the Command Center's TRIGGERS tab —
-      // everything that wakes the hive without you, schedules first among them.
+      // ─── 老板的墙历 → TRIGGERS ───────────────────────────────
+      // 一个小撕页月历挂在 CEO 办公室墙上。点击它
+      // 选择迈克尔（神）并打开指挥中心的 TRIGGERS 标签页——
+      // 一切唤醒蜂巢而没有你的东西，调度排第一。
       const calTs = mapRenderer.tileSize;
       const calG = new Graphics();
       calG.eventMode = 'static';
@@ -314,7 +313,7 @@ export function OfficeFloor() {
         if (god) st.select(god.id);
         st.requestCommandCenterTab('triggers');
       });
-      // nail + ring binding above a white page with a red month header
+      // 钉子 + 环绑定在带有红色月份标题的白色页面上方
       calG.rect(7, -2, 2, 2).fill(0x4a3b52);                  // nail
       calG.rect(0, 0, 16, 20).fill(0x4a3b52);                 // frame/shadow
       calG.rect(1, 1, 14, 18).fill(0xf2ead8);                 // the page
@@ -329,9 +328,9 @@ export function OfficeFloor() {
       calG.rect(8, 11, 2, 2).fill(0xc94f4f);                  // today, circled red
       charLayer.addChild(calG);
 
-      // Build the ordered seat list once: PC desks + named desks first, then
-      // conference-room chairs as overflow. Each agent claims one and stays there;
-      // they never wander off it (except when blocked, or on a coffee break).
+      // 一次性构建有序座位列表：PC 桌面 + 命名桌面优先，然后
+      // 会议室椅子作为溢出。每个代理认领一个并保持在那里；
+      // 他们从不离开它（除非被阻塞，或在咖啡休息时）。
       const seatTiles: Tile[] = [];
       const seatSeen = new Set<string>();
       const addSeat = (t?: Tile) => {
@@ -351,13 +350,13 @@ export function OfficeFloor() {
           }
         }
       };
-      addZoneSeats('boardroom');       // conference room overflow
-      // The bottom-right open area is the cafeteria (break room) — see the
-      // coffee-break director below. It is deliberately NOT added as overflow
-      // desk seating, so the café tables stay free for breaks.
+      addZoneSeats('boardroom');       // 会议室溢出
+      // 右下角开放区域是咖啡间（休息室）——见下面的
+      // 咖啡休息导演。故意不作为溢出
+      // 工位座位添加，这样咖啡馆桌子保持用于休息。
 
-      // Waiting spots near the entrance — where a blocked agent walks to signal
-      // it needs the user. Collected as walkable tiles in rings around the door.
+      // 入口附近的等待点——被阻塞的代理走到那里发出信号
+      // 它需要用户。作为门周围的环中的可步行图块收集。
       const entrance = mapRenderer.getSpawnPoint('entrance')
         ?? { x: Math.floor(mapRenderer.width / 2), y: mapRenderer.height - 2 };
       const waitTiles: Tile[] = [];
@@ -375,8 +374,8 @@ export function OfficeFloor() {
       }
       if (waitTiles.length === 0) waitTiles.push(entrance);
 
-      // Seat 0 is desk-ceo — "Michael's room" — reserved for the god agent.
-      // All other workers claim seats from 1 onward.
+      // 座位 0 是 desk-ceo——"迈克尔的房间"——为神代理预留。
+      // 所有其他 workers 从 1 开始认领座位。
       const GOD_SEAT = 0;
       const claimSeat = (agent: Agent): number | null => {
         if (agent.isGod) { seatClaims.add(GOD_SEAT); return GOD_SEAT; }
@@ -386,28 +385,28 @@ export function OfficeFloor() {
         return null;
       };
 
-      // Face a seated agent toward their desk (the adjacent non-walkable
-      // furniture). Standard desks put the monitor to the north and the chair to
-      // the south, so the agent faces 'up' and we see their back — like a real
-      // worker. Only a desk directly to the SOUTH (face 'down') puts furniture in
-      // front of them, which is the one case the leg-crop tucks legs under.
+      // 让就座代理面向他们的桌面（相邻不可步行
+      // 家具）。标准桌子把显示器放在北边，椅子放在
+      // 南边，所以代理面向"上"我们看到他们的背部——像真实的
+      // 工人。只有直接在南方（面向"下"）的桌子才会把家具放在
+      // 他们前面，这是腿部裁剪将腿 tucked 下的唯一情况。
       const facingForSeat = (t: Tile): 'up' | 'down' | 'left' | 'right' => {
         if (!mapRenderer.isWalkable(t.x, t.y - 1)) return 'up';
         if (!mapRenderer.isWalkable(t.x, t.y + 1)) return 'down';
         if (!mapRenderer.isWalkable(t.x - 1, t.y)) return 'left';
         if (!mapRenderer.isWalkable(t.x + 1, t.y)) return 'right';
-        return 'up'; // open-floor overflow seat — no desk, just face away
+        return 'up'; // 开放地板溢出座位——没有桌子，只是面向远离
       };
 
-      // ─── Cafeteria: purposeful coffee breaks ───────────────────────────────
-      // Idle / finished agents occasionally stroll to the break area, sit at a
-      // café table (or stand at the coffee machine / vending machine), emit an
-      // in-character one-liner, then head back. Two agents at the same table
-      // trade a two-beat quip. This is what makes "lingering" feel purposeful.
+      // ─── 咖啡间：有目的的咖啡休息 ───────────────────────────────
+      // 空闲/完成的代理偶尔漫步到休息区，坐在
+      // 咖啡馆桌子（或站在咖啡机/自动售货机旁），发出一个
+      // 角色内的一行台词，然后返回。同一桌子的两个代理
+      // 交换一个双拍俏皮话。这就是让"停留"感觉有目的的原因。
       interface CafeSpot { tile: Tile; facing: Facing; spot: BreakSpot; seated: boolean; partner: number; }
       const cafeSpots: CafeSpot[] = [];
 
-      // Stand spots face the first adjacent non-walkable tile (the appliance).
+      // 站立点面向第一个相邻不可步行图块（电器）。
       const faceFurniture = (t: Tile): Facing => {
         if (!mapRenderer.isWalkable(t.x + 1, t.y)) return 'right';
         if (!mapRenderer.isWalkable(t.x - 1, t.y)) return 'left';
@@ -415,12 +414,12 @@ export function OfficeFloor() {
         return 'down';
       };
 
-      // Seats first (so partner indices are stable), then the standing spots.
+      // 先座位（所以搭档索引稳定），然后站立点。
       for (const name of theme.cafeSeatNames) {
         const p = mapRenderer.getSpawnPoint(name);
         if (p) cafeSpots.push({ tile: p, facing: facingForSeat(p), spot: 'table', seated: true, partner: -1 });
       }
-      // Pair the two seats that share a table (same column, two tiles apart).
+      // 配对共享同一张桌子的两个座位（同一列，相隔两个图块）。
       for (let i = 0; i < cafeSpots.length; i++) {
         for (let j = i + 1; j < cafeSpots.length; j++) {
           const a = cafeSpots[i].tile, b = cafeSpots[j].tile;
@@ -436,16 +435,16 @@ export function OfficeFloor() {
       const agentById = (id: string): Agent | undefined =>
         useStore.getState().agents.find((a) => a.id === id);
 
-      // ─── The coffee economy: sideboard → machine → desk → sink → sideboard ─
-      // A finite stock of mugs lives on a sideboard next to the kitchen counter.
-      // Brewing requires a mug in hand (a clean one off the rack, or your own
-      // brought back from the desk for a lazy refill); washing at the counter
-      // sink puts a mug back into the clean stock. If every mug is parked on a
-      // desk somewhere, the rack runs dry — and the floor feels it.
-      const TRAY_TILE: Tile = theme.coffee.trayTile;        // the sideboard (counter piece)
+      // ─── 咖啡经济：边柜 → 机器 → 桌面 → 水槽 → 边柜 ─
+      // 有限数量的杯子存放在厨房柜台旁的边柜上。
+      // 冲泡需要手中有一个杯子（架子上的干净杯子，或你自己的
+      // 从桌面带回用于懒加载的杯子）；在柜台
+      // 水槽清洗后将杯子放回干净库存。如果每个杯子都停在
+      // 某个地方的桌面上，架子会变空——地板会感受到这一点。
+      const TRAY_TILE: Tile = theme.coffee.trayTile;        // 边柜（柜台组件）
       const TRAY_STAND: Tile = theme.coffee.trayStand;
-      const MACHINE_STAND: Tile = theme.coffee.machineStand; // below the counter machine
-      const SINK_TILE: Tile = theme.coffee.sinkTile;        // free counter top, right end
+      const MACHINE_STAND: Tile = theme.coffee.machineStand; // 柜台机器下方
+      const SINK_TILE: Tile = theme.coffee.sinkTile;        // 空闲柜台顶，右端
       const SINK_STAND: Tile = theme.coffee.sinkStand;
       const MAX_CUPS = theme.coffee.maxCups;
       let cleanCups = MAX_CUPS;
@@ -470,17 +469,17 @@ export function OfficeFloor() {
       sinkG.position.set(SINK_TILE.x * ts0, SINK_TILE.y * ts0);
       sinkG.zIndex = (SINK_TILE.y + 1) * ts0;
       charLayer.addChild(sinkG);
-      let sinkBusy = 0; // seconds of wash animation left
+      let sinkBusy = 0; // 清洗动画剩余的秒数
       const drawSink = (t: number): void => {
         sinkG.clear();
-        // steel basin set into the white counter top + a small faucet
+        // 白色柜台顶嵌入的钢盆 + 一个小水龙头
         sinkG.rect(2, 6, 12, 8).fill(0xb9c2c9);
         sinkG.rect(3, 7, 10, 6).fill(0x87939d);
         sinkG.rect(7, 9, 2, 2).fill(0x5d676f);          // drain
         sinkG.rect(7, 2, 2, 4).fill(0x6b7680);          // faucet riser
         sinkG.rect(6, 2, 4, 1).fill(0x6b7680);
         if (sinkBusy > 0) {
-          // running water + a couple of suds while someone scrubs
+          // 流动的水 + 几个人在擦洗时的几个泡沫
           sinkG.rect(7, 6, 2, 4).fill({ color: 0x9fd6f0, alpha: 0.9 });
           for (let i = 0; i < 3; i++) {
             const ph = (t * 1.2 + i / 3) % 1;
@@ -490,7 +489,7 @@ export function OfficeFloor() {
       };
       drawSink(0);
 
-      const machineG = new Graphics(); // steam over the counter machine while brewing
+      const machineG = new Graphics(); // 冲泡期间柜台机器上方的蒸汽
       machineG.eventMode = 'none';
       machineG.position.set(26 * ts0, 17 * ts0);
       machineG.zIndex = 19 * ts0;
@@ -506,8 +505,8 @@ export function OfficeFloor() {
         }
       };
 
-      // One coffee-run leg: walk somewhere, then act. Drives rt.run through its
-      // phases; the per-tick engine below advances the timed (acting) phases.
+      // 一个咖啡行程 leg：走到某处然后执行动作。驱动 rt.run 通过其
+      // 阶段；每秒引擎推进定时（执行）阶段。
       const finishRun = (rt: Runtime): void => {
         rt.run = undefined;
         const c = rt.character;
@@ -529,10 +528,10 @@ export function OfficeFloor() {
           : TRAY_STAND;
         c.walkToAndThen(dest, () => {
           if (!rt.run || rt.run.phase !== phase) return;
-          c.faceDirection('up'); // every station faces its counter to the north
+          c.faceDirection('up'); // 每个站都面向其北边柜台
           if (phase === 'toTray') {
             if (cleanCups <= 0) {
-              // Rack ran dry — every mug is parked on someone's desk.
+              // 架子用完了——每个杯子都停在某人的桌面上。
               c.showThought(t('office.mugs.empty'));
               rt.run = { phase: 'placing', timer: -1 }; // brief sulk, then move on
               return;
@@ -558,8 +557,8 @@ export function OfficeFloor() {
         });
       };
 
-      /** Cancel a coffee run (real work / teardown). A held mug rides along to
-       *  the desk via cupCarryHome; the floor fixtures just stop animating. */
+      /** 取消咖啡行程（真实工作/拆除）。手持的杯子随
+       * cupCarryHome 到达桌面；地板设施只是停止动画。 */
       const releaseRun = (rt: Runtime): void => {
         if (!rt.run) return;
         rt.run = undefined;
@@ -599,7 +598,7 @@ export function OfficeFloor() {
         }
       };
 
-      /** Distance from the god's avatar in px, or Infinity when he's absent. */
+      /** 距离神的化身 px 数，或他缺席时为 Infinity。 */
       const godDistance = (px: number, py: number): number => {
         const god = useStore.getState().agents.find((a) => a.isGod);
         const grt = god ? runtimes.get(god.id) : undefined;
@@ -612,9 +611,9 @@ export function OfficeFloor() {
         const spot = cafeSpots[spotIdx];
         const character = agentById(id)?.character ?? DEFAULT_CHARACTER;
         const seed = Math.floor(Math.random() * 1e6);
-        // Out of the boss's earshot, café talk turns to… the boss. In his
-        // presence it's the usual harmless quips (the sucking up happens via
-        // the proximity director below).
+        // 在老板的耳边外，咖啡馆谈话转向……老板。在他
+        // 在场时是通常无害的俏皮话（讨好行为通过
+        // 下面的接近性导演完成）。
         const p = rt.character.getPixelPosition();
         if (godDistance(p.x, p.y) > 96 && Math.random() < 0.35) {
           rt.character.showThought(t(GOSSIP_KEYS[Math.floor(Math.random() * GOSSIP_KEYS.length)]));
@@ -623,10 +622,10 @@ export function OfficeFloor() {
         rt.character.showThought(pickSoloLine(character, spot.spot, seed));
       };
 
-      // If the newcomer's table-mate is already lingering (and neither is mid-
-      // conversation), start a multi-beat exchange. The newcomer is the
-      // initiator and owns the script; the partner just gets marked engaged.
-      // Returns true if a chat was started.
+      // 如果新来者的桌子搭档已经在停留（且双方都不是在
+      // 对话中），开始多拍交换。新来者是
+      // 发起者并拥有脚本；搭档只被标记为参与。
+      // 如果启动了对话则返回 true。
       const maybePairChat = (id: string, rt: Runtime, spotIdx: number): boolean => {
         const spot = cafeSpots[spotIdx];
         if (spot.partner < 0 || !rt.brk) return false;
@@ -642,8 +641,8 @@ export function OfficeFloor() {
         return true;
       };
 
-      // Free a café seat and tidy up any conversation links so neither agent is
-      // left mid-chat. Called when a break ends OR is interrupted by real work.
+      // 释放咖啡馆座位并整理任何对话链接以便两个代理都不会
+      // 留在对话中间。在休息结束 OR 被真实工作打断时调用。
       const releaseBreak = (rt: Runtime): void => {
         if (!rt.brk) return;
         if (rt.brk.chat) {
@@ -658,12 +657,12 @@ export function OfficeFloor() {
         rt.brk = undefined;
       };
 
-      // End a break gracefully: free the seat, drop the bubble — and settle the
-      // coffee question. An agent that brought its used desk mug along either
-      // just REFILLS it at the machine (the lazy path) or properly WASHES it at
-      // the sink and racks it back on the sideboard. An agent without a mug
-      // fetches a clean one off the rack first — no mug, no coffee: if the rack
-      // ran dry the run ends in a sulk instead of a brew.
+      // 优雅结束休息：释放座位，丢弃气泡——并解决
+      // 咖啡问题。携带其用过的桌面杯子的代理要么
+      // 仅在机器处 REFILL（懒路径）或正确地在
+      // 水槽 WASH 并将其放回边柜。没有杯子的代理
+      // 首先从架子上取一个干净的——没有杯子，没有咖啡：如果架子
+      // 用完了行程以沮丧结束而不是冲泡。
       const endBreak = (id: string, rt: Runtime): void => {
         const arrived = rt.brk?.phase === 'lingering';
         releaseBreak(rt);
@@ -672,13 +671,13 @@ export function OfficeFloor() {
         if (agent?.isGod) { rt.character.sitAtDesk(true); return; }
         const c = rt.character;
         if (!arrived) {
-          // Never made it to the café (watchdog) — a held mug still goes home.
+           // 从未到达咖啡店（看门狗）——拿着的杯子还是要回家。
           if (c.isCarryingCup()) { rt.cupCarryHome = true; c.sitAtDesk(false); }
           else c.startWandering();
           return;
         }
         if (c.isCarryingCup()) {
-          // Brought the used desk mug along: 60% lazy refill, 40% proper wash.
+           // 把用过的办公桌杯子带回来了：60% 懒补给，40% 正确清洗。
           if (Math.random() < 0.6) startRunLeg(rt, 'toMachine');
           else startRunLeg(rt, 'toSink');
         } else if (!c.hasCupOnDesk() && Math.random() < 0.75) {
@@ -689,8 +688,8 @@ export function OfficeFloor() {
       };
 
       const startBreak = (id: string, rt: Runtime): void => {
-        // Prefer (≈half the time) a seat whose table-mate is already there, so
-        // pairs form and chat; otherwise any free spot.
+        // 优先（≈一半时间）一个桌子搭档已经在那里的座位，所以
+        // 形成配对并聊天；否则任何空闲点。
         const free: number[] = [];
         const social: number[] = [];
         for (let i = 0; i < cafeSpots.length; i++) {
@@ -706,22 +705,22 @@ export function OfficeFloor() {
         cafeTaken[idx] = id;
         rt.brk = { spotIdx: idx, phase: 'walking', timer: 0, quipTimer: 0 };
         const c = rt.character;
-        // A mug still parked on the desk comes along to the break — it stays
-        // in hand through the lingering (sipping at the table) and gets either
-        // refilled or washed when the break ends (see endBreak).
+        // 仍然停在桌面上的杯子会带到休息——它保持
+        // 在手通过停留（在桌子旁啜饮）并在休息结束时
+        // 重新填充或清洗（见 endBreak）。
         if (c.hasCupOnDesk()) {
           c.setCupOnDesk(false);
           c.setCarryingCup(true);
         }
         c.walkToAndThen(spot.tile, () => {
-          // Bail if the break was cancelled or reassigned while walking.
+          // 如果在行走时休息被取消或重新分配则返回
           if (!rt.brk || rt.brk.spotIdx !== idx) return;
           if (spot.seated) c.sitInPlace(spot.facing);
           else { c.setIdle(); c.faceDirection(spot.facing); }
           rt.brk.phase = 'lingering';
           rt.brk.timer = 8 + Math.random() * 8;   // 8–16s of lingering
           rt.brk.quipTimer = 4 + Math.random() * 4;
-          // Start a conversation if the table-mate is here; otherwise a solo quip.
+           // 如果桌伴在这里就开始对话；否则自言自语。
           if (!maybePairChat(id, rt, idx)) emitQuip(id, rt, idx);
         });
       };
@@ -734,7 +733,7 @@ export function OfficeFloor() {
 
       let cafeCooldown = 5;
       const updateCafeteria = (dt: number): void => {
-        // Advance every in-progress break.
+         // 推进每个进行中的休息。
         for (const [id, rt] of runtimes) {
           const b = rt.brk;
           if (!b) continue;
@@ -745,7 +744,7 @@ export function OfficeFloor() {
           }
           // lingering
           if (b.chat) {
-            // Play the conversation one beat at a time, alternating speakers.
+            // 一次一个节拍播放对话，交替说话者。
             b.chat.beat -= dt;
             if (b.chat.beat <= 0) {
               if (b.chat.idx < b.chat.lines.length) {
@@ -757,32 +756,32 @@ export function OfficeFloor() {
                 const prt = runtimes.get(b.chat.partnerId);
                 if (prt?.brk) prt.brk.timer = Math.max(prt.brk.timer, 3.5);
               } else {
-                // Conversation over — release the partner and resume solo quips.
+                // 对话结束——释放搭档并恢复单人俏皮话。
                 const prt = runtimes.get(b.chat.partnerId);
                 if (prt?.brk) prt.brk.chattingWith = undefined;
                 b.chat = undefined;
               }
             }
           } else if (!b.chattingWith) {
-            // Not in a conversation (and not being spoken to) — swap a solo quip.
+            // 不在对话中（且不被说话）——切换单人俏皮话。
             b.quipTimer -= dt;
             if (b.quipTimer <= 0) {
               b.quipTimer = 4 + Math.random() * 4;
               emitQuip(id, rt, b.spotIdx);
             }
-            // Occasionally strike up a chat with a table-mate who arrived too.
+            // 偶尔与也到达的桌子搭档开始对话。
             else if (Math.random() < 0.004) maybePairChat(id, rt, b.spotIdx);
           }
           b.timer -= dt;
           if (b.timer <= 0) endBreak(id, rt);
         }
 
-        // Periodically send one idle agent on a break — but cap the room at 4.
+        // 定期发送一个空闲代理去休息——但将房间限制为 4 个。
         cafeCooldown -= dt;
         if (cafeCooldown > 0) return;
         cafeCooldown = 6 + Math.random() * 6;
         if (cafeTaken.filter(Boolean).length >= 4) return;
-        if (Math.random() >= 0.7) return;          // not every window — keep it casual
+        if (Math.random() >= 0.7) return;          // 不是每个窗口——保持随意
         const candidates: Array<[Agent, Runtime]> = [];
         for (const agent of useStore.getState().agents) {
           const rt = runtimes.get(agent.id);
@@ -793,13 +792,13 @@ export function OfficeFloor() {
         startBreak(agent.id, rt);
       };
 
-      // ─── Idle errands: small purposeful busywork for a quiet floor ─────────
-      // Plants get watered, windows opened for a breeze, the dispenser poured,
-      // the fridge inspected, the shelf browsed, scrap paper binned. Every spot
-      // has a stand tile + facing; `fx` anchors a little ambient animation.
+      // ─── 空闲跑腿：安静地板的小有目的繁忙工作 ─────────
+      // 给植物浇水，打开窗户通风，倒出分配器，
+      // 检查冰箱，浏览架子，将废纸扔进垃圾桶。每个点
+      // 有一个站立图块 + 方向；`fx` 锚定一点环境动画。
       const ERRAND_SPOTS: ErrandSpot[] = theme.errandSpots;
       const errandTaken: (string | null)[] = new Array(ERRAND_SPOTS.length).fill(null);
-      // Lazily-created ambient fx layer per active errand spot.
+      // 每个活跃跑腿点懒创建的环境 fx 层。
       const errandFx = new Map<number, Graphics>();
 
       const fxFor = (idx: number): Graphics => {
@@ -816,34 +815,34 @@ export function OfficeFloor() {
         return g;
       };
 
-      /** Draw one errand's ambient animation frame (local coords on its fx tile). */
+      /** 绘制一个跑腿的环境动画帧（在其 fx 图块上的本地坐标）。 */
       const drawErrandFx = (kind: ErrandKind, g: Graphics, t: number): void => {
         g.clear();
         if (kind === 'window' || kind === 'smoke') {
-          // wind streaks slipping in under the sash and drifting down-room —
-          // for 'smoke' the boss cracked HIS window open for the cigar.
+          // 风条纹从窗框下溜进并漂向房间——
+          // 对于 'smoke' 老板打开了他的窗户抽雪茄。
           for (let i = 0; i < 3; i++) {
             const ph = (t * 0.7 + i / 3) % 1;
             g.rect(2 + i * 9 - ph * 5, 26 + ph * 16, 7, 1)
               .fill({ color: 0xd8f1f7, alpha: 0.55 * (1 - ph) });
           }
         } else if (kind === 'dispenser') {
-          // glugging bottle: a drip line + a bubble rising in the tank
+          // 咕噜瓶子：滴线 + 气泡在罐中上升
           const ph = (t * 1.6) % 1;
           g.rect(7, 18 + ph * 6, 1, 3).fill({ color: 0x9fd6f0, alpha: 0.9 * (1 - ph) });
           const bp = (t * 0.9) % 1;
           g.circle(8, 12 - bp * 6, 1).fill({ color: 0xffffff, alpha: 0.6 * (1 - bp) });
         } else if (kind === 'fridge') {
-          // the open-door light cone spilling onto the floor, gently flickering
+          // 开门光束洒在地板上，轻轻闪烁
           const a = 0.16 + 0.05 * Math.sin(t * 5);
           g.poly([3, 12, 13, 12, 16, 30, 0, 30]).fill({ color: 0xfff2b8, alpha: a });
         } else if (kind === 'shelf') {
-          // a little glint wandering across the shelves
+          // 一个小闪烁在架子间游走
           const ph = (t * 0.5) % 1;
           g.rect(2 + ph * 24, 4 + (Math.floor(t * 0.5) % 3) * 9, 2, 2)
             .fill({ color: 0xfff7c8, alpha: 0.8 * Math.sin(ph * Math.PI) });
         } else if (kind === 'bin') {
-          // a paper ball arcing in from the agent's side, once per second
+          // 一个纸球从代理一侧抛入，每秒一次
           const ph = (t * 1.0) % 1;
           if (ph < 0.45) {
             const p = ph / 0.45;
@@ -853,7 +852,7 @@ export function OfficeFloor() {
             g.rect(Math.round(x), Math.round(y), 2, 2).fill({ color: 0xf5f1e6, alpha: 0.95 });
           }
         }
-        // 'water' draws nothing here — droplets ride on the character itself
+         // 'water' 在这里不绘制任何东西——水滴随角色本身
       };
 
       const releaseErrand = (rt: Runtime): void => {
@@ -876,8 +875,8 @@ export function OfficeFloor() {
             if (err.timer > 20) { releaseErrand(rt); rt.character.startWandering(); }
             continue;
           }
-          // doing: animate the spot; watering + smoking complete via their
-          // own Character callbacks, the rest by this timer
+           // 执行：动画这个点；浇水 + 吸烟通过各自的
+           // Character 回调完成，其余由这个计时器处理
           drawErrandFx(spot.kind, fxFor(err.idx), err.timer);
           if (spot.kind !== 'water' && spot.kind !== 'smoke' && err.timer >= spot.duration) {
             releaseErrand(rt);
@@ -893,9 +892,9 @@ export function OfficeFloor() {
         if (free.length === 0) return;
         const idx = free[Math.floor(Math.random() * free.length)];
         const spot = ERRAND_SPOTS[idx];
-        // Pick the performer. The CEO office's spots belong to Michael alone —
-        // and unlike workers he runs his errands FROM his desk (he's seated
-        // while idle, so the sitting check doesn't apply to him).
+         // 选择表演者。CEO 办公室的位点仅属于 Michael——
+         // 与 workers 不同，他从自己的办公桌执行跑腿（他坐着
+         // 空闲时，所以坐着检查不适用于他）。
         let agent: Agent | undefined;
         let rt: Runtime | undefined;
         if (spot.godOnly) {
@@ -903,7 +902,7 @@ export function OfficeFloor() {
           const grt = god ? runtimes.get(god.id) : undefined;
           if (!god || !grt || grt.err || grt.brk
             || (god.status !== 'idle' && god.status !== 'success')
-            || Math.random() >= 0.5) return;        // the boss is unhurried
+            || Math.random() >= 0.5) return;        // 老板不慌不忙
           agent = god; rt = grt;
         } else {
           const candidates: Array<[Agent, Runtime]> = [];
@@ -936,17 +935,17 @@ export function OfficeFloor() {
         });
       };
 
-      // ─── The boss aura: performative excellence in Michael's presence ──────
-      // When the god's avatar wanders close to a worker, the worker bursts
-      // into suck-up mode — including REAL stats ("already shipped N tasks,
-      // Michael. raise?" with N from the actual ledger). What they say once
-      // he's out of earshot is a different story (see emitQuip's gossip).
+      // ─── 老板 aura：迈克尔在场时的表演性卓越 ──────
+      // 当神的化身漫游接近 worker 时，worker 爆发
+      // 进入讨好模式——包括真实统计（"已经交付 N 个任务，
+      // 迈克尔。加薪？" 带有来自实际账簿的 N）。一旦他
+      // 离开可听范围他们会说什么则是另一回事（见 emitQuip 的 gossip）。
       const lastSuckUp = new Map<string, number>();
       let doneByAssignee = new Map<string, number>();
       let statsAge = 999;
       let auraCooldown = 1.5;
       const updateBossAura = (dt: number): void => {
-        // refresh the done-counts from the ledger at a relaxed cadence
+        // 以轻松的节奏从账簿刷新完成计数
         statsAge += dt;
         if (statsAge > 30) {
           statsAge = 0;
@@ -961,8 +960,7 @@ export function OfficeFloor() {
               }
             }
             doneByAssignee = m;
-          }).catch(() => { /* keep last counts */ });
-        }
+          }).catch(() => { /* 保持最后计数 */ });        }
         auraCooldown -= dt;
         if (auraCooldown > 0) return;
         auraCooldown = 1.5;
@@ -975,7 +973,7 @@ export function OfficeFloor() {
           if (id === god!.id) continue;
           const a = agentById(id);
           if (!a) continue;
-          // only relaxed workers perform — not someone mid-thought of real work
+          // 只有 relaxed workers 表演——不是正在思考真实工作中的某人
           if (a.status !== 'idle' && a.status !== 'success') continue;
           if (rt.brk?.chat || rt.brk?.chattingWith) continue;
           const p = rt.character.getPixelPosition();
@@ -991,12 +989,12 @@ export function OfficeFloor() {
         }
       };
 
-      // ─── Coffee delivery + desk screens, every frame ───────────────────────
+       // ─── 咖啡配送 + 桌面屏幕，每帧 ───────────────────────
       const updateDeskLife = (dt: number): void => {
         for (const [id, rt] of runtimes) {
-          // Park the carried coffee the moment its courier is seated at home —
-          // then, if there's still nothing to do, get up and wander off (the
-          // cup stays, steaming, beside the monitor).
+           // 当送杯者在家就座时立即放下咖啡——
+           // 然后，如果仍无事可做，起身走开（杯子
+           // 留在显示器旁，冒着热气）。
           if (rt.cupCarryHome && rt.character.isSittingAtDesk()) {
             rt.cupCarryHome = false;
             rt.character.setCarryingCup(false);
@@ -1006,24 +1004,24 @@ export function OfficeFloor() {
               rt.character.startWandering();
             }
           }
-          // The monitor lights up whenever its owner is in the chair.
+          // 只要其所有者坐在椅子上显示器就点亮。
           if (rt.screen) {
             rt.screen.setOn(rt.character.isSittingAtDesk());
             rt.screen.update(dt);
           }
         }
       };
-      // ─── The office task boards: hive/tasks.json pinned to the wall ────────
-      // TWO cork boards hang side by side on the wall band above the open-plan
-      // desks: BLOCKERS (red) on the left, TODO (yellow) on the right — each
-      // with a colored header strip. A worker who picks a task up (doing +
-      // assignee) literally TAKES THE NOTE ALONG: it leaves the boards and
-      // sticks to that worker's desk instead. Finished tasks archive as a green
-      // stack on the little table at the end. Clicking any of it selects
-      // Michael and opens the Command Center's tasks tab.
+      // ─── 办公室任务板：hive/tasks.json 钉在墙上 ────────
+      // 两块软木板并排挂在开放式计划
+      // 桌面上方的墙带上：BLOCKERS（红色）在左侧，TODO（黄色）在右侧——各
+      // 带有一条彩色标题条。认领任务的 worker（doing +
+      // assignee）字面上 TAKE THE NOTE ALONG：它离开板子
+      // 粘到该 worker 的桌面上。完成的任务以绿色
+      // 堆叠归档在尽头的小桌子上。点击任何内容选择
+      // 迈克尔并打开指挥中心的任务标签页。
       const BOARD_TILE: Tile = theme.anchors.boards;
-      // The ensemble (two boards + archive table) is 82px wide; the wall run
-      // between the two doorways spans tiles 6..12 (112px) — center it.
+      // 整个组合（两块板 + 归档桌子）82px 宽；两个门之间的墙
+      // 跨越图块 6..12（112px）——居中。
       const BOARD_CENTER_PAD = 15;
       const NOTE_COLORS: Record<string, number> = theme.palette.noteColors;
       interface BoardTask { status: string; assignee?: string }
@@ -1041,15 +1039,15 @@ export function OfficeFloor() {
         st.requestCommandCenterTab('tasks');
       });
       charLayer.addChild(boardG);
-      // One small Graphics per desk currently holding a taken note.
+      // 每个当前持有取走便条的桌面一个小的 Graphics。
       const deskNoteG = new Map<string, Graphics>();
       const clearDeskNotes = (): void => {
         for (const g of deskNoteG.values()) { g.parent?.removeChild(g); g.destroy(); }
         deskNoteG.clear();
       };
 
-      /** One cork board with a colored header at local x `ox`; draws up to 12
-       *  of `notes`, overflow as a corner pile. */
+      /** 一个带有本地 x `ox` 处彩色标题的软木板；绘制最多 12
+       * 个 `notes`，溢出作为角落堆。 */
       const drawCork = (ox: number, header: number, notes: string[]): void => {
         boardG.rect(ox, -8, 30, 22).fill(0x6e5639);        // frame
         boardG.rect(ox + 1, -7, 28, 3).fill(header);       // header strip
@@ -1073,9 +1071,9 @@ export function OfficeFloor() {
         const blocked = tasks.filter((t) => t.status === 'blocked').map(() => 'blocked');
         const todoNotes: string[] = tasks.filter((t) => t.status === 'todo').map(() => 'todo');
         let done = 0;
-        // doing → taken off the wall: pin it to the assignee's desk. Without a
-        // resolvable desk (no assignee / not on the floor) it falls back onto
-        // the TODO board as a blue note, so nothing ever silently disappears.
+        // doing → 从墙上取下：钉到 assignee 的桌面上。没有
+        // 可解析的桌面（无 assignee / 不在地板上）时回退到
+        // TODO 板上作为蓝色便条，这样 nothing 永远不会无声消失。
         for (const t of tasks) {
           if (t.status === 'done') { done++; continue; }
           if (t.status !== 'doing') continue;
@@ -1091,16 +1089,16 @@ export function OfficeFloor() {
             charLayer.addChild(g);
             deskNoteG.set(t.assignee!, g);
           }
-          // stack multiple taken notes side by side on the same desk
+          // 在同一桌面上并排堆放多个取走的便条
           const idx = (g as any).__count ?? 0;
           (g as any).__count = idx + 1;
           g.rect(idx * 7, -(idx % 2), 5, 4).fill(NOTE_COLORS.doing);
           g.rect(idx * 7 + 2, -(idx % 2), 1, 1).fill(0x4a3b52);
         }
-        drawCork(0, NOTE_COLORS.blocked, blocked);   // left: what's burning
-        drawCork(34, NOTE_COLORS.todo, todoNotes);   // right: what's queued
-        // The archive table: every finished task adds a green sheet to the
-        // pile (visible stack capped at 6 — beyond that it just sits proud).
+        drawCork(0, NOTE_COLORS.blocked, blocked);   // 左边：正在燃烧的
+        drawCork(34, NOTE_COLORS.todo, todoNotes);   // 右边：排队的
+        // 归档桌子：每个完成的任务向堆添加一张绿色纸
+        // （可见堆限制为 6——超过它就只是突出）。
         boardG.rect(68, 6, 14, 4).fill(0xb08d5e);    // table top
         boardG.rect(68, 10, 14, 4).fill(0x8a6f4d);   // table front
         boardG.rect(69, 14, 2, 2).fill(0x6e5639);    // legs
@@ -1114,11 +1112,11 @@ export function OfficeFloor() {
       };
       drawTaskBoard([]);
 
-      // ─── The office clock: clicking it is CLOCKING OUT ─────────────────────
-      // The wall clock beside Michael's window doubles as the quit entry:
-      // a click runs the real close flow (window.close() → the main process
-      // intercepts while agents run → the "Quitting now?" dialog with its
-      // closing-time option). The office clock literally opens quitting time.
+      // ─── 办公室时钟：点击它是下班时间 ─────────────────────
+      // 迈克尔窗户旁边的墙钟兼作退出入口：
+      // 一次点击运行真实的关闭流程（window.close() → 主进程
+      // 拦截而代理运行时 → "正在退出？"对话框及其
+      // 关闭时间选项）。办公室时钟字面上打开关闭时间。
       const clockG = new Graphics();
       clockG.eventMode = 'static';
       clockG.cursor = 'pointer';
@@ -1131,12 +1129,12 @@ export function OfficeFloor() {
       });
       charLayer.addChild(clockG);
 
-      // ─── The ASK ME board: tasks waiting on the HUMAN, first class ─────────
-      // Hangs on the right wall run (between the second doorway and the war
-      // room): one lilac note per open question the god parked for the human.
-      // It pulses while anything waits — clicking it opens the Command Center's
-      // ASK ME tab, where the human reads the questions, answers, and the
-      // answers flow back to the god (documented on the card itself).
+      // ─── ASK ME 板：等待 HUMAN 的任务，一等公民 ─────────
+      // 挂在右侧墙带（第二个门和战争室之间）：一个
+      // 神为 human 停放的一个薰衣草便条每个开放问题。
+      // 它在有等待时脉冲——点击它打开指挥中心的
+      // ASK ME 标签页，human 在其中读取问题，回答，和
+      // 答案流回神（在卡片本身记录）。
       const askG = new Graphics();
       askG.eventMode = 'static';
       askG.cursor = 'pointer';
@@ -1154,12 +1152,12 @@ export function OfficeFloor() {
       let askPulse = 0;
       const drawAskBoard = (pulse: number): void => {
         askG.clear();
-        // lilac-framed board with a big "?" identity
+        // 薰衣草框架板带有大的 "?" 标识
         askG.rect(0, -8, 30, 22).fill(0x5b4a6b);
         askG.rect(1, -7, 28, 3).fill(0xcdb4e8);
         askG.rect(1, -4, 28, 17).fill(0xc9b083);
         if (askCount === 0) {
-          // quiet: a faint "?" watermark
+          // 安静：一个微弱的 "?" 水印
           askG.rect(13, -1, 4, 2).fill({ color: 0x8a755f, alpha: 0.8 });
           askG.rect(15, 1, 2, 4).fill({ color: 0x8a755f, alpha: 0.8 });
           askG.rect(15, 7, 2, 2).fill({ color: 0x8a755f, alpha: 0.8 });
@@ -1171,41 +1169,41 @@ export function OfficeFloor() {
             askG.rect(x, y, 5, 4).fill(0xcdb4e8);
             askG.rect(x + 2, y, 1, 1).fill(0x4a3b52);
           }
-          // attention pulse around the frame while questions wait
+          // 在问题等待时框架周围的注意力脉冲
           const a = 0.35 + 0.3 * Math.sin(pulse * 4);
           askG.rect(-2, -10, 34, 26).stroke({ color: 0xcdb4e8, width: 2, alpha: a });
         }
       };
       drawAskBoard(0);
 
-      // ─── Board choreography: every ledger move is ACTED on the floor ───────
-      // Michael walks over and pins fresh cards; an assigned worker walks to
-      // the TODO board, takes its note and carries it home; finishing carries
-      // the note to the archive table; a card going blocked gets walked to the
-      // red board. While a move is in flight, the boards keep showing the OLD
-      // state for that card — the redraw lands exactly when the actor acts.
-      // Un-choreographable diffs (no actor on the floor, bulk edits, restarts)
-      // simply redraw — animation is sugar, the ledger stays the truth.
+      // ─── 板编排：每次账簿移动都在地板上表演 ───────
+      // 迈克尔走上来钉新鲜的卡片；分配的 worker 走到
+      // TODO 板，取下它的便条并带回家；完成携带
+      // 便条到归档桌子；一个被阻塞的卡片被走到
+      // 红色板。在移动进行时，板继续显示 OLD
+      // 该卡片的状态——重绘恰好落在演员行动时。
+      // 无法编排的差异（地板上没有演员，批量编辑，重启）
+      // 只需重绘——动画是糖，账簿保持真理。
       interface LedgerTask extends BoardTask { id: string }
       interface BoardMove {
         kind: 'pin' | 'take' | 'archive';
         taskId: string;
         actorId: string;
-        /** What this card should look like in visualTasks once the move lands. */
+        /** 此卡片在移动落地后在 visualTasks 中应该是什么样。 */
         after: BoardTask;
         carryColor: number;
         stand: Tile;
         thought: string;
       }
-      const PIN_STAND: Tile = { x: 8, y: 11 };      // under the blockers board
-      const TAKE_STAND: Tile = { x: 9, y: 11 };     // under the todo board
-      const ARCHIVE_STAND: Tile = { x: 12, y: 11 }; // beside the archive table
-      /** What the boards currently SHOW (lags the ledger while moves play). */
+      const PIN_STAND: Tile = { x: 8, y: 11 };      // 在 blockers 板下方
+      const TAKE_STAND: Tile = { x: 9, y: 11 };     // 在 todo 板下方
+      const ARCHIVE_STAND: Tile = { x: 12, y: 11 }; // 在归档桌子旁边
+      /** 板当前显示的（在移动播放时落后于账簿）。 */
       let visualTasks = new Map<string, BoardTask>();
       const moveQueue: BoardMove[] = [];
       const busyActors = new Set<string>();
-      // The note riding in an actor's hand, floor-side so it needs no Character
-      // support: one tiny Graphics per active move, repositioned every tick.
+      // 演员手中携带的便条，地板侧所以它不需要 Character
+      // 支持：每个活跃移动一个小的 Graphics，每秒重新定位。
       const carriedNotes = new Map<string, Graphics>();
 
       const redrawVisual = (): void => drawTaskBoard([...visualTasks.values()]);
@@ -1239,7 +1237,7 @@ export function OfficeFloor() {
         busyActors.add(mv.actorId);
         const c = rt.character;
         if (mv.kind === 'archive') {
-          // picks the note up at its desk before walking — in hand, off the desk
+          // 在行走前从桌面捡起便条——手中，离开桌面
           attachCarriedNote(mv.actorId, mv.carryColor);
           visualTasks.set(mv.taskId, { status: '__carried__' });
           redrawVisual();
@@ -1248,16 +1246,16 @@ export function OfficeFloor() {
         c.walkToAndThen(mv.stand, () => {
           c.faceDirection('up');
           if (mv.kind === 'take') attachCarriedNote(mv.actorId, mv.carryColor);
-          // brief acting beat, then the boards update under their hands
+          // 短暂的表演节拍，然后板在它们的手下方更新
           setTimeout(() => {
             if (mv.kind === 'take') {
-              // carry it home: the desk note appears on arrival via finishMove
+              // 带回家：桌面便条在到达时通过 finishMove 出现
               const rt2 = runtimes.get(mv.actorId);
               if (!rt2) { finishMove(mv, undefined); return; }
               visualTasks.set(mv.taskId, { ...mv.after, status: '__carried__' });
               redrawVisual();
               rt2.character.walkToAndThen(rt2.character.getDeskTile(), () => finishMove(mv, rt2));
-              // watchdog below also covers this leg
+              // 下面的看门狗也覆盖这个 leg
             } else {
               finishMove(mv, runtimes.get(mv.actorId));
             }
@@ -1267,7 +1265,7 @@ export function OfficeFloor() {
 
       let moveWatchdog = 0;
       const updateBoardMoves = (dt: number): void => {
-        // carried notes ride at the actor's hand
+        // 携带的便条骑在演员的手上
         for (const [id, g] of carriedNotes) {
           const rt = runtimes.get(id);
           if (!rt) continue;
@@ -1275,17 +1273,17 @@ export function OfficeFloor() {
           g.position.set(p.x + 5, p.y - 10);
           g.zIndex = p.y + 1;
         }
-        // start queued moves whose actor is free
+        // 开始演员空闲的排队移动
         for (let i = moveQueue.length - 1; i >= 0; i--) {
           if (!busyActors.has(moveQueue[i].actorId)) {
             const mv = moveQueue.splice(i, 1)[0];
             startMove(mv);
           }
         }
-        // the ASK ME board pulses for attention while questions wait
+        // ASK ME 板在问题等待时脉冲获取注意力
         askPulse += dt;
         if (askCount > 0) drawAskBoard(askPulse);
-        // global watchdog: if anything has been in flight too long, hard-sync
+        // 全局看门狗：如果任何东西在空中太久，硬同步
         moveWatchdog += dt;
         if (moveWatchdog > 30 && busyActors.size > 0) {
           moveWatchdog = 0;
@@ -1299,8 +1297,8 @@ export function OfficeFloor() {
         }
       };
 
-      /** Pick who performs a ledger change: the assignee if on the floor, the
-       *  god for fresh pins / orphan cards. Returns undefined → instant redraw. */
+      /** 选择执行账簿变更的人：如果在地板上的 assignee，
+       * 神用于新鲜钉入/孤立卡片。返回 undefined → 即时重绘。 */
       const actorFor = (assignee: string | undefined, preferGod: boolean): string | undefined => {
         if (!preferGod && assignee && runtimes.has(assignee)) return assignee;
         const god = useStore.getState().agents.find((a) => a.isGod);
@@ -1318,7 +1316,7 @@ export function OfficeFloor() {
             status: String(t?.status ?? 'todo'),
             assignee: typeof t?.assignee === 'string' && t.assignee ? t.assignee : undefined
           }));
-          // tasks waiting on the HUMAN feed the ASK ME board's note count
+          // 等待 HUMAN 的任务喂养 ASK ME 板的便条计数
           const newAsk = arr.filter((t) =>
             String(t?.status) === 'blocked'
             && Array.isArray(t?.humanQA)
@@ -1329,7 +1327,7 @@ export function OfficeFloor() {
             drawAskBoard(askPulse);
           }
           if (firstPoll) {
-            // cold start: no theatre, just show the truth
+            // 冷启动：没有剧院，只显示真相
             firstPoll = false;
             visualTasks = new Map(ledger.map((t) => [t.id, { status: t.status, assignee: t.assignee }]));
             redrawVisual();
@@ -1349,7 +1347,7 @@ export function OfficeFloor() {
               if (actor) mv = { kind: 'pin', taskId: t.id, actorId: actor, after, carryColor: NOTE_COLORS[t.status], stand: t.status === 'blocked' ? PIN_STAND : TAKE_STAND, thought: 'pinning a new task 📌' };
             } else if (oldS !== 'doing' && t.status === 'doing') {
               const actor = actorFor(t.assignee, false);
-              if (actor && actor === t.assignee) mv = { kind: 'take', taskId: t.id, actorId: actor, after, carryColor: NOTE_COLORS.doing, stand: TAKE_STAND, thought: 'grabbing my task' };
+              if (actor && actor === t.assignee) mv = { kind: 'take', taskId: t.id, actorId: actor, after, carryColor: NOTE_COLORS.doing, stand: TAKE_STAND, thought: '去接我的任务' };
             } else if (t.status === 'done' && oldS !== 'done') {
               const actor = actorFor(old?.assignee ?? t.assignee, false);
               if (actor) mv = { kind: 'archive', taskId: t.id, actorId: actor, after, carryColor: NOTE_COLORS.done, stand: ARCHIVE_STAND, thought: 'filing it as done ✔' };
@@ -1365,14 +1363,13 @@ export function OfficeFloor() {
               instant = true;
             }
           }
-          // removed cards vanish without theatre
+          // 移除的卡片无声消失
           for (const id of [...visualTasks.keys()]) {
             if (!ledger.some((t) => t.id === id)) { visualTasks.delete(id); instant = true; }
           }
           if (instant) redrawVisual();
           lastLedger = ledger;
-        } catch { /* keep the last drawing */ }
-      };
+        } catch { /* 保持最后绘图 */ }      };
       void pollTaskBoard();
       const taskBoardPoll = setInterval(() => { void pollTaskBoard(); }, 5000);
       (app as any).__taskBoardPoll = taskBoardPoll;
@@ -1386,7 +1383,7 @@ export function OfficeFloor() {
           ?? { x: 2, y: 2 };
         const waitTile = waitTiles[(seatIndex ?? 0) % waitTiles.length];
         const frames = await theme.cast.getFrames(charName);
-        // Bail if the agent was removed (or scene torn down) while loading.
+        // 如果代理被移除（或场景拆除）则在加载时返回
         if (mountIdRef.current !== mountId) return;
         if (!useStore.getState().agents.some((a) => a.id === agent.id)) {
           if (seatIndex != null) seatClaims.delete(seatIndex);
@@ -1398,17 +1395,17 @@ export function OfficeFloor() {
           frames,
           seatTile,
           seatDirection: facingForSeat(seatTile),
-          spawnTile: entrance, // walk in from the office door
+          spawnTile: entrance, // 从办公室门走进来
           glowColor: hexNum(colors.accent[agent.accent]) ?? hexToNumber(member.shirt),
           onClick: (id) => useStore.getState().select(id),
         });
         character.show(charLayer);
         const rt: Runtime = { character, seatIndex, waitTile, charName };
-        // Standard desks paint the 2×2 PC monitor two rows above the seat —
-        // give those a DeskScreen (lights up while seated) and a cup spot
-        // beside the monitor, exactly where the tileset's baked-in mug used
-        // to sit before we cleared it (desks start clean now; cups only exist
-        // where an agent actually carried one).
+        // 标准桌子将 2×2 PC 显示器绘制在座位上两行上方——
+        // 给这些 DeskScreen（就座时点亮）和杯子位置
+        // 在显示器旁边，恰好是图块集烘焙的杯子曾经坐的位置
+        // 我们在清除它之前（桌子现在开始干净；杯子只存在于
+        // 一个代理实际携带一个的地方）。
         if (mapRenderer.gidAt('furniture-above', seatTile.x, seatTile.y - 2) === theme.monitor.offTopLeftGid) {
           const top = { x: seatTile.x, y: seatTile.y - 2 };
           rt.screen = new DeskScreen(mapRenderer, top, theme.monitor);
@@ -1423,15 +1420,15 @@ export function OfficeFloor() {
       const removeCharacter = (id: string) => {
         const rt = runtimes.get(id);
         if (!rt) return;
-        releaseBreak(rt);                // free any café seat it was holding
-        releaseErrand(rt);               // and any idle errand it was running
-        releaseRun(rt);                  // and any coffee run in progress
-        // Facilities collects an abandoned mug (carried or parked on the desk)
-        // back onto the sideboard, so the finite cup stock can never leak away.
+        releaseBreak(rt);                // 释放它持有的任何咖啡馆座位
+        releaseErrand(rt);               // 以及它运行的任何空闲跑腿
+        releaseRun(rt);                  // 以及任何进行中的咖啡行程
+        // 设施收集一个被遗弃的杯子（携带或停在桌面上）
+        // 回到边柜，这样有限杯库存永远不会泄漏。
         if (rt.character.isCarryingCup() || rt.character.hasCupOnDesk()) {
-          // The clamp guarantees "never leak", but a clamp that actually FIRES
-          // means the accounting double-counted somewhere — surface it instead
-          // of silently pinning the stock at the cap.
+          // 夹紧保证"永不泄漏"，但实际触发的夹紧
+          // 意味着账目在某处重复计数——显示它而不是
+          // 无声地将库存固定在上限。
           if (cleanCups >= MAX_CUPS) console.warn('[office] mug reclaim over cap — cup accounting drifted');
           cleanCups = Math.min(MAX_CUPS, cleanCups + 1);
           drawTray();
@@ -1439,12 +1436,12 @@ export function OfficeFloor() {
         if (rt.seatIndex != null) seatClaims.delete(rt.seatIndex);
         rt.screen?.destroy();
         rt.character.hide(0);
-        // give the fade-out a moment, then destroy
+         // 给淡出一点时间，然后销毁
         setTimeout(() => rt.character.destroy(), 700);
         runtimes.delete(id);
       };
 
-      // Map an agent's store state onto its on-floor character.
+      // 将代理的存储状态映射到其地板上的角色。
       const applyState = (agent: Agent, rt: Runtime, force = false) => {
         const changed = force
           || rt.prevStatus !== agent.status
@@ -1452,11 +1449,11 @@ export function OfficeFloor() {
           || rt.prevCarrying !== agent.carrying
           || rt.prevPrompt !== agent.lastPrompt;
         if (!changed) return;
-        // Finishing real work (working/thinking/compacting → done) earns a
-        // little celebration before the avatar goes back to roaming — but only
-        // after a SUBSTANTIAL busy stretch (see CHEER_MIN_BUSY_MS): an inbox
-        // nudge or heartbeat reply that flips busy for a few seconds ends
-        // quietly instead of "celebrating" every few minutes over nothing.
+        // 完成真实工作（working/thinking/compacting → done）赢得一个
+        // 小庆祝在角色回到漫游之前——但只在
+        // 实质性忙碌时段之后（见 CHEER_MIN_BUSY_MS）：一个收件箱
+        // 提示或心跳回复翻转繁忙几秒后安静结束
+        // 而不是"庆祝"每几分钟无事可做。
         const wasBusy = rt.prevStatus === 'working' || rt.prevStatus === 'thinking' || rt.prevStatus === 'compacting';
         const isBusy = agent.status === 'working' || agent.status === 'thinking' || agent.status === 'compacting';
         if (isBusy && !wasBusy) rt.busySince = Date.now();
@@ -1472,10 +1469,10 @@ export function OfficeFloor() {
         const c = rt.character;
         c.setBaseAlpha(agent.status === 'ghost' ? 0.5 : 1);
 
-        // While an agent is on a coffee break the director owns its avatar — a
-        // mere idle/success refresh must not yank it back to wandering. Any
-        // other live status (work, blocked, …) cancels the break and falls
-        // through to normal handling, sending it back to its desk / the door.
+         // 当代理在咖啡休息时，导演拥有其头像——一个
+         // 简单的空闲/成功刷新不能把它拉回漫游。任何
+         // 其他实时状态（工作、阻塞、...）取消休息并转
+         // 为正常处理，将其发送回其办公桌/门口。
         if (rt.brk) {
           if (agent.status === 'idle' || agent.status === 'success') {
             c.setStatusGlyph(agent.status === 'success' ? 'success' : 'none');
@@ -1483,8 +1480,8 @@ export function OfficeFloor() {
           }
           releaseBreak(rt);
         }
-        // Same for an idle errand (watering, window, fridge…): idle refreshes
-        // leave it alone, real work cancels it and the agent heads to its desk.
+        // 空闲跑腿（浇水，窗户，冰箱…）也是一样：空闲刷新
+        // 让它 alone，真实工作取消它代理 heading 到桌面。
         if (rt.err) {
           if (agent.status === 'idle' || agent.status === 'success') {
             c.setStatusGlyph(agent.status === 'success' ? 'success' : 'none');
@@ -1492,8 +1489,8 @@ export function OfficeFloor() {
           }
           releaseErrand(rt);
         }
-        // And for a coffee run: real work cancels it mid-stride — a mug already
-        // in hand simply rides along to the desk (cupCarryHome parks it there).
+        // 和咖啡行程一样：真实工作在中途取消它——一个杯子已经
+        // 在手只是骑到桌面（cupCarryHome 停放它在那里）。
         if (rt.run) {
           if (agent.status === 'idle' || agent.status === 'success') {
             c.setStatusGlyph(agent.status === 'success' ? 'success' : 'none');
@@ -1502,9 +1499,9 @@ export function OfficeFloor() {
           releaseRun(rt);
         }
 
-        // A thought cloud above the head shows what the agent is doing RIGHT NOW
-        // (its live `action`, e.g. "edit App.tsx"). Working → sit at the desk;
-        // blocked → walk to the door and flash "!"; done/idle → wander.
+        // 头顶上方的思想云显示代理正在做什么 RIGHT NOW
+        // （其实时 `action`，如"编辑 App.tsx"）。工作 → 坐在桌面；
+        // 阻塞 → 走到门并闪烁 "!"；完成/空闲 → 漫游。
         switch (agent.status) {
           case 'working':
           case 'thinking':
@@ -1513,9 +1510,9 @@ export function OfficeFloor() {
             c.showThought(liveActivity(agent), agent.carrying);
             break;
           case 'waiting':
-            // Parked at the desk awaiting god / another agent — not actively
-            // working (no focus glow) and NOT at the door (that's reserved for
-            // agents that need the human).
+            // 停在桌面等待神/另一个代理——不是活动
+            // 工作（无焦点光晕）且不在门口（那是预留的
+            // 需要 human 的代理）。
             c.setStatusGlyph('none');
             c.sitAtDesk(false);
             c.showThought(liveActivity(agent, t('office.activity.waiting')), agent.carrying);
@@ -1526,15 +1523,15 @@ export function OfficeFloor() {
             c.walkToTile(rt.waitTile);
             break;
           case 'compacting':
-            // #5C — mid-/compact: stay put at the desk, "boxing up" glyph + thought,
-            // so an agent compacting context reads as busy rather than frozen.
+            // #5C —— 中/紧凑：待在桌面，"打包" 图标 + 思想，
+            // 所以紧凑上下文的代理读起来像忙碌而不是冻结。
             c.setStatusGlyph('compacting');
             c.sitAtDesk(true);
             c.showThought(liveActivity(agent, t('office.activity.compacting')));
             break;
           case 'looping':
-            // #5C — circuit-breaker armed (#6): hold position with the spinning
-            // warning glyph so a runaway agent is visible on the floor.
+            // #5C —— 熔断器已武装（#6）：保持位置带旋转
+            // 警告图标让失控的代理在地板上可见。
             c.setStatusGlyph('looping');
             c.sitAtDesk(false);
             c.showThought(liveActivity(agent, t('office.activity.looping')));
@@ -1558,10 +1555,10 @@ export function OfficeFloor() {
           case 'idle':
           default:
             c.setStatusGlyph('none');
-            // The god runs the floor from its desk; everyone else wanders when idle.
+            // 神从桌面运行地板；其他人在空闲时漫游。
             if (agent.isGod) { c.sitAtDesk(true); c.showThought(liveActivity(agent, t('office.activity.runningFloor'))); }
             else if (finishedWork) {
-              // Task done → a quick cheer on the spot, then back to roaming.
+              // 任务完成 → 快速的就地欢呼，然后回到漫游。
               c.startWandering();
               c.cheer();
               c.showThought(t(CHEER_KEYS[Math.floor(Math.random() * CHEER_KEYS.length)]));
@@ -1600,10 +1597,10 @@ export function OfficeFloor() {
       });
       (app as any).__unsub = unsubscribe;
 
-      // Fly an envelope from a sender's desk to each recipient when the hive
-      // routes a message. Endpoints are snapshotted at spawn, so the paper flies
-      // a clean arc even if the avatars wander mid-flight. 'human' recipients
-      // (escalations) fly to the office door.
+      // 当蜂巢路由消息时将信封从发送者桌面飞到每个接收者
+      // 端点在生成时快照，所以纸张飞行
+      // 一个干净的弧线即使化身在半空中漫游。'human' 接收者
+      // （升级）飞到办公室门。
       const ts = mapRenderer.tileSize;
       const humanPos = { x: entrance.x * ts + ts / 2, y: entrance.y * ts + ts };
       const posFor = (id: string): { x: number; y: number } | null => {
@@ -1613,25 +1610,25 @@ export function OfficeFloor() {
       };
       const spawnHandoff = (fromId: string, toId: string, act: MessageAct, needsHuman: boolean) => {
         if (envelopes.length >= MAX_ENVELOPES) return;
-        if (toId === fromId) return; // never mail yourself
+        if (toId === fromId) return; // 从不给自己发邮件
         const from = posFor(fromId);
         const to = posFor(toId);
-        if (!from || !to) return; // sender or recipient not on the floor
+        if (!from || !to) return; // 发送者或接收者不在地板上
         const env = new MessageEnvelope(from, to, act, needsHuman);
         charLayer.addChild(env.container);
         envelopes.push(env);
       };
 
-      // Real path: the main-process router emits one event per routed message.
-      // Guarded so a stale preload bridge (e.g. before a dev-server restart adds
-      // this method) degrades to "no envelopes" rather than crashing the floor.
+      // 真实路径：主进程路由器为每个路由消息发出一个事件。
+      // 守卫所以陈旧预加载桥（例如在 dev-server 重启添加
+      // 此方法之前）退化为"无信封"而不是崩溃地板。
       const offMessage = window.cth.onHiveMessage
         ? window.cth.onHiveMessage((e) => {
             for (const target of e.targets) spawnHandoff(e.from, target, e.act, e.needsHuman);
           })
         : () => { /* onHiveMessage unavailable — real handoffs disabled this session */ };
-      // Demo path: with no live hive, the mock loop dispatches synthetic handoffs
-      // so the animation is still visible. Clearly demo-only, fed by mockEvents.ts.
+      // 演示路径：无活动蜂巢时，模拟循环调度合成交接
+      // 这样动画仍然可见。明显仅限演示，由 mockEvents.ts 提供。
       const onDemoHandoff = (ev: Event) => {
         const d = (ev as CustomEvent<{ from: string; to: string; act: MessageAct }>).detail;
         if (d) spawnHandoff(d.from, d.to, d.act, false);
@@ -1642,9 +1639,9 @@ export function OfficeFloor() {
         window.removeEventListener('cth:demo-handoff', onDemoHandoff);
       };
 
-      // Keep two nearby thought clouds from covering each other: stack the
-      // overlapping ones upward. Computed from each bubble's BASE rect (ignoring
-      // the lift already applied) so the result is stable frame-to-frame.
+      // 让两个附近的思想云不互相覆盖：堆叠重叠的
+      // 向上。从每个气泡的 BASE 矩形计算（忽略
+      // 已经应用的提升）所以结果帧到帧稳定。
       const resolveBubbleOverlaps = () => {
         const items: Array<{ rt: Runtime; x: number; y: number; w: number; h: number }> = [];
         for (const rt of runtimes.values()) {
@@ -1655,8 +1652,8 @@ export function OfficeFloor() {
           for (const it of items) it.rt.character.setThoughtLift(0);
           return;
         }
-        // Lower bubbles (greater bottom edge) and left-most ones hold their spot;
-        // the rest get pushed above them. Deterministic ordering → no flicker.
+        // 较低的气泡（更大的底部边缘）和最左边的保持其位置；
+        // 其余的被推上去。确定性排序 → 无闪烁。
         items.sort((a, b) => (b.y + b.h) - (a.y + a.h) || a.x - b.x);
         const placed: Array<{ x: number; y: number; w: number; h: number }> = [];
         const pad = 2;
@@ -1679,8 +1676,8 @@ export function OfficeFloor() {
       const onTick = (ticker: Ticker) => {
         const dt = ticker.deltaMS / 1000;
         camera.update(dt);
-        // Thought clouds counter-scale against the camera so their text never
-        // renders below 1:1 screen size when the window/world shrinks.
+        // 思想云根据相机反向缩放以便其文本从不
+        // 当窗口/世界缩小到低于 1:1 屏幕尺寸时渲染。
         const zoom = world.scale.x;
         for (const rt of runtimes.values()) {
           rt.character.setBubbleZoom(zoom);
@@ -1701,8 +1698,8 @@ export function OfficeFloor() {
         }
       };
       app.ticker.add(onTick);
-      // init() is async: the floor may already be behind a fullscreen terminal by
-      // the time we get here, and app.init() starts the ticker itself.
+      // init() 是异步的：当我们到达时地板可能已经在
+      // 全屏终端后面，app.init() 自己启动 ticker。
       if (pausedRef.current) app.ticker.stop();
 
       const resize = new ResizeObserver((entries) => {
@@ -1715,7 +1712,7 @@ export function OfficeFloor() {
       });
       resize.observe(host);
       (app as any).__resize = resize;
-      // The floor is up: give the next crowded start-up a full budget again.
+      // 地板已启动：给下一次拥挤启动完整预算。
       initRetriesRef.current = 0;
     };
 
@@ -1723,10 +1720,10 @@ export function OfficeFloor() {
       if (mountIdRef.current !== mountId) return;
       const plan = planInitFailure(err, initRetriesRef.current);
 
-      // Pixi could not get a context — usually the GPU process restarting under
-      // us — and reports that as "this browser does not support WebGL". Retry
-      // through the same rebuild path an eviction uses; the half-built app is
-      // torn down by this effect's cleanup when the generation bump re-runs it.
+      // Pixi 无法获取上下文——通常 GPU 进程在我们
+      // 之下重启——并报告为"此浏览器不支持 WebGL"。重试
+      // 通过驱逐使用的相同重建路径；半构建的 app 是
+      // 此效果的清理拆除当 generation 递增重新运行它。
       if (plan.action === 'retry') {
         initRetriesRef.current = plan.attempt;
         console.warn(`[OfficeFloor] could not get a WebGL context (the GPU process may be restarting) — retrying, attempt ${plan.attempt}/${DEFAULT_MAX_INIT_RETRIES}`);
@@ -1736,14 +1733,14 @@ export function OfficeFloor() {
         return;
       }
 
-      // Out of budget. The stack would say "does not support WebGL", which is
-      // both untrue and unactionable; say what actually helps instead.
+      // 超出预算。堆栈会说"不支持 WebGL"，这是
+      // 既不真实也不可操作；说实际有帮助的话。
       if (plan.action === 'give-up') {
         console.error(`[OfficeFloor] still no WebGL context after ${DEFAULT_MAX_INIT_RETRIES} retries:`, err);
         host.appendChild(floorNote(
-          'The office floor could not get a GPU context.\n\n' +
-          'The GPU may still be restarting, or too many terminals are\n' +
-          'using it at once. Close a few agent terminals, or restart\n' +
+          '办公室地板无法获取 GPU 上下文。\n\n' +
+          'GPU 可能仍在重启，或太多终端正在\n' +
+          '使用它。关闭几个代理终端，或重启\n' +
           'the app, to bring the floor back.'));
         return;
       }
@@ -1783,8 +1780,8 @@ export function OfficeFloor() {
   );
 }
 
-/** A message where the floor should be — the only thing the user sees when the
- *  scene cannot run, so all three failure paths share one look. */
+/** 地板应该出现的地方的一条消息——当
+ * 场景无法运行时用户看到的唯一东西，所以三个失败路径共享一个外观。 */
 function floorNote(text: string): HTMLDivElement {
   const note = document.createElement('div');
   note.style.cssText =

--- a/src/renderer/src/scene/office/SeatPool.ts
+++ b/src/renderer/src/scene/office/SeatPool.ts
@@ -1,7 +1,7 @@
 /**
- * Reservation pool for a fixed ordered list of seat identifiers (the desk/pc
- * spawn points in the Tiled map). Used to hand each dynamically-added agent a
- * distinct seat. Ported verbatim from shahar061/the-office (office/SeatPool.ts).
+ * 固定有序座位标识符列表（Tiled 地图里的桌/电脑生成点）的预留池。用于给每个
+ * 动态添加的 agent 一个不同的座位。从 shahar061/the-office 逐字移植
+ * （office/SeatPool.ts）。
  */
 export class SeatPool {
   private readonly seats: readonly string[];
@@ -11,7 +11,7 @@ export class SeatPool {
     this.seats = seats;
   }
 
-  /** Reserve the first unoccupied seat in list order, or null if all taken. */
+  /** 按列表顺序预留第一个未占用座位；全被占用则返回 null。 */
   reserveNext(): string | null {
     for (const seat of this.seats) {
       if (!this.claimed.has(seat)) {
@@ -22,7 +22,7 @@ export class SeatPool {
     return null;
   }
 
-  /** Release a previously-reserved seat. Idempotent. */
+  /** 释放之前预留的座位。幂等。 */
   release(seat: string): void {
     this.claimed.delete(seat);
   }

--- a/src/renderer/src/scene/office/SpriteAdapter.ts
+++ b/src/renderer/src/scene/office/SpriteAdapter.ts
@@ -8,16 +8,16 @@ export interface SpriteSheetConfig {
 }
 
 /**
- * Maps a LimeZu character walk sheet to the 3-row frame grid CharacterSprite
- * expects. Ported from shahar061/the-office (office/characters/SpriteAdapter.ts).
+ * 把 LimeZu 角色行走表映射到 CharacterSprite 期望的 3 行帧网格。从
+ * shahar061/the-office 移植（office/characters/SpriteAdapter.ts）。
  *
- * LimeZu walk row packs 4 directions, each with `framesPerDirection` frames,
- * in the order: right, up, left, down.
+ * LimeZu 行走行打包了 4 个方向，每个方向 `framesPerDirection` 帧，
+ * 顺序为：右、上、左、下。
  *
- * Output: 3 rows (down, up, right) each with 7 frames:
+ * 输出：3 行（down、up、right），每行 7 帧：
  *   [walk1, walk2, walk3, type1, type2, read1, read2]
- * Left is rendered by horizontally flipping the "right" row at draw time.
- * Type/read frames reuse the idle (first walk) frame — LimeZu has no desk anims.
+ * 左侧通过绘制时水平翻转“right”行渲染。
+ * Type/read 帧复用 idle（第一帧 walk）帧——LimeZu 没有办公桌动画。
  */
 export class SpriteAdapter {
   private static readonly DIRECTION_GROUP = { down: 3, left: 2, up: 1, right: 0 };
@@ -31,7 +31,7 @@ export class SpriteAdapter {
       const frames: Texture[] = [];
       const groupStart = this.DIRECTION_GROUP[dir] * framesPerDirection;
 
-      // 3 walk frames sampled every other frame from the cycle
+      // 从循环里每隔一帧采样 3 个行走帧
       for (let i = 0; i < framesPerDirection; i += 2) {
         const frame = new Rectangle(
           (groupStart + i) * frameWidth,

--- a/src/renderer/src/scene/office/ThoughtBubble.ts
+++ b/src/renderer/src/scene/office/ThoughtBubble.ts
@@ -2,36 +2,35 @@ import { Container, Graphics, Text } from 'pixi.js';
 import { colors } from '@/design/tokens';
 import { toolIcon } from './ToolBubble';
 
-// A comic "thought cloud" pinned above an avatar's head showing what it's doing
-// RIGHT NOW (the agent's live `action`, e.g. "edit App.tsx" / "bash npm test").
-// Distinct from the darker ToolBubble speech bubble: a light cream cloud with a
-// trailing-puff tail — the visual shorthand for "thinking". Built to DESIGN.md:
-// integer pixels, hard 1px ink outline, limited palette, no soft shadows.
+// 一个漫画式“思想云”，钉在头像上方，显示它此刻正在做什么（agent 的实时
+// `action`，例如 "edit App.tsx" / "bash npm test"）。与较暗的 ToolBubble 对话
+// 气泡不同：一个浅奶油色云朵，带一串拖尾小 puff 尾巴——“思考中”的视觉速记。
+// 按 DESIGN.md 构建：整像素、硬 1px 墨线轮廓、有限调色板、无软阴影。
 //
-// Shares ToolBubble's fade state machine and word-wrapping so behaviour reads
-// consistently; the differences are the look (cloud + tail, light fill) and that
-// it stays put until the action changes (no auto-linger while the agent works).
+// 与 ToolBubble 共享淡入淡出状态机和自动换行，让行为读起来一致；区别在于
+// 外观（云 + 尾巴、浅填充），以及它会一直停留到动作变化为止（agent 工作期间
+// 不自动停留）。
 
 const PADDING_X = 6;
 const PADDING_Y = 3;
 const CORNER_RADIUS = 5;
 const MAX_WIDTH = 150;
-const FILL_COLOR = colors.cream[50];   // light cloud
+const FILL_COLOR = colors.cream[50];   // 浅色云朵
 const OUTLINE_COLOR = colors.ink[900];
 const TEXT_COLOR = '#3d2e4a';           // ink-700
 const FONT_SIZE = 12;
-const RENDER_SCALE = 0.5;               // render at 2x, scale down for crispness
-const OFFSET_Y = -38;                   // a touch higher than the tool bubble
+const RENDER_SCALE = 0.5;               // 以 2x 渲染、缩小以求清晰
+const OFFSET_Y = -38;                   // 比工具气泡略高
 const FADE_IN_DURATION = 0.15;
 const FADE_OUT_DURATION = 0.3;
-const LINGER_DURATION = 1.2;            // only used when hide() is requested
+const LINGER_DURATION = 1.2;            // 仅在请求 hide() 时使用
 const DOTS_CYCLE_SPEED = 0.45;
-// Word-wrap width in the inner (unscaled) space — the inner container renders at
-// RENDER_SCALE, so the on-screen cap is MAX_WIDTH. breakWords splits unbroken
-// tokens (long paths/hashes) that would otherwise still spill past the cloud.
+// 内部（未缩放）空间里的换行宽度——内部容器以 RENDER_SCALE 渲染，所以屏幕
+// 上限是 MAX_WIDTH。breakWords 拆分那些本会溢过云朵的无断点 token（长路径/
+// 哈希）。
 const WRAP_WIDTH = MAX_WIDTH / RENDER_SCALE - PADDING_X * 2;
-// Hard cap on raw characters so a pathological action string wraps to a few
-// lines instead of a runaway-tall cloud (~4 lines at this width).
+// 原始字符的硬性上限，让病态的长 action 字符串折成几行，而不是变成高得离谱
+// 的云朵（此宽度下约 4 行）。
 const MAX_CHARS = 160;
 
 type BubbleState = 'hidden' | 'fading-in' | 'visible' | 'lingering' | 'fading-out';
@@ -50,18 +49,17 @@ export class ThoughtBubble {
   private isThinking = false;
   private dotsElapsed = 0;
   private dotsPhase = 0;
-  // Extra upward shift (px) applied on top of OFFSET_Y so two nearby bubbles can
-  // stack instead of overlapping. Set each frame by the scene's overlap pass.
+  // 叠加在 OFFSET_Y 之上的额外向上位移（px），让两个相邻气泡能堆叠而不是
+  // 重叠。每帧由场景的重叠扫描设置。
   private extraLift = 0;
-  // Current camera zoom. The bubble lives inside the zoomed world container, so
-  // when the window shrinks (fit-to-screen zoom < 1) the text used to scale
-  // down with the map and turn into ragged mush. Counter-scale so the bubble
-  // never renders below its designed 1:1 screen size; at zoom ≥ 1 it keeps
-  // scaling with the world as before.
+  // 当前相机缩放。气泡活在已缩放的世界上层容器里，所以窗口缩小时
+  // （fit-to-screen 缩放 < 1）文字原本会随地图一起缩小、变成粗糙的糊状。
+  // 反向缩放，让气泡永不渲染到设计 1:1 屏幕尺寸以下；缩放 ≥ 1 时它像以前
+  // 一样随世界缩放。
   private zoom = 1;
-  // World bounds (map size in px). An avatar near the map edge — Michael's CEO
-  // room sits in the top-left corner — would otherwise push its cloud out of
-  // the visible world. setPosition clamps the rect back inside, tooltip-style.
+  // 世界边界（地图尺寸，px）。靠近地图边缘的头像——Michael 的 CEO 室在
+  // 左上角——否则会把它的云推出可见世界。setPosition 以 tooltip 方式把矩形
+  // 钳回内部。
   private boundsW = 0;
   private boundsH = 0;
 
@@ -94,12 +92,12 @@ export class ThoughtBubble {
     this.label.x = PADDING_X;
     this.label.y = PADDING_Y;
 
-    // tail first so it sits behind the body
+    // 尾巴先加，让它坐在身体后面
     this.inner.addChild(this.tail, this.bg, this.label);
   }
 
-  /** Show the current activity. Empty text → an animated "…" (model thinking).
-   *  `tool` (an agent's `carrying`) prefixes a small glyph when present. */
+  /** 显示当前活动。空文本 → 动画省略号“…”（模型思考中）。
+   *  `tool`（agent 的 `carrying`）存在时前缀一个小图标。 */
   show(text: string, tool?: string): void {
     this.isThinking = !text.trim();
     if (this.isThinking) {
@@ -108,9 +106,8 @@ export class ThoughtBubble {
       this.label.text = '.';
     } else {
       const display = tool ? `${toolIcon(tool)} ${text}` : text;
-      // Word-wrap (style.wordWrap) handles the horizontal fit, so the card can no
-      // longer overflow; we only cap the raw length so a very long action wraps to
-      // a few lines rather than a wall of text.
+      // 自动换行（style.wordWrap）处理横向适配，所以卡片不会再溢出；我们
+      // 只限制原始长度，让很长的 action 折成几行而不是一整墙文字。
       this.label.text = display.length > MAX_CHARS
         ? display.slice(0, MAX_CHARS - 1).trimEnd() + '…'
         : display;
@@ -125,34 +122,33 @@ export class ThoughtBubble {
       this.fadeElapsed = 0;
       this.container.visible = true;
     } else {
-      // already up — swap text in place without re-fading
+      // 已经显示了——原地换文本，不再重新淡入
       this.state = 'visible';
       this.container.alpha = 1;
     }
     this.lingerElapsed = 0;
   }
 
-  /** Begin fading out (after a short linger) — call when the agent goes quiet. */
+  /** 开始淡出（短暂停留后）——agent 安静下来时调用。 */
   startLinger(): void {
     if (this.state === 'hidden') return;
     this.state = 'lingering';
     this.lingerElapsed = 0;
   }
 
-  /** Update for the camera zoom: keep the bubble's SCREEN size from dropping
-   *  below 1:1 by counter-scaling while the world is zoomed out. */
+  /** 为相机缩放更新：世界被缩小显示时反向缩放，让气泡的屏幕尺寸不低于 1:1。 */
   setZoom(z: number): void {
     if (!(z > 0) || z === this.zoom) return;
     this.zoom = z;
     this.container.scale.set(this.compensation());
   }
 
-  /** World-units multiplier that cancels a < 1 camera zoom (1 at zoom ≥ 1). */
+  /** 取消 < 1 相机缩放的世界单位乘数（缩放 ≥ 1 时为 1）。 */
   private compensation(): number {
     return 1 / Math.min(this.zoom, 1);
   }
 
-  /** The world rect the bubble must stay inside (the map size, in px). */
+  /** 气泡必须待在其中的世界矩形（地图尺寸，px）。 */
   setBounds(w: number, h: number): void {
     this.boundsW = w;
     this.boundsH = h;
@@ -165,9 +161,8 @@ export class ThoughtBubble {
     let x = px - w / 2;
     let y = py + OFFSET_Y - h - this.extraLift;
     if (this.boundsW > 0) {
-      // Clamp into the world, tooltip-style: slide horizontally, and a cloud
-      // that would poke above the top edge slides down instead (it may then
-      // cover the avatar's hat — better than being unreadable off-world).
+      // 以 tooltip 方式钳进世界：水平滑动；而会从顶部戳出去的气泡改为向下滑
+      // （它可能盖住头像的帽子——总比在世界外读不到好）。
       x = Math.min(Math.max(x, 1), Math.max(1, this.boundsW - w - 1));
       y = Math.min(Math.max(y, 1), Math.max(1, this.boundsH - h - 1));
     }
@@ -175,13 +170,13 @@ export class ThoughtBubble {
     this.container.y = Math.round(y);
   }
 
-  /** Extra upward shift (px), set by the scene's bubble-overlap pass. */
+  /** 额外向上位移（px），由场景的气泡重叠扫描设置。 */
   setLift(px: number): void {
     this.extraLift = px;
   }
 
-  /** The bubble's base screen rect (ignoring any lift) for a given anchor, or
-   *  null when hidden. Used by the scene to detect and resolve overlaps. */
+  /** 气泡对给定锚点的基准屏幕矩形（忽略任何位移），隐藏时为 null。供场景
+   *  检测并解决重叠。 */
   getLayout(px: number, py: number): { x: number; y: number; w: number; h: number } | null {
     if (this.state === 'hidden') return null;
     const comp = this.compensation();
@@ -190,8 +185,8 @@ export class ThoughtBubble {
     let x = px - w / 2;
     let y = py + OFFSET_Y - h;
     if (this.boundsW > 0) {
-      // Report the CLAMPED base rect so the overlap resolver stacks bubbles
-      // where they actually render, not where they ideally would.
+      // 报告钳制后的基准矩形，让重叠解析器在气泡实际渲染处堆叠它们，
+      // 而不是理想位置上。
       x = Math.min(Math.max(x, 1), Math.max(1, this.boundsW - w - 1));
       y = Math.min(Math.max(y, 1), Math.max(1, this.boundsH - h - 1));
     }
@@ -251,11 +246,10 @@ export class ThoughtBubble {
   }
 
   private redraw(): void {
-    // The cloud always wraps the MEASURED text. Clamping the bg to MAX_WIDTH
-    // while the label keeps its real width let text paint past the bubble edge
-    // whenever the measurement overshot wordWrapWidth a touch (emoji glyphs,
-    // fallback-font metrics) — on the dark map that read as "horizontally cut".
-    // wordWrap already bounds the label, so the bg needs no clamp of its own.
+    // 云朵总是包裹实测文本。之前把 bg 钳到 MAX_WIDTH 而 label 保持真实宽度，
+    // 一旦测量略微超过 wordWrapWidth（emoji 字形、回退字体度量），文字就会
+    // 画过气泡边缘——在深色地图上读起来像“横向被切”。wordWrap 已经界定了
+    // label，所以 bg 无需自己的钳制。
     this.bgW = this.label.width + PADDING_X * 2;
     this.bgH = this.label.height + PADDING_Y * 2;
 
@@ -264,8 +258,8 @@ export class ThoughtBubble {
     this.bg.fill({ color: FILL_COLOR });
     this.bg.stroke({ color: OUTLINE_COLOR, width: 1 });
 
-    // Thought-cloud tail: two shrinking puffs trailing down from the bubble's
-    // lower-left toward the head below — the cue that says "thinking", not "speech".
+    // 思想云尾巴：两团缩小的 puff 从气泡左下角朝下方头部拖出——这是说
+    // “思考中”而不是“说话中”的提示。
     this.tail.clear();
     const baseX = this.bgW * 0.32;
     const puff = (cx: number, cy: number, r: number) => {

--- a/src/renderer/src/scene/office/TiledMapRenderer.ts
+++ b/src/renderer/src/scene/office/TiledMapRenderer.ts
@@ -1,9 +1,8 @@
 import { Container, Sprite, Texture, Rectangle } from 'pixi.js';
 
-// Trimmed port of shahar061/the-office (office/engine/TiledMapRenderer.ts):
-// renders floor/walls/furniture tile layers and parses collision, spawn-points
-// and zones. Interactive-object / war-room / monitor-glow extraction is dropped
-// (we render every tile statically), so no tiles ever go missing.
+// shahar061/the-office 的精简移植（office/engine/TiledMapRenderer.ts）：
+// 渲染地板/墙/家具瓦片层，并解析碰撞、生成点与区域。可交互对象 / 作战室 /
+// 显示器辉光提取被去掉（我们静态渲染每个瓦片），所以不会有瓦片丢失。
 
 const FLIPPED_H_FLAG = 0x80000000;
 const FLIPPED_V_FLAG = 0x40000000;
@@ -101,20 +100,18 @@ export class TiledMapRenderer {
   getZone(name: string): ZoneRect | undefined { return this.zones.get(name); }
   getAllZones(): Map<string, ZoneRect> { return this.zones; }
 
-  /** The (flip-stripped) gid painted at a tile of a layer, 0 when empty.
-   *  Lets the scene locate furniture by art — e.g. each desk's monitor block. */
+  /** 画在某层某瓦片上的（去翻转位的）gid，空为 0。
+   *  让场景能按美术定位家具——例如每张桌子的显示器块。 */
   gidAt(layerName: string, tx: number, ty: number): number {
     const layer = this.findLayer(layerName, 'tilelayer');
     if (!layer?.data || tx < 0 || ty < 0 || tx >= this.width || ty >= this.height) return 0;
     return (layer.data[ty * this.width + tx] ?? 0) & TILE_ID_MASK;
   }
 
-  /** A sub-texture for one tileset tile, addressed by gid — for dynamic props
-   *  that reuse map art (e.g. the lit monitor variant overlaid when an agent
-   *  sits down). Returns undefined for gid 0 / out-of-range.
-   *  NOTE: allocates a fresh Texture per call and the CALLER owns its lifetime
-   *  (fine for constructor-time use, kept alive by sprites; do NOT call this
-   *  per frame or the textures leak). */
+  /** 一个 tileset 瓦片的子纹理，按 gid 寻址——供复用地图美术的动态道具用
+   *  （例如 agent 坐下时叠上的点亮显示器变体）。gid 0 / 越界返回 undefined。
+   *  注意：每次调用分配一个新 Texture，且 CALLER 拥有其生命周期（构造期
+   *  使用没问题，被精灵持有；绝不要每帧调用，否则纹理泄漏）。 */
   textureForGid(gid: number): Texture | undefined {
     const tileId = gid & TILE_ID_MASK;
     if (tileId === 0) return undefined;
@@ -152,8 +149,8 @@ export class TiledMapRenderer {
     }
   }
 
-  /** Force seat/desk tiles walkable so agents can path onto them even though
-   *  the underlying chair/desk tile is non-walkable in the collision layer. */
+  /** 强制把座位/桌子瓦片设为可行走，让 agent 能寻路走到它们上，即使底层
+   *  椅子/桌子瓦片在碰撞层里不可行走。 */
   private markWalkableSpawnPoints(): void {
     for (const [name, point] of this.spawnPoints) {
       if (!TiledMapRenderer.WALKABLE_SPAWN_PREFIXES.some((p) => name.startsWith(p))) continue;
@@ -251,7 +248,7 @@ export class TiledMapRenderer {
       this.rootContainer.addChild(container);
     }
 
-    // Characters render above every tile layer.
+    // 角色渲染在所有瓦片层之上。
     this.rootContainer.addChild(this.characterContainer);
   }
 

--- a/src/renderer/src/scene/office/ToolBubble.ts
+++ b/src/renderer/src/scene/office/ToolBubble.ts
@@ -1,8 +1,8 @@
 import { Container, Graphics, Text } from 'pixi.js';
 
-// Speech bubble shown above a character: "<icon> <target>" (e.g. "> App.tsx").
-// Ported from shahar061/the-office (office/characters/ToolBubble.ts); tool icon
-// map extended to cover our ToolKind set.
+// 显示在角色上方的对话气泡：“<icon> <target>”（例如 “> App.tsx”）。
+// 从 shahar061/the-office 移植（office/characters/ToolBubble.ts）；工具图标
+// 映射扩展以覆盖我们的 ToolKind 集合。
 
 const TOOL_ICONS: Record<string, string> = {
   Read: '<',
@@ -24,20 +24,19 @@ const PADDING_Y = 3;
 const CORNER_RADIUS = 4;
 const MAX_WIDTH = 140;
 const BG_COLOR = 0x1a1320; // ink-900
-const BG_ALPHA = 0.95;     // near-opaque: thin text over a busy floor was hard to read
+const BG_ALPHA = 0.95;     // 近不透明：在繁忙地板上细文字原本很难读
 const TEXT_COLOR = '#fffdf5';
 const FONT_SIZE = 12;
-const RENDER_SCALE = 0.5; // render at 2x, scale down for crispness
+const RENDER_SCALE = 0.5; // 以 2x 渲染、缩小以求清晰
 const OFFSET_Y = -36;
 const FADE_IN_DURATION = 0.15;
 const FADE_OUT_DURATION = 0.3;
 const LINGER_DURATION = 2.0;
 const DOTS_CYCLE_SPEED = 0.5;
-// Word-wrap width in the inner (unscaled) space — the inner renders at
-// RENDER_SCALE, so the on-screen cap is MAX_WIDTH. breakWords splits unbroken
-// tokens (long paths/hashes) that would otherwise still spill past the bubble.
+// 内部（未缩放）空间里的换行宽度——内部以 RENDER_SCALE 渲染，所以屏幕上限
+// 是 MAX_WIDTH。breakWords 拆分那些本会溢过气泡的无断点 token（长路径/哈希）。
 const WRAP_WIDTH = MAX_WIDTH / RENDER_SCALE - PADDING_X * 2;
-// Cap raw chars so a long target wraps to a few lines, not a runaway-tall bubble.
+// 限制原始字符，让长 target 折成几行，而不是高得离谱的气泡。
 const MAX_CHARS = 150;
 
 type BubbleState = 'hidden' | 'fading-in' | 'visible' | 'lingering' | 'fading-out';
@@ -91,7 +90,7 @@ export class ToolBubble {
     this.inner.addChild(this.bg, this.label);
   }
 
-  /** Show a tool action. Pass toolName='' & target='...' to render a thinking ellipsis. */
+  /** 显示一个工具动作。传 toolName='' & target='...' 以渲染思考省略号。 */
   show(toolName: string, target: string): void {
     const icon = toolIcon(toolName);
     this.isThinking = !toolName && target === '...';
@@ -102,8 +101,8 @@ export class ToolBubble {
       this.label.text = '.';
     } else {
       const displayText = target ? `${icon} ${target}` : icon;
-      // Word-wrap (style.wordWrap) handles the horizontal fit, so the bubble can no
-      // longer overflow; we only cap the raw length to keep it a few lines tall.
+      // 自动换行（style.wordWrap）处理横向适配，所以气泡不会再溢出；我们
+      // 只限制原始长度，让它保持几行高。
       this.label.text = displayText.length > MAX_CHARS
         ? displayText.slice(0, MAX_CHARS - 1).trimEnd() + '…'
         : displayText;
@@ -113,12 +112,12 @@ export class ToolBubble {
     this.reveal();
   }
 
-  /** Show plain text (no tool icon) — used for the "last prompt" card above a
-   *  seated agent. Stays put until replaced/hidden (no auto-linger). */
+  /** 显示纯文本（无工具图标）——用于坐姿 agent 上方的“上一条提示”卡片。
+   *  一直停留到被替换/隐藏（不自动停留）。 */
   showText(text: string): void {
     this.isThinking = false;
     const display = text || '…';
-    // Word-wrap handles the horizontal fit; cap raw length to bound the height.
+    // 自动换行处理横向适配；限制原始长度以界定高度。
     this.label.text = display.length > MAX_CHARS
       ? display.slice(0, MAX_CHARS - 1).trimEnd() + '…'
       : display;
@@ -146,10 +145,9 @@ export class ToolBubble {
 
   setPosition(px: number, py: number): void {
     const halfBubble = (this.bgW * RENDER_SCALE) / 2;
-    // Round: the avatar glides at sub-pixel steps every frame, and a bubble
-    // following it on fractional coordinates makes the half-scaled text
-    // resample differently each frame — visible as shimmering/flickering
-    // while the character walks. (ThoughtBubble already does this.)
+    // 取整：头像每帧以亚像素步长滑行，而跟在它后面的气泡若用小数坐标，会让
+    // 半缩放的文字每帧重采样不同——角色行走时表现为闪烁/抖动。
+    // （ThoughtBubble 已经这么做。）
     this.container.x = Math.round(px - halfBubble);
     this.container.y = Math.round(py + OFFSET_Y - this.bgH * RENDER_SCALE);
   }
@@ -207,10 +205,9 @@ export class ToolBubble {
   }
 
   private redrawBg(): void {
-    // Always wrap the MEASURED text — clamping the bg while the label keeps
-    // its real width lets text paint past the bubble edge when the measurement
-    // overshoots wordWrapWidth (emoji glyphs, fallback metrics). wordWrap
-    // already bounds the label, so the bg needs no clamp of its own.
+    // 总是包裹实测文本——之前把 bg 钳住而 label 保持真实宽度，测量略微超过
+    // wordWrapWidth（emoji 字形、回退度量）时文字就会画过气泡边缘。wordWrap
+    // 已经界定了 label，所以 bg 无需自己的钳制。
     this.bgW = this.label.width + PADDING_X * 2;
     this.bgH = this.label.height + PADDING_Y * 2;
     this.bg.clear();

--- a/src/renderer/src/scene/office/cafeteriaLines.ts
+++ b/src/renderer/src/scene/office/cafeteriaLines.ts
@@ -1,235 +1,233 @@
-// Cafeteria small-talk — The Office edition.
+// 咖啡间闲聊——《办公室》版本。
 //
-// The cast ARE Dunder Mifflin (see cast.ts), so an agent's coffee break is an
-// excuse for a one-liner in character. Two kinds of line:
-//   • solo  — one quip shown above a single agent at a break spot
-//   • pair  — a two-beat exchange between two agents at the same table
+// 角色群就是 Dunder Mifflin（见 cast.ts），所以 agent 的咖啡休息是来一句
+// 符合人设的单行话的借口。两种台词：
+//   • solo —— 一个单口短句，显示在休息点的一个 agent 上方
+//   • pair —— 同一张桌子的两个 agent 之间的一段两拍交流
 //
-// Lines are kept short so they fit the ThoughtBubble (≈MAX_WIDTH). Character
-// keys match OfficeCharacterName; anyone without bespoke lines falls back to the
-// shared GENERIC pool so the floor never feels empty.
+// 台词保持简短以放进 ThoughtBubble（≈MAX_WIDTH）。角色键匹配
+// OfficeCharacterName；没有专属台词的任何角色都回退到共享 GENERIC 池，
+// 让地板永远不会显得冷清。
 
 import type { OfficeCharacterName } from './cast';
 
-/** Where an agent is lingering — picks a contextual line pool. */
+/** agent 正在逗留的地方——挑选一个带语境的台词池。 */
 export type BreakSpot = 'coffee' | 'vending' | 'snack' | 'table';
 
 const pick = <T,>(arr: readonly T[], seed: number): T =>
   arr[((seed % arr.length) + arr.length) % arr.length];
 
-// ─── solo lines, by spot ─────────────────────────────────────────────────────
+// ─── 单口台词，按地点 ───────────────────────────────────────
 
 const COFFEE: readonly string[] = [
-  'is this… decaf?? who did this',
-  "we're out of beans again",
-  'World’s Best Boss mug',
-  'first cup of the day. and the fifth.',
-  'the coffee here is basically a hug',
-  'who took my mug?',
+  '这是…低因咖啡？？谁干的',
+  '豆子又没了',
+  '「世界最佳老板」马克杯',
+  '今天第一杯。也是第五杯。',
+  '这儿的咖啡就像个拥抱',
+  '谁拿走了我的杯子？',
 ];
 
 const VENDING: readonly string[] = [
-  'the machine ate my dollar',
-  'B4… please be the pretzels',
-  'it’s stuck. classic.',
-  'shaking it. gently. respectfully.',
-  'one (1) emotional-support snack',
-  'A1 again. living dangerously.',
+  '机器吞了我的钱',
+  'B4…拜托是椒盐卷饼',
+  '卡住了。经典。',
+  '摇摇它。轻轻摇。充满敬意地摇。',
+  '一份(1)情感支持小零食',
+  '又是A1。活得真刺激。',
 ];
 
 const SNACK: readonly string[] = [
-  'is it Pretzel Day?',
-  'who finished the chips??',
-  'just a little treat',
-  'these are everyone’s? cool cool cool',
-  'second breakfast',
+  '今天是椒盐卷饼日吗？',
+  '谁把薯片吃光了？？',
+  '就一点点小奖励',
+  '这些是大家的？行行行',
+  '第二顿早餐',
 ];
 
 const TABLE: readonly string[] = [
-  'big day. lots of meetings.',
-  'just five more minutes',
-  'did you see the standup notes?',
-  'pretending to read my notes',
-  'I needed this break, honestly',
-  'do NOT tell Michael I’m in here',
+  '大日子。一堆会。',
+  '再待五分钟',
+  '你看到站会纪要了吗？',
+  '假装在看笔记',
+  '说真的，我需要这休息',
+  '千万别告诉 Michael 我在这儿',
 ];
 
 const SPOT_POOL: Record<BreakSpot, readonly string[]> = {
   coffee: COFFEE, vending: VENDING, snack: SNACK, table: TABLE,
 };
 
-// ─── character flavour — overrides the generic pool when present ─────────────
+// ─── 角色风味——存在时覆盖通用池 ────────────────────────────
 
 const BY_CHARACTER: Partial<Record<OfficeCharacterName, readonly string[]>> = {
-  michael:  ['I DECLARE… BANKRUPTCY!', "that's what she said", "I'm not superstitious. just a little stitious.", 'no meetings before coffee. that’s the rule.'],
-  dwight:   ['FALSE.', 'identity theft is not a joke', 'that mug is regulation', 'this fridge needs a beet drawer', 'Schrute Farms has better coffee'],
-  jim:      ["...that's what she said", 'bears. beets. Battlestar Galactica.', 'I moved Dwight’s stapler again', 'just here for the gossip'],
-  pam:      ['Dunder Mifflin, this is Pam', 'sketching the vending machine', 'the watercolor of the break room'],
-  kevin:    ['the chili is NOT ready', 'why waste time say lot word', 'me want snack', 'cookie? cookie.'],
-  angela:   ['this break room is filthy', 'party planning committee, 3pm', 'I’m judging the fridge'],
-  oscar:    ['actually, it’s “espresso”', 'well, actually…', 'the budget for snacks is concerning'],
-  stanley:  ['is it Pretzel Day?', 'did I stutter?', 'crossword and coffee. leave me be.', "I'll retire before this brews"],
-  phyllis:  ['Bob is picking me up at five', 'knitting and a nice cup of tea'],
-  andy:     ['Cornell, ever heard of it?', 'rit-dit-dit, coffee break!', 'Big Tuna, grab a chair'],
-  kelly:    ['did you HEAR what happened??', 'so. much. to tell you.', 'I am the GOSSIP queen'],
-  ryan:     ['I’m kind of a big deal', 'the temp needs caffeine', 'starting a coffee startup, actually'],
-  toby:     ['I should write that up…', 'HR-wise this break is fine', 'no one ever sits with me'],
-  creed:    ['which one of you is the new guy?', 'I’ve eaten worse out of that fridge', 'mung beans. under my desk.'],
-  meredith: ['is it 5 o’clock yet?', 'someone spike the coffee?'],
+  michael:  ['我宣布…破产！', '她说啥了', '我不迷信。就是有点信。', '咖啡前不开会。这是规矩。'],
+  dwight:   ['错误。', '身份盗窃不是玩笑', '那个马克杯是规定品', '这冰箱该有个甜菜抽屉', 'Schrute 农场的咖啡更好'],
+  jim:      ['…她说啥了', '熊。甜菜。太空堡垒卡拉狄加。', '我又挪了 Dwight 的订书机', '就是来听八卦的'],
+  pam:      ['Dunder Mifflin，这里是 Pam', '在画那台售货机', '休息室的水彩画'],
+  kevin:    ['辣椒还没好', '为啥说那么多词', '我要吃零食', '饼干？饼干。'],
+  angela:   ['这休息室太脏了', '派对策划委员会，下午三点', '我在评判那台冰箱'],
+  oscar:    ['其实，那是「浓缩咖啡」', '嗯，其实呢…', '零食预算令人担忧'],
+  stanley:  ['今天是椒盐卷饼日吗？', '我说话不清楚吗？', '填字游戏和咖啡。别烦我。', '我宁愿在这咖啡煮好前退休'],
+  phyllis:  ['Bob 五点钟来接我', '织毛衣，喝杯好茶'],
+  andy:     ['康奈尔，听说过吗？', 'rit-dit-dit，咖啡时间！', 'Big Tuna，拿把椅子来'],
+  kelly:    ['你听说发生什么了吗？？', '好多。好多话要跟你说。', '我可是八卦女王'],
+  ryan:     ['我可是个大人物', '临时工需要咖啡因', '其实我要开个咖啡创业公司'],
+  toby:     ['我该记下来…', '从 HR 角度这休息没问题', '没人愿意跟我坐一桌'],
+  creed:    ['你们谁是新来的？', '那冰箱里更糟的东西我都吃过', '绿豆。藏在我桌下。'],
+  meredith: ['到五点了没？', '有人给咖啡下料了吗？'],
 };
 
-/** A solo break-room line. Character flavour ~60% of the time, else the line
- *  fits the spot the agent is standing at. `seed` keeps it deterministic per
- *  call site (avoids Math.random, which Pixi/Electron CSP-safe code prefers). */
+/** 一条单口休息室台词。约 60% 时间用角色风味，否则用 agent 所在地点的台词。
+ *  `seed` 让每个调用点保持确定性（避免 Math.random，Pixi/Electron CSP 安全
+ *  代码更偏好这种）。 */
 export function pickSoloLine(character: OfficeCharacterName, spot: BreakSpot, seed: number): string {
   const flavour = BY_CHARACTER[character];
   if (flavour && seed % 5 < 3) return pick(flavour, Math.floor(seed / 5));
   return pick(SPOT_POOL[spot], seed);
 }
 
-// ─── paired exchanges (two agents at one table) ──────────────────────────────
+// ─── 成对交流（一张桌子的两个 agent）────────────────────────
 //
-// Each exchange is a list of beats that ALTERNATE between the two agents:
-// beat[0] = the speaker who sat down, beat[1] = their table-mate, beat[2] =
-// speaker again, and so on. The director plays them out one beat at a time.
-// Lines are trimmed to fit the thought cloud; longer ones auto-truncate.
+// 每段交流是两条 agent 之间交替的节拍列表：
+// beat[0] = 坐下的说话者，beat[1] = 他们的同桌，beat[2] =
+// 又是说话者，依此类推。导演一次播放一个节拍。
+// 台词被裁剪以塞进思想云；更长的自动截断。
 
 type Exchange = readonly string[];
 
-// Generic banter — works between any two agents (they're all Dunder Mifflin).
+// 通用打趣——任意两个 agent 之间都能用（他们都是 Dunder Mifflin 的）。
 const EXCHANGES: readonly Exchange[] = [
-  ['world’s best boss.', 'you are. I had the mug made.', 'and I cherish it.'],
-  ['would an idiot do this?', '...if yes, I don’t.', 'that’s my boy.'],
-  ['feared or loved? both.', 'that’s beautiful.', 'I know.'],
-  ['I edited your wiki page again.', 'I know. thank you.'],
-  ['question. how many bears?', 'one.', 'that’s too many.'],
-  ['fact: bears eat beets.', 'bears. beets. Galactica.', 'what is happening.'],
-  ['I grew up on a beet farm.', 'shocking.', '...not shocking at all.'],
-  ['what’s Schrute Farms smell like?', 'victory. and beets.'],
-  ['did you just throw your phone?', 'didn’t like what it said.', 'cool.'],
-  ['is a hot dog a sandwich?', 'it is.', 'I know, right?'],
-  ['three-hole-punch Jim returns.', 'never gets old.'],
-  ['why few word when lot word?', '...genuinely profound.', 'I know.'],
-  ['I am not a bad person.', '...', 'not a great person either.', 'there it is.'],
-  ['I love my cats more than people.', 'including us?', 'especially you.'],
-  ['cats are better than dogs.', 'dogs are better.', '...sorry.'],
-  ['do you love me?', 'I love… being here.', 'that’s a yes.'],
-  ['I’m kind of a big deal.', 'you are?', 'in my mind. yes.'],
-  ['did you miss me?', 'no.', 'a little?', '...there it is.'],
-  ['did you just roll your eyes?', 'I did.', 'why?', 'muscle memory.'],
-  ['I’ve watched that clock since 4.', 'weren’t you working?', 'watching the clock.'],
-  ['what do we sell again?', 'paper.', 'sure, yeah.'],
-  ['how old are you?', 'yeah.', 'that’s not an answer.', 'sure it is.'],
-  ['that’s not how math works.', 'I know.', 'then why?', 'faster.'],
-  ['I’m not an alcoholic.', 'you went to a meeting.', 'for the food.'],
-  ['I went to Cornell.', 'nobody cares.', 'I went to Cornell.', 'still nobody cares.'],
-  ['I have a lot of feelings.', 'I can tell.', 'is that bad?', 'for us? yes.'],
-  ['why are you the way you are?', '...', 'honestly.'],
-  ['your cat died.', 'I know.', 'I’m sorry.', '...thank you.'],
-  ['stop looking at me.', 'you stop looking at me.'],
-  ['sign this.', 'what is it?', 'doesn’t matter.', '...fine.'],
-  ['you can’t say that.', 'I just did.', 'gonna stop me?', '...no.'],
-  ['that’s a fire lane.', 'fire hasn’t happened yet.'],
-  ['I wrapped your stapler in Jello.', 'I’ll eat around it.', 'fair.'],
-  ['zombie attack plan?', 'especially that.', 'of course.'],
-  ['just seeing if you’d answer.', 'I hate you.', 'I know.'],
-  ['a little stitious, not super.', 'that’s not a word.', 'it is now.'],
-  ['funniest person in the office?', 'and other times?', 'other times I know it.'],
-  ['that’s what she said.', '...every time.', 'come on.'],
-  ['I started the fire.', 'no you didn’t.', 'in our hearts, I did.'],
-  ['is today a day ending in Y?', 'yes.', 'then no.'],
-  ['Bob Vance.', 'Phyllis Vance.', 'Vance Refrigeration.'],
-  ['you look beautiful today.', '...I know.'],
-  ['I’m better than you in every way.', 'probably.', 'definitely.', 'sure.'],
-  ['I’m a nice guy.', 'you’re okay.', 'nicest thing you’ve said.'],
-  ['are you okay?', 'I’ve been worse.', 'when?', 'can’t narrow it down.'],
-  ['there’s a spider on your desk.', 'where?', '...you ate it.', 'protein.'],
-  ['soul mates can be bosses.', 'you’re my boss.', 'exactly.'],
-  ['standup ran 40 minutes.', 'could’ve been an email.'],
-  ['is the build green yet?', '...don’t look.'],
-  ['who reply-all’d everyone?', 'we don’t talk about it.'],
+  ['世界最佳老板。', '就是你。杯子是我订做的。', '我宝贝得很。'],
+  ['笨蛋会干这事吗？', '…要是会，那我不会。', '这才是我的好孩子。'],
+  ['让人怕还是让人爱？两个都要。', '说得真好。', '我知道。'],
+  ['我又改了你的 wiki 页。', '我知道。谢谢。'],
+  ['问个问题。多少只熊？', '一只。', '那太多了。'],
+  ['事实：熊吃甜菜。', '熊。甜菜。卡拉狄加。', '这是怎么了。'],
+  ['我在甜菜农场长大。', '惊人。', '…一点都不惊人。'],
+  ['Schrute 农场闻起来什么味？', '胜利。还有甜菜。'],
+  ['你刚才是不是把手机扔了？', '它说的话我不爱听。', '行吧。'],
+  ['热狗算三明治吗？', '算。', '我就说吧。'],
+  ['三孔打洞 Jim 回来了。', '永远看不腻。'],
+  ['为啥用那么多词？', '…真有深度。', '我知道。'],
+  ['我不是坏人。', '…', '也算不上好人。', '就是这话。'],
+  ['我爱我的猫胜过爱人。', '包括我们？', '尤其是你。'],
+  ['猫比狗好。', '狗更好。', '…抱歉。'],
+  ['你爱我吗？', '我爱…待在这儿。', '那就是爱。'],
+  ['我可是个大人物。', '是吗？', '在我心里。是的。'],
+  ['你想我了吗？', '没有。', '一点点？', '…就是这话。'],
+  ['你刚才是不是翻白眼了？', '翻了。', '为什么？', '肌肉记忆。'],
+  ['我从四点就开始盯那钟了。', '你不是在干活吗？', '我在盯钟。'],
+  ['咱卖的是什么来着？', '纸。', '行，没错。'],
+  ['你多大了？', '是啊。', '那不是回答。', '那就是回答。'],
+  ['数学不是这么算的。', '我知道。', '那为啥？', '快。'],
+  ['我不是酒鬼。', '你去开会了。', '为了吃的。'],
+  ['我上过康奈尔。', '没人在乎。', '我上过康奈尔。', '还是没人在乎。'],
+  ['我有很多感受。', '看得出来。', '那不好吗？', '对我们？不好。'],
+  ['你怎么会这样？', '…', '说真的。'],
+  ['你的猫死了。', '我知道。', '节哀。', '…谢谢。'],
+  ['别看我。', '你才别看我。'],
+  ['签这个。', '这是什么？', '不重要。', '…行吧。'],
+  ['这话你不能说。', '我刚说了。', '要拦我吗？', '…不。'],
+  ['那是消防通道。', '火还没发生呢。'],
+  ['我把你的订书机包进果冻了。', '我绕着吃。', '公平。'],
+  ['僵尸来袭计划？', '尤其那个。', '当然。'],
+  ['就看看你会不会回。', '我恨你。', '我知道。'],
+  ['有点信，不是大信。', '那不是词。', '现在就是了。'],
+  ['办公室里最搞笑的人？', '那其他时候呢？', '其他时候我也知道。'],
+  ['她说啥了。', '…每次都这样。', '拜托。'],
+  ['火是我放的。', '不是你。', '在心里，是我。'],
+  ['今天是以 Y 结尾的日子吗？', '是。', '那不行。'],
+  ['Bob Vance。', 'Phyllis Vance。', 'Vance 制冷。'],
+  ['你今天真漂亮。', '…我知道。'],
+  ['我各方面都比你强。', '大概吧。', '确定。', '行。'],
+  ['我是好人。', '你还可以。', '你说的最中听的一句。'],
+  ['你还好吗？', '我经历过更糟的。', '什么时候？', '说不清。'],
+  ['你桌上有只蜘蛛。', '哪？', '…你把它吃了。', '蛋白质。'],
+  ['灵魂伴侣可以是老板。', '你是我老板。', '正是。'],
+  ['站会开了四十分钟。', '本来一封邮件就能说清。'],
+  ['构建变绿了吗？', '…别看。'],
+  ['谁回复全部了？', '这事别提了。'],
 ];
 
-// ─── "that's what she said" ──────────────────────────────────────────────────
+// ─── “她说啥了” ────────────────────────────────────────
 //
-// The office's favourite bit. These are generic (added to the shared pool
-// below) so ANY two agents at a table can run them: whoever sits down first
-// delivers the innocent setup (beat 0) and their table-mate lands the punchline
-// (beat 1). Some carry the show's follow-up beats — a sheepish clarification and
-// the inevitable "still counts." Setups are trimmed to fit the thought cloud.
+// 办公室最爱的段子。这些是通用的（加进下面的共享池），所以任意两个 agent
+// 同桌都能演：先坐下的人说出无辜的铺垫（beat 0），同桌接住笑点（beat 1）。
+// 有些带剧集后续拍——一个讪讪的解释和那句不可避免的“still counts.”。
+// 铺垫被裁剪以塞进思想云。
 const TWSS_EXCHANGES: readonly Exchange[] = [
-  ['taking way longer than I expected.', 'that’s what she said.'],
-  ['it’s too big, can’t fit it in my mouth.', 'that’s what she said.'],
-  ['you really need to slow down.', 'that’s what she said.'],
-  ['gonna need a bigger one.', 'that’s what she said.'],
-  ['help, I can’t get it to go in.', 'that’s what she said.'],
-  ['it’s not that hard if you just push.', 'that’s what she said.'],
-  ['I can’t do this all night.', 'that’s what she said.'],
-  ['I need it now, I can’t wait.', 'that’s what she said.'],
-  ['so hot in here, I’m sweating.', 'that’s what she said.'],
-  ['it keeps slipping out of my hands.', 'that’s what she said.'],
-  ['why not just stick it in already?', 'that’s what she said.', '*looks at camera*'],
-  ['I just need a few more inches.', 'that’s what she said.', 'for the shelf!', 'still counts.'],
-  ['make it louder, I can barely feel it.', 'that’s what she said.'],
-  ['can we get this over with quickly?', 'that’s what she said.', 'I meant the meeting.', 'sure.'],
-  ['I just need you to hold it steady.', 'that’s what she said.'],
-  ['can’t believe I did that all morning.', 'that’s what she said.'],
-  ['my hands are cramping.', 'that’s what she said.', 'from typing!', 'that’s what she said.'],
-  ['hours in and barely halfway done.', 'that’s what she said.'],
-  ['surprisingly heavy for its size.', 'that’s what she said.'],
-  ['be more precise. less sloppy.', 'that’s what she said.', 'I meant the spreadsheet.', 'I know.'],
-  ['how long was it?', 'that’s what she said.', '*the whole room goes quiet*', 'I’m sorry, I can’t help it.'],
-  ['too tight, cutting off my circulation.', 'that’s what she said.', '*mouths thank you*'],
-  ['I don’t think it’ll fit.', 'that’s what she said.', '*stands up and applauds*'],
-  ['stop, you’re doing it wrong.', 'that’s what she said.', 'never been prouder.'],
-  ['this just keeps getting harder.', 'that’s what she said.', 'he’s ready.'],
-  ['not wide enough, I need more room.', 'that’s what she said.'],
-  ['I can hold it a really long time.', 'that’s what she said.', 'my breath!', 'still.'],
-  ['why is it taking so long?', 'that’s what she said.', 'I hate you.', 'then why set me up?'],
-  ['I can’t do it with people watching.', 'that’s what she said.', 'the presentation!', 'sure.'],
-  ['it’s deeper than it looks.', 'that’s what she said.', 'the pothole, Michael!', 'doesn’t matter.'],
-  ['so much longer than last time.', 'that’s what she said.', 'the report, Michael.', 'right, right.'],
-  ['oh my god, it went on FOREVER.', 'that’s what she said.', 'the Twilight movie!', 'classic.'],
-  ['can’t believe how thick this is.', 'that’s what she said.', 'the folder. *stares*'],
-  ['I fit all THAT in one day?', 'that’s what she said.', 'that’s actually what I said!', 'meta.'],
-  ['I went at it hard this morning.', 'that’s what she said.', 'at the gym!', 'irrelevant.'],
-  ['someone help me finish this off.', 'that’s what she said.', 'the leftover cake!', 'still works.'],
-  ['get in, do my thing, get out.', 'that’s what she said.', '*doesn’t look up from crossword*'],
-  ['can’t believe it took this long.', 'that’s what she said.', 'the raise. eight years.', 'that one’s on me.'],
-  ['do it slower, it’ll hurt less.', 'that’s what she said.', 'for the quarterly review.', 'sure, Oscar.'],
-  ['didn’t realize how big it’d be.', 'that’s what she said.', 'the calzone, it’s enormous!', 'I love this office.'],
-  ['*to no one* that’s what she said.', 'nobody said anything.', 'just thinking about earlier.'],
-  ['*on the phone* that’s what she said.', 'who was that?', 'my mother. about a sandwich.'],
-  ['too hot in here! that’s what she said.', 'you said both parts.', 'I contain multitudes.'],
-  ['*at the TV* that’s what she said.', 'you’re alone, Michael.', 'she doesn’t know that.'],
-  ['you need to be more professional.', 'that’s what she said.', 'I am she.', '...that’s what she said.'],
-  ['stop. just stop. every time—', 'that’s what she said.', '*leaves the room*', '*whispers* that’s what she said.'],
-  ['as you can see, it’s going up.', 'that’s what she said.', '*everyone groans*', 'set that one up myself.'],
-  ['I declared bankruptcy once. felt good.', 'what does that have to do with—', 'that’s what she said.', 'it doesn’t.', 'I know.'],
-  ['you didn’t say it.', 'I know.', 'why not?', 'I’m growing.', '...that’s what she said.', 'there it is.'],
-  ['impressive you held back today.', 'thank you.', 'I counted zero times.', 'that’s what she said.', 'still counts.'],
+  ['比我想的慢太多了。', '她说啥了。'],
+  ['太大了，我嘴里放不下。', '她说啥了。'],
+  ['你真得慢点。', '她说啥了。'],
+  ['得来个更大的。', '她说啥了。'],
+  ['帮帮忙，我塞不进去。', '她说啥了。'],
+  ['只要用力推就不难。', '她说啥了。'],
+  ['我撑不了一整晚。', '她说啥了。'],
+  ['我现在就要，等不了。', '她说啥了。'],
+  ['这儿好热，我直冒汗。', '她说啥了。'],
+  ['一直从我手里滑出去。', '她说啥了。'],
+  ['为啥不直接插进去？', '她说啥了。', '＊看向镜头＊'],
+  ['我还差几英寸。', '她说啥了。', '够到架子！', '照样算。'],
+  ['大点声，我几乎没感觉。', '她说啥了。'],
+  ['能快点弄完吗？', '她说啥了。', '我说的是会议。', '行。'],
+  ['你帮我扶稳就行。', '她说啥了。'],
+  ['不敢相信我一早上都在干这个。', '她说啥了。'],
+  ['我手都抽筋了。', '她说啥了。', '是打字！', '她说啥了。'],
+  ['都几个小时了才做一半。', '她说啥了。'],
+  ['个头不大，倒是挺重。', '她说啥了。'],
+  ['再精准点。别太马虎。', '她说啥了。', '我说的是表格。', '我知道。'],
+  ['它有多长？', '她说啥了。', '＊全场安静＊', '抱歉，我忍不住。'],
+  ['太紧了，血脉都不通了。', '她说啥了。', '＊口型说谢谢＊'],
+  ['我觉得放不进去。', '她说啥了。', '＊起立鼓掌＊'],
+  ['停，你弄错了。', '她说啥了。', '从没这么骄傲过。'],
+  ['这越来越难了。', '她说啥了。', '他准备好了。'],
+  ['不够宽，我要更多空间。', '她说啥了。'],
+  ['我能憋很长时间。', '她说啥了。', '我憋气！', '照样。'],
+  ['为啥这么慢？', '她说啥了。', '我恨你。', '那你为啥给我挖坑？'],
+  ['有人看着我做不来。', '她说啥了。', '是演示！', '行。'],
+  ['比看起来深。', '她说啥了。', '那坑，Michael！', '无所谓。'],
+  ['比上次久太多了。', '她说啥了。', '报告，Michael。', '对对。'],
+  ['天哪，没完没了。', '她说啥了。', '《暮光之城》！', '经典。'],
+  ['不敢相信这么厚。', '她说啥了。', '文件夹。＊盯着看＊'],
+  ['我一天装下那么多？', '她说啥了。', '这还真是我说的！', '元梗。'],
+  ['今早我猛干了一场。', '她说啥了。', '在健身房！', '无关。'],
+  ['谁来帮我收个尾。', '她说啥了。', '剩下的蛋糕！', '照样成立。'],
+  ['进去，办完事，出来。', '她说啥了。', '＊没从填字游戏抬头＊'],
+  ['不敢相信拖了这么久。', '她说啥了。', '加薪。八年。', '这个我认。'],
+  ['慢点来，没那么疼。', '她说啥了。', '季度考核。', '行，Oscar。'],
+  ['没想到会这么大。', '她说啥了。', '那个意式馅饼，巨大！', '我爱这办公室。'],
+  ['＊对空气＊她说啥了。', '没人说话。', '在想刚才的事。'],
+  ['＊打电话＊她说啥了。', '谁啊？', '我妈。关于一个三明治。'],
+  ['这儿太热了！她说啥了。', '你两半都说了。', '我内涵丰富。'],
+  ['＊对电视＊她说啥了。', '你一个人，Michael。', '她不知道。'],
+  ['你要专业点。', '她说啥了。', '我就是她。', '…她说啥了。'],
+  ['停。别说了。每次都—', '她说啥了。', '＊离开房间＊', '＊耳语＊她说啥了。'],
+  ['如你们所见，在往上走。', '她说啥了。', '＊全体叹息＊', '这个我自己铺的梗。'],
+  ['我破产过一次。感觉不错。', '那跟这有什么关系—', '她说啥了。', '没关系。', '我知道。'],
+  ['你没说。', '我知道。', '为啥？', '我在成长。', '…她说啥了。', '就是这话。'],
+  ['你今天居然忍住了。', '谢谢。', '我数了，零次。', '她说啥了。', '照样算。'],
 ];
 
-// Everything any table-mate pair can draw from.
+// 任意同桌配对的备选池。
 const PAIR_POOL: readonly Exchange[] = [...EXCHANGES, ...TWSS_EXCHANGES];
 
-// Keyed off the SPEAKER so, when the right character sits down first, they get
-// to open with their signature bit.
+// 按说话者索引，让对的角色先坐下时，能用他们的招牌段子开场。
 const KEYED_EXCHANGES: Partial<Record<OfficeCharacterName, Exchange>> = {
-  michael:  ['that’s what she said.', '...there it is.'],
-  dwight:   ['identity theft is not a joke.', 'nobody touched your stapler, Dwight.'],
-  kevin:    ['why few word when lot word?', '...just use the words, Kevin.'],
-  kelly:    ['okay don’t freak out, but—', 'I’m already freaking out.'],
-  oscar:    ['well, actually—', '...here we go.'],
-  angela:   ['this table is filthy.', 'it’s a break room, Angela.'],
-  creed:    ['which one are you again?', '...we sit next to each other.'],
-  stanley:  ['is it Pretzel Day?', 'no, Stanley.', '...did I stutter?'],
-  andy:     ['I went to Cornell.', 'nobody cares.', '...I went to Cornell.'],
-  jim:      ['question.', 'yes.', 'nothing. just checking.'],
+  michael:  ['她说啥了。', '…就是这话。'],
+  dwight:   ['身份盗窃不是玩笑。', '没人碰你的订书机，Dwight。'],
+  kevin:    ['为啥用那么多词？', '…好好用词，Kevin。'],
+  kelly:    ['好吧别慌，但是—', '我已经慌了。'],
+  oscar:    ['嗯，其实呢—', '…又来了。'],
+  angela:   ['这桌子真脏。', '这是休息室，Angela。'],
+  creed:    ['你又是谁来着？', '…咱俩坐隔壁。'],
+  stanley:  ['今天是椒盐卷饼日吗？', '不是，Stanley。', '…我说话不清楚吗？'],
+  andy:     ['我上过康奈尔。', '没人在乎。', '…我上过康奈尔。'],
+  jim:      ['问个问题。', '说。', '没事。就问问。'],
 };
 
-/** A multi-beat exchange for two agents sharing a table. Beats alternate:
- *  index 0 = `speaker`, 1 = the table-mate, 2 = speaker, … */
+/** 两个 agent 同桌的一段多拍交流。节拍交替：
+ *  index 0 = `speaker`，1 = 同桌，2 = speaker，…… */
 export function pickExchange(speaker: OfficeCharacterName, seed: number): Exchange {
   const keyed = KEYED_EXCHANGES[speaker];
   if (keyed && seed % 4 === 0) return keyed;

--- a/src/renderer/src/scene/office/cast.ts
+++ b/src/renderer/src/scene/office/cast.ts
@@ -1,10 +1,9 @@
-// The Office cast — roster metadata + sprite frames.
+// 《办公室》角色群——名单元数据 + 精灵帧。
 //
-// Both the static portraits (cards / picker) and the in-scene walking sprites are
-// now fully custom-drawn from the same per-character recipes in portraitArt.ts:
-// the scene sprite reuses the portrait's exact head/face/clothing and adds legs,
-// so an agent on the office floor looks identical to its card. The LimeZu base
-// sheets are no longer used for the cast. See assets/ATTRIBUTION.md.
+// 静态肖像（卡片 / 选择器）和场景内行走精灵现在都完全按 portraitArt.ts 里
+// 每个角色的配方自定义绘制：场景精灵复用肖像的精确头/脸/服装并加上腿，
+// 所以办公室地板上的 agent 与它的卡片看起来一模一样。LimeZu 基础表不再
+// 用于角色群。见 assets/ATTRIBUTION.md。
 
 import { Texture } from 'pixi.js';
 import { paintPortrait, sceneFrameBufs, SCENE_W, SCENE_H } from './portraitArt';
@@ -17,13 +16,13 @@ export type OfficeCharacterName =
 export interface CastMember {
   name: OfficeCharacterName;
   displayName: string;
-  /** Signature accent color (hex) — used for the in-scene selection glow. */
+  /** 招牌强调色（十六进制）——用于场景内的选中光晕。 */
   shirt: string;
-  /** Blurb shown when this character is picked / has no description yet. */
+  /** 该角色被选中 / 尚无描述时显示的一句话。 */
   blurb: string;
 }
 
-/** Selectable roster, in display order. */
+/** 可选择的角色名单，按显示顺序。 */
 export const OFFICE_CAST: CastMember[] = [
   { name: 'michael',  displayName: 'Michael',  shirt: '#5a6b8c', blurb: "World's best boss" },
   { name: 'jim',      displayName: 'Jim',      shirt: '#6fa8dc', blurb: 'Salesman, prankster' },
@@ -51,7 +50,7 @@ export function hexToNumber(hex: string): number {
   return parseInt(hex.replace('#', ''), 16);
 }
 
-// ─── scene frames ────────────────────────────────────────────────────────────
+// ─── 场景帧 ──────────────────────────────────────────────────────────
 const frameCache = new Map<OfficeCharacterName, Texture[][]>();
 
 function bufToTexture(buf: Uint8ClampedArray): Texture {
@@ -67,11 +66,10 @@ function bufToTexture(buf: Uint8ClampedArray): Texture {
 }
 
 /**
- * Frame grid CharacterSprite expects: 3 rows (down, up, right) × 7 frames
- * [walk1, walk2, walk3, type1, type2, read1, read2]. We provide a front view
- * (down — and reused for the side row, so left/right walkers still show a face)
- * and a back view (up — agents seated facing their desk show their back). The
- * three walk frames are stand / step-left / step-right.
+ * CharacterSprite 期望的帧网格：3 行（down、up、right）× 7 帧
+ * [walk1, walk2, walk3, type1, type2, read1, read2]。我们提供正面视角
+ * （down——并复用于侧行，所以左/右行走者仍露脸）和背面视角（up——面朝
+ * 桌子坐下的 agent 显示后背）。三个行走帧是站立 / 左步 / 右步。
  */
 export async function getCastFrames(name: OfficeCharacterName): Promise<Texture[][]> {
   const cached = frameCache.get(name);
@@ -88,8 +86,8 @@ export async function getCastFrames(name: OfficeCharacterName): Promise<Texture[
 }
 
 /**
- * Paint a character's static portrait for cards / the picker (delegates to the
- * custom procedural composer in portraitArt.ts).
+ * 为卡片 / 选择器绘制角色的静态肖像（委托给 portraitArt.ts 里的自定义
+ * 程序化合成器）。
  */
 export async function paintCastPortrait(
   ctx: CanvasRenderingContext2D,

--- a/src/renderer/src/scene/office/glRecovery.ts
+++ b/src/renderer/src/scene/office/glRecovery.ts
@@ -1,37 +1,34 @@
 /**
- * Surviving a lost WebGL context.
+ * 挺过丢失的 WebGL 上下文。
  *
- * Chromium caps how many WebGL contexts one renderer process may hold (~16) and,
- * when a new one pushes past the cap, it EVICTS THE OLDEST — logging only
+ * Chromium 限制一个渲染进程能持有的 WebGL 上下文数量（约 16 个），当新的
+ * 一个越过上限时，它会驱逐最旧的那个——只记录一句
  * "WARNING: Too many active WebGL contexts. Oldest context will be lost."
  *
- * The office floor's context is created at app startup, so it is always the
- * oldest one alive. Every terminal xterm opens takes another context
- * (@xterm/addon-webgl), so on a busy floor — enough agents, or a second window —
- * the office is the first thing evicted. Pixi does not notice: no exception, no
- * rejected promise, no failure banner. The canvas simply stops drawing and the
- * office goes blank until the app is restarted. That is the blank-office bug.
+ * 办公室楼层的上下文在应用启动时创建，所以它总是活着的最旧的那个。每个
+ * 终端 xterm 打开都会再占一个上下文（@xterm/addon-webgl），所以在繁忙的
+ * 楼层上——足够的 agent，或第二个窗口——办公室就是最先被驱逐的。Pixi
+ * 不会察觉：没有异常、没有拒绝的 promise、没有失败横幅。画布只是停止绘制，
+ * 办公室变空白直到应用重启。这就是空白办公室 bug。
  *
- * xterm already handles this by falling back to its DOM renderer. Pixi has no
- * such fallback, so the scene has to be rebuilt instead. This module is only the
- * event wiring, kept separate from OfficeFloor so the recovery policy — cancel
- * the event, debounce, cap the retries, give up loudly — is testable against a
- * plain EventTarget with no browser, no GPU and no Pixi.
+ * xterm 已经通过回退到它的 DOM 渲染器处理了这个问题。Pixi 没有这种回退，
+ * 所以场景必须重建。这个模块只是事件接线，与 OfficeFloor 分开，让恢复策略
+ * ——取消事件、防抖、限制重试次数、响亮地放弃——可以针对一个不带浏览器、
+ * 不带 GPU、不带 Pixi 的普通 EventTarget 做测试。
  */
 
 export interface GlRecoveryOptions {
-  /** Rebuild attempts before we stop fighting for a context. */
+  /** 在停止争夺上下文前的重建尝试次数。 */
   maxRebuilds?: number;
-  /** Wait before rebuilding: the eviction arrives mid-storm (several contexts
-   *  are usually created at once), and claiming one back immediately just races
-   *  the terminals that displaced us. */
+  /** 重建前等待：驱逐是在一阵风暴中到来的（通常会同时创建好几个上下文），
+   *  立刻抢回一个只是在跟顶替我们的终端赛跑。 */
   delayMs?: number;
-  /** Rebuild the scene (in OfficeFloor: bump the effect's generation dep). */
+  /** 重建场景（OfficeFloor：bump 效果的 generation 依赖）。 */
   onRebuild: () => void;
-  /** Called once, when the retry budget is spent — the caller should say
-   *  something visible rather than leaving a silently blank canvas. */
+  /** 重试预算耗尽时调用一次——调用方应该说点什么可见的东西，而不是留下
+   *  一个静默空白的画布。 */
   onGiveUp?: () => void;
-  /** Injectable for tests. */
+  /** 可注入，供测试用。 */
   schedule?: (fn: () => void, ms: number) => unknown;
   log?: (msg: string) => void;
 }
@@ -39,8 +36,8 @@ export interface GlRecoveryOptions {
 export const DEFAULT_MAX_REBUILDS = 3;
 export const DEFAULT_REBUILD_DELAY_MS = 1500;
 
-/** Listen for context loss on `canvas` and rebuild. Returns an uninstall fn;
- *  call it from the effect cleanup so a torn-down scene stops responding. */
+/** 监听 `canvas` 上的上下文丢失并重建。返回卸载函数；在 effect 清理时调用
+ *  它，让已拆除的场景停止响应。 */
 export function installContextLossRecovery(
   canvas: EventTarget,
   opts: GlRecoveryOptions
@@ -54,9 +51,8 @@ export function installContextLossRecovery(
   let live = true;
 
   const onLost = (e: Event) => {
-    // WITHOUT preventDefault the browser will never hand the context back — the
-    // canvas is dead for good. This one line is the difference between a
-    // recoverable scene and a permanently blank one.
+    // 不 preventDefault 浏览器就绝不会把上下文交还——画布就此永久作废。
+    // 这一行是可恢复场景与永久空白之间的分水岭。
     e.preventDefault();
     if (!live) return;
     if (rebuilds >= max) {
@@ -77,53 +73,49 @@ export function installContextLossRecovery(
   };
 }
 
-/* ─── Failing to GET a context in the first place ──────────────────────────────
+/* ─── 一开始就 FAILED 去 GET 上下文 ────────────────────────────────────
  *
- * The recovery above only starts listening once `app.init()` has resolved, so it
- * cannot help when the REBUILD it schedules cannot get a context either. That is
- * what happens when the GPU process dies rather than when a context is evicted:
- * the floor loses its context, the rebuild fires 1500ms later, and Chromium is
- * still bringing the GPU process back. getContext() returns null and Pixi turns
- * that into
+ * 上面的恢复只在 `app.init()` resolve 之后才开始监听，所以当它安排的 REBUILD
+ * 也拿不到上下文时，它帮不上忙。这正是 GPU 进程死亡（而不是上下文被驱逐）
+ * 时发生的事：楼层失去上下文，重建在 1500ms 后触发，而 Chromium 还在把 GPU
+ * 进程拉回来。getContext() 返回 null，Pixi 把它变成
  *
  *   Error: This browser does not support WebGL. Try using the canvas renderer
  *
- * which OfficeFloor then painted onto the floor as a wall of minified frames.
- * The message is a lie about the cause — the browser supports WebGL fine, the
- * GPU process just is not there yet — so treating it as fatal leaves the floor
- * dead until the whole app is restarted, over a condition that clears itself in
- * a second or two.
+ * 然后 OfficeFloor 把它画到地板上，变成一墙压缩过的帧。这条消息对原因的
+ * 描述是骗人的——浏览器支持 WebGL 得很，只是 GPU 进程还没就位——所以把它
+ * 当致命错误，会让楼层死到整个应用重启为止，而那个条件一两秒内就会自行
+ * 清除。
  *
- * REPRODUCED on v0.4.5 (Windows, Intel UHD, Electron 32) by killing the app's
- * --type=gpu-process out from under a live floor: the eviction path logs its
- * rebuild, and the rebuild's init() throws the error above.
+ * 已在 v0.4.5（Windows、Intel UHD、Electron 32）上复现：从活跃楼层的脚下
+ * 杀掉应用的 --type=gpu-process：驱逐路径记录它的重建，重建的 init() 抛出
+ * 上面那个错误。
  *
- * Note the two are NOT the same failure. Eviction pressure alone does not get
- * here: a getContext() call that pushes past Chromium's ~16-context cap evicts
- * somebody else and SUCCEEDS, so the floor's rebuild always wins its slot back.
- * It takes an absent GPU process for the request itself to fail.
+ * 注意两者不是同一种失败。单靠驱逐压力到不了这里：一个推过 Chromium 约
+ * 16 个上下文上限的 getContext() 调用会驱逐别人并 SUCCEED，所以楼层的重建
+ * 总能赢回自己的槽位。只有 GPU 进程缺位，才会让请求本身失败。
  *
- * Kept as a pure classifier + planner so the policy is testable without a
- * browser, a GPU or Pixi — same as the loss path.
+ * 保持为纯分类器 + 规划器，让策略可以在无浏览器、无 GPU、无 Pixi 的情况下
+ * 测试——与丢失路径相同。
  */
 
-/** Retries before we accept that the floor cannot have a context right now.
- *  Three at 1500ms covers a GPU process restart with room to spare. */
+/** 在承认楼层现在拿不到上下文前的重试次数。三次 1500ms 覆盖一次 GPU 进程
+ *  重启还有富余。 */
 export const DEFAULT_MAX_INIT_RETRIES = 3;
 
-/** Messages meaning "no context for you", across Pixi and Chromium wordings.
- *  Deliberately narrow: anything that is NOT recognised here is reported as the
- *  bug it probably is, rather than hidden behind several seconds of retries. */
+/** 表示“没有给你的上下文”的消息，涵盖 Pixi 与 Chromium 的说法。
+ *  刻意收窄：这里没识别到的任何东西都被当作它很可能就是的 bug 上报，
+ *  而不是藏在几秒重试后面。 */
 const CONTEXT_UNAVAILABLE = [
-  /does not support webgl/i,                              // Pixi 8, verbatim
+  /does not support webgl/i,                              // Pixi 8，原话
   /web(gl|gpu)\d?\s*(is\s+)?(not\s+(supported|available)|unsupported|unavailable)/i,
   /(unable|failed) to (create|get|obtain)[^.]*context/i,
   /no (webgl|gpu|rendering) context/i,
 ];
 
-/** True when `err` says a rendering context could not be obtained — a busy
- *  process, not a browser without WebGL. Follows the `cause` chain so a caller
- *  that wrapped the failure in its own Error still classifies correctly. */
+/** 当 `err` 表示无法获得渲染上下文时为 true——进程繁忙，而不是一个没有
+ *  WebGL 的浏览器。顺着 `cause` 链走，让用自己 Error 包装了失败的上层
+ *  调用方仍能正确分类。 */
 export function isContextUnavailableError(err: unknown): boolean {
   for (let e: unknown = err, depth = 0; e && depth < 5; depth++) {
     const msg = typeof e === 'string' ? e : (e as { message?: unknown })?.message;
@@ -134,15 +126,15 @@ export function isContextUnavailableError(err: unknown): boolean {
 }
 
 export type InitFailurePlan =
-  /** Wait `delayMs`, then build the scene again from scratch. */
+  /** 等 `delayMs`，然后从头重建场景。 */
   | { action: 'retry'; delayMs: number; attempt: number }
-  /** Out of budget: tell the user, in words, that the GPU is oversubscribed. */
+  /** 预算耗尽：用语言告诉用户，GPU 已超订。 */
   | { action: 'give-up' }
-  /** Not a context problem — show the error, it is a real failure. */
+  /** 不是上下文问题——显示错误，这是一个真实失败。 */
   | { action: 'report' };
 
-/** Decide what a rejected `app.init()` means. `attemptsUsed` is how many retries
- *  this mount has already spent, so the budget survives across rebuilds. */
+/** 判断一次被拒绝的 `app.init()` 意味着什么。`attemptsUsed` 是本次挂载已经
+ *  花掉的重试次数，所以预算能跨重建存续。 */
 export function planInitFailure(
   err: unknown,
   attemptsUsed: number,
@@ -151,7 +143,6 @@ export function planInitFailure(
   if (!isContextUnavailableError(err)) return { action: 'report' };
   const max = opts.maxRetries ?? DEFAULT_MAX_INIT_RETRIES;
   if (attemptsUsed >= max) return { action: 'give-up' };
-  // Same delay as a rebuild: a GPU process takes a moment to come back, and
-  // asking again immediately just gets the same null.
+  // 与重建相同的延迟：GPU 进程要花一会儿才能回来，立刻再问只会得到同一个 null。
   return { action: 'retry', delayMs: opts.delayMs ?? DEFAULT_REBUILD_DELAY_MS, attempt: attemptsUsed + 1 };
 }

--- a/src/renderer/src/scene/office/pathfinding.ts
+++ b/src/renderer/src/scene/office/pathfinding.ts
@@ -1,5 +1,5 @@
-// BFS pathfinding on a tile walkability grid.
-// Ported verbatim from shahar061/the-office (office/engine/pathfinding.ts).
+// 基于瓦片可行走网格的 BFS 寻路。
+// 从 shahar061/the-office 逐字移植（office/engine/pathfinding.ts）。
 
 export interface Walkable {
   width: number;

--- a/src/renderer/src/scene/office/portraitArt.ts
+++ b/src/renderer/src/scene/office/portraitArt.ts
@@ -1,27 +1,26 @@
-// Procedural portraits for The Office cast.
+// 《办公室》角色群的程序化肖像。
 //
-// These are fully custom-drawn busts (NOT recolored LimeZu sprites): each
-// character is an explicit recipe layering skin → clothing → face → facial hair
-// → hairstyle → glasses on an 18×28 canvas. This gives real control over each
-// person's hairstyle shape, garment cut/color, and facial hair so they read as
-// the specific show character. The in-scene walking sprites still use the LimeZu
-// recolor in cast.ts; this module only powers the static portraits in the UI.
+// 这些是完全自定义绘制的半身像（不是重新着色的 LimeZu 精灵）：每个角色都是
+// 一个显式配方，在 18×28 画布上按 皮肤 → 服装 → 脸 → 胡须 → 发型 → 眼镜
+// 分层绘制。这让人能真正控制每个人的发型形状、服装裁剪/颜色和胡须，使他们
+// 读起来就是具体的剧集角色。场景内行走精灵仍使用 cast.ts 里的 LimeZu 重着色；
+// 本模块只为 UI 中的静态肖像供能。
 
 import type { OfficeCharacterName } from './cast';
 
 export const PORTRAIT_W = 18;
 export const PORTRAIT_H = 28;
-// In-scene walking sprite: same width + upper body as the portrait, taller to add legs.
+// 场景内行走精灵：与肖像同宽 + 上半身，更高以加腿。
 export const SCENE_W = 18;
 export const SCENE_H = 32;
 const OUTLINE: RGB = [38, 34, 46];
-const HX0 = 4, HX1 = 13; // head skin columns
+const HX0 = 4, HX1 = 13; // 头部肤色列
 
 type RGB = [number, number, number];
 type Buf = Uint8ClampedArray;
 
-// Current canvas dims — set per compose() so the same drawing primitives serve
-// both the 18×28 portrait and the 18×32 scene sprite. (Rendering is synchronous.)
+// 当前画布尺寸——在每次 compose() 里设置，让同一套绘制原语既能服务于
+// 18×28 肖像也能服务于 18×32 场景精灵。（渲染是同步的。）
 let CUR_W = PORTRAIT_W, CUR_H = PORTRAIT_H;
 
 const clamp = (v: number) => (v < 0 ? 0 : v > 255 ? 255 : Math.round(v));
@@ -85,8 +84,8 @@ function drawFace(buf: Buf, skin: string, brow: Brow, mouth: Mouth, blush: boole
   for (const [a, b, p] of [[5, 6, 6], [10, 11, 10]] as const) {
     set(buf, a, 9, white); set(buf, b, 9, white); set(buf, p, 9, pup);
   }
-  // Feminine eyes: a dark upper lash line + an outer flick, and a bright glint
-  // in each pupil so they read as bigger, rounder, more expressive.
+  // 女性化眼睛：深色上睫毛线 + 外侧上挑，每个瞳孔里一点亮光，让眼睛读起来
+  // 更大、更圆、更有表现力。
   if (lashes) {
     const lash: RGB = [54, 40, 48], glint: RGB = [252, 250, 248];
     for (const x of [5, 6, 10, 11]) set(buf, x, 8, lash);
@@ -123,7 +122,7 @@ const styleShort: HairFn = (buf, color, skinBase, a) => {
   for (let x = HX0; x <= HX1; x++) set(buf, x, 5, base);
   if (recede) {
     for (let y = 3; y < 6; y++) for (let x = 6; x < 12; x++) if (eq(rgbAt(buf, x, y), base)) set(buf, x, y, skinBase);
-    set(buf, 8, 5, base); // widow's peak
+    set(buf, 8, 5, base); // 寡妇尖（M 形发际线）
   }
   const hx = part === 'L' ? 6 : 11;
   for (let y = 2; y < 6; y++) set(buf, hx, y, sh);
@@ -221,21 +220,20 @@ const styleSpiky: HairFn = (buf, color, skinBase) => {
   for (const [x, y] of spikes) set(buf, x, y, hi);
 };
 
-// Bald: a rounded skin crown (with a sheen) and only a low horseshoe fringe of
-// hair around the temples / back of the head.
+// 秃头：圆润的肤色头顶（带光泽），只在太阳穴 / 后脑有一圈低低的马蹄形发际线。
 const styleBald: HairFn = (buf, color, skinBase, a) => {
   const [shi, sbase, ssh] = shades(skinBase, 1.1, 0.82);
-  // rounded skin dome above the forehead
+  // 额头之上圆润的肤色穹顶
   for (let x = 6; x <= 11; x++) set(buf, x, 2, sbase);
   for (let x = 5; x <= 12; x++) set(buf, x, 3, sbase);
   for (let x = HX0; x <= HX1; x++) set(buf, x, 4, sbase);
-  // bald-head sheen + side falloff
+  // 秃顶光泽 + 两侧衰减
   for (const x of [7, 8, 9]) set(buf, x, 2, shi);
   set(buf, 6, 3, shi); set(buf, 7, 3, shi);
   set(buf, 5, 3, ssh); set(buf, 12, 3, ssh); set(buf, HX1, 4, ssh);
-  // low horseshoe hair fringe — sides only, leaving the crown bald.
+  // 低低的马蹄形发际线——只有两侧，头顶保持秃。
   const [, base, sh] = shades(color);
-  const top = a.recede ? 8 : 6; // recede:1 → only a thin fringe very low
+  const top = a.recede ? 8 : 6; // recede:1 → 只有极低处一条细发边
   for (let y = top; y <= 10; y++) {
     set(buf, HX0 - 1, y, base); set(buf, HX0, y, base);
     set(buf, HX1, y, base); set(buf, HX1 + 1, y, base);
@@ -265,25 +263,24 @@ function drawFacial(buf: Buf, kind: Facial, color: RGB): void {
   }
 }
 
-// ─── glasses ─────────────────────────────────────────────────────────────────
-// Clear prescription glasses (NOT sunglasses): a thin rim that frames each eye
-// without covering it. The lens interior keeps the eye/skin already drawn, plus
-// a small white glint so the lens reads as transparent glass.
+// ─── 眼镜 ─────────────────────────────────────────────────────────────────
+// 透明处方眼镜（不是墨镜）：一圈包住每只眼睛但不遮住它的细框。镜片内部
+// 保留已画的眼/肤，加一小点白色反光，让镜片读起来像透明玻璃。
 function drawGlasses(buf: Buf): void {
   const frame: RGB = [60, 54, 62];
   const glint: RGB = [236, 240, 246];
-  // Left lens rim around the eye at (5-6, 9): top, bottom, outer + inner edge.
+  // 左镜片框住眼睛 (5-6, 9) 的圈：上、下、外缘 + 内缘。
   for (const x of [5, 6]) { set(buf, x, 8, frame); set(buf, x, 10, frame); }
   set(buf, 4, 9, frame); set(buf, 7, 9, frame);
   set(buf, 4, 8, frame); set(buf, 7, 8, frame);
-  // Right lens rim around the eye at (10-11, 9).
+  // 右镜片框住眼睛 (10-11, 9) 的圈。
   for (const x of [10, 11]) { set(buf, x, 8, frame); set(buf, x, 10, frame); }
   set(buf, 9, 9, frame); set(buf, 12, 9, frame);
   set(buf, 9, 8, frame); set(buf, 12, 8, frame);
-  // Bridge over the nose + temple arms out to the hair.
+  // 鼻梁上的桥 + 伸向头发的镜腿。
   set(buf, 8, 8, frame);
   set(buf, 3, 9, frame); set(buf, 13, 9, frame);
-  // Glass glint on each rim's top-outer corner so the lens reads as clear glass.
+  // 每个镜框外上角一点玻璃反光，让镜片读起来像透明玻璃。
   set(buf, 4, 8, glint); set(buf, 9, 8, glint);
 }
 
@@ -332,19 +329,19 @@ function collarNeck(buf: Buf, skin: string): void {
   rect(buf, 7, 18, 10, 19, SKIN[skin].sh);
 }
 
-// ─── scene body (full standing figure: torso + legs, front or back) ──────────
-// Proportioned for standing (not the portrait bust): a narrower torso over real
-// legs. Head (rows 2-16) sits above; this draws rows 18-31.
+// ─── 场景身体（完整站立形象：躯干 + 腿，正面或背面）────────────────────
+// 为站立而配比（不是肖像半身像）：更窄的躯干架在真正的腿上。头部（2-16 行）
+// 在上方；这里画 18-31 行。
 const SHOE: RGB = [44, 40, 48];
 
 function drawSceneLegs(buf: Buf, pants: RGB, phase: number): void {
   const [, base, sh] = shades(pants);
-  // two legs cols 5-7 / 10-12, gap at 8-9
+  // 两条腿，列 5-7 / 10-12，8-9 处留缝
   for (const [lx0, lx1] of [[5, 7], [10, 12]] as const) {
     rect(buf, lx0, 25, lx1, 30, base);
-    for (let y = 25; y <= 30; y++) set(buf, lx1, y, sh); // inner shade
+    for (let y = 25; y <= 30; y++) set(buf, lx1, y, sh); // 内侧阴影
   }
-  // feet — lift one foot per walk phase for a simple gait
+  // 脚——每个行走相位抬起一只脚，形成简单步态
   const leftLow = phase !== 1, rightLow = phase !== 2;
   rect(buf, 5, leftLow ? 31 : 30, 7, leftLow ? 31 : 30, SHOE);
   rect(buf, 10, rightLow ? 31 : 30, 12, rightLow ? 31 : 30, SHOE);
@@ -352,7 +349,7 @@ function drawSceneLegs(buf: Buf, pants: RGB, phase: number): void {
 
 function drawSceneTorso(buf: Buf, r: Recipe, back: boolean): void {
   const [hi, base, sh] = shades(r.c1);
-  // shoulders → torso, narrower than the portrait bust (wider + rounder if heavy)
+  // 肩膀 → 躯干，比肖像半身像窄（heavy 时更宽更圆）
   if (r.heavy) {
     rect(buf, 3, 18, 14, 18, base);
     rect(buf, 2, 19, 15, 19, base);
@@ -362,10 +359,10 @@ function drawSceneTorso(buf: Buf, r: Recipe, back: boolean): void {
     rect(buf, 4, 18, 13, 18, base);
     rect(buf, 3, 19, 14, 19, base);
     rect(buf, 4, 20, 13, 24, base);
-    for (let y = 20; y <= 24; y++) { set(buf, 3, y, sh); set(buf, 14, y, sh); set(buf, 13, y, sh); } // arms / right shade
+    for (let y = 20; y <= 24; y++) { set(buf, 3, y, sh); set(buf, 14, y, sh); set(buf, 13, y, sh); } // 手臂 / 右侧阴影
   }
   if (back) {
-    // plain back with a collar line + center seam
+    // 朴素背面：一条领线 + 中央缝线
     rect(buf, 6, 18, 11, 18, sh);
     for (let y = 19; y <= 24; y++) set(buf, 8, y, sh);
     return;
@@ -395,35 +392,35 @@ function drawSceneTorso(buf: Buf, r: Recipe, back: boolean): void {
   }
 }
 
-/** Back of the head: a rounded hair-covered skull with crown sheen + nape, no face. */
+/** 后脑勺：一个圆润的、被头发覆盖的头骨，带顶冠光泽 + 后颈，没有脸。 */
 function drawHeadBack(buf: Buf, r: Recipe): void {
   const s = SKIN[r.skin];
   if (r.hair === 'styleBald') { drawHeadBackBald(buf, r); return; }
   const [hi, base, sh] = shades(r.hairc);
-  // rounded skull silhouette (narrow at crown + nape, full through the middle)
+  // 圆润头骨轮廓（顶冠与后颈收窄，中部饱满）
   const rows: [number, number, number][] = [
     [2, 6, 11], [3, 5, 12], [4, 4, 13], [5, 4, 13], [6, 4, 13], [7, 4, 13], [8, 4, 13],
     [9, 4, 13], [10, 4, 13], [11, 4, 13], [12, 4, 13], [13, 5, 12], [14, 6, 11],
   ];
   for (const [y, a, b] of rows) rect(buf, a, y, b, y, base);
-  // long styles drape down the sides past the head
+  // 长发型式垂过头部两侧
   const len = r.hair === 'styleFrame' ? (r.hairargs?.length ?? 17)
             : r.hair === 'styleMessy' ? (r.hairargs?.length ?? 9) : 0;
   for (let y = 11; y <= len; y++) { set(buf, HX0 - 1, y, base); set(buf, HX0, y, base); set(buf, HX1, y, base); set(buf, HX1 + 1, y, base); }
-  // roundness: darken the side edges and the nape
+  // 圆润度：压暗侧边与后颈
   for (let y = 4; y <= 12; y++) { set(buf, 4, y, sh); set(buf, 13, y, sh); }
   for (const [x, y] of [[5, 3], [12, 3], [5, 13], [12, 13], [6, 14], [11, 14]] as const) set(buf, x, y, sh);
-  // crown sheen (rounded top catching the light) + subtle center part
+  // 顶冠光泽（圆润顶部接光）+ 一条细微中分线
   for (const [x, y] of [[7, 2], [8, 2], [9, 2], [10, 2], [7, 3], [8, 3], [9, 3]] as const) set(buf, x, y, hi);
-  for (let y = 4; y <= 11; y++) set(buf, 9, y, hi);   // sheen down the crown
-  for (let y = 4; y <= 12; y++) set(buf, 8, y, sh);   // part line
-  // nape + neck (skin)
+  for (let y = 4; y <= 11; y++) set(buf, 9, y, hi);   // 光泽顺顶冠而下
+  for (let y = 4; y <= 12; y++) set(buf, 8, y, sh);   // 分界线
+  // 后颈 + 脖子（肤色）
   rect(buf, 7, 14, 10, 14, sh);
   rect(buf, 7, 15, 10, 17, s.sh);
   rect(buf, 7, 15, 9, 15, s.base);
 }
 
-/** Back of a bald head: a skin skull with a sheen and a low hair fringe ring. */
+/** 秃头后脑勺：一个带光泽的肤色头骨 + 一圈低发际线。 */
 function drawHeadBackBald(buf: Buf, r: Recipe): void {
   const s = SKIN[r.skin];
   const [shi, sbase, ssh] = shades(s.base, 1.1, 0.82);
@@ -434,11 +431,11 @@ function drawHeadBackBald(buf: Buf, r: Recipe): void {
   for (const [y, a, b] of rows) rect(buf, a, y, b, y, sbase);
   for (let y = 4; y <= 12; y++) { set(buf, 4, y, ssh); set(buf, 13, y, ssh); }
   for (const [x, y] of [[7, 2], [8, 2], [9, 2], [8, 3], [9, 4], [9, 5]] as const) set(buf, x, y, shi);
-  // low hair fringe ring around the back/sides
+  // 背面/两侧的低发际线环
   const [, base, sh] = shades(r.hairc);
   for (let x = 4; x <= 13; x++) { set(buf, x, 11, base); set(buf, x, 12, base); }
   for (const x of [4, 13]) { set(buf, x, 11, sh); set(buf, x, 12, sh); }
-  // nape + neck (skin)
+  // 后颈 + 脖子（肤色）
   rect(buf, 7, 14, 10, 14, s.sh);
   rect(buf, 7, 15, 10, 17, s.sh);
   rect(buf, 7, 15, 9, 15, s.base);
@@ -468,26 +465,25 @@ interface Recipe {
   skin: string; hairc: RGB; hair: HairStyle; hairargs?: HairArgs;
   cloth: Cloth; c1: RGB; c2?: RGB; tie?: RGB; pants?: RGB;
   brow?: Brow; mouth?: Mouth; blush?: boolean; facial?: Facial; glasses?: boolean;
-  /** Bigger, lashed eyes for a more feminine, expressive face. */
+  /** 更大、带睫毛的眼睛，营造更女性化、更有表现力的脸。 */
   lashes?: boolean;
-  /** Heavier build: chubby cheeks, a double chin, and a wider torso. */
+  /** 更壮的体格：圆脸颊、双下巴、更宽的躯干。 */
   heavy?: boolean;
 }
 
-// Puff the lower face into round cheeks + a double chin so a character reads as
-// heavier. Runs after drawHead (adds skin at the jaw) and is safe before the
-// face features, which sit higher (eyes y9, mouth y14).
+// 把下半张脸鼓起成圆脸颊 + 双下巴，让角色读起来更壮。在 drawHead 之后跑
+// （在颚线处加肤色），并且在脸部五官（眼睛 y9、嘴 y14）之前跑是安全的。
 function drawHeavyFace(buf: Buf, skin: string): void {
   const s = SKIN[skin];
-  // Chubby cheeks: bulge the jaw outward past the normal x4..13 head box.
+  // 圆脸颊：把颚线鼓出正常的 x4..13 头部盒之外。
   for (let y = 11; y <= 15; y++) { set(buf, HX0 - 1, y, s.base); set(buf, HX1 + 1, y, s.base); }
   set(buf, HX0 - 1, 15, s.sh); set(buf, HX1 + 1, 15, s.sh);
-  // Fuller, rounder lower jaw.
+  // 更饱满、更圆的下颚。
   for (const x of [5, 6, 11, 12]) set(buf, x, 16, s.base);
-  // Double chin: a second rounded roll under the jaw.
+  // 双下巴：颚下第二道圆滚滚的肉褶。
   rect(buf, 6, 17, 11, 18, s.base);
   for (const x of [6, 7, 8, 9, 10, 11]) set(buf, x, 18, s.sh);
-  set(buf, 7, 17, s.sh); set(buf, 10, 17, s.sh); // crease shadow between chin + roll
+  set(buf, 7, 17, s.sh); set(buf, 10, 17, s.sh); // 下巴与肉褶之间的褶痕阴影
 }
 
 const RECIPES: Record<OfficeCharacterName, Recipe> = {
@@ -524,7 +520,7 @@ function defaultPants(r: Recipe): RGB {
   return r.cloth === 'suit' ? shades(r.c1)[2] : [54, 56, 70];
 }
 
-/** Portrait bust: shoulders-height clothing + front head group. */
+/** 肖像半身像：及肩服装 + 正面头部组合。 */
 function compose(r: Recipe): Buf {
   CUR_W = PORTRAIT_W; CUR_H = PORTRAIT_H;
   const buf = new Uint8ClampedArray(PORTRAIT_W * PORTRAIT_H * 4);
@@ -535,7 +531,7 @@ function compose(r: Recipe): Buf {
   return buf;
 }
 
-/** Full-body 18×32 scene sprite. `back=false` reuses the portrait's exact face. */
+/** 全身体 18×32 场景精灵。`back=false` 复用肖像的精确实脸。 */
 function composeScene(r: Recipe, phase: number, back: boolean): Buf {
   CUR_W = SCENE_W; CUR_H = SCENE_H;
   const buf = new Uint8ClampedArray(SCENE_W * SCENE_H * 4);
@@ -561,7 +557,7 @@ function getBuf(name: OfficeCharacterName): Buf {
 
 export interface SceneFrames { front: Buf[]; back: Buf[]; }
 
-/** Walk-phase frames (stand, step-L, step-R) for the in-scene sprite, front + back. */
+/** 场景内精灵的行走相位帧（站立、左步、右步），正面 + 背面。 */
 export function sceneFrameBufs(name: OfficeCharacterName): SceneFrames {
   let frames = sceneCache.get(name);
   if (!frames) {
@@ -575,10 +571,10 @@ export function sceneFrameBufs(name: OfficeCharacterName): SceneFrames {
   return frames;
 }
 
-/** Paint a character's procedural portrait onto `ctx`, nearest-neighbor at `scale`. */
+/** 把角色的程序化肖像画到 `ctx` 上，以 `scale` 最近邻放大。 */
 export function paintPortrait(ctx: CanvasRenderingContext2D, name: OfficeCharacterName, scale = 2): void {
   const buf = getBuf(name);
-  // Stage at 1× on an offscreen canvas, then blit scaled with smoothing off.
+  // 先在离屏画布上以 1× 暂存，再关掉平滑放大 blit。
   const stage = document.createElement('canvas');
   stage.width = PORTRAIT_W; stage.height = PORTRAIT_H;
   const sctx = stage.getContext('2d')!;

--- a/src/renderer/src/scene/office/themeLoader.ts
+++ b/src/renderer/src/scene/office/themeLoader.ts
@@ -1,11 +1,10 @@
-// Theme loader — resolves a ThemeConfig into a ready-to-render map.
+// 主题加载器——把 ThemeConfig 解析成可直接渲染的地图。
 //
-// Phase 0 keeps this thin: it parses the theme's Tiled JSON and patches the
-// appended tileset atlases with their inline metadata (the same patch the
-// office scene did inline as resolveMap()). The async `loadTheme` signature is
-// deliberate headroom for later phases, where a show bundle may be fetched and
-// validated before it's handed to the scene; on any failure it falls back to
-// the office theme so a bad/absent bundle never breaks the floor (report §E).
+// Phase 0 保持轻薄：解析主题的 Tiled JSON，并把追加的 tileset 图集补上它们
+// 的行内元数据（与办公场景在 resolveMap() 里内联做的补丁相同）。异步的
+// `loadTheme` 签名是为后续阶段刻意留的余量——届时节目包在交给场景前可能会
+// 被拉取并校验；任何失败都回退到办公主题，让坏/缺失的包永远不弄坏楼层
+// （报告 §E）。
 
 import type { TiledMap } from './TiledMapRenderer';
 import {
@@ -15,30 +14,30 @@ import {
   type ThemeId,
 } from './themeRegistry';
 
-/** Parse a theme's raw Tiled JSON and patch its tileset array.
- *  `embedded` atlases keep the map's own inline metadata; the rest are replaced
- *  by the theme's inline metadata (firstgid + image dimensions). The result's
- *  tileset order matches the texture-load order (texture[i] ↔ tilesets[i]). */
+/** 解析主题的原始 Tiled JSON 并修补其 tileset 数组。
+ *  `embedded` 图集保留地图自身的行内元数据；其余被主题的行内元数据
+ *  （firstgid + 图片尺寸）替换。结果的 tileset 顺序与纹理加载顺序一致
+ *  （texture[i] ↔ tilesets[i]）。 */
 export function resolveThemeMap(theme: ThemeConfig): TiledMap {
   const m = JSON.parse(theme.mapRaw) as TiledMap;
   return {
     ...m,
     tilesets: theme.tilesets.map((t, i) => {
       if (t.embedded) return m.tilesets[i];
-      // Strip the renderer-only fields (url/embedded); the rest is Tiled metadata.
+      // 剥掉仅渲染器使用的字段（url/embedded）；其余是 Tiled 元数据。
       const { url: _url, embedded: _embedded, ...meta } = t;
       return meta as TiledMap['tilesets'][number];
     }),
   };
 }
 
-/** The ordered tileset image URLs to load as textures, matching the map's
- *  tileset order (so texture[i] lines up with tilesets[i]). */
+/** 要作为纹理加载的有序 tileset 图片 URL，与地图的 tileset 顺序一致
+ *  （这样 texture[i] 与 tilesets[i] 对齐）。 */
 export function themeTilesetUrls(theme: ThemeConfig): string[] {
   return theme.tilesets.map((t) => t.url);
 }
 
-/** Light validation: the theme's map must parse and carry sane dimensions. */
+/** 轻量校验：主题的地图必须能解析并携带合理的尺寸。 */
 function isThemeRenderable(theme: ThemeConfig): boolean {
   try {
     const m = JSON.parse(theme.mapRaw) as TiledMap;
@@ -52,9 +51,8 @@ function isThemeRenderable(theme: ThemeConfig): boolean {
   }
 }
 
-/** Resolve a theme id to a renderable ThemeConfig. Async by design (later
- *  phases may fetch a show bundle here); falls back to the office theme if the
- *  requested theme is missing or its map won't parse. */
+/** 把主题 id 解析成可渲染的 ThemeConfig。刻意设计为异步（后续阶段可能在这里
+ *  拉取节目包）；请求的主题缺失或其地图无法解析时回退到办公主题。 */
 export async function loadTheme(id: ThemeId): Promise<ThemeConfig> {
   const theme = getTheme(id);
   if (!isThemeRenderable(theme)) {

--- a/src/renderer/src/scene/office/themeRegistry.ts
+++ b/src/renderer/src/scene/office/themeRegistry.ts
@@ -1,16 +1,14 @@
-// Theme registry — the pluggable "office theme" contract.
+// 主题注册表——可插拔的“办公室主题”契约。
 //
-// Phase 0 of the TV-show-offices feature (card tvshow-phase0-abstraction):
-// extract the ~40% of constants that were hard-coded inside OfficeFloor.tsx
-// (errand spots, coffee-economy tile coords, prop anchors, seat names, tileset
-// URLs, palette, monitor gids) into a ThemeConfig so the scene becomes
-// swappable per show. This phase ships the EXISTING office unchanged as
-// `theme: 'office'`: every value below is copied byte-for-byte from the old
-// in-file literals, so the office renders and behaves identically.
+// 电视剧办公室功能的 Phase 0（卡片 tvshow-phase0-abstraction）：把原来硬编码
+// 在 OfficeFloor.tsx 里约 40% 的常量（跑腿点、咖啡经济瓦片坐标、道具锚点、
+// 座位名、tileset URL、调色板、显示器 gid）抽成 ThemeConfig，让场景可按剧集
+// 替换。本阶段按原样发布现有办公室为 `theme: 'office'`：下面每个值都是从旧
+// 文件内字面量逐字复制来的，所以办公室渲染与行为完全一致。
 //
-// The engine (TiledMapRenderer / BFS pathfinding / Camera / sprite animation)
-// is already fully generic and needs no change. cast.ts is read-only here
-// (uncommitted human WIP) — the office theme references its existing exports.
+// 引擎（TiledMapRenderer / BFS 寻路 / Camera / 精灵动画）已经完全通用，无需
+// 改动。cast.ts 在这里是只读的（未提交的人类 WIP）——office 主题引用它已有
+// 的导出。
 
 import type { Texture } from 'pixi.js';
 import { colors } from '@/design/tokens';
@@ -25,12 +23,12 @@ import {
 import officeTilesetUrl from '@/assets/tilesets/office-tileset.png?url';
 import a5FloorsWallsUrl from '@/assets/tilesets/a5-office-floors-walls.png?url';
 import interiorsUrl from '@/assets/tilesets/interiors.png?url';
-// .tmj is Tiled JSON; imported as raw text and parsed by the loader.
+// .tmj 是 Tiled JSON；作为原始文本导入，由加载器解析。
 import officeMapRaw from '@/assets/maps/office.tmj?raw';
 import brooklyn99MapRaw from '@/assets/maps/brooklyn99.tmj?raw';
 
-/** Theme identifiers. Only `office` exists in Phase 0; the five TV-show themes
- *  (friends, brooklyn99, siliconvalley, got, hogwarts) land in later phases. */
+/** 主题标识符。Phase 0 只有 `office`；五个电视剧主题（friends、
+ *  brooklyn99、siliconvalley、got、hogwarts）在后续阶段落地。 */
 export type ThemeId =
   | 'office'
   | 'friends'
@@ -42,13 +40,13 @@ export type ThemeId =
 export interface Tile { x: number; y: number; }
 export type Facing = 'up' | 'down' | 'left' | 'right';
 
-/** Kinds of small idle errands around the office (incl. plant watering).
- *  'smoke' is the boss special: cigar at the open window, god only. */
+/** 办公室周围的小型空闲跑腿种类（含浇花）。'smoke' 是老板特供：在开着的
+ *  窗边抽雪茄，只有 god。 */
 export type ErrandKind =
   | 'water' | 'window' | 'dispenser' | 'fridge' | 'shelf' | 'bin' | 'smoke';
 
-/** One idle-errand anchor: a stand tile + facing, an `fx` tile for the ambient
- *  animation, a duration, and an optional god-only restriction. */
+/** 一个空闲跑腿锚点：一个站立瓦片 + 朝向、一个用于氛围动画的 `fx` 瓦片、
+ *  一段时长，以及可选的神明专属限制。 */
 export interface ErrandSpot {
   kind: ErrandKind;
   stand: Tile;
@@ -58,9 +56,9 @@ export interface ErrandSpot {
   godOnly?: boolean;
 }
 
-/** One tileset atlas + its placement in the global gid space. `embedded` marks
- *  the atlas whose metadata already lives inline in the map's own `tilesets[0]`
- *  (the loader keeps the map's copy and only patches the appended atlases). */
+/** 一个 tileset 图集及其在全局 gid 空间里的位置。`embedded` 标记元数据已
+ *  行内存在于地图自身 `tilesets[0]` 的图集（加载器保留地图的副本，只修补
+ *  追加的图集）。 */
 export interface TilesetEntry {
   url: string;
   embedded?: boolean;
@@ -74,17 +72,17 @@ export interface TilesetEntry {
   tilecount?: number;
 }
 
-/** Desk-monitor overlay gids. The map paints an OFF monitor block; DeskScreen
- *  overlays the matching ON tiles while the desk's agent is seated. */
+/** 桌面显示器覆盖 gid。地图画一块 OFF 显示器；DeskScreen 在桌子的 agent
+ *  坐下时把匹配的 ON 瓦片叠上去。 */
 export interface MonitorConfig {
-  /** gid of the OFF monitor block's top-left tile, as painted in the map. */
+  /** OFF 显示器块左上瓦片的 gid，按地图所画。 */
   offTopLeftGid: number;
-  /** Matching ON tiles as [gid, dx, dy] relative to the block's top-left. */
+  /** 匹配的 ON 瓦片，为相对块左上角的 [gid, dx, dy]。 */
   onGids: ReadonlyArray<readonly [number, number, number]>;
 }
 
-/** The coffee economy's fixed tiles: sideboard (mug rack) → counter machine →
- *  sink → back to the sideboard. `maxCups` caps the clean-mug stock. */
+/** 咖啡经济的固定瓦片：餐边柜（马克杯架）→ 柜台咖啡机 → 水槽 → 回到
+ *  餐边柜。`maxCups` 限制干净马克杯的库存。 */
 export interface CoffeeConfig {
   trayTile: Tile;
   trayStand: Tile;
@@ -94,42 +92,42 @@ export interface CoffeeConfig {
   maxCups: number;
 }
 
-/** Clickable prop anchors (tile coords). calendar → TRIGGERS, boards → TASKS,
- *  clock → CLOSING TIME. */
+/** 可点击道具锚点（瓦片坐标）。calendar → TRIGGERS，boards → TASKS，
+ *  clock → CLOSING TIME。 */
 export interface AnchorConfig {
   calendar: Tile;
   boards: Tile;
   clock: Tile;
 }
 
-/** Theme palette. `background` is the canvas clear color; `noteColors` are the
- *  kanban note colors keyed by task status. */
+/** 主题调色板。`background` 是画布清除色；`noteColors` 是按任务状态索引的
+ *  kanban 便签颜色。 */
 export interface PaletteConfig {
   background: number;
   noteColors: Record<string, number>;
 }
 
-/** Per-theme cast loader — the indirection point so a future show can swap its
- *  own roster + sprite frames. The office theme points at cast.ts's exports. */
+/** 每主题角色群加载器——未来的剧集可以借此替换自己的名册 + 精灵帧。
+ *  office 主题指向 cast.ts 的导出。 */
 export interface ThemeCast {
   byName: Record<string, CastMember>;
   getFrames: (name: string) => Promise<Texture[][]>;
   defaultCharacter: string;
 }
 
-/** The full contract a theme must supply. See report §A (theme contract). */
+/** 主题必须提供的完整契约。见报告 §A（主题契约）。 */
 export interface ThemeConfig {
   id: ThemeId;
-  /** Raw Tiled JSON text; parsed + tileset-patched by themeLoader. */
+  /** 原始 Tiled JSON 文本；由 themeLoader 解析并修补 tileset。 */
   mapRaw: string;
-  /** Ordered atlases — order matches both the texture load order and the map's
-   *  tileset array (texture[i] ↔ tilesets[i]). */
+  /** 有序图集——顺序同时匹配纹理加载顺序与地图的 tileset 数组
+   *  （texture[i] ↔ tilesets[i]）。 */
   tilesets: TilesetEntry[];
-  /** Desk-claim order, by spawn-point name (seat 0 = god / desk-ceo). */
+  /** 桌面认领顺序，按生成点名（座位 0 = god / desk-ceo）。 */
   primarySeatNames: string[];
-  /** Paired café table seats, in order. */
+  /** 成对的咖啡桌座位，按顺序。 */
   cafeSeatNames: string[];
-  /** Café standing spots: [spawn-point name, kind]. */
+  /** 咖啡厅站立点：[生成点名, kind]。 */
   cafeStands: ReadonlyArray<readonly [string, 'coffee' | 'vending']>;
   coffee: CoffeeConfig;
   anchors: AnchorConfig;
@@ -139,13 +137,13 @@ export interface ThemeConfig {
   cast: ThemeCast;
 }
 
-/** The existing office, expressed as a theme. Values are copied verbatim from
- *  the former in-file constants in OfficeFloor.tsx / DeskScreen.ts. */
+/** 现有办公室，表达为一个主题。值逐字复制自 OfficeFloor.tsx / DeskScreen.ts
+ *  里此前的文件内常量。 */
 export const OFFICE_THEME: ThemeConfig = {
   id: 'office',
   mapRaw: officeMapRaw,
   tilesets: [
-    // office-tileset.png — embedded in the map (firstgid 1); keep the map's copy.
+    // office-tileset.png — 嵌入在地图中（firstgid 1）；保留地图的副本。
     { url: officeTilesetUrl, embedded: true },
     { url: a5FloorsWallsUrl, firstgid: 513, image: 'a5', imagewidth: 256, imageheight: 512, tilewidth: 16, tileheight: 16, columns: 16, tilecount: 512 },
     { url: interiorsUrl, firstgid: 1025, image: 'interiors', imagewidth: 256, imageheight: 1424, tilewidth: 16, tileheight: 16, columns: 16, tilecount: 1424 },
@@ -163,10 +161,10 @@ export const OFFICE_THEME: ThemeConfig = {
     ['cafe-stand-vending', 'vending'],
   ],
   coffee: {
-    trayTile: { x: 29, y: 15 },     // the sideboard (counter piece)
+    trayTile: { x: 29, y: 15 },     // 餐边柜（柜台件）
     trayStand: { x: 29, y: 16 },
-    machineStand: { x: 26, y: 20 }, // below the counter machine
-    sinkTile: { x: 28, y: 18 },     // free counter top, right end
+    machineStand: { x: 26, y: 20 }, // 柜台咖啡机下方
+    sinkTile: { x: 28, y: 18 },     // 空柜台顶，右端
     sinkStand: { x: 28, y: 20 },
     maxCups: 4,
   },
@@ -176,25 +174,25 @@ export const OFFICE_THEME: ThemeConfig = {
     clock: { x: 1, y: 1 },
   },
   errandSpots: [
-    // plants (droplets ride on the character via startWatering)
+    // 植物（水滴经 startWatering 骑在角色上）
     { kind: 'water', stand: { x: 2, y: 20 }, facing: 'left', fx: { x: 1, y: 20 }, duration: 4.5 },
     { kind: 'water', stand: { x: 22, y: 20 }, facing: 'right', fx: { x: 23, y: 20 }, duration: 4.5 },
     { kind: 'water', stand: { x: 30, y: 20 }, facing: 'right', fx: { x: 31, y: 20 }, duration: 4.5 },
-    // the CEO office is the god's domain: its plant, window, cigar. Workers
-    // never set foot in there for errands.
+    // CEO 办公室是 god 的地盘：它的植物、窗户、雪茄。普通员工绝不会为跑腿
+    // 踏进那里。
     { kind: 'water', stand: { x: 6, y: 4 }, facing: 'up', fx: { x: 6, y: 3 }, duration: 4.5, godOnly: true },
     { kind: 'smoke', stand: { x: 2, y: 3 }, facing: 'up', fx: { x: 2, y: 1 }, duration: 18, godOnly: true },
     { kind: 'water', stand: { x: 17, y: 4 }, facing: 'up', fx: { x: 17, y: 3 }, duration: 4.5 },
-    // the two public wall windows — wind streaks drift into the room
+    // 两扇公共墙窗——风痕飘进房间
     { kind: 'window', stand: { x: 10, y: 3 }, facing: 'up', fx: { x: 10, y: 1 }, duration: 5 },
     { kind: 'window', stand: { x: 15, y: 3 }, facing: 'up', fx: { x: 14, y: 1 }, duration: 5 },
-    // water dispensers (hallway + the top-right corner one)
+    // 饮水机（走廊 + 右上角那台）
     { kind: 'dispenser', stand: { x: 16, y: 3 }, facing: 'down', fx: { x: 16, y: 4 }, duration: 3.5 },
     { kind: 'dispenser', stand: { x: 32, y: 4 }, facing: 'up', fx: { x: 32, y: 3 }, duration: 3.5 },
-    // the café fridge (door light spills out) + the shelf beside it
+    // 咖啡厅冰箱（门缝灯泄出）+ 它旁边的架子
     { kind: 'fridge', stand: { x: 29, y: 20 }, facing: 'up', fx: { x: 29, y: 19 }, duration: 3.2 },
     { kind: 'shelf', stand: { x: 30, y: 20 }, facing: 'up', fx: { x: 30, y: 18 }, duration: 4 },
-    // garbage bins (entrance + café) — a paper ball arcs in
+    // 垃圾桶（入口 + 咖啡厅）——纸团弧线飞入
     { kind: 'bin', stand: { x: 18, y: 20 }, facing: 'left', fx: { x: 17, y: 20 }, duration: 2.6 },
     { kind: 'bin', stand: { x: 31, y: 16 }, facing: 'right', fx: { x: 32, y: 16 }, duration: 2.6 },
   ],
@@ -216,25 +214,24 @@ export const OFFICE_THEME: ThemeConfig = {
   },
 };
 
-/** Brooklyn Nine-Nine — the 99th precinct (TV-show offices Phase 2, structure).
- *  The map (brooklyn99.tmj) is a precinct bullpen: Captain Holt's glass office
- *  in the back corner (`desk-ceo`), an 8-desk detective bullpen (`pc-1..8`), a
- *  briefing room (boardroom zone) + break room (cafeteria zone) with the coffee
- *  economy. PLACEHOLDER ART: the map reuses the office tileset gids, so the
- *  tilesets / monitor / palette / cast below reuse the office theme verbatim —
- *  Pam's license-clean B99 tileset + cast likenesses (§C/§D) drop into those
- *  same seams later. Only the layout-bound anchors (seats, café, coffee, props,
- *  errands) are authored to brooklyn99.tmj's own coordinates. */
+/** Brooklyn Nine-Nine —— 99 分局（电视剧办公室功能 Phase 2，结构）。
+ *  地图（brooklyn99.tmj）是一个分局大厅：后角是 Holt 警监的玻璃办公室
+ *  （`desk-ceo`），8 桌探员大厅（`pc-1..8`），一个案情简报室（boardroom
+ *  区域）+ 带咖啡经济的休息室（cafeteria 区域）。占位美术：地图复用办公室
+ *  tileset 的 gid，所以下面的 tilesets / monitor / palette / cast 逐字复用
+ *  office 主题——Pam 的许可干净 B99 tileset + 角色形象（§C/§D）稍后落入
+ *  同样的接缝。只有布局绑定的锚点（座位、咖啡厅、咖啡、道具、跑腿）按
+ *  brooklyn99.tmj 自己的坐标编写。 */
 export const BROOKLYN99_THEME: ThemeConfig = {
   id: 'brooklyn99',
   mapRaw: brooklyn99MapRaw,
-  // PLACEHOLDER: brooklyn99.tmj uses the office gid space, so the same atlases
-  // (office-tileset embedded @1, a5 @513, interiors @1025) resolve every tile.
+  // 占位：brooklyn99.tmj 使用办公室 gid 空间，所以同一批图集
+  // （office-tileset 嵌入 @1、a5 @513、interiors @1025）解析所有瓦片。
   tilesets: OFFICE_THEME.tilesets,
   primarySeatNames: [
-    'desk-ceo',                                            // Captain Holt's glass office
-    'pc-1', 'pc-2', 'pc-3', 'pc-4',                        // bullpen — front row
-    'pc-5', 'pc-6', 'pc-7', 'pc-8',                        // bullpen — back row
+    'desk-ceo',                                            // Holt 警监的玻璃办公室
+    'pc-1', 'pc-2', 'pc-3', 'pc-4',                        // 大厅——前排
+    'pc-5', 'pc-6', 'pc-7', 'pc-8',                        // 大厅——后排
   ],
   cafeSeatNames: ['cafe-seat-1', 'cafe-seat-2', 'cafe-seat-3', 'cafe-seat-4'],
   cafeStands: [
@@ -250,50 +247,49 @@ export const BROOKLYN99_THEME: ThemeConfig = {
     maxCups: 4,
   },
   anchors: {
-    calendar: { x: 4, y: 1 },   // briefing-room top wall → TRIGGERS
-    boards: { x: 14, y: 1 },    // over the bullpen → TASKS
-    clock: { x: 1, y: 1 },      // top-left corner → CLOSING TIME
+    calendar: { x: 4, y: 1 },   // 简报室顶墙 → TRIGGERS
+    boards: { x: 14, y: 1 },    // 大厅上方 → TASKS
+    clock: { x: 1, y: 1 },      // 左上角 → CLOSING TIME
   },
-  // Placeholder errand anchors authored to brooklyn99.tmj's open floor (verified
-  // walkable against the map's collision layer + desk stamps). The godOnly spots
-  // sit inside Holt's glass office.
+  // 占位跑腿锚点，按 brooklyn99.tmj 的开阔地板编写（已对照地图碰撞层 +
+  // 桌子印章验证可行走）。godOnly 点位于 Holt 的玻璃办公室内。
   errandSpots: [
-    // public plants around the bullpen
+    // 大厅周围的公共植物
     { kind: 'water', stand: { x: 2, y: 13 }, facing: 'left', fx: { x: 1, y: 13 }, duration: 4.5 },
     { kind: 'water', stand: { x: 24, y: 15 }, facing: 'right', fx: { x: 25, y: 15 }, duration: 4.5 },
     { kind: 'water', stand: { x: 13, y: 15 }, facing: 'down', fx: { x: 13, y: 16 }, duration: 4.5 },
-    // Captain Holt's glass office — god's domain (plant + cigar at the window)
+    // Holt 警监的玻璃办公室——god 的地盘（植物 + 窗边雪茄）
     { kind: 'water', stand: { x: 28, y: 6 }, facing: 'up', fx: { x: 28, y: 5 }, duration: 4.5, godOnly: true },
     { kind: 'smoke', stand: { x: 34, y: 2 }, facing: 'up', fx: { x: 34, y: 0 }, duration: 18, godOnly: true },
-    // public windows on the north wall — wind streaks drift in
+    // 北墙的公共窗户——风痕飘入
     { kind: 'window', stand: { x: 14, y: 1 }, facing: 'up', fx: { x: 14, y: 0 }, duration: 5 },
     { kind: 'window', stand: { x: 22, y: 1 }, facing: 'up', fx: { x: 22, y: 0 }, duration: 5 },
-    // water dispensers (bullpen + entrance corridor)
+    // 饮水机（大厅 + 入口走廊）
     { kind: 'dispenser', stand: { x: 8, y: 15 }, facing: 'down', fx: { x: 8, y: 16 }, duration: 3.5 },
     { kind: 'dispenser', stand: { x: 17, y: 20 }, facing: 'down', fx: { x: 17, y: 21 }, duration: 3.5 },
-    // break-room fridge + shelf (by the coffee economy)
+    // 休息室冰箱 + 架子（挨着咖啡经济）
     { kind: 'fridge', stand: { x: 29, y: 21 }, facing: 'up', fx: { x: 29, y: 20 }, duration: 3.2 },
     { kind: 'shelf', stand: { x: 34, y: 18 }, facing: 'up', fx: { x: 34, y: 17 }, duration: 4 },
-    // garbage bins (entrance + break room)
+    // 垃圾桶（入口 + 休息室）
     { kind: 'bin', stand: { x: 19, y: 20 }, facing: 'left', fx: { x: 18, y: 20 }, duration: 2.6 },
     { kind: 'bin', stand: { x: 34, y: 15 }, facing: 'up', fx: { x: 34, y: 14 }, duration: 2.6 },
   ],
-  // PLACEHOLDER: brooklyn99.tmj paints the office desk stamp (monitor gid 365).
+  // 占位：brooklyn99.tmj 画的是办公室桌面印章（显示器 gid 365）。
   monitor: OFFICE_THEME.monitor,
-  // PLACEHOLDER: office palette + cast until Pam's B99 art (§C/§D) lands.
+  // 占位：在 Pam 的 B99 美术（§C/§D）落地前用 office 调色板 + 角色群。
   palette: OFFICE_THEME.palette,
   cast: OFFICE_THEME.cast,
 };
 
-/** All registered themes. Phase 0 ships only the office; show themes register
- *  here as their content lands (Phase 2). */
+/** 所有已注册主题。Phase 0 只发布 office；剧集主题随内容落地（Phase 2）
+ *  在此注册。 */
 export const THEMES: Partial<Record<ThemeId, ThemeConfig>> = {
   office: OFFICE_THEME,
   brooklyn99: BROOKLYN99_THEME,
 };
 
-/** Look up a theme by id, falling back to the office theme if unknown/missing
- *  (a bad/absent show bundle must never break the floor — see report §E). */
+/** 按 id 查主题，未知/缺失时回退到 office 主题（坏/缺失的剧集包绝不能弄坏
+ *  楼层——见报告 §E）。 */
 export function getTheme(id: ThemeId): ThemeConfig {
   return THEMES[id] ?? OFFICE_THEME;
 }

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -1,5 +1,5 @@
-// Mirrors src/main/config.ts. Kept as a renderer-side type-only module
-// so we don't have to reach into the preload package to type-check.
+// 镜像 src/main/config.ts。作为渲染端只类型的模块保留，这样我们不必伸手
+// 进 preload 包来做类型检查。
 import {
   AGENT_PROVIDER_PRESETS,
   providerPreset,
@@ -23,7 +23,7 @@ export {
   type AgentProvider
 };
 
-/** A recurring auto-dispatched mission (mirrors src/main/config.ts). */
+/** 周期性自动派发的任务（镜像 src/main/config.ts）。 */
 export interface ScheduledMission {
   id: string;
   label: string;
@@ -37,7 +37,7 @@ export interface ScheduledMission {
   quietThresholdMs?: number;
 }
 
-/** Circuit-breaker thresholds (mirrors src/main/config.ts CircuitBreakerConfig). */
+/** 熔断器阈值（镜像 src/main/config.ts 的 CircuitBreakerConfig）。 */
 export interface CircuitBreakerConfig {
   enabled?: boolean;
   hardStop?: boolean;
@@ -46,7 +46,7 @@ export interface CircuitBreakerConfig {
   tokenVelocityPerMin?: number;
 }
 
-/** Enterprise Knowledge Graph config (mirrors src/main/config.ts KnowledgeGraphConfig). */
+/** 企业知识图谱配置（镜像 src/main/config.ts 的 KnowledgeGraphConfig）。 */
 export interface KnowledgeGraphConfig {
   enabled?: boolean;
   rootPath?: string;
@@ -54,28 +54,28 @@ export interface KnowledgeGraphConfig {
 
 export interface HarnessConfig {
   onboardingComplete: boolean;
-  /** Self-identified audience from the first onboarding screen ('technical' vs
-   *  'non-technical') — drives the copy register across onboarding. Mirrors
-   *  src/main/config.ts. */
+  /** 首个 onboarding 屏幕自报的受众（'technical' 对 'non-technical'）——
+   *  驱动整个 onboarding 的文案语气。镜像 src/main/config.ts。 */
   audience?: 'technical' | 'non-technical';
   harnessHome: string | null;
-  /** Recently-opened hive home folders (most-recent first) for the launch picker.
-   *  Mirrors src/main/config.ts. */
+  /** 最近打开的 hive 主目录（最近的在前），供启动选择器使用。
+   *  镜像 src/main/config.ts。 */
   recentHives?: string[];
   registeredRepos: string[];
   autoMode: boolean;
-  /** May the orchestrator ("Michael") spin up agents on its own? Default FALSE,
-   *  so an absent value reads as off. Mirrors src/main/config.ts. */
+  /** 编排者（“Michael”）能否自行拉起 agent？默认 FALSE，所以缺省值读作
+   *  关闭。镜像 src/main/config.ts。 */
   orchestratorMaySpawn?: boolean;
   defaultCommand: string;
-  /** Default model for newly spawned agents (e.g. 'claude-sonnet-4-6[1m]'); unset = CLI default. */
+  /** 新 spawn agent 的默认模型（例如 'claude-sonnet-4-6[1m]'）；未设置 =
+   *  CLI 默认。 */
   defaultModel?: string;
-  /** Which provider+model powers the GOD orchestrator ("Michael"). Default
-   *  'claude' / 'claude-opus-4-8'. Mirrors src/main/config.ts. */
+  /** 哪个 provider+model 为 GOD 编排者（“Michael”）供电。默认
+   *  'claude' / 'claude-opus-4-8'。镜像 src/main/config.ts。 */
   godProvider?: AgentProvider;
   godModel?: string;
-  /** Per-server consent for the default MCP bundle, keyed by catalog id (mirrors
-   *  src/main/config.ts; seeded from MCP_CATALOG). */
+  /** 默认 MCP 捆绑的按服务器同意，以目录 id 为键（镜像 src/main/config.ts；
+   *  由 MCP_CATALOG 播种）。 */
   mcpDefaults?: { [id: string]: { enabled: boolean } };
   semanticMemory: boolean;
   embeddingModel: 'minilm' | 'embeddinggemma';
@@ -83,98 +83,94 @@ export interface HarnessConfig {
   opsStandupSeeded?: boolean;
   heartbeatSeeded?: boolean;
   notifications?: boolean;
-  /** Opt-in "strong keep-alive": escalates the in-app power blocker to
-   *  prevent-display-sleep so scheduled missions/terminals keep firing on time
-   *  while away (battery cost; best on AC). Default off = survive + catch up on
-   *  resume. Mirrors the main-process field (src/main/config.ts). */
+  /** 选用的“强力保活”：把应用内电源阻止器升级为阻止显示器睡眠，让定时
+   *  任务/终端在你离开时也能准点触发（耗电；最好插电）。默认关闭 =
+   *  恢复后补跑。镜像主进程字段（src/main/config.ts）。 */
   strongKeepalive?: boolean;
-  /** Auto-update from GitHub releases (default ON; Settings → General). */
+  /** 从 GitHub releases 自动更新（默认开；设置 → 通用）。 */
   autoUpdate?: boolean;
-  /** Anonymous product analytics (default ON, opt-out; see TELEMETRY.md).
-   *  Mirrors the main-process field (src/main/config.ts). */
+  /** 匿名产品分析（默认开，可退出；见 TELEMETRY.md）。
+   *  镜像主进程字段（src/main/config.ts）。 */
   telemetryEnabled?: boolean;
   slackEnabled?: boolean;
   slackSigningSecret?: string;
   slackBotToken?: string;
   slackChannelId?: string;
   slackPort?: number;
-  /** Opt-in app/voice-initiated proactive Slack posting (default OFF). Mirrors
-   *  src/main/config.ts; the Slack-origin done-reply round-trip is never gated. */
+  /** 选用的应用/语音发起主动 Slack 发帖（默认关）。镜像
+   *  src/main/config.ts；Slack 来源的完成回复往返永不被门控。 */
   slackProactivePosting?: boolean;
-  /** Free Flow voice dictation (mirrors src/main/config.ts). */
+  /** Free Flow 语音听写（镜像 src/main/config.ts）。 */
   freeflowEnabled?: boolean;
   groqApiKey?: string;
   freeflowModel?: string;
-  /** Realtime voice idle auto-disconnect (ms); default 180000 (3 min), 0 = never.
-   *  Tuned in Settings → Realtime Michael; the cost cap stays the runaway guard. */
+  /** 实时语音空闲自动断开（毫秒）；默认 180000（3 分钟），0 = 永不。
+   *  在 设置 → 实时 Michael 中调；成本上限仍是失控守卫。 */
   realtimeIdleDisconnectMs?: number;
   costCapUsd?: number;
-  /** Hard total-token ceiling across active agents (the user-facing budget). */
+  /** 跨活跃 agent 的硬性总 token 上限（面向用户的预算）。 */
   costCapTokens?: number;
-  /** Per-agent total-token ceiling, keyed by agent id. Overrides the floor budget
-   *  for that agent's meter and trips the breaker for it alone. */
+  /** 按 agent 的 token 总上限，以 agent id 为键。覆盖该 agent 计量表的
+   *  楼层预算，并只为它触发熔断器。 */
   agentTokenCaps?: Record<string, number>;
   autoDeliveryPausedAgents?: string[];
   maxTurns?: number;
   circuitBreaker?: CircuitBreakerConfig;
-  /** Enterprise Knowledge Graph (multimodal context for agents). Default OFF. */
+  /** 企业知识图谱（面向 agent 的多模态上下文）。默认关。 */
   knowledgeGraph?: KnowledgeGraphConfig;
-  /** TV-show office themes feature flag (Settings picker + switch flow). Default OFF. */
+  /** 电视剧主题办公室功能开关（设置选择器 + 切换流程）。默认关。 */
   tvShowOffices?: boolean;
-  /** Active office map/cast theme (honored only when tvShowOffices is on). */
+  /** 活跃办公室地图/角色主题（仅 tvShowOffices 开启时生效）。 */
   officeTheme?: 'office' | 'friends' | 'brooklyn99' | 'siliconvalley' | 'got' | 'hogwarts';
-  /** Per-CLI-provider local/self-hosted base URL (Ollama/LM Studio/vLLM, …) for the
-   *  OpenCode/Crush/pi/qwen engines; applied at spawn. API KEYS are NOT stored here —
-   *  they live write-only in the secret broker. */
+  /** 每个 CLI provider 的本地/自托管基础 URL（Ollama/LM Studio/vLLM 等），
+   *  用于 OpenCode/Crush/pi/qwen 引擎；spawn 时应用。API 密钥不存这里——
+   *  它们只写在 secret broker 中。 */
   providerBaseUrls?: Partial<Record<AgentProvider, string>>;
-  /** Per-CLI-provider default model slug, used to pre-fill the model picker. */
+  /** 每个 CLI provider 的默认模型 slug，用于预填模型选择器。 */
   providerDefaultModels?: Partial<Record<AgentProvider, string>>;
-  /** Legacy single-webhook fields (mirrors src/main/config.ts, where they are
-   *  deprecated in favour of `webhookTriggers` but still read until the server is
-   *  rewired). Declared here so the surfaces that show them can stop widening this
-   *  type locally.
-   *  @deprecated Use `webhookTriggers`. */
+  /** 旧版单 webhook 字段（镜像 src/main/config.ts，其中它们已废弃、
+   *  改用 `webhookTriggers`，但在服务器重新接线前仍会被读取）。在此声明，
+   *  好让展示它们的界面可以停止在本地加宽此类型。
+   *  @deprecated 使用 `webhookTriggers`。 */
   webhookEnabled?: boolean;
-  /** @deprecated Use `webhookTriggers[].secret`. */
+  /** @deprecated 使用 `webhookTriggers[].secret`。 */
   webhookSecret?: string;
-  /** @deprecated The port belongs to the shared server, not to any one trigger. */
+  /** @deprecated 端口属于共享服务器，不属于任何一个触发器。 */
   webhookPort?: number;
-  /** Auto-compaction / auto-clearing of agent terminal context. Main deep-fills
-   *  both halves on read, so the renderer can treat the sub-keys as present
-   *  (mirrors src/main/config.ts). */
+  /** agent 终端上下文的自动压缩 / 自动清空。主进程读取时深度填充两半，
+   *  渲染端可以把子键当作存在（镜像 src/main/config.ts）。 */
   contextTrigger?: ContextTriggerConfig;
-  /** Inbound HTTP endpoints, one per caller — replaces the legacy trio above. */
+  /** 入站 HTTP 端点，每个调用方一个——取代上面的旧版三元组。 */
   webhookTriggers?: WebhookTrigger[];
-  /** Peer messaging between teammates' clone nodes (persistence + UI only). */
+  /** 队友克隆节点之间的对等消息（仅持久化 + UI）。 */
   orgTrigger?: OrgTriggerConfig;
-  /** One-time guard for the main-process triggers migration; read-only here. */
+  /** 主进程触发器迁移的一次性守卫；这里只读。 */
   triggersMigratedV1?: boolean;
 }
 
-/** The Sonnet model with the 1M-token context window — used for Michael's prep
- *  assistant (cheap, large-context context gathering). Mirrors ASSISTANT_MODEL
- *  in src/main/assistant.ts; keep the two in sync. */
+/** 1M-token 上下文窗口的 Sonnet 模型——用于 Michael 的预备助手（廉价、
+ *  大上下文的信息收集）。镜像 src/main/assistant.ts 的 ASSISTANT_MODEL；
+ *  两者要保持同步。 */
 export const ASSISTANT_MODEL = 'claude-sonnet-4-6[1m]';
 
 export interface ModelOption {
-  /** undefined = use the CLI default (no --model flag) */
+  /** undefined = 使用 CLI 默认（不带 --model 标志） */
   id?: string;
   label: string;
 }
 
-/** One row of the model catalog. `minAppVersion` / `maxAppVersion` are INCLUSIVE
- *  app-version bounds: the model is offered while the running build sits inside
- *  them, and null (or an absent key) means unbounded in that direction. That is
- *  what lets a release introduce or retire a model without a code change.
+/** 模型目录的一行。`minAppVersion` / `maxAppVersion` 是 INCLUSIVE 的应用
+ *  版本边界：当运行中的构建落在它们内部时该模型被提供，null（或缺失键）
+ *  表示该方向无界。这正是一个版本可以在不改代码的情况下引入或退役一个
+ *  模型的方式。
  *
- *  PRERELEASES COUNT AS THEIR RELEASE. The comparison is major.minor.patch only
- *  (`isNewer` discards a `-rc.N` suffix), so `minAppVersion: '0.4.6'` IS offered
- *  on `0.4.6-rc.1`. That is deliberate and ruled on: an rc of a release should
- *  count as that release, it matches the update badge's own comparison, and the
- *  alternative would hide a new model from exactly the testers meant to
- *  exercise it. Bound a model to the release, not to its rc. */
+ *  预发布版按其发布版计。比较只做 major.minor.patch（`isNewer` 丢弃
+ *  `-rc.N` 后缀），因此 `minAppVersion: '0.4.6'` 在 `0.4.6-rc.1` 上也提供。
+ *  这是刻意且已裁决的：一个版本的 rc 应算作那个版本，它与更新徽章自身的
+ *  比较一致，反之会把新模型藏起来不让本应测试它的测试者看到。把模型绑定
+ *  到发布版，而不是它的 rc。 */
 interface CatalogModel {
-  /** absent = use the CLI default (no --model flag) */
+  /** 缺失 = 使用 CLI 默认（不带 --model 标志） */
   id?: string;
   label: string;
   minAppVersion?: string | null;
@@ -186,127 +182,101 @@ interface ModelCatalog {
   providers: Record<string, CatalogModel[]>;
 }
 
-/** The model presets every provider picker offers.
+/** 每个 provider 选择器提供的模型预设。
  *
- *  These were a dozen hardcoded `ModelOption[]` arrays in this file, so shipping
- *  a model — one string — meant editing, type-checking and rebuilding renderer
- *  source. They now live in src/shared/modelCatalog.json, imported at BUILD time
- *  (no fs, no network, offline-safe) and filtered per running version, so adding
- *  a model is a one-line JSON edit and a model can name the releases it belongs
- *  to instead of appearing in builds whose CLI never shipped it.
+ *  这些曾经是本文件里一打硬编码的 `ModelOption[]` 数组，发版一个模型——
+ *  一个字符串——意味着编辑、类型检查并重建渲染端源码。现在它们住在
+ *  src/shared/modelCatalog.json，构建时导入（无 fs、无网络、离线安全），
+ *  并按运行版本过滤，因此加一个模型就是一行 JSON 编辑，模型还可以指名
+ *  它所属的版本，而不是出现在从未随该版本一起发过它的 CLI 的构建里。
  *
- *  What the arrays used to say — kept, because it explains why the entries look
- *  the way they do:
+ *  这些数组以前想说的——保留下来，因为它解释条目为什么长这样：
  *
- *  - claude: `[1m]` selects the 1M-token context-window variant. The list
- *    deliberately has NO "pass no --model flag" entry: every option names a real
- *    model, because the whole reason to open this picker is to know which model
- *    an agent is on, and a no-flag option resolves to whatever Claude Code
- *    happens to choose — which the UI cannot show and the user cannot predict.
- *    The harness default is marked ` · default` instead, and it names a real model.
- *  - The leading `CLI default` entry several providers carry means no `--model`
- *    flag at all — whatever the CLI itself defaults to. That is NOT the harness's
- *    `config.defaultModel`; the pickers mark that one separately, and labelling
- *    both "default" is what made the two impossible to tell apart.
- *  - codex: current OpenAI models offered by Codex. The command field stays
- *    editable and `codex --model <id>` is the source of truth.
- *  - antigravity: agy's `--model` takes the DISPLAY-NAME LABEL exactly as
- *    `agy models` prints it (verified: agy logs `Propagating selected model
- *    override … label="…"`), not a slug — so these ids ARE labels, spaces and
- *    parens included; buildSpawnCommand quotes them and the command tokenizer
- *    keeps them whole. `agy models` is the source of truth for the live list.
- *  - gemini: stable aliases accepted by the official Google Gemini CLI. They
- *    follow the CLI instead of pinning preview model ids that drift.
- *  - qwen: qwen-code (`qwen`), the proxy-bridge CLI driving an OpenAI-compatible
- *    endpoint. Starting suggestions only. // TODO-verify the live list.
- *  - opencode: `--model` takes a `provider/model` slug; curated BYOK suggestions
- *    (`opencode models` / models.dev is the source of truth). `CLI default` is the
- *    PRESELECTED entry, because a BYOK slug the user holds no key for fails
- *    silently — see the recommendedOrchestratorModel note in agentProvider.ts.
- *    // TODO-verify exact live slugs (they drift).
- *  - crush: `--model` takes a `provider/model-id` slug; free-text editable (Crush
- *    accepts arbitrary slugs). The local pick is an OpenAI-wire slug so traffic
- *    routes through the proxy (the harness overrides the `openai` provider's
- *    base_url → loopback → your configured Crush base-URL); an `ollama/*` slug
- *    would bypass the proxy. // TODO-verify exact live ids.
- *  - pi: `--model` takes a `provider/model` slug (thinking via a `:high` suffix).
- *    Curated BYOK suggestions; free-text editable. // TODO-verify exact live slugs.
- *  - copilot: `--model` takes a plain model id ('auto' lets Copilot pick); curated
- *    suggestions, editable command field. // TODO-verify exact live ids (the
- *    /model picker is the source of truth; they drift).
- *  - cursor: ids match `cursor-agent models` / `--model` (Cursor account catalog).
- *    Luna is the cheap, high-context default for Michael; the rest are curated
- *    quick-picks and the command field stays editable for any live slug.
- *  - grok: the models reported by the installed Grok CLI (`grok models`).
- *  - kimi: managed Kimi Code aliases accepted by `kimi --model <alias>`.
- *  - custom: no presets at all; the command field is the whole interface.
+ *  - claude: `[1m]` 选择 1M-token 上下文窗口变体。列表刻意没有
+ *    “不传 --model 标志”的条目：每个选项都指名一个真实模型，因为打开这个
+ *    选择器的全部理由就是知道 agent 在用哪个模型，而无标志选项会解析成
+ *    Claude Code 碰巧选的任何东西——UI 显示不了、用户也无法预测。harness
+ *    默认改用 ` · default` 标记，而且它指名一个真实模型。
+ *  - 多个 provider 携带的前导 `CLI default` 条目意味着完全没有 `--model`
+ *    标志——CLI 自身默认什么就是什么。那不是 harness 的
+ *    `config.defaultModel`；选择器单独标记后者，把两者都标成 "default" 正是
+ *    让它们无法区分的原因。
+ *  - codex: Codex 提供的当前 OpenAI 模型。command 字段保持可编辑，
+ *    `codex --model <id>` 是事实来源。
+ *  - antigravity: agy 的 `--model` 接受 DISPLAY-NAME LABEL，与 `agy models`
+ *    打印的一模一样（已验证：agy 记录 `Propagating selected model override
+ *    … label="…"`），不是 slug——所以这些 id 就是标签，含空格和括号；
+ *    buildSpawnCommand 引用它们，命令分词器保持其完整。`agy models` 是
+ *    实时列表的事实来源。
+ *  - gemini: 官方 Google Gemini CLI 接受的稳定别名。它们跟随 CLI 而不是
+ *    钉住会漂移的预览模型 id。
+ *  - qwen: qwen-code (`qwen`)，驱动 OpenAI 兼容端点的代理桥 CLI。仅为
+ *    起始建议。 // TODO-verify the live list.
+ *  - kimi: `kimi --model <alias>` 接受的托管 Kimi Code 别名。
+ *  - custom: 完全没有预设；命令字段就是整个界面。
  */
 const CATALOG: ModelCatalog = modelCatalog;
 
 declare const __APP_VERSION__: string | undefined;
 
-/** The version of the running build. electron-vite replaces `__APP_VERSION__`
- *  with package.json's version at build time — the same value the update badge
- *  shows — so the renderer knows it synchronously, with no round trip to main.
- *  Outside a build (unit tests) the define is absent and there is no version to
- *  compare against; see the fail-open note on `offeredAtVersion`. */
+/** 运行中构建的版本。electron-vite 在构建时把 `__APP_VERSION__` 替换成
+ *  package.json 的版本——与更新徽章显示的同一个值——因此渲染端可以同步
+ *  得知它，无需往返 main。构建外（单元测试）该 define 缺失，也没有可比较
+ *  的版本；见 `offeredAtVersion` 上的 fail-open 说明。 */
 export function runningAppVersion(): string {
   return typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '';
 }
 
-/** Whether a catalog entry belongs in a picker on this build. Both bounds are
- *  inclusive of the release they name. Anything unparseable — an absent bound, a
- *  malformed one, an unknown app version — is ignored rather than hiding the
- *  model: a picker that silently loses every model is far worse than one that
- *  offers a model this build's CLI cannot run (the command field is editable and
- *  the CLI reports the bad slug). */
+/** 目录条目是否属于本构建的选择器。两个边界都包含其所指名的版本。任何
+ *  无法解析的——缺失的边界、格式错误、未知应用版本——都被忽略而不是隐藏
+ *  模型：一个静默丢失所有模型的选择器，远比一个提供了本构建 CLI 跑不了
+ *  的模型（命令字段可编辑，CLI 会报出坏 slug）要糟糕得多。 */
 function offeredAtVersion(model: CatalogModel, appVersion: string): boolean {
   if (model.minAppVersion && isNewer(model.minAppVersion, appVersion)) return false;
   if (model.maxAppVersion && isNewer(appVersion, model.maxAppVersion)) return false;
   return true;
 }
 
-/** The model preset list for a provider's picker, as of a given app version.
- *  `providers` is injectable so the version filter can be exercised against
- *  bounded entries — the shipped catalog is deliberately all-unbounded. */
+/** 某个 provider 的选择器在给定应用版本下的模型预设列表。
+ *  `providers` 可注入，让版本过滤能对有界条目做验证——发版目录刻意全部
+ *  无界。 */
 export function modelsForProviderAtVersion(
   provider: AgentProvider,
   appVersion: string,
   providers: Record<string, CatalogModel[]> = CATALOG.providers
 ): ModelOption[] {
-  // An unknown provider falls back to the Claude list, as the hardcoded dispatch
-  // did. 'custom' is a real key holding an empty list, not a missing one.
+  // 未知 provider 回退到 Claude 列表，与硬编码分派过去的行为一致。
+  // 'custom' 是持有空列表的真实键，不是缺失键。
   const entries = providers[provider] ?? providers.claude ?? [];
   return entries
     .filter((model) => offeredAtVersion(model, appVersion))
     .map((model) => (model.id === undefined ? { label: model.label } : { id: model.id, label: model.label }));
 }
 
-// tokenizeCommand moved to src/shared/commandLine.ts so main's spawn-request
-// path splits command lines with the SAME rules as the renderer's spawn flows
-// (they used to carry byte-identical copies). Re-exported here so existing
-// importers keep their path.
+// tokenizeCommand 移到 src/shared/commandLine.ts，让 main 的 spawn-request
+// 路径用与渲染端 spawn 流程相同的规则切分命令行（过去它们是逐字节相同的
+// 副本）。在这里重新导出，让既有导入方保持路径。
 export { tokenizeCommand } from '@shared/commandLine';
 
-/** The model preset list for a given provider's picker, on this build. */
+/** 某个 provider 的选择器在本构建上的模型预设列表。 */
 export function modelsForProvider(provider: AgentProvider): ModelOption[] {
   return modelsForProviderAtVersion(provider, runningAppVersion());
 }
 
-/** The Claude presets, for the surfaces that only ever offer Claude models. */
+/** Claude 预设，供只提供 Claude 模型的界面使用。 */
 export const AGENT_MODELS: ModelOption[] = modelsForProvider('claude');
 
-/** Providers shown in the Command Center's cross-provider model picker.
- *  God must remain on a provider with a working inbox drain; otherwise switching
- *  to a terminal-only provider would silently disable orchestration. */
+/** 指挥中心跨 provider 模型选择器里显示的 provider。
+ *  God 必须留在 inbox 排空可用的 provider 上；否则切到纯终端 provider 会
+ *  静默禁用编排。 */
 export function modelProvidersForAgent(isGod = false) {
   return AGENT_PROVIDER_PRESETS.filter((preset) =>
-    preset.supportsModel && (!isGod || preset.canReceiveInbox)
+    preset.supportsModel && (!isGod || preset.canReceiveInbox || preset.id === 'kimi')
   );
 }
 
-/** Native <select> values must carry both provider and model because each
- *  provider has its own "default" option and model namespace. */
+/** 原生 <select> 的值必须同时携带 provider 和 model，因为每个 provider 有
+ *  自己的 "default" 选项和模型命名空间。 */
 export function encodeProviderModel(provider: AgentProvider, model?: string): string {
   return `${provider}:${encodeURIComponent(model ?? '')}`;
 }
@@ -327,19 +297,18 @@ export function decodeProviderModel(value: string): {
   }
 }
 
-/** Build the command line to feed into spawnPty, honoring the provider's flags,
- *  autoMode, and an optional per-agent model override. Claude keeps the user's
- *  configured `defaultCommand`; other providers use their preset binary so the
- *  app works without Claude installed. */
+/** 构建要喂给 spawnPty 的命令行，遵循 provider 的标志、autoMode，以及可选
+ *  的按 agent 模型覆盖。Claude 保留用户配置的 `defaultCommand`；其他
+ *  provider 使用其预设二进制，让应用在没有安装 Claude 时也能工作。 */
 export function buildSpawnCommand(
   config: Pick<HarnessConfig, 'defaultCommand' | 'autoMode'>,
   model?: string,
   provider: AgentProvider = inferAgentProvider(config.defaultCommand)
 ): string {
   const preset = providerPreset(provider);
-  // Claude keeps the user's configured defaultCommand; custom falls back to it
-  // too; every other provider (codex, grok, kimi, agy) uses its preset binary so the app
-  // works even without Claude installed.
+  // Claude 保留用户配置的 defaultCommand；custom 也回退到它；
+  // 其他每个 provider（codex, grok, kimi, agy）用其预设二进制，让应用
+  // 在未安装 Claude 时也能工作。
   const base =
     provider === 'claude'
       ? config.defaultCommand || preset.defaultCommand
@@ -348,14 +317,14 @@ export function buildSpawnCommand(
         : preset.defaultCommand;
   let cmd = base;
   if (preset.supportsModel && model && preset.modelFlag) {
-    // Quote model values that contain whitespace (agy labels like
-    // "Gemini 3.1 Pro (High)") so the command tokenizer keeps them one arg.
+    // 引用含空格的模型值（agy 标签如 "Gemini 3.1 Pro (High)"），让命令
+    // 分词器把它们保持为一个参数。
     const m = /\s/.test(model) ? `"${model}"` : model;
     cmd = `${cmd} ${preset.modelFlag} ${m}`;
   }
-  // Auto (skip-permissions) mode appends each provider's own flag — Claude's
-  // bypassPermissions, Codex's dangerous bypass, Grok's always-approve, Kimi's
-  // auto, or agy's skip flag.
+  // Auto（跳过权限）模式追加每个 provider 自己的标志——Claude 的
+  // bypassPermissions、Codex 的 dangerous bypass、Grok 的 always-approve、
+  // Kimi 的 auto、或 agy 的 skip 标志。
   if (config.autoMode && preset.autoFlag) cmd = `${cmd} ${preset.autoFlag}`;
   return cmd;
 }

--- a/src/renderer/src/store/focusMode.ts
+++ b/src/renderer/src/store/focusMode.ts
@@ -1,35 +1,33 @@
 /**
- * Focus mode: which agent the full-window terminal is showing, and whether the
- * user wants that view by default.
+ * 专注模式：全窗口终端正在显示哪个 agent，以及用户是否默认想要该视图。
  *
- * Kept out of the store, and structural rather than typed against `Agent`, so
- * the rules below are testable without dragging zustand into a unit test. Same
- * reasoning as `hooks/queueDelivery.ts`.
+ * 放在 store 之外，并且是结构化而非针对 `Agent` 类型化的，这样下面的规则
+ * 可以在不把 zustand 拖进单元测试的情况下测试。与 hooks/queueDelivery.ts
+ * 的理由相同。
  */
 
-/** The subset of an agent these rules need. */
+/** 这些规则所需的 agent 子集。 */
 export interface FocusCandidate {
   id: string;
-  /** Present once the agent has a terminal. Absent for synthetic agents and for
-   *  a persisted agent whose PTY has not been re-established yet. */
+  /** agent 有终端时才存在。对合成 agent 以及 PTY 尚未重建的持久化 agent
+   *  都缺失。 */
   ptyId?: string;
 }
 
 /**
- * Keep focus mode pointed at an agent that still exists.
+ * 让专注模式始终指向一个仍然存在的 agent。
  *
- * Every path that removes an agent already re-homes `selectedId`, but none of
- * them re-homed the focused id, so closing the agent you were focused on left it
- * pointing at nothing. `App.tsx` then finds no agent to render and drops the
- * whole window back to the sidebar, which reads as the app deciding to leave
- * focus mode on your behalf.
+ * 每条移除 agent 的路径都会重新安置 `selectedId`，但没有一条会重新安置
+ * 专注 id，所以关闭你正在专注的那个 agent 会让它指向空。`App.tsx` 随后
+ * 找不到可渲染的 agent，把整个窗口丢回侧边栏——看起来像是应用替你决定
+ * 退出专注模式。
  *
- * Closing an agent is not a request to leave focus mode. So follow the selection
- * instead, and only fall out once the last agent is gone.
+ * 关闭一个 agent 并不是退出专注模式的请求。所以跟随选中状态走，只有在
+ * 最后一个 agent 也消失后才退出。
  *
- * Applies to every removal path, including `reconcileWithLivePtys`: that one runs
- * at STARTUP and prunes agents whose PTY did not survive, so without it a
- * restored focus-mode preference would be undone by the first reconcile.
+ * 适用于每条移除路径，包括 `reconcileWithLivePtys`：它在 STARTUP 时运行并
+ * 修剪 PTY 未能存活的 agent，没有它，恢复的专注模式偏好会被第一次对账
+ * 撤销。
  */
 export function refocusAfterRemoval(
   fullscreenAgentId: string | null,
@@ -42,13 +40,12 @@ export function refocusAfterRemoval(
 }
 
 /**
- * Resolve a persisted focus-mode preference into an agent to focus on load.
+ * 把持久化的专注模式偏好解析为加载时要专注的 agent。
  *
- * The preference is stored as a BOOLEAN, deliberately not as the focused agent's
- * id. An id is meaningless across a restart: that agent may have been closed, or
- * its PTY may not come back, and restoring a stale one lands straight in the
- * dangling reference `refocusAfterRemoval` exists to prevent. The preference
- * means "I work in focus mode", so it resolves against whoever is selected now.
+ * 偏好存为 BOOLEAN，刻意不存被专注 agent 的 id。id 跨重启无意义：那个
+ * agent 可能已被关闭，或其 PTY 可能不再回来，恢复一个过期的会直接落入
+ * `refocusAfterRemoval` 要防止的悬空引用。偏好意味着“我在专注模式下工作”，
+ * 所以它针对当前选中的 agent 解析。
  */
 export function focusOnLoad(
   prefersFocusMode: boolean,
@@ -58,26 +55,21 @@ export function focusOnLoad(
 }
 
 /**
- * Re-enter focus mode once there is something to focus on.
+ * 一旦有可专注的东西就重新进入专注模式。
  *
- * `focusOnLoad` alone was not enough and the reason is a startup ordering one.
- * The store resolves the preference ONCE, while it is being constructed, against
- * the roster read from disk. Every agent in that roster still carries the PTY id
- * it had in the PREVIOUS session, and none of those PTYs exist yet, so the first
- * `reconcileWithLivePtys` correctly prunes the lot and `refocusAfterRemoval`
- * correctly returns null. By the time god respawns with a live terminal the
- * preference has already been read and discarded, so the app opens in the
- * sidebar with `cth.prefersFocusMode` still set to 1.
+ * 单独的 `focusOnLoad` 不够，原因是启动顺序问题。store 在构造期间、针对
+ * 从磁盘读到的名单一次性解析偏好。名单里的每个 agent 仍带着它在上一个
+ * 会话里的 PTY id，而这些 PTY 都还不存在，所以第一次
+ * `reconcileWithLivePtys` 正确地修剪掉全部，`refocusAfterRemoval` 也正确地
+ * 返回 null。等 god 带着活跃终端重新 spawn 时，偏好已经被读掉并丢弃，
+ * 于是应用在 `cth.prefersFocusMode` 仍为 1 的情况下从侧边栏打开。
  *
- * So the preference has to be re-checked whenever the roster changes, not once
- * at construction.
+ * 所以偏好必须在名单每次变化时重新检查，而不是构造时一次。
  *
- * Restores only onto an agent that HAS a terminal. `FullscreenTerminal` renders
- * nothing without one and its own re-home effect would immediately bounce us
- * back out, which is a loop rather than a restore.
+ * 只恢复到有终端的 agent 上。`FullscreenTerminal` 没有终端就什么都不渲染，
+ * 它自己的重新安置 effect 会立刻把我们弹回去——那是循环而非恢复。
  *
- * Returns the current value unchanged when there is nothing to do, so callers
- * can compare by identity and skip the state write.
+ * 无事可做时原样返回当前值，调用方可以按引用比较并跳过状态写入。
  */
 export function restoreFocus(
   prefersFocusMode: boolean,

--- a/src/renderer/src/store/mockEvents.ts
+++ b/src/renderer/src/store/mockEvents.ts
@@ -1,4 +1,4 @@
-// Synthetic event stream so the avatars actually move while we wait on real tmux/hook wiring.
+// 合成事件流，让头像在等待真实 tmux/hook 接线期间真的会动。
 
 import { useStore, type Agent, type StationKind, type ToolKind } from './store';
 
@@ -13,41 +13,41 @@ const STATION_BY_TOOL: Record<ToolKind, StationKind> = {
 
 interface ToolSample {
   tool: ToolKind;
-  what: string;            // short — used as the action text
-  lines: string[];         // terminal stream output
-  thought: string;         // first-person assistant text, streamed in the sidebar
+  what: string;            // 简短 —— 用作动作文本
+  lines: string[];         // 终端流输出
+  thought: string;         // 第一人称助手文本，在侧边栏流式显示
 }
 
 const TOOL_SAMPLES: ToolSample[] = [
   {
-    tool: 'Read', what: 'reading SPEC.md',
+    tool: 'Read', what: '正在读取 SPEC.md',
     lines: ['\x1b[36m● Read\x1b[0m SPEC.md', '   read 412 lines.'],
-    thought: "Pulling up the spec so I can confirm the state machine before touching the implementation."
+    thought: "先翻出规格文档，确认状态机后再动手改实现。"
   },
   {
-    tool: 'Edit', what: 'editing PixelPanel.tsx',
+    tool: 'Edit', what: '正在编辑 PixelPanel.tsx',
     lines: ['\x1b[36m● Edit\x1b[0m src/renderer/src/components/PixelPanel.tsx', '   +14 / -3'],
-    thought: "Tightening up the panel border math — the inner stroke was a pixel off in inset mode."
+    thought: "正在收紧面板边框的数学——内缩模式下内描边偏了一个像素。"
   },
   {
-    tool: 'Bash', what: 'running tests',
+    tool: 'Bash', what: '正在运行测试',
     lines: ['\x1b[36m● Bash\x1b[0m npm test', '   ✓ 24 passed'],
-    thought: "Running the renderer suite to make sure nothing regressed before I move on."
+    thought: "先跑一遍渲染器测试套件，确保继续之前没有回归。"
   },
   {
-    tool: 'WebFetch', what: 'fetching docs',
+    tool: 'WebFetch', what: '正在获取文档',
     lines: ['\x1b[36m● WebFetch\x1b[0m https://docs.example.com/hooks', '   ok 200 (1.2kb)'],
-    thought: "Grabbing the hooks doc to double-check the PreToolUse payload shape — my memory of the field names is hazy."
+    thought: "翻一下 hooks 文档，核对 PreToolUse 载荷的结构——字段名我记得不太清。"
   },
   {
-    tool: 'Glob', what: 'searching for skill files',
+    tool: 'Glob', what: '正在搜索技能文件',
     lines: ['\x1b[36m● Glob\x1b[0m **/*.skill.md', '   23 matches'],
-    thought: "Enumerating all the skill files so I can walk each one and look for stale script paths."
+    thought: "把技能文件全部枚举出来，逐个检查过时的脚本路径。"
   },
   {
-    tool: 'TodoWrite', what: 'updating the todo board',
+    tool: 'TodoWrite', what: '正在更新待办看板',
     lines: ['\x1b[36m● TodoWrite\x1b[0m 4 items'],
-    thought: "Splitting the remaining work into four discrete tasks so I can track them as I go."
+    thought: "把剩余工作拆成四个独立任务，好边做边跟踪进度。"
   }
 ];
 
@@ -61,19 +61,19 @@ function stepAgent(agent: Agent) {
   const { updateAgent, pushFeed } = useStore.getState();
 
   if (agent.status === 'blocked') {
-    // Wait for user action; don't move automatically.
+    // 等待用户操作；不要自动移动。
     return;
   }
 
-  // Decision based on current status
+  // 基于当前状态决策
   if (agent.status === 'idle') {
-    // Maybe start a new task
+    // 也许开始一个新任务
     if (Math.random() < 0.4) {
       const sample = pickSample();
       const station = STATION_BY_TOOL[sample.tool];
       updateAgent(agent.id, {
         status: 'thinking',
-        action: `heading to ${station}`,
+        action: `正前往 ${station}`,
         currentStation: station,
         progress: 1
       });
@@ -82,8 +82,8 @@ function stepAgent(agent: Agent) {
   }
 
   if (agent.status === 'thinking') {
-    // Arrived at the station — kick off the tool
-    // (in real life this fires on PreToolUse arrival)
+    // 到达站位——启动工具
+    // （真实环境中这会在 PreToolUse 到达时触发）
 
     const station = agent.currentStation ?? 'desk';
     const tool: ToolKind = station === 'shelf' ? (Math.random() < 0.5 ? 'Read' : 'Edit')
@@ -104,21 +104,21 @@ function stepAgent(agent: Agent) {
   }
 
   if (agent.status === 'working') {
-    // Finish the tool and either keep going or settle
+    // 结束当前工具：要么继续，要么稳定下来
     if (Math.random() < 0.5) {
       updateAgent(agent.id, {
         status: 'thinking',
-        action: 'heading back to desk',
+        action: '正走回工位',
         currentStation: 'desk',
         progress: Math.min(agent.progress + 1, 8)
       });
     } else {
-      // Move to a new station
+      // 前往新站位
       const sample = pickSample();
       const station = STATION_BY_TOOL[sample.tool];
       updateAgent(agent.id, {
         status: 'thinking',
-        action: `heading to ${station}`,
+        action: `正前往 ${station}`,
         currentStation: station,
         progress: Math.min(agent.progress + 1, 8)
       });
@@ -129,10 +129,9 @@ function stepAgent(agent: Agent) {
 
 const MOCK_ACTS = ['request', 'inform', 'propose', 'query', 'agree'] as const;
 
-/** Occasionally fire a synthetic agent-to-agent message so the office floor's
- *  envelope-handoff animation is visible in demo mode (no live hive routing
- *  happens without real `claude` agents). The scene listens for this event and
- *  flies an envelope between the two avatars; see OfficeFloor's demo path. */
+/** 偶尔触发一条合成 agent 间消息，让办公室楼层的信封交接动画在演示模式下
+ *  可见（没有真实 `claude` agent 就不会有真实 hive 路由）。场景监听该事件
+ *  并在两个头像之间飞一个信封；见 OfficeFloor 的 demo 路径。 */
 function maybeFlyMessage(mockIds: string[]): void {
   if (mockIds.length < 2 || Math.random() >= 0.45) return;
   const from = mockIds[Math.floor(Math.random() * mockIds.length)];
@@ -151,7 +150,7 @@ export function startMockLoop() {
   if (interval !== null) return;
   interval = window.setInterval(() => {
     const { agents } = useStore.getState();
-    // Only step mock agents (no ptyId). Real agents are driven by the pty parser.
+    // 只步进 mock agent（没有 ptyId）。真实 agent 由 pty 解析器驱动。
     for (const a of agents) if (!a.ptyId) stepAgent(a);
 
     const { agents: a2, updateAgent } = useStore.getState();
@@ -160,9 +159,9 @@ export function startMockLoop() {
       if (a.status === 'thinking' && a.currentStation === 'desk' && Math.random() < 0.4) {
         updateAgent(a.id, {
           status: 'idle',
-          action: 'awaiting',
+          action: '等待中',
           carrying: undefined,
-          recentAssistantText: 'Done with that one. What next?',
+          recentAssistantText: '那件事办完了。接下来呢？',
           recentTextTs: Date.now()
         });
       }

--- a/src/renderer/src/store/rosterSource.ts
+++ b/src/renderer/src/store/rosterSource.ts
@@ -1,15 +1,12 @@
-/** Which store the roster is loaded FROM at boot — the file beside the hive, or
- *  this origin's localStorage.
+/** 启动时名单从哪里加载——hive 旁的文件，还是这个 origin 的 localStorage。
  *
- *  Split out of store.ts because it is the one decision that has to be right on
- *  every launch and cannot be observed from the UI when it is wrong: the roster
- *  just appears, and nothing says where it came from.
+ *  从 store.ts 拆出来，因为它是每次启动都必须正确、且出错时无法从 UI
+ *  观察的少数决策之一：名单就那么出现了，没人说它来自哪里。
  *
- *  localStorage is partitioned by ORIGIN, not by hive. Every hive this app ever
- *  opens shares exactly one of them, so it can only ever hold the roster of
- *  whichever hive wrote it last. Adopting it into a DIFFERENT hive is how one
- *  workspace's team turns up in another — restorable entries and all, each one
- *  still carrying the `cwd` of the workspace it was hired in. */
+ *  localStorage 按 ORIGIN 分区，而不是按 hive。本应用打开过的每个 hive
+ *  共享它们当中的一个，所以它只能保存最近写它的那个 hive 的名单。把它
+ *  采用进一个不同的 hive，就是一个工作区的团队出现在另一个里的方式——
+ *  可恢复条目、一切照旧，每一条都还带着它在被雇佣的那个工作区的 `cwd`。 */
 
 export interface RosterCounts {
   agents: unknown[];
@@ -18,27 +15,27 @@ export interface RosterCounts {
 }
 
 export interface RosterSourceInput {
-  /** `<harnessHome>/roster.json` as read at boot, or `null` when there is none. */
+  /** 启动时读到的 `<harnessHome>/roster.json`，没有则为 `null`。 */
   fileRoster: RosterCounts | null;
-  /** The hive this window is opening. `null` before onboarding picks one. */
+  /** 本窗口正在打开的 hive。onboarding 选定前为 `null`。 */
   currentHome: string | null;
-  /** The hive localStorage was last written for, or `null` when it predates the
-   *  stamp (an install that upgraded into this behaviour). */
+  /** localStorage 最后一次写入所对应的 hive；当它早于时间戳（一个升级进
+   *  此行为的安装）时为 `null`。 */
   storedHome: string | null;
 }
 
 export interface RosterSource {
-  /** Load the slices out of the file. */
+  /** 从文件加载这些切片。 */
   useFileRoster: boolean;
-  /** Load the slices out of localStorage — and, on a first run, seed the file
-   *  from them. False means BOTH stores are ignored and the floor starts empty. */
+  /** 从 localStorage 加载这些切片——并且，在首次运行时，用它们为文件
+   *  播种。为 false 表示两个 store 都被忽略，楼层从空开始。 */
   useLocalFallback: boolean;
 }
 
-/** An empty file must never win over a populated localStorage: that is the
- *  "opened the packaged build once and my floor went blank" failure the mirror
- *  exists to prevent (the two origins do not share a localStorage, the file is
- *  what bridges them). A genuine delete-all clears both, so nothing resurrects. */
+/** 空文件绝不能赢过有内容的 localStorage：这正是镜像要防止的
+ *  “开过一次打包构建然后我的楼层空白了”失败（两个 origin 不共享
+ *  localStorage，文件才是桥接它们的东西）。真正的全删会清空两者，
+ *  所以什么都不会复活。 */
 function fileHasRoster(file: RosterCounts | null): boolean {
   return !!file
     && file.agents.length + file.archived.length + file.restorable.length > 0;
@@ -51,10 +48,9 @@ export function chooseRosterSource({
 }: RosterSourceInput): RosterSource {
   if (fileHasRoster(fileRoster)) return { useFileRoster: true, useLocalFallback: false };
 
-  // No file roster, so the only candidate left is localStorage — which is worth
-  // reading only if it was written for THIS hive. `null` is the pre-stamp case:
-  // an install whose localStorage predates the stamp is adopted once, because
-  // refusing it would blank the floor of everyone upgrading.
+  // 没有文件名单，剩下的唯一候选是 localStorage——而只有当它是为 THIS hive
+  // 写入时才值得读取。`null` 是盖章前的情况：localStorage 早于盖章的安装
+  // 会被采用一次，因为拒绝它会抹掉每个升级用户的楼层。
   const belongsHere = storedHome === null || currentHome === null || storedHome === currentHome;
   return { useFileRoster: false, useLocalFallback: belongsHere };
 }

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -27,13 +27,13 @@ export type StationKind =
   | 'shelf' | 'terminal' | 'web' | 'board' | 'mailbox' | 'mcp' | 'desk';
 
 export interface BlockReason {
-  summary: string;                 // short headline shown on banner
-  detail: string;                  // longer explanation
-  command?: string;                // verbatim command awaiting confirmation, if any
+  summary: string;                 // 横幅上显示的短标题
+  detail: string;                  // 更长的解释
+  command?: string;                // 待确认的逐字命令（若有）
   actions: Array<{
     label: string;
     kind: 'approve' | 'deny' | 'neutral';
-    /** what we'd send to the tmux pane on click */
+    /** 点击时我们会发给 tmux 窗格的内容 */
     send?: string;
   }>;
 }
@@ -41,72 +41,71 @@ export interface BlockReason {
 export interface Agent {
   id: string;
   name: string;
-  /** which Office character represents this agent on the floor */
+  /** 楼面上哪个 Office 角色代表这个 agent */
   character: OfficeCharacterName;
   accent: AccentColorName;
-  /** persistent job / hire one-liner — same string as hive registry `role`.
-   *  Live status belongs on `status` / `action`, never here. */
+  /** 持久的职位 / 雇佣一句话——与 hive 注册表 `role` 是同一个字符串。
+   *  实时状态属于 `status` / `action`，绝不写在这里。 */
   description: string;
   project: string;
-  /** legacy field — populated only for the seeded mock agents */
+  /** 遗留字段——只为播种的 mock agent 填充 */
   tmuxTarget: string;
   cwd: string;
   goal?: string;
-  /** User-authored private note shown and edited from the roster-card hover. */
+  /** 用户撰写的私有笔记，在名单卡片悬停上显示和编辑。 */
   note?: string;
   status: StatusKind;
   action: string;
   progress: number;
   currentStation?: StationKind;
   carrying?: ToolKind;
-  /** latest assistant message, streamed character-by-character in the sidebar */
+  /** 最新的助手消息，在侧边栏逐字符流式显示 */
   recentAssistantText?: string;
-  /** epoch ms — used to drive the typewriter so identical strings still re-stream */
+  /** 纪元毫秒——用于驱动打字机效果，让相同字符串也能重新播放 */
   recentTextTs?: number;
-  /** populated when status === 'blocked' */
+  /** status === 'blocked' 时填充 */
   blockReason?: BlockReason;
-  /** present iff this agent has a real PTY in the main process */
+  /** 仅当该 agent 在主进程里有真实 PTY 时才存在 */
   ptyId?: string;
-  /** Incremented by Restart & Continue to remount this agent's xterm without
-   * changing its durable PTY/session identity. */
+  /** 由 Restart & Continue 递增，用于在不改变该 agent 持久 PTY/会话身份
+   * 的情况下重新挂载其 xterm。 */
   terminalGeneration?: number;
-  /** the command being run in the PTY (e.g. 'claude' or 'agy') */
+  /** 正在 PTY 中运行的命令（例如 'claude' 或 'agy'） */
   command?: string;
-  /** which agent CLI preset owns this PTY recipe; drives the model picker +
-   *  spawn flags. Defaults to 'claude' when unset (legacy agents / inferred
-   *  from command). */
+  /** 拥有此 PTY 配方的 agent CLI 预设；驱动模型选择器与 spawn 标志。
+   *  未设置时默认 'claude'（遗留 agent / 从命令推断）。 */
   provider?: AgentProvider;
-  /** the model this agent runs on (e.g. 'claude-sonnet-4-6[1m]' or 'gemini-3-pro');
-   *  drives the model selector + the --model arg used when (re)spawning the agent */
+  /** 该 agent 运行的模型（例如 'claude-sonnet-4-6[1m]' 或 'gemini-3-pro'）；
+   *  驱动模型选择器以及（重新）spawn agent 时所用的 --model 参数 */
   model?: string;
-  /** the last prompt the user submitted to this agent in Claude Code —
-   *  shown on the floor as a card above the seated avatar */
+  /** 用户在 Claude Code 中最后提交给该 agent 的提示——
+   *  作为坐姿头像上方的卡片显示在楼面上 */
   lastPrompt?: string;
-  /** the orchestrator ("god") agent — seated in Michael's room, runs the floor */
+  /** 编排者（“god”）agent——坐在 Michael 的房间里，运行整个楼层 */
   isGod?: boolean;
-  /** Michael's prep assistant — send-only; enriches prompts and forwards them to
-   *  the god. Excluded from broadcast fan-out and from the restorable-dead sweep. */
+  /** Michael 的预备助手——只发不收；润色提示并转发给 god。从广播扇出和
+   *  可恢复-死亡清扫中排除。 */
   isAssistant?: boolean;
-  /** The human has this agent 1:1 and Michael has been told to leave it alone.
-   *  Mirrors `RegistryAgent.onHold`; main owns the record, this is the copy the
-   *  title bar renders from. */
+  /** 人类正与该 agent 1:1 交流，Michael 已被告知别打扰它。
+   *  镜像 `RegistryAgent.onHold`；记录归 main 管，这里是标题栏据此渲染的
+   *  副本。 */
   onHold?: boolean;
-  /** When git isolation is enabled, the dedicated worktree path the agent runs
-   *  in (its own `agent/<id>` branch); undefined for shared-cwd agents. */
+  /** 当 git 隔离启用时，agent 运行的专用工作树路径（其自有 `agent/<id>`
+   *  分支）；共享 cwd 的 agent 为 undefined。 */
   worktreePath?: string;
-  /** Live context size of the agent's Claude session (tokens), polled from its
-   *  transcript. Drives the context gauge on the agent card. */
+  /** agent 的 Claude 会话的实时上下文大小（tokens），从其 transcript 轮询
+   *  得到。驱动 agent 卡片上的上下文计量表。 */
   contextTokens?: number;
-  /** The context-window limit assumed for this agent's model (tokens). */
+  /** 为该 agent 的模型假定的上下文窗口上限（tokens）。 */
   contextLimit?: number;
-  /** True once this agent's terminal was closed. Archived agents are retained
-   *  (in the store's `archivedAgents` list + the hive registry) but flagged and
-   *  kept off the floor; only live-PTY agents are 'active'. */
+  /** 该 agent 的终端一旦被关闭即为 true。归档 agent 会被保留（在 store 的
+   *  `archivedAgents` 列表 + hive 注册表中），但被标记且不上楼面；只有
+   *  有活 PTY 的 agent 才是 'active'。 */
   archived?: boolean;
-  /** Hive protocol to TYPE into this agent's TUI as its first turn, set at spawn
-   *  for `seedDelivery:'type-into-tui'` providers (Crush) whose bare TUI rejects a
-   *  positional seed. useHive types it once after boot-grace then clears it.
-   *  Ephemeral spawn state — not persisted. (ondev-b) */
+  /** 要在该 agent 的 TUI 中作为其第一回合 TYPE 的 hive 协议，在 spawn 时为
+   *  `seedDelivery:'type-into-tui'` provider（Crush）设置，其裸 TUI 拒绝
+   *  位置种子。useHive 在启动宽限后输入一次然后清空。瞬时 spawn 状态——
+   *  不持久化。(ondev-b) */
   seedPrompt?: string;
 }
 
@@ -116,229 +115,210 @@ export interface FeedEntry {
   ts: number;
 }
 
-/** A message the user has parked for an agent while its terminal was busy.
- *  Queued messages are drained one at a time when the agent next goes idle (see
- *  useHive's flush loop). */
+/** 用户在 agent 终端忙时为它停靠的消息。排队消息在 agent 下次空闲时
+ *  逐条排空（见 useHive 的 flush 循环）。 */
 export interface QueuedMessage {
   id: string;
   text: string;
-  /** epoch ms the message was queued — drives ordering and the "queued 2m ago" hint */
+  /** 消息入队的纪元毫秒——驱动排序和 “queued 2m ago” 提示 */
   ts: number;
-  /** Slack-originated: thread coordinates so the office can reply in-thread. */
+  /** Slack 来源：线程坐标，让办公室可以在线程内回复。 */
   slack?: { channel: string; thread_ts: string };
-  /** Optional override for the text actually typed into the agent's PTY. When set,
-   *  the drain submits THIS instead of `text`, while UI/card surfaces keep using
-   *  `text`. Used by Slack-origin work to carry the autonomy preamble to god's
-   *  prompt without polluting the human-readable kanban card title (= raw `text`). */
+  /** 实际输入 agent PTY 文本的可选覆盖。设置时，排空提交 THIS 而不是
+   *  `text`，而 UI/卡片界面继续使用 `text`。Slack 来源的工作用它把自治
+   *  前言带给 god 的提示，而不污染人类可读的看板卡片标题（= 原始
+   *  `text`）。 */
   instruction?: string;
-  /** User clicked "send now" while floor-wide auto-delivery was paused. Bypasses
-   *  ONLY the pause gate in the drain loop — idle/draft/picker safety still hold,
-   *  so it delivers the moment the terminal is actually free. */
+  /** 楼层级自动投递被暂停时用户点了“立即发送”。只绕过排空循环中的
+   *  暂停门——idle/草稿/选择器安全仍然生效，所以它在终端真正空闲的瞬间
+   *  投递。 */
   manual?: boolean;
-  /** Delivery-time precondition, re-checked by the drain immediately before the
-   *  message is typed; a message whose precondition no longer holds is DROPPED
-   *  rather than deferred (deferring would park it at the queue head forever and
-   *  starve everything behind it).
+  /** 投递时前置条件，由排空在消息输入前立即重新检查；前置条件不再成立的
+   *  消息被 DROP 而不是延迟（延迟会让它永久停在队首、饿死它后面的一切）。
    *
-   *  Exists because a queued message is evaluated at enqueue time but delivered
-   *  an arbitrary interval later, and some messages are only worth sending if the
-   *  world they described still exists. 'inbox-nonempty' is the inbox-wake nudge:
-   *  the agent can drain its whole inbox in the same turn the nudge was queued
-   *  from, and delivering it afterwards costs a full turn to discover nothing is
-   *  there. Declarative (a string, not a closure) so it survives persistQueues. */
+   *  它存在是因为排队消息在入队时评估、却在间隔任意长之后投递，而有些
+   *  消息只有在其描述的世界仍然存在时才值得发送。'inbox-nonempty' 是
+   *  inbox 唤醒 nudge：agent 可以在 nudge 入队的同一回合排空整个 inbox，
+   *  之后再投递它要花整整一个回合去发现里面是空的。声明式（字符串而非
+   *  闭包），所以能挺过 persistQueues。 */
   precondition?: 'inbox-nonempty';
-    /** Token count captured when a /compact was enqueued for this agent, carried
-   *  through to the point of successful delivery so the "already compacted at
-   *  N tokens" latch (see useHive) can be written there instead of at enqueue
-   *  time. Enqueue time is too early: a /compact stuck behind an undeliverable
-   *  status would otherwise latch out every future compact attempt for a
-   *  compaction that never actually happened. */
+    /** 为该 agent 入队 /compact 时捕获的 token 数，一路携带到成功投递点，
+   *  让 “已在 N tokens 压缩过” 的闩锁（见 useHive）可以写在那里而不是
+   *  入队时。入队时间太早：一条卡在不可投递状态后面的 /compact，否则会对
+   *  一次从未真正发生的压缩闩死此后所有的压缩尝试。 */
   compactUsed?: number;
 }
 
-// 'files' retired in v0.3.4 (the per-agent IDE button superseded it) — a
-// persisted 'files' selection falls back to 'terminal' on load. 'git' added in
-// v0.3.4: at-a-glance branch/status/log without opening the IDE.
+// 'files' 在 v0.3.4 退役（按 agent 的 IDE 按钮取代了它）——持久化的
+// 'files' 选择在加载时回退到 'terminal'。'git' 在 v0.3.4 加入：不打开
+// IDE 也能一眼看到分支/状态/日志。
 export type SidebarTab = 'terminal' | 'messages' | 'traces' | 'git';
 
-/** Lifecycle of the god agent ("Michael") bootstrap on launch.
- *  'booting' until his PTY is confirmed live, then 'ready' (or 'failed' if the
- *  spawn errored). The empty-floor UI shows a loader while 'booting' so users
- *  don't see the "add agent" prompt before Michael has clocked in. */
+/** 启动时 god agent（“Michael”）引导的生命周期。
+ *  在其 PTY 被确认为活跃之前为 'booting'，然后 'ready'（或 spawn 出错时
+ *  'failed'）。空楼层 UI 在 'booting' 期间显示加载器，让用户在 Michael
+ *  打卡上班之前看不到“添加 agent”提示。 */
 export type GodStatus = 'booting' | 'ready' | 'failed';
 
 interface State {
   agents: Agent[];
-  /** Agents whose terminal was closed — retained + flagged, kept off the active
-   *  roster/floor. The hive registry retains them durably; this mirrors them for
-   *  the renderer's "Archived" view. */
+  /** 终端已被关闭的 agent——保留 + 标记，不上活跃名单/楼层。hive 注册表
+   *  持久保留它们；这里为渲染端的 “Archived” 视图做镜像。 */
   archivedAgents: Agent[];
-  /** Workers from the previous session whose terminal died with the app (quit /
-   *  crash). Kept with their full spawn recipe (id, cwd, model, command) so the
-   *  user can one-click respawn them with the SAME agent id — memory, inbox and
-   *  registry entry reattach by themselves. God/assistant are excluded (they
-   *  auto-respawn). */
+  /** 上一个会话中、终端随应用（退出/崩溃）一起死亡的 worker。带着完整
+   *  spawn 配方（id, cwd, model, command）保留，让用户可以用同一个 agent id
+   *  一键重启它们——记忆、inbox 与注册表条目自行重新挂接。god/assistant
+   *  被排除（它们自动重启）。 */
   restorableAgents: Agent[];
   selectedId: string | null;
   feeds: Record<string, string[]>;
   addAgentOpen: boolean;
   fullscreenAgentId: string | null;
-  /** Does the user work in focus mode by default? Persisted as a boolean, and
-   *  written ONLY by an explicit toggle. Kept in the store rather than read once
-   *  at construction because the roster arrives after the store does. */
+  /** 用户默认是否以专注模式工作？持久化为布尔值，只由显式开关写入。放在
+   *  store 里而不是构造时读一次，因为名单在 store 之后才到达。 */
   prefersFocusMode: boolean;
-  /** Absolute path queued for the IDE to open on next mount. Consumed-and-cleared
-   *  by IdePanel, which routes it the same way a tree click would (Monaco for
-   *  source, preview for markdown, the viewer for images). */
+  /** 排队等待 IDE 下次挂载时打开的绝对路径。由 IdePanel 消费并清空，它会
+   *  像树点击一样路由（源码用 Monaco，markdown 用预览，图片用查看器）。 */
   ideInitialFile: string | null;
-  /** Whether the full-window IDE panel (file manager + Monaco editor + git diff)
-   *  is open. Toggled from the title-bar IDE button; a global feature surface,
-   *  independent of the per-agent sidebar Files/Git tabs. */
+  /** 全窗口 IDE 面板（文件管理器 + Monaco 编辑器 + git diff）是否打开。
+   *  由标题栏 IDE 按钮切换；这是一个全局功能面，独立于按 agent 的侧边栏
+   *  Files/Git 标签页。 */
   ideOpen: boolean;
-  /** WHICH agent the IDE was opened FOR — set by whoever opens it.
+  /** IDE 是为 WHICH agent 打开的——由打开它的人设置。
    *
-   *  The IDE used to infer its workspace purely from `selectedId`, which is a
-   *  guess that is usually right and occasionally wrong: `setFullscreen` puts an
-   *  agent's terminal on screen WITHOUT selecting it, so hitting IDE from a
-   *  fullscreen terminal could open a different agent's directory than the one
-   *  being looked at. That was invisible while the title said only "IDE" and the
-   *  folder name; it becomes a flatly wrong agent NAME once the title names one.
-   *  Callers therefore state their intent, and `selectedId` stays as the
-   *  fallback for anything that genuinely has no particular agent in mind. */
+   *  IDE 以前纯粹从 `selectedId` 推断其工作区，那是个通常正确、偶尔错误
+   *  的猜测：`setFullscreen` 把一个 agent 的终端放上屏幕却不选中它，所以
+   *  从全屏终端按 IDE 可能打开另一个 agent 的目录而不是正在看的那个。
+   *  当标题只写 “IDE” 和文件夹名时这不可见；一旦标题指名 agent，就会变成
+   *  完全错误的 agent 名字。因此调用方要声明其意图，`selectedId` 作为真正
+   *  没有特定 agent 在意的场景的回退。 */
   ideAgentId: string | null;
   sidebarWidth: number;
   sidebarTab: SidebarTab;
   godStatus: GodStatus;
-  /** Per-agent outgoing message queue (agent id → messages awaiting delivery).
-   *  Lets the user keep "talking" to a busy agent: messages park here and are
-   *  drained to the terminal one-by-one once the agent is free. */
+  /** 按 agent 的外发消息队列（agent id → 等待投递的消息）。让用户可以对
+   *  忙碌的 agent 继续“说话”：消息停在这里，agent 一有空就被逐条排空到
+   *  终端。 */
   messageQueues: Record<string, QueuedMessage[]>;
-  /** Per-agent tool-call count this session — a lightweight activity/usage proxy
-   *  shown in the command center (interactive sessions don't expose billed $). */
+  /** 本会话按 agent 的工具调用次数——一个轻量的活动/用量代理，显示在
+   *  指挥中心（交互式会话不暴露计费 $）。 */
   toolCounts: Record<string, number>;
   bumpToolCount: (id: string) => void;
   setGodStatus: (status: GodStatus) => void;
   select: (id: string) => void;
   updateAgent: (id: string, patch: Partial<Agent>) => void;
-  /** Copy durable hive roles onto roster descriptions (and the reverse is a
-   *  no-op when the roster already has a real job string). */
+  /** 把持久的 hive 角色复制到名单描述上（名单已有真实职位字符串时，反向
+   *  是 no-op）。 */
   syncDescriptionsFromRoles: (roles: Record<string, string>) => void;
-  /** Persist a display-name change to both the hive registry and renderer roster.
-   *  The agent id and all id-derived paths remain unchanged. */
+  /** 把显示名变更同时持久化到 hive 注册表和渲染端名单。
+   *  agent id 及所有由 id 派生的路径保持不变。 */
   renameAgent: (id: string, name: string) => Promise<{ ok: boolean; error?: string }>;
   setAgentNote: (id: string, note: string) => void;
   pushFeed: (id: string, line: string) => void;
   addAgent: (agent: Agent) => void;
   removeAgent: (id: string) => void;
-  /** Archive an agent (its terminal was closed): move it from the active roster
-   *  into `archivedAgents` with its PTY cleared. Retained + flagged, NOT deleted. */
+  /** 归档一个 agent（其终端已关闭）：把它从活跃名单移入 `archivedAgents`，
+   *  清空其 PTY。保留 + 标记，而不是删除。 */
   archiveAgent: (id: string) => void;
-  /** Permanently forget an archived agent (drops the renderer entry only; the
-   *  hive registry keeps its record). */
+  /** 永久遗忘一个归档 agent（只删渲染端条目；hive 注册表保留其记录）。 */
   removeArchivedAgent: (id: string) => void;
-  /** Drop one agent from the restorable list (it was respawned or dismissed). */
+  /** 从可恢复列表里移除一个 agent（它已被重启或已关闭）。 */
   removeRestorableAgent: (id: string) => void;
-  reorderAgents: (fromId: string, toId: string) => void; // move agent fromId into toId's slot (AgentStrip drag-reorder) and persist the new order
-  /** One-shot request to open a Command-Center tab (e.g. clicking the office
-   *  task board → 'tasks'). `seq` makes repeated identical requests distinct. */
+  reorderAgents: (fromId: string, toId: string) => void; // 把 agent fromId 移到 toId 的槽位（AgentStrip 拖拽重排）并持久化新顺序
+  /** 一次性请求打开某个指挥中心标签页（例如点办公室任务板 → 'tasks'）。
+   *  `seq` 让重复的相同请求可区分。 */
   ccTabRequest: { tab: string; seq: number } | null;
   requestCommandCenterTab: (tab: string) => void;
-  /** The task whose detail overlay is open (rendered app-wide over the office
-   *  floor — the card content grows: contracts, deps, the human Q&A trail). */
+  /** 详情浮层打开的那个任务（在办公室楼层上方全局渲染——卡片内容会生长：
+   *  契约、依赖、人类问答轨迹）。 */
   taskDetailId: string | null;
   openTaskDetail: (id: string) => void;
   closeTaskDetail: () => void;
-  /** One-shot prefill for the Command Center's dispatch box (a task detail's
-   *  "assign" from anywhere in the app). seq-keyed like ccTabRequest. */
+  /** 指挥中心派发框的一次性预填（从应用任意位置的任务详情 “assign”）。
+   *  与 ccTabRequest 一样用 seq 作键。 */
   dispatchSeedRequest: { text: string; seq: number } | null;
   requestDispatchSeed: (text: string) => void;
-  /** Unsent ASK ME answer drafts, keyed by task id — so switching tabs (which
-   *  unmounts the ask-me view) doesn't eat a half-typed answer. */
+  /** 未发送的 ASK ME 回答草稿，按任务 id 为键——这样切换标签页（会卸载
+   *  ask-me 视图）不会吃掉写到一半的回答。 */
   answerDrafts: Record<string, string>;
   setAnswerDraft: (taskId: string, text: string) => void;
-  /** Unsent composer drafts, per agent — so switching agents (which remounts the
-   *  composer) doesn't eat what the user was typing. */
+  /** 未发送的输入框草稿，按 agent 为键——这样切换 agent（会重挂载输入框）
+   *  不会吃掉用户正在输入的内容。 */
   drafts: Record<string, string>;
   setDraft: (agentId: string, text: string) => void;
-  /** Mirror of config.freeflowEnabled so the composer can show/hide the Free Flow
-   *  mic button reactively (set by App on config load and by Settings on save). */
+  /** 镜像 config.freeflowEnabled，让输入框可以响应式地显示/隐藏 Free Flow
+   *  麦克风按钮（由 App 在 config 加载时设置、Settings 在保存时设置）。 */
   freeflowEnabled: boolean;
   setFreeflowEnabled: (on: boolean) => void;
-  /** Mirror of `!!config.groqApiKey` — boolean presence ONLY; the key value never
-   *  enters the store. Lets the composer show the voice button disabled (with a
-   *  "add a Groq key" tooltip) instead of hiding it. Set by App on config load and
-   *  by Settings on save. */
+  /** 镜像 `!!config.groqApiKey` ——只表示布尔存在；密钥值绝不进 store。
+   *  让输入框显示禁用的语音按钮（带 “添加 Groq 密钥” 提示）而不是隐藏它。
+   *  由 App 在 config 加载时设置、Settings 在保存时设置。 */
   hasGroqKey: boolean;
   setHasGroqKey: (has: boolean) => void;
-  /** Mirror of BYOK OpenAI key presence (boolean only — the key lives in the main
-   *  secret broker, never the store). Gates the Realtime Michael voice toggle the
-   *  way hasGroqKey gates the Free Flow mic. Set by App on load via
-   *  window.cth.realtimeHasOpenAiKey(). */
+  /** 镜像 BYOK OpenAI 密钥存在性（仅布尔——密钥住在主进程 secret broker，
+   *  绝不进 store）。像 hasGroqKey 门控 Free Flow 麦克风那样门控 Realtime
+   *  Michael 语音开关。App 加载时经 window.cth.realtimeHasOpenAiKey() 设置。 */
   hasOpenAiKey: boolean;
   setHasOpenAiKey: (has: boolean) => void;
-  /** Mirror of the active office theme (set by App on config load + by Settings
-   *  on switch). OfficeFloor depends on this and rebuilds the scene on change. */
+  /** 镜像活跃办公室主题（由 App 在 config 加载时 + Settings 切换时设置）。
+   *  OfficeFloor 依赖它并在变化时重建场景。 */
   officeTheme: ThemeId;
   setOfficeTheme: (theme: ThemeId) => void;
-  /** Mirror of config.webhookTriggers — the inbound HTTP endpoints. Webhooks are
-   *  editable from BOTH Settings → Connections and the Triggers tab, so neither
-   *  surface keeps its own copy: both render off this list and both call the
-   *  setter after persisting, and the other one repaints without a refetch.
-   *  Seeded by App from getConfig() (main deep-fills the field on every read).
+  /** 镜像 config.webhookTriggers —— 入站 HTTP 端点。Webhook 在 设置 →
+   *  连接 和 Triggers 标签页两处都可编辑，所以任一面都不保留自己的副本：
+   *  两者都基于此列表渲染、都在持久化后调用 setter，另一个无需重新拉取
+   *  就会重绘。由 App 从 getConfig() 播种（main 每次读取都深度填充该字段）。
    *
-   *  Holds per-endpoint secrets, because a secret is what the UI has to show for
-   *  reveal/copy to mean anything. Renderer memory only — never persisted to
-   *  localStorage or the roster file, never logged, masked in every surface. */
+   *  持有每个端点的密钥，因为密钥正是 UI 要显示、让 reveal/copy 有意义
+   *  的东西。仅渲染端内存——绝不持久化到 localStorage 或名单文件、绝不
+   *  记录、在每一个界面里掩码显示。 */
   webhookTriggers: WebhookTrigger[];
   setWebhookTriggers: (list: WebhookTrigger[]) => void;
-  /** Mirror of config.orgTrigger (peer messaging between teammates' clone nodes).
-   *  Same two-way contract as `webhookTriggers`, and the same handling for
-   *  `apiKey` — in memory for the two surfaces that display it masked, nowhere
-   *  else. Configuration only for now: no transport reads the key yet. */
+  /** 镜像 config.orgTrigger（队友克隆节点之间的对等消息）。与
+   *  `webhookTriggers` 相同的双向契约，`apiKey` 也同等对待——只在内存里
+   *  供两个掩码显示它的界面使用，别处不存。目前只是配置：还没有传输读取
+   *  该密钥。 */
   orgTrigger: OrgTriggerConfig;
   setOrgTrigger: (cfg: OrgTriggerConfig) => void;
-  /** Park a message for an agent. Returns nothing; the flush loop delivers it.
-   *  `meta.instruction`, when set, is what gets typed into the PTY instead of
-   *  `text` (UI/card surfaces still show `text`). */
+  /** 为 agent 停靠一条消息。不返回任何东西；flush 循环投递它。
+   *  设置 `meta.instruction` 时，它是实际输入 PTY 的内容，而不是 `text`
+   *  （UI/卡片界面仍显示 `text`）。 */
     enqueueMessage: (agentId: string, text: string, meta?: { slack?: { channel: string; thread_ts: string }; instruction?: string; precondition?: QueuedMessage['precondition']; compactUsed?: number }) => void;
-  /** Drop a single queued message (user removed it, or it was just delivered). */
+  /** 丢弃一条已排队的消息（用户移除了它，或它刚被投递）。 */
   removeQueuedMessage: (agentId: string, messageId: string) => void;
-  /** "Send now" while floor auto-delivery is paused: marks the message manual
-   *  (drain bypasses the pause gate for it) and moves it to the queue front. */
+  /** 楼层级自动投递被暂停时的 “立即发送”：把消息标记为 manual（排空只为
+   *  它绕过暂停门）并移到队首。 */
   releaseQueuedMessage: (agentId: string, messageId: string) => void;
-  /** Clear an agent's entire pending queue. */
+  /** 清空某个 agent 的整个待决队列。 */
   clearQueue: (agentId: string) => void;
   setAddAgentOpen: (open: boolean) => void;
-  /** Validated manifests waiting for one-at-a-time human review. */
+  /** 等待逐个人工审查的已校验清单。 */
   hireQueue: HireReviewQueue;
   enqueuePendingHires: (manifests: readonly HireManifest[]) => void;
   finishPendingHire: () => void;
   clearPendingHires: () => void;
   setFullscreen: (id: string | null) => void;
-  /** Move focus mode WITHOUT touching the preference. For the paths that re-home
-   *  a focused agent that went away: the app is following the user, not being
-   *  told what the user wants. `setFullscreen` is the explicit toggle. */
+  /** 移动专注模式而不碰偏好。用于重新安置消失的聚焦 agent 的路径：
+   *  应用是在跟随用户，而不是被告知用户想要什么。`setFullscreen` 才是显式
+   *  开关。 */
   refocusFullscreen: (id: string | null) => void;
-  /** Re-apply the persisted preference now that the roster has changed. */
+  /** 名单已变化，现在重新应用持久化偏好。 */
   restoreFocusMode: () => void;
-  /** Open an absolute path in the IDE — the ONE way to show a file.
+  /** 在 IDE 中打开绝对路径——显示文件的唯一方式。
    *
-   *  v0.4.5 removed a second, worse file surface (a fullscreen overlay wrapping
-   *  a bare Monaco). It could not scroll, had no tabs, no tree, and no git, and
-   *  every file it opened was one click from "open in IDE" anyway. Everything
-   *  that used to open it now comes here, so there is exactly one editor to fix
-   *  when an editor bug shows up. */
+   *  v0.4.5 移除了第二个更差的文件界面（一个包裹裸 Monaco 的全屏浮层）。
+   *  它不能滚动、没有标签页、没有树、没有 git，而且它打开的每个文件反正
+   *  都离 “在 IDE 中打开” 只有一次点击。以前打开它的所有东西现在都到这里，
+   *  所以出现编辑器 bug 时恰好只有一个编辑器要修。 */
   openFileInIde: (absPath: string) => void;
-  /** Open/close the IDE. `agentId` names the agent whose workspace it should
-   *  show; omit it only when the caller truly has no specific agent (the IDE
-   *  then falls back to the selection and says so in its title). */
+  /** 打开/关闭 IDE。`agentId` 指名要显示其工作区的 agent；只有当调用方
+   *  确实没有特定 agent 时才省略（IDE 随后回退到选中项并在标题里说明）。 */
   setIdeOpen: (open: boolean, agentId?: string | null) => void;
   setIdeInitialFile: (path: string | null) => void;
   setSidebarWidth: (px: number) => void;
   setSidebarTab: (tab: SidebarTab) => void;
-  /** Drop persisted agents whose PTY is no longer alive in the main process.
-   *  Called once at startup so a renderer reload (e.g. after the laptop sleeps)
-   *  restores still-running agents and only removes truly-dead ones. */
+  /** 丢弃主进程中 PTY 已不再存活的持久化 agent。启动时调用一次，让渲染端
+   *  重载（例如笔记本睡眠后）恢复仍在运行的 agent、只移除真正死掉的。 */
   reconcileWithLivePtys: (livePtyIds: string[]) => void;
 }
 
@@ -349,35 +329,33 @@ const LS_ARCHIVED = 'cth.archivedAgents';
 const LS_RESTORABLE = 'cth.restorableAgents';
 const LS_SELECTED = 'cth.selectedId';
 const LS_QUEUES = 'cth.messageQueues';
-/** Which hive this origin's roster keys were last written for. See rosterSource.ts. */
+/** 此 origin 的名单键最近一次是为哪个 hive 写的。见 rosterSource.ts。 */
 const LS_ROSTER_HOME = 'cth.rosterHome';
 const LS_FOCUS_MODE = 'cth.prefersFocusMode';
 
-// Fields that are large or transient — not worth persisting across reloads.
-// contextTokens/contextLimit describe a LIVE session; persisting them showed a
-// dead session's context gauge after a restart until the poll caught up.
+// 大或瞬态的字段——不值得跨重载持久化。contextTokens/contextLimit 描述
+// 一个 LIVE 会话；持久化它们会在重启后显示死会话的上下文计量表，直到
+// 轮询追上。
 type PersistedAgent = Omit<Agent, 'recentAssistantText' | 'recentTextTs' | 'blockReason' | 'contextTokens' | 'contextLimit' | 'seedPrompt'>;
 
-// ─── The roster mirror ──────────────────────────────────────────────────────
+// ─── 名单镜像 ──────────────────────────────────────────────────────────────
 //
-// localStorage is partitioned by ORIGIN, and the two ways this app runs do not
-// share one: `npm run dev` serves the renderer from http://localhost:5173, a
-// packaged build loads it from file://. So the roster — agents, their private
-// notes, worktree paths, archived entries, parked queues — was invisible to
-// whichever of the two you were not currently in, even though the hive on disk
-// (sessions, memory, inboxes, tasks) was shared and intact the whole time.
+// localStorage 按 ORIGIN 分区，而本应用运行的两种方式并不共享同一个：
+// `npm run dev` 从 http://localhost:5173 服务渲染端，打包构建从 file://
+// 加载。因此名单——agent、它们的私有笔记、工作树路径、归档条目、停靠的
+// 队列——对你当前不在的那一边是不可见的，即使磁盘上的 hive（会话、记忆、
+// inbox、任务）全程都是共享且完整的。
 //
-// So we also mirror it to <harnessHome>/roster.json, which both sides reach by
-// path. localStorage keeps being written byte-for-byte as before: it is the
-// fallback when there is no file yet, and a standing backup afterwards. Main
-// keeps every previous version of the file under roster-backups/.
+// 所以我们还把它镜像到 <harnessHome>/roster.json，两边都能按路径到达。
+// localStorage 继续逐字节照写：它是还没有文件时的回退，以及之后常驻的
+// 备份。Main 在 roster-backups/ 下保留文件的每个旧版本。
 const fileRoster = (() => {
   try { return window.cth?.rosterReadSync?.() ?? null; } catch { return null; }
 })();
 
-/** Which hive we are opening, and which one this origin's localStorage was last
- *  written for. Both read synchronously, for the same reason the roster is: the
- *  store is built at module load, so an async answer would arrive too late. */
+/** 我们打开的是哪个 hive，以及此 origin 的 localStorage 上次是为哪个写的。
+ *  两者同步读取，理由与名单相同：store 在模块加载时构建，异步答案会来得
+ *  太晚。 */
 const currentHome = (() => {
   try { return window.cth?.harnessHomeSync?.() ?? null; } catch { return null; }
 })();
@@ -391,18 +369,17 @@ const { useFileRoster, useLocalFallback } = chooseRosterSource({
   storedHome
 });
 
-/** Claim this origin's roster keys for the hive we just opened. Written even
- *  when nothing loaded: from here on localStorage describes THIS hive, so the
- *  next hive we open knows not to adopt it. */
+/** 为刚打开的 hive 认领此 origin 的名单键。即使什么都没加载也要写：从
+ *  现在起 localStorage 描述 THIS hive，我们下次打开的 hive 才知道不要采用
+ *  它。 */
 try {
   if (currentHome) window.localStorage.setItem(LS_ROSTER_HOME, currentHome);
 } catch { /* noop */ }
 
-/** The renderer's running copy of what should be on disk. Kept as a mutable
- *  mirror updated slice-by-slice rather than read back out of the store, because
- *  every persist* call happens INSIDE a zustand `set()` — `getState()` there
- *  still returns the pre-update state, so a snapshot built that way would
- *  reliably be one edit stale. */
+/** 渲染端持有的“磁盘上应有什么”的运行副本。作为可变镜像逐切片更新，而
+ *  不是从 store 读回，因为每次 persist* 调用都发生在 zustand `set()` 内部
+ *  ——那里的 `getState()` 仍返回更新前的状态，这样构建的快照可靠地滞后
+ *  一次编辑。 */
 const rosterMirror: {
   agents: PersistedAgent[];
   archived: PersistedAgent[];
@@ -425,22 +402,21 @@ function flushRosterNow(): void {
       queues: rosterMirror.queues,
       selectedId: rosterMirror.selectedId
     });
-  } catch { /* the file is a mirror — localStorage already took the write */ }
+  } catch { /* 文件只是镜像——localStorage 已经收下了这次写入 */ }
 }
 
-/** Coalesce a burst of persist* calls into one disk write. Agent edits arrive in
- *  clusters (spawn writes agents + selection + queues in the same tick). */
+/** 把一次 persist* 突发合并成一次磁盘写入。agent 编辑总是成簇到达
+ *  （spawn 在同一 tick 写入 agents + selection + queues）。 */
 function scheduleRosterFlush(): void {
   if (rosterFlush) return;
   rosterFlush = setTimeout(flushRosterNow, 500);
 }
 
-// Don't let a quit inside the debounce window drop the last edit. localStorage
-// would still have it, but only for THIS origin — and the whole point is that
-// the other origin can read it too.
+// 别让去抖窗口内的退出丢掉最后一次编辑。localStorage 仍会保留它，但那只
+// 对 THIS origin——而全部意义就在于另一个 origin 也能读到。
 try {
   window.addEventListener('beforeunload', flushRosterNow);
-} catch { /* not a browser context (unit tests) */ }
+} catch { /* 非浏览器上下文（单元测试） */ }
 
 function slimAgents(agents: Agent[]): PersistedAgent[] {
   return agents.map(({ recentAssistantText, recentTextTs, blockReason, contextTokens, contextLimit, seedPrompt, ...rest }) => {
@@ -460,10 +436,9 @@ function persistAgents(agents: Agent[], selectedId: string | null): void {
   scheduleRosterFlush();
 }
 
-/** Run-state an agent recomputes from its live pty on every reload. A patch made
- *  only of these is not worth a localStorage write; anything else is. Listed as
- *  the volatile set rather than the durable set on purpose — a new durable field
- *  then persists by default instead of being silently dropped. */
+/** 每个 reload 时 agent 从其实时 pty 重新计算的运行状态。只由这些组成的
+ *  补丁不值得一次 localStorage 写入；其他都值得。刻意列成易变集合而非
+ *  持久集合——这样新增的持久字段默认会被持久化，而不是被静默丢弃。 */
 const VOLATILE_AGENT_FIELDS = new Set<keyof Agent>([
   'status', 'action', 'progress', 'currentStation', 'carrying',
   'recentAssistantText', 'recentTextTs', 'blockReason',
@@ -474,9 +449,9 @@ function touchesDurableAgentField(patch: Partial<Agent>): boolean {
   return Object.keys(patch).some((k) => !VOLATILE_AGENT_FIELDS.has(k as keyof Agent));
 }
 
-/** The persisted list for one slice: the shared file when it has a roster,
- *  otherwise this origin's localStorage — but only when that localStorage was
- *  written for this hive. Returns [] on anything malformed. */
+/** 一个切片的持久化列表：有名单时是共享文件，否则是此 origin 的
+ *  localStorage——但只有该 localStorage 是为这个 hive 写的。任何格式错误
+ *  都返回 []。 */
 function persistedSlice(
   key: string,
   fromFile: unknown[] | undefined
@@ -497,12 +472,12 @@ function loadPersistedAgents(): Agent[] {
   try {
     const parsed = persistedSlice(LS_AGENTS, fileRoster?.agents);
     if (!parsed.length) return [];
-    // Reset volatile run-state; the PTY stream / mock loop will repopulate it.
+    // 重置易变运行状态；PTY 流 / mock 循环会重新填充它。
     return parsed.map((a) => ({
       ...a,
       progress: 0,
       status: 'idle',
-      action: 'reconnecting…',
+      action: '正在重连…',
       currentStation: 'desk',
       carrying: undefined,
       recentTextTs: Date.now(),
@@ -525,7 +500,7 @@ function loadPersistedArchived(): Agent[] {
   try {
     const parsed = persistedSlice(LS_ARCHIVED, fileRoster?.archived);
     if (!parsed.length) return [];
-    // Archived agents have no live process — force the flag + clear run-state.
+    // 归档 agent 没有活进程——强制打上标记并清空运行状态。
     return parsed.map((a) => ({
       ...a,
       archived: true,
@@ -540,9 +515,8 @@ function loadPersistedArchived(): Agent[] {
 }
 
 function persistRestorable(restorable: Agent[]): void {
-  // Keeps contextTokens/contextLimit, unlike the other two: a restorable entry
-  // is a spawn recipe for a session that has not been re-entered yet, so its
-  // last known context size is still meaningful.
+  // 保留 contextTokens/contextLimit，不同于另外两个：可恢复条目是一个尚未
+  // 重新进入的会话的 spawn 配方，所以其最后已知的上下文大小仍有意义。
   const slim: PersistedAgent[] = restorable.map(({ recentAssistantText, recentTextTs, blockReason, seedPrompt, ...rest }) => {
     void recentAssistantText; void recentTextTs; void blockReason; void seedPrompt;
     return rest;
@@ -558,7 +532,7 @@ function loadPersistedRestorable(): Agent[] {
   try {
     const parsed = persistedSlice(LS_RESTORABLE, fileRoster?.restorable);
     if (!parsed.length) return [];
-    // No live process — clear run-state; the spawn recipe fields are what matter.
+    // 没有活进程——清空运行状态；spawn 配方字段才是要紧的。
     return parsed.map((a) => ({
       ...a,
       status: 'idle',
@@ -572,7 +546,7 @@ function loadPersistedRestorable(): Agent[] {
 
 function persistQueues(queues: Record<string, QueuedMessage[]>): void {
   try {
-    // Only keep non-empty queues so the key stays small.
+    // 只保留非空队列，让键保持小巧。
     const slim: Record<string, QueuedMessage[]> = {};
     for (const [id, q] of Object.entries(queues)) if (q.length) slim[id] = q;
     window.localStorage.setItem(LS_QUEUES, JSON.stringify(slim));
@@ -589,7 +563,7 @@ function loadPersistedQueues(): Record<string, QueuedMessage[]> {
         ? JSON.parse(window.localStorage.getItem(LS_QUEUES) ?? 'null') as Record<string, QueuedMessage[]> | null
         : null;
     if (!parsed || typeof parsed !== 'object') return {};
-    // Defensively keep only well-formed entries.
+    // 防御性地只保留结构良好的条目。
     const out: Record<string, QueuedMessage[]> = {};
     for (const [id, q] of Object.entries(parsed)) {
       if (Array.isArray(q)) {
@@ -628,13 +602,12 @@ const initialSidebarTab: SidebarTab = (() => {
   return 'terminal';
 })();
 
-/** Does the user want focus mode as their default view?
+/** 用户是否想把专注模式作为默认视图？
  *
- *  Persisted as a BOOLEAN, deliberately not as the focused agent's id. The id is
- *  meaningless across a restart: that agent may have been closed, or its PTY may
- *  not come back, and restoring a stale one lands us straight in the dangling
- *  reference `refocusAfterRemoval` exists to prevent. The preference is "I work
- *  in focus mode", so on load we resolve it against whoever is selected now. */
+ *  持久化为 BOOLEAN，刻意不存被专注 agent 的 id。id 跨重启无意义：那个
+ *  agent 可能已被关闭，或其 PTY 可能不再回来，恢复一个过期的会直接落入
+ *  `refocusAfterRemoval` 要防止的悬空引用。偏好是“我在专注模式下工作”，
+ *  所以加载时我们针对当前选中的 agent 解析它。 */
 const initialPrefersFocusMode = (() => {
   try {
     return window.localStorage.getItem(LS_FOCUS_MODE) === '1';
@@ -649,24 +622,23 @@ const initialRestorableAgents = loadPersistedRestorable();
 const initialSelectedId = loadPersistedSelectedId(initialAgents);
 const initialQueues = loadPersistedQueues();
 
-// Prime the mirror with whatever we just loaded, so a later persist of ONE slice
-// writes a complete file rather than blanking the slices it didn't touch.
+// 用刚加载的内容给镜像做种子，这样稍后对某一个切片的 persist 会写完整
+// 文件，而不是抹掉它没碰到的切片。
 rosterMirror.agents = slimAgents(initialAgents);
 rosterMirror.archived = slimAgents(initialArchivedAgents);
 rosterMirror.restorable = slimAgents(initialRestorableAgents);
 rosterMirror.queues = initialQueues;
 rosterMirror.selectedId = initialSelectedId;
 
-// First run with the file: seed it from this origin's localStorage. Only when
-// there is something to seed — writing an empty file here would hand a blank
-// roster to the other side, which is precisely the outcome being designed out.
+// 第一次用文件运行：从该 origin 的 localStorage 给它播种。只有当有东西
+// 可播种时——在这里写空文件会把空名单交给另一边，而那正是要被设计掉的
+// 结果。
 if (useLocalFallback && rosterMirror.agents.length + rosterMirror.archived.length + rosterMirror.restorable.length > 0) {
   scheduleRosterFlush();
 }
 
 let queuedSeq = 0;
-/** Process-unique id for a queued message (timestamp + counter avoids collisions
- *  when several are queued within the same millisecond). */
+/** 排队消息的进程内唯一 id（时间戳 + 计数器避免同毫秒内入队多条时冲突）。 */
 function newQueuedId(): string {
   queuedSeq += 1;
   return `q-${Date.now()}-${queuedSeq}`;
@@ -699,12 +671,10 @@ export const useStore = create<State>((set, get) => ({
   updateAgent: (id, patch) =>
     set((s) => {
       const agents = s.agents.map(a => a.id === id ? { ...a, ...patch } : a);
-      // Persist only when something DURABLE changed. `updateAgent` is also the
-      // pty parser's per-chunk write (status/action/progress), so persisting
-      // unconditionally would rewrite localStorage on every burst of terminal
-      // output. Persisting nothing was worse: a model or command change lived
-      // only in memory, so the selector snapped back to the old model on reload
-      // and restore relaunched the old command.
+      // 只在有 DURABLE 变化时持久化。`updateAgent` 同时也是 pty 解析器的
+      // 逐块写入（status/action/progress），无条件持久化会在每次终端输出
+      // 突发时重写 localStorage。完全持久化更糟：model 或 command 的变更
+      // 只活在内存里，重载后选择器弹回旧 model、restore 重启旧命令。
       if (touchesDurableAgentField(patch)) persistAgents(agents, s.selectedId);
       return { agents };
     }),
@@ -734,7 +704,7 @@ export const useStore = create<State>((set, get) => ({
   renameAgent: async (id, name) => {
     try {
       const result = await window.cth.hiveRenameAgent(id, name);
-      if (!result.ok || !result.name) return { ok: false, error: result.error ?? 'Could not rename agent' };
+      if (!result.ok || !result.name) return { ok: false, error: result.error ?? '无法重命名 agent' };
       const nextName = result.name;
 
       set((s) => {
@@ -750,7 +720,7 @@ export const useStore = create<State>((set, get) => ({
       });
       return { ok: true };
     } catch (error) {
-      return { ok: false, error: error instanceof Error ? error.message : 'Could not rename agent' };
+      return { ok: false, error: error instanceof Error ? error.message : '无法重命名 agent' };
     }
   },
   setAgentNote: (id, note) =>
@@ -763,29 +733,27 @@ export const useStore = create<State>((set, get) => ({
     set((s) => ({ feeds: { ...s.feeds, [id]: [...(s.feeds[id] ?? []), line] } })),
   addAgent: (agent) =>
     set((s) => {
-      // Idempotent by id: a MAIN-initiated spawn broadcast (hive:agentSpawned, e.g.
-      // a voice hire) and a renderer-initiated hire (AddAgentModal) can both call
-      // addAgent for the same id — never render a duplicate card. The first writer
-      // (richer local record) wins; the broadcast is a no-op for it.
+      // 按 id 幂等：MAIN 发起的 spawn 广播（hive:agentSpawned，如语音雇佣）
+      // 和渲染端发起的雇佣（AddAgentModal）可能对同一 id 都调用 addAgent
+      // ——绝不渲染重复卡片。第一个写入者（更丰富的本地记录）获胜；广播
+      // 对它而言是 no-op。
       if (s.agents.some((a) => a.id === agent.id)) return s;
-      // GOD enters at the HEAD, everyone else at the tail. Michael's position was
-      // otherwise decided by a race he usually lost: useHive's bootstrap removes
-      // the restored god entry, then spawns him asynchronously (a setTimeout, a
-      // listPtys round-trip, and a --resume that seeds a transcript first), while
-      // useRestoreTeam respawns last session's workers in parallel. Whoever
-      // resolved first landed first, so a session with workers to restore put the
-      // BOSS card fourth — and persistAgents() then wrote that order to disk, so
-      // it stuck across restarts instead of flickering once.
+      // GOD 在队首进入，其他人在队尾。Michael 的位置以前由一个他常输的
+      // 竞争决定：useHive 的引导移除恢复的 god 条目，然后异步 spawn 他
+      // （一个 setTimeout、一次 listPtys 往返、以及一个先播种 transcript 的
+      // --resume），而 useRestoreTeam 并行重启上一会话的 workers。谁先
+      // resolve 谁先落地，于是有 worker 要恢复的会话把 BOSS 卡片放到第四
+      // 位——persistAgents() 随后把那个顺序写盘，于是它跨重启固定下来，
+      // 而不是只闪烁一次。
       //
-      // Fixed at insertion rather than by sorting in AgentStrip: the strip has
-      // drag-reorder (reorderAgents) whose whole point is a persisted manual
-      // order, and a god-first sort at render time would silently override the
-      // user's own arrangement every frame. This just makes the head the honest
-      // default; a deliberate drag still wins and still persists.
+      // 在插入点修复，而不是在 AgentStrip 里排序：条带有拖拽重排
+      // (reorderAgents)，其全部意义就是持久化的人工顺序，渲染时 god-first
+      // 排序会每帧静默覆盖用户自己的安排。这里只是让队首成为诚实的默认；
+      // 刻意拖拽仍然有效并仍然持久化。
       const agents = agent.isGod ? [agent, ...s.agents] : [...s.agents, agent];
-      // Re-spawning an archived agent un-archives it: an id is active xor archived.
+      // 重新 spawn 一个归档 agent 会取消归档：一个 id 要么活跃要么归档。
       const archivedAgents = s.archivedAgents.filter((a) => a.id !== agent.id);
-      // A live (re)spawn also consumes any restorable entry for the same id.
+      // 活跃（重新）spawn 也会消费同一 id 的任何可恢复条目。
       const restorableAgents = s.restorableAgents.filter((a) => a.id !== agent.id);
       persistAgents(agents, agent.id);
       persistArchived(archivedAgents);
@@ -814,13 +782,13 @@ export const useStore = create<State>((set, get) => ({
       const target = s.agents.find((a) => a.id === id);
       if (!target) return s;
       const agents = s.agents.filter((a) => a.id !== id);
-      // Retain a flagged copy; the PTY is gone, so clear all live run-state.
+      // 保留一份带标记的副本；PTY 已消失，所以清空所有实时运行状态。
       const archivedEntry: Agent = {
         ...target,
         archived: true,
         ptyId: undefined,
         status: 'idle',
-        action: 'archived',
+        action: '已归档',
         carrying: undefined,
         currentStation: undefined
       };
@@ -857,8 +825,8 @@ export const useStore = create<State>((set, get) => ({
       const agents = [...s.agents];
       const [moved] = agents.splice(from, 1);
       agents.splice(to, 0, moved);
-      // Persist the new roster order so it survives a reload (same slim key the
-      // rest of the roster uses). selectedId is unchanged by a reorder.
+      // 持久化新名单顺序，让它跨重载存活（与名单其余部分相同的精简键）。
+      // 重排不改变 selectedId。
       persistAgents(agents, s.selectedId);
       return { agents };
     }),
@@ -884,39 +852,35 @@ export const useStore = create<State>((set, get) => ({
   setOfficeTheme: (theme) => set({ officeTheme: theme }),
   webhookTriggers: [],
   setWebhookTriggers: (list) => set({ webhookTriggers: list }),
-  // A copy, not the shared DEFAULT_ORG_TRIGGER instance — main takes the same
-  // care (withTriggerDefaults), and handing the module-level default out is how
-  // one careless mutation rewrites the default for everyone.
+  // 副本，不是共享的 DEFAULT_ORG_TRIGGER 实例——main 也这样小心
+  // (withTriggerDefaults)，把模块级默认交出去就是一次粗心改动改写所有人
+  // 默认的方式。
   orgTrigger: { ...DEFAULT_ORG_TRIGGER },
   setOrgTrigger: (cfg) => set({ orgTrigger: cfg }),
   enqueueMessage: (agentId, text, meta) =>
     set((s) => {
       const trimmed = text.trim();
       if (!trimmed) return s;
-      // ONE PENDING COMPACT PER AGENT. Compaction is idempotent in the worst way:
-      // the first `/compact` does the work and every one behind it answers
-      // "nothing to compact", so a queue that accumulates them spends a delivery
-      // slot and a model round-trip per copy to achieve nothing, and buries the
-      // operator's real backlog behind them.
+      // 每个 agent 只有一个待决 COMPACT。压缩在最坏的意义上是幂等的：第一条
+      // `/compact` 完成工作，它后面的每一条都回答 “nothing to compact”，所以
+      // 累积它们的队列会为每个副本花费一个投递槽和一次模型往返却毫无所得，
+      // 并把操作员的真实积压埋在后面。
       //
-      // The invariant lives HERE rather than at the call sites because there are
-      // several — the context trigger, god dispatching a work order, Slack, the
-      // composer — and each one that grew its own check could still be bypassed
-      // by the next path someone adds. The context trigger's own check stays as
-      // cheap defence in depth, but this is the one that cannot be routed around.
+      // 这个不变量住在 HERE 而不是调用点，因为调用点有好几个——context
+      // trigger、god 派发工单、Slack、输入框——而每个自建检查的调用点仍可能
+      // 被某人新增的下一条路径绕过。context trigger 自己的检查保留为廉价的
+      // 纵深防御，但这里这一个无法被绕开。
       const queued = s.messageQueues[agentId] ?? [];
       if (isCompactionCommand(trimmed) && queued.some((m) => isCompactionCommand(m.text))) {
         return s;
       }
-      // ONE PENDING INBOX NUDGE PER AGENT — the same property, for the same
-      // reason. The first nudge makes the agent drain its WHOLE inbox, so every
-      // nudge queued behind it lands on a directory that agent has already
-      // emptied and answers "nothing new": a delivery slot and a model
-      // round-trip each, to say nothing. Mail arriving while an agent is mid-turn
-      // queues one nudge per poll, so this is the common case rather than the
-      // rare one, and the floor reports it as repeated empty-inbox wakes.
-      // Suppressing the copy loses nothing — the surviving nudge sends the agent
-      // to the same authoritative directory, where the newer mail is waiting too.
+      // 每个 agent 只有一个待决 INBOX NUDGE——同样的性质，同样的理由。
+      // 第一个 nudge 让 agent 排空其整个 inbox，所以排在后面的每个 nudge
+      // 都落在一个 agent 已经清空的目录上并回答 “nothing new”：每个花费
+      // 一个投递槽和一次模型往返，却无话可说。agent 回合中途到达的邮件会
+      // 每个轮询排一个 nudge，所以这是常见情形而非罕见情形，楼层把它报告
+      // 为重复的空 inbox 唤醒。抑制副本不损失任何东西——幸存的 nudge 把
+      // agent 送到同一个权威目录，更新的邮件也等在那里。
       if (isInboxNudge(trimmed) && queued.some((m) => isInboxNudge(m.text))) {
         return s;
       }
@@ -963,12 +927,11 @@ export const useStore = create<State>((set, get) => ({
   reconcileWithLivePtys: (livePtyIds) =>
     set((s) => {
       const live = new Set(livePtyIds);
-      // Keep agents with no PTY (synthetic) or whose PTY is still alive.
+      // 保留没有 PTY（合成）或 PTY 仍存活的 agent。
       const agents = s.agents.filter((a) => !a.ptyId || live.has(a.ptyId));
       if (agents.length === s.agents.length) return s;
-      // Workers whose terminal died with the previous session become restorable
-      // (full spawn recipe retained) instead of silently vanishing. God and the
-      // prep assistant are excluded — they auto-respawn at boot.
+      // 终端随上一会话死亡的 worker 变为可恢复（保留完整 spawn 配方）而不是
+      // 静默消失。god 与预备助手被排除——它们启动时自动重启。
       const dead = s.agents.filter(
         (a) => a.ptyId && !live.has(a.ptyId) && !a.isGod && !a.isAssistant
       );
@@ -998,10 +961,9 @@ export const useStore = create<State>((set, get) => ({
     hireQueue: clearHireQueue(s.hireQueue)
   })),
   setFullscreen: (id) => {
-    // Entering focus mode makes it the default view; leaving it clears that.
-    // Only an explicit toggle writes the preference, so an agent closing under
-    // you never silently changes how the app opens next time. Every non-explicit
-    // mover goes through `refocusFullscreen` instead.
+    // 进入专注模式让它成为默认视图；离开则清除。只有显式开关才写偏好，所以
+    // 一个 agent 在你面前关闭绝不会静默改变应用下次打开的方式。每个非显式
+    // 的移动者都改走 `refocusFullscreen`。
     try { window.localStorage.setItem(LS_FOCUS_MODE, id ? '1' : '0'); } catch { /* noop */ }
     set({ fullscreenAgentId: id, prefersFocusMode: !!id });
   },
@@ -1013,15 +975,13 @@ export const useStore = create<State>((set, get) => ({
     }),
   openFileInIde: (absPath) => {
     const s = get();
-    // Resolve the OWNING agent here rather than in each caller: a terminal link
-    // or a Files-tab click often has nothing selected, and the IDE would
-    // otherwise fall back to the selection and open the wrong workspace.
+    // 在这里解析 OWNING agent，而不是在调用方：终端链接或 Files 标签页点击
+    // 常常没有选中项，否则 IDE 会回退到选中项并打开错误的工作区。
     const owner = s.agents.find((a) => absPath === a.cwd || absPath.startsWith(a.cwd + '/'));
     set({ ideInitialFile: absPath, ideOpen: true, ideAgentId: owner?.id ?? null });
   },
-  // Closing CLEARS the target: the id is scoped to one IDE session, and a stale
-  // one left behind would silently win over the selection on the next open from
-  // a caller that passes nothing.
+  // 关闭时 CLEARS 目标：id 的作用域是一次 IDE 会话，留下的过期 id 会在
+  // 没有传参的调用方下次打开时静默压过选中项。
   setIdeOpen: (open, agentId) => set({ ideOpen: open, ideAgentId: open ? (agentId ?? null) : null }),
   setIdeInitialFile: (path) => set({ ideInitialFile: path }),
   setSidebarWidth: (px) => {
@@ -1039,10 +999,9 @@ export function selectedAgent(s: State): Agent | undefined {
   return s.agents.find(a => a.id === s.selectedId);
 }
 
-/** Whether the Command Center's Trigger History tab has anything to be about
- *  yet: an organisation key is set, or at least one webhook exists. Derived from
- *  the two mirrors rather than stored beside them, so it cannot fall out of step
- *  with the thing it describes. Use as `useStore(triggerHistoryVisible)`. */
+/** 指挥中心的触发器历史标签页是否已经有事可谈：设置了组织密钥，或至少
+ *  存在一个 webhook。由两个镜像推导而来，而不是存在它们旁边，因此它不会
+ *  与它所描述的东西脱节。用法：`useStore(triggerHistoryVisible)`。 */
 export function triggerHistoryVisible(s: State): boolean {
   return s.webhookTriggers.length > 0 || s.orgTrigger.apiKey.trim() !== '';
 }

--- a/src/renderer/src/terminal/arabicJoiner.ts
+++ b/src/renderer/src/terminal/arabicJoiner.ts
@@ -1,43 +1,42 @@
 /**
- * Arabic rendering for the terminal — the working recipe, three parts:
+ * 终端阿拉伯语渲染 —— 工作配方，三部分：
  *
- * 1. DOM renderer (terminalPool skips the WebGL lease in Arabic mode). Rows
- *    become real DOM text, so the browser's text engine is in play at all.
+ * 1. DOM 渲染器（terminalPool 在阿拉伯语模式下跳过 WebGL 租赁）。行
+ *    变为真实 DOM 文本，浏览器文本引擎全程参与。
  *
- * 2. A character joiner (this file). On its own the DOM renderer emits a span
- *    PER CELL with letter-spacing — atomic boxes the browser can neither shape
- *    across nor reorder. Joining every Arabic phrase into one range makes it a
- *    single span: real contextual shaping, lam-alef ligatures, marks on their
- *    letters — by the font itself, no presentation-form tricks.
+ * 2. 字符连接符（本文件）。仅 DOM 渲染器会按单元格发一个 span，
+ *    带 letter-spacing —— 原子盒子，浏览器既不能跨盒
+ *    拼形也不能重排。将每段阿拉伯语短语合并为一个范围，就是一个
+ *    单独的 span：真实的语境拼形、lam-alef 连字、标点落在字符上 ——
+ *    由字体本身负责，无需预组合形字符的 trick。
  *
- * 3. CSS in design/global.css: rows get `unicode-bidi: plaintext` (each row
- *    takes its base direction from its first strong character, like dir=auto)
- *    and spans drop to `display: inline` (inline-block boxes are atomic to the
- *    bidi algorithm — inline text isn't, so phrase order follows the UBA).
+ * 3. design/global.css 中的 CSS：行获得 `unicode-bidi: plaintext`（每行
+ *    从其第一个强字符取基础方向，类似 dir=auto），span 降为
+ *    `display: inline`（inline-block 盒子对
+ *    双向算法是原子的 —— inline 文本不是，因此短语顺序遵循 UBA）。
  *
- * Result measured in a real browser: Arabic rows right-aligned and correctly
- * ordered, mixed Arabic/Latin rows interleave properly, Latin rows unchanged.
+ * 真实浏览器测量结果：阿拉伯语行右对齐且顺序正确，
+ * 混合阿拉伯语/拉丁语行正确交错，拉丁语行不变。
  *
- * KNOWN TRADE: the block cursor is drawn at the logical cell offset, counted
- * from the left — on an RTL row it does not sit where the next glyph will
- * appear. Reading correctness is worth a misplaced cursor.
+ * 已知权衡：块光标绘制在逻辑单元格偏移处，从左计数 ——
+ * 在 RTL 行上它不会落在下一个字形出现的位置。
+ * 阅读正确性值得一个错位的光标。
  */
 
-/** Arabic script, its supplements, and the presentation-form blocks. */
+/** 阿拉伯字母、其补充区块，以及预组合形区块。 */
 export function isArabicCp(cp: number): boolean {
   return (cp >= 0x0600 && cp <= 0x06ff) || (cp >= 0x0750 && cp <= 0x077f) ||
          (cp >= 0xfb50 && cp <= 0xfdff) || (cp >= 0xfe70 && cp <= 0xfeff);
 }
 
-/** Characters a phrase may flow across without ending the join: the space and
- *  punctuation that sit BETWEEN Arabic words. The range still only extends as
- *  far as the last Arabic character, so trailing punctuation stays outside. */
+/** 短语可跨越而不结束连接的字符：阿拉伯语单词之间的空格和
+ *  标点。范围仍只延伸到最后一个阿拉伯字符，因此尾部标点留在范围外。 */
 const PHRASE_GLUE = ' ,.:;()«»،؛؟!ـ-—';
 
 /**
- * Ranges of `text` (one terminal row) to render as single units: every maximal
- * stretch that containsArabic, glued across the punctuation between words.
- * Shape matches xterm's registerCharacterJoiner contract: [start, end).
+ * 要作为单个单位渲染的 `text`（终端一行）的范围：每个包含
+ * 阿拉伯语的最大连续段，跨单词间的标点粘合。
+ * 拼形匹配 xterm 的 registerCharacterJoiner 约定：[start, end)。
  */
 export function arabicJoinRanges(text: string): [number, number][] {
   const ranges: [number, number][] = [];

--- a/src/renderer/src/terminal/arabicSetting.ts
+++ b/src/renderer/src/terminal/arabicSetting.ts
@@ -1,40 +1,39 @@
 import i18n, { isRtlLanguage } from '@/i18n';
 
 /**
- * The renderer switch for RTL-script terminal support: ON keeps xterm on its
- * DOM renderer, registers the Arabic character joiner, and lets the bidi CSS
- * in design/global.css do its work — together these render Arabic (and other
- * RTL scripts' neutral runs) shaped and correctly ordered, which the WebGL
- * cell painter structurally cannot (xterm.js has no bidi: xtermjs/xterm.js#701).
- * OFF leases the WebGL renderer: faster, and exactly the previous behavior.
+ * RTL 脚本终端支持的渲染器开关：ON 保持 xterm 使用其
+ * DOM 渲染器，注册阿拉伯语字符连接符，并让 design/global.css 中的
+ * bidi CSS 发挥作用 —— 这些共同渲染阿拉伯语（和其他
+ * RTL 脚本的中性运行）正确排列，这是 WebGL
+ * 单元格绘制器结构上无法做到的（xterm.js 无双向支持：xtermjs/xterm.js#701）。
+ * OFF 使用 WebGL 渲染器：更快，且与之前行为完全一致。
  *
- * THE LANGUAGE SETS THE DEFAULT; THE TOGGLE IS AN OVERRIDE.
+ * 语言设置默认值；切换是覆盖。
  *
- * This shipped in 59d721ed as a manual switch, defaulting off for everyone,
- * because at the time Arabic could not be selected as a UI language at all — a
- * manual switch was the only door there was. Now that it can, a user who picks
- * Arabic has already answered the question this toggle asks, and asking twice
- * is the confusion the founder reported. So picking an RTL app language turns
- * it on by itself.
+ * 这在 59d721ed 中作为手动开关交付，默认对所有用户关闭，
+ * 因为当时阿拉伯语根本无法选为 UI 语言 ——
+ * 手动开关是唯一的途径。现在它可以了，选择
+ * 阿拉伯语的用户已经回答了此切换的问题，再次询问
+ * 正是创始人报告的混淆来源。因此选择 RTL 应用语言会自动开启它。
  *
- * It is a DEFAULT and not a derived value, because the tradeoff is real in both
- * directions and neither side is rare enough to lock out:
- *   - An ENGLISH user whose colleagues write Arabic, or whose logs carry it,
- *     has a genuine reason to switch this on without changing their UI language.
- *   - An ARABIC user may want the GPU renderer's speed back. It is their machine.
- * So the state is THREE-valued, not two: unset (follow the language), forced on,
- * forced off. An explicit choice outlives a language switch in both directions —
- * a user who deliberately turned this on does not lose it by moving off Arabic.
+ * 它是默认值而非派生值，因为权衡在两个方向都是真实的，且
+ * 任何一方都不罕见到可以锁定：
+ *   - 同事写阿拉伯语或其日志携带阿拉伯语的英文用户，
+ *     有正当理由在不更改 UI 语言的情况下开启此功能。
+ *   - 阿拉伯语用户可能希望恢复 GPU 渲染器的速度。这是他们的机器。
+ * 因此状态是三值的，而非两值：未设置（跟随语言）、强制开启、
+ * 强制关闭。明确选择在任何方向的切换中都保留 ——
+ * 刻意开启的用户不会因移开阿拉伯语而丢失它。
  *
- * What it deliberately does NOT do is sniff the OS locale, which is the same
- * auto-detect the language picker refuses: `navigator.languages` is not a
- * choice the user made in this app, and acting on it would move an existing
- * user off the GPU renderer on upgrade without them asking. Nothing here reads
- * anything but the language they picked and the override they set.
+ * 它刻意不去嗅探 OS 区域设置，这与语言选择器拒绝的
+ * 自动检测相同：`navigator.languages` 不是用户在此应用中
+ * 做出的选择，对其做出反应会在升级时使现有用户
+ * 脱离 GPU 渲染器而无需他们同意。这里只读取
+ * 他们选择的语言和设定的覆盖。
  */
 const KEY = 'cth.arabicTerminal';
 
-/** The user's explicit choice, or `null` for "follow the app language". */
+/** 用户的显式选择，或 `null` 表示"跟随应用语言"。 */
 type Override = boolean | null;
 
 let override: Override = readOverride();
@@ -48,32 +47,31 @@ function readOverride(): Override {
   return null;
 }
 
-/** What the current app language asks for, absent an override. */
+/** 无覆盖时，当前应用语言所要求的值。 */
 function languageDefault(): boolean {
-  // Read live rather than caching: the language changes at runtime, and this is
-  // called on terminal attach, which can happen long after module init.
+  // 实时读取而非缓存：语言在运行时可能变更，且此函数在
+  // 终端挂载时调用，可能在模块初始化之后很长时间的。
   try { return isRtlLanguage(i18n.language); } catch { return false; }
 }
 
-/** Hot path — called on terminal attach and on every renderer lease. */
+/** 热路径 —— 在终端挂载和每次 renderer 租约时调用。 */
 export function isArabicTerminalEnabled(): boolean {
   return override ?? languageDefault();
 }
 
-/** True when the value above is coming from the language, not a stored choice.
- *  Settings uses this to say so rather than presenting a default as a decision. */
+/** 当上方的值来自语言而非存储的选择时为 true。
+ *  Settings 用它来表明，而不是把一个默认值当作决策呈现。 */
 export function isArabicTerminalFollowingLanguage(): boolean {
   return override === null;
 }
 
-/** Record an explicit choice. Always writes — an override that happens to agree
- *  with the language today must still survive a switch away from it tomorrow. */
+/** 记录显式选择。始终写入 —— 今日与语言一致的覆盖，
+ *  明日语言切换后也必须保留。 */
 export function setArabicTerminalEnabled(next: boolean): void {
   override = next;
   try { window.localStorage.setItem(KEY, next ? '1' : '0'); } catch { /* private mode */ }
 }
-
-/** Drop the override and go back to following the app language. */
+/** 移除覆盖，重新跟随应用语言。 */
 export function clearArabicTerminalOverride(): void {
   override = null;
   try { window.localStorage.removeItem(KEY); } catch { /* private mode */ }

--- a/src/renderer/src/terminal/arabicSpacingFix.ts
+++ b/src/renderer/src/terminal/arabicSpacingFix.ts
@@ -1,20 +1,20 @@
 /**
- * Part 4 of the Arabic terminal recipe (see arabicJoiner.ts for parts 1–3):
- * neutralize xterm's letter-spacing on Arabic spans.
+ * 阿拉伯语终端配方的第 4 部分（第 1–3 部分见 arabicJoiner.ts）：
+ * 中和 xterm 在阿拉伯语 span 上的 letter-spacing。
  *
- * The DOM renderer pads every text run with `letter-spacing` so its width comes
- * out at an exact number of cells. For Latin monospace that is a sub-pixel
- * correction; for a joined Arabic phrase — whose natural width is far narrower
- * than one-cell-per-character — it stretches the phrase across its whole cell
- * span. Two failures at once: huge gaps between letters, and the browser
- * DISABLES cursive joining on any text with letter-spacing, so the letters
- * disconnect exactly like the bug this whole effort exists to fix.
+ * DOM 渲染器用 `letter-spacing` 填充每个文本运行，使其宽度
+ * 恰好是整数个单元格。对拉丁等宽字体这是亚像素修正；
+ * 对已粘合的阿拉伯语短语 —— 其自然宽度远窄于每字符一单元格 ——
+ * 它把短语拉伸到整个单元格跨度。两个错误同时发生：
+ * 字母间巨大间隙，且浏览器在任何带 letter-spacing 的文本上
+ * 禁用草书连接，因此字母恰好断开 —— 这正是整个努力的
+ * 要修复的 bug。
  *
- * CSS cannot express "spans whose text is Arabic", so this is a
- * MutationObserver: whenever rows change, any span containing Arabic gets its
- * letter-spacing forced to normal. Latin spans keep their correction, so TUI
- * box-drawing stays cell-aligned. The pass is cheap — it touches only added
- * nodes and changed text, a handful of spans per repaint.
+ * CSS 无法表达 "文本是阿拉伯语的 span"，因此这是一个
+ * MutationObserver：行变化时，任何包含阿拉伯语的 span
+ * 的 letter-spacing 强制为 normal。拉丁语 span 保留修正，
+ * 使 TUI 框线绘制保持单元格对齐。遍历代价低廉 ——
+ * 只触及新增节点和变更文本，每次重绘仅少数几个 span。
  */
 import { isArabicCp } from './arabicJoiner';
 
@@ -33,7 +33,7 @@ function sweep(root: ParentNode): void {
   for (const el of root.querySelectorAll('span')) fixSpan(el);
 }
 
-/** Observe a terminal's host element; returns a disposer. */
+/** 观察终端的宿主元素；返回清理函数。 */
 export function attachArabicSpacingFix(host: HTMLElement): () => void {
   sweep(host);
   const mo = new MutationObserver((records) => {

--- a/src/renderer/src/terminal/useArabicTerminalSync.ts
+++ b/src/renderer/src/terminal/useArabicTerminalSync.ts
@@ -4,16 +4,15 @@ import { isArabicTerminalEnabled } from './arabicSetting';
 import { notifyArabicTerminalChangeAll } from '@/components/terminalPool';
 
 /**
- * Make terminal Arabic/RTL rendering follow the app language.
+ * 让终端阿拉伯语/RTL 渲染跟随应用语言。
  *
- * Mounted once, near the root. `isArabicTerminalEnabled()` already reads the
- * language, so the VALUE is correct the moment a user switches — but terminals
- * that are already open read it at attach time and would otherwise keep
- * rendering the old way until they were recreated. This is the push half.
+ * 在根附近挂载一次。`isArabicTerminalEnabled()` 已读取
+ * 语言，因此用户切换时 VALUE 立刻正确 —— 但已打开的
+ * 终端在 attach 时读取它，否则会继续用旧方式渲染
+ * 直到被重建。这是推送端。
  *
- * Skips the first run: on mount every terminal was created under the current
- * setting already, so there is nothing to switch, and firing anyway would drop
- * a WebGL lease at boot for no reason.
+ * 跳过首次运行：挂载时每个终端都已在当前设置下创建，
+ * 因此无需切换，触发会无故在启动时丢弃一个 WebGL 租赁。
  */
 export function useArabicTerminalSync(): void {
   const { i18n } = useTranslation();

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -1,57 +1,43 @@
 /**
- * Agent providers — the CLI a worker runs on. The app is no longer Claude-only:
- * a worker can run Claude Code, the OpenAI Codex CLI (`codex`), Kimi Code
- * (`kimi`), xAI Grok (`grok`), the Antigravity CLI (`agy`, Gemini models), or
- * any custom command.
- * Each provider declares how to build its spawn command (model/auto-mode flags) and
- * whether it accepts the hive's Claude-specific identity injection
- * (`--append-system-prompt` + `--settings`).
+ * Agent providers——worker 运行所用的 CLI。应用不再只支持 Claude：
+ * worker 可以运行 Claude Code、OpenAI Codex CLI（`codex`）、Kimi Code
+ * （`kimi`）、Qwen Code（`qwen`）或任意自定义命令。
+ * 每个 provider 声明如何构建其 spawn 命令（model/auto-mode 标志），以及
+ * 是否接受 hive 专属的 Claude 身份注入
+ * （`--append-system-prompt` + `--settings`）。
  *
- * Shared between main and renderer; keep it dependency-free (no electron, no UI).
- * Mirrors the shape of the upstream provider-preset work (PR #47 / issue #21) so
- * the two reconcile cleanly — this build adds the `antigravity` preset alongside
- * the existing `codex` preset.
+ * 主进程与渲染进程共享；保持零依赖（无 electron、无 UI）。
+ * 与上游 provider-preset 工作的形态对齐（PR #47 / issue #21），
+ * 以便与上游 provider-preset 工作干净调和。
  */
 import type { CmdGroup } from './claudeCommands';
 import { COMMAND_GROUPS as CLAUDE_COMMAND_GROUPS } from './claudeCommands';
 import { CODEX_COMMAND_GROUPS } from './codexCommands';
-import { GROK_COMMAND_GROUPS } from './grokCommands';
 
-// NOTE: 'claw' (claw-code) was removed as a selectable provider — its upstream is
-// an unmaintained "museum exhibit" repo, not a production CLI. Re-add a supported
-// fork here (plus its preset/models/logo) after review. The proxy-bridge tier it
-// shared with qwen stays in place for qwen.
+// NOTE: 'claw' (claw-code) 已从可选 provider 中移除——其上游是一个无人维护的
+// "博物馆展品" 仓库，而非生产级 CLI。审核通过后在此重新添加受支持的
+// fork（连同其 preset/models/logo）。它与 qwen 共享的 proxy-bridge 层级
+// 保留给 qwen 使用。
 export type AgentProvider =
   | 'claude'
   | 'codex'
-  | 'grok'
   | 'kimi'
-  | 'gemini'
-  | 'antigravity'
   | 'qwen'
-  | 'opencode'
-  | 'crush'
-  | 'pi'
-  | 'copilot'
-  | 'cursor'
   | 'custom';
 
-/** Structured descriptor for how a NON-hiveAware provider gets hive lifecycle
- *  events (live status + Stop→inbox-drain + cost), introduced alongside the legacy
- *  `hookBridge` so call sites can switch on `bridge.kind` without a big-bang
- *  rewrite. Two kinds:
- *   - 'hooks'  → a config-file hook shim is installed (agy/codex). Derived from the
- *               legacy `hookBridge` by `bridgeOf`, so agy/codex keep working with no
- *               preset change.
- *   - 'proxy'  → the CLI has NO hook surface (qwen), so a loopback reverse-proxy
- *               sidecar observes its LLM traffic and SYNTHESIZES the same HIVE_SOCK
- *               payloads the shims emit. `api` selects the usage/tool-call shape
- *               (OpenAI vs Anthropic), `baseUrlEnv` is the env var the CLI reads for
- *               its upstream base URL (the sidecar's loopback URL is injected there),
- *               and `inboxDelivery` is how mail reaches it ('terminal' work-order
- *               handoff today; 'serve' reserved for a future HTTP push path). */
+/** 描述 NON-hiveAware provider 如何获取 hive 生命周期事件（在线状态 +
+ *  Stop→收件箱排空 + 成本）的结构化描述符，与遗留的 `hookBridge` 一并引入，
+ *  这样调用点无需大爆炸式重写即可根据 `bridge.kind` 分支。两种类型：
+ *   - 'hooks'  → 安装配置文件形式的 hook shim（agy/codex）。由 `bridgeOf`
+ *               从遗留 `hookBridge` 派生，因此 agy/codex 无需改动预设即可继续工作。
+ *   - 'proxy'  → CLI 没有任何 hook 表面（qwen），因此回环反向代理
+ *               侧车观察其 LLM 流量并合成 shim 发出的相同 HIVE_SOCK
+ *               负载。`api` 选择用量/工具调用形态（OpenAI vs Anthropic），
+ *               `baseUrlEnv` 是 CLI 读取其上游 base URL 的环境变量
+ *               （侧车的回环 URL 注入于此），`inboxDelivery` 是邮件到达方式
+ *               （目前为 'terminal' 工单交接；'serve' 预留给未来的 HTTP 推送路径）。 */
 export type BridgeDescriptor =
-  | { kind: 'hooks'; shim: 'agy' | 'codex' | 'pi' | 'opencode' | 'grok' | 'gemini' }
+  | { kind: 'hooks'; shim: 'codex' }
   | {
       kind: 'proxy';
       api: 'openai' | 'anthropic';
@@ -62,109 +48,103 @@ export type BridgeDescriptor =
 export interface AgentProviderPreset {
   id: AgentProvider;
   label: string;
-  /** The binary spawned when the user hasn't typed a custom command. */
+  /** 用户未输入自定义命令时生成的二进制。 */
   defaultCommand: string;
-  /** Slash / CLI command reference for this provider. */
+  /** 该 provider 的 Slash / CLI 命令参考。 */
   commandGroups: CmdGroup[];
-  /** Environment variable to set for non-interactive / first-run suppression. */
+  /** 为抑制非交互 / 首次运行提示而设置的环境变量。 */
   nonInteractiveEnv?: Record<string, string>;
-  /** Flag(s) appended to the command string when auto mode is active.
-   *  Kept alongside `autoFlag` (same value) for the HEAD consumers that read
-   *  `autoModeFlag` via `autoModeFlagForProvider`. */
+  /** 自动模式启用时追加到命令串的标志。
+   *  与 `autoFlag`（同值）并存，供通过 `autoModeFlagForProvider`
+   *  读取 `autoModeFlag` 的 HEAD 消费方使用。 */
   autoModeFlag: string;
-  /** Show a model picker and splice the model into the command. */
+  /** 显示模型选择器并把模型拼接到命令中。 */
   supportsModel: boolean;
-  /** Flag that selects the session model, e.g. `--model`. */
+  /** 选择会话模型的标志，例如 `--model`。 */
   modelFlag?: string;
-  /** Flag appended when the floor is in auto (skip-permissions) mode.
-   *  PR #54 consumers read this; mirrors `autoModeFlag`. */
+  /** 底层处于 auto（跳过权限）模式时追加的标志。
+   *  PR #54 的消费方读取此值；与 `autoModeFlag` 镜像。 */
   autoFlag?: string;
-  /** Claude Code accepts the hive identity injection (`--append-system-prompt`
-   *  + hook `--settings`). Other CLIs don't — they spawn with the shared AGENT_*
-   *  env only. Gates the Claude-specific spawn injection in hive.ensureAgent.
-   *  NOTE: this gates the *Claude-only* flag path specifically — it is NOT the
-   *  same as "participates in the hive". A non-hiveAware provider can still be a
-   *  full hive citizen (live status + guarded idle delivery) via a `hookBridge`. */
+  /** Claude Code 接受 hive 身份注入（`--append-system-prompt`
+   *  + hook `--settings`）。其他 CLI 不支持——它们只用共享的 AGENT_*
+   *  环境变量生成。在 hive.ensureAgent 中门控 Claude 专属的 spawn 注入。
+   *  NOTE：这里专门门控 *Claude-only* 标志路径——它并不等同于
+   *  "参与 hive"。非 hiveAware provider 仍可通过 `hookBridge`
+   *  成为完整的 hive 成员（在线状态 + 受保护的闲置投递）。 */
   hiveAware: boolean;
-  /** Which config-file lifecycle-hook bridge a NON-hiveAware provider uses to get
-   *  the same live status that Claude gets from `--settings`:
-   *    - 'agy'   → installAgyHooks() writes ~/.gemini/.../hooks.json (translating
-   *                shim, because agy's stdin/stdout shape differs from Claude's).
-   *    - 'codex' → installCodexHooks() writes a per-agent CODEX_HOME config and
-   *                reuses the Claude `cth-hook` shim verbatim (Codex's hook payload
-   *                + response contract are already Claude-shaped).
-   *    - 'grok'  → installGrokHooks() installs an AGENT_ID-scoped adapter for
-   *                Grok's camelCase lifecycle payloads.
-   *  Claude leaves this undefined (it uses its native `--settings` path, gated by
-   *  hiveAware); `custom` leaves it undefined (no bridge → no hooks). This is the
-   *  single switch hive.ensureAgent dispatches on to wire the bridge. */
-  hookBridge?: 'agy' | 'codex' | 'grok';
-  /** Structured bridge descriptor (the forward-looking replacement for the legacy
-   *  `hookBridge`). Set explicitly only for PROXY-tier providers (qwen) that
-   *  have no hook file to install; agy/codex leave it undefined and `bridgeOf`
-   *  derives `{kind:'hooks'}` from their `hookBridge`. claude/custom leave it
-   *  undefined (no bridge). Prefer `bridgeOf(provider)` over reading this directly. */
+  /** NON-hiveAware provider 用哪个配置文件生命周期 hook 桥来获得
+   *  Claude 从 `--settings` 获得的那种在线状态：
+   *    - 'codex' → installCodexHooks() 写入每 agent 的 CODEX_HOME 配置，
+   *                并原样复用 Claude 的 `cth-hook` shim（Codex 的 hook 负载
+   *                + 响应契约已经是 Claude 形态）。
+   *  Claude 将此项留空（它走原生 `--settings` 路径，由 hiveAware 门控）；
+   *  `custom` 也留空（无桥 → 无 hooks）。这是 hive.ensureAgent
+   *  分发接线 bridge 的唯一开关。 */
+  hookBridge?: 'codex';
+  /** 结构化 bridge 描述符（遗留 `hookBridge` 的前瞻性替代）。仅为没有
+   *  hook 文件可装的 PROXY 层级 provider（qwen）显式设置；agy/codex 留空，
+   *  由 `bridgeOf` 从它们的 `hookBridge` 派生 `{kind:'hooks'}`。claude/custom
+   *  留空（无桥）。优先使用 `bridgeOf(provider)`，而非直接读取此字段。 */
   bridge?: BridgeDescriptor;
-  /** The model the GOD orchestrator ("Michael") defaults to when this provider
-   *  powers it — surfaced as the picker default and the advisory "give Michael a
-   *  longer-context, higher-capability model". `modelForRole` resolves the GOD
-   *  model as `config.godModel ?? preset.recommendedOrchestratorModel ?? MODEL_GOD`.
-   *  Advisory + user-overridable. */
+  /** 该 provider 为 GOD 编排器（"Michael"）供电时默认使用的模型——
+   *  作为选择器默认值以及建议 "give Michael a longer-context, higher-capability model"
+   *  呈现。`modelForRole` 把 GOD 模型解析为
+   *  `config.godModel ?? preset.recommendedOrchestratorModel ?? MODEL_GOD`。
+   *  仅建议性，用户可覆盖。 */
   recommendedOrchestratorModel?: string;
-  /** Whether the router may DELIVER inbox mail to this provider (vs bouncing it
-   *  to the god). Requires lifecycle status so the renderer can deliver only at a
-   *  safe idle prompt: Claude natively, Antigravity/Codex/Grok via hook bridges.
-   *  A hookless custom provider cannot expose safe-idle state, so mail bounces.
-   *  Distinct from hiveAware: agy/codex/grok are NOT hiveAware (no Claude injection)
-   *  but CAN receive inbox via their bridge. */
+  /** 路由是否可以把收件箱邮件 DELIVER 给此 provider（而不是弹回给 god）。
+   *  需要生命周期状态，渲染器才能仅在安全的闲置提示点投递：Claude 原生支持，
+   *  Antigravity/Codex/Grok 经由 hook 桥。无 hook 的 custom provider 无法暴露
+   *  安全闲置状态，因此邮件会弹回。与 hiveAware 不同：
+   *  agy/codex/grok 不是 hiveAware（无 Claude 注入），但可以通过它们的
+   *  bridge 接收收件箱。 */
   canReceiveInbox: boolean;
-  /** For non-hive-aware CLIs that still take an INITIAL prompt to orient the
-   *  session (Antigravity's `agy -i "<prompt>"`), the flag to pass it under. The
-   *  hive identity+protocol rides in as the first turn — the closest thing to
-   *  Claude's `--append-system-prompt` these CLIs offer. undefined = the CLI
-   *  takes its initial prompt POSITIONALLY (Codex: `codex "<prompt>"`) and the
-   *  injection branch appends it as a quoted trailing arg instead of a flag. */
+  /** 对仍接受 INITIAL prompt 来定向会话的非 hive-aware CLI
+   *  （Antigravity 的 `agy -i "<prompt>"`），传入 prompt 所用的标志。
+   *  hive 身份+协议作为第一轮输入进入——这是这些 CLI 提供的
+   *  最接近 Claude `--append-system-prompt` 的机制。undefined = CLI
+   *  以位置参数接收初始 prompt（Codex：`codex "<prompt>"`），
+   *  注入分支把它作为带引号的尾部参数追加，而不是用标志。 */
   initialPromptFlag?: string;
-  /** How the hive protocol seed is delivered for a CLI that takes NEITHER a flag
-   *  nor a positional seed. `'type-into-tui'` = the CLI is a bare interactive TUI
-   *  that rejects a positional initial prompt (Crush: its first positional is read
-   *  as a Cobra SUBCOMMAND → `Unknown command "You are…"`), so the harness must NOT
-   *  append the protocol to argv — it spawns the bare TUI and hands the protocol
-   *  back as `seedPrompt`, which the renderer types into the TUI's editor after boot
-   *  (through the SAME per-pty write-chain as the inbox-wake nudge, so they can't
-   *  collide). Absent/undefined = today's flag-or-positional behavior. (ondev-b) */
+  /** 对既不接受标志也不接受位置种子的 CLI，hive 协议种子如何交付。
+   *  `'type-into-tui'` = CLI 是裸交互式 TUI，拒绝位置初始 prompt
+   *  （Crush：其第一个位置参数被当作 Cobra SUBCOMMAND 解析 →
+   *  `Unknown command "You are…"`），因此 harness 绝不能把协议追加到
+   *  argv——它生成裸 TUI，并把协议作为 `seedPrompt` 交回，由渲染器在
+   *  启动后输入到 TUI 的编辑器（与收件箱唤醒提示共用同一条 per-pty
+   *  写链路，因此不会冲突）。缺省/undefined = 现行的标志或位置参数
+   *  行为。（ondev-b） */
   seedDelivery?: 'type-into-tui';
-  /** This CLI accepts the initial hive prompt as a trailing positional argument.
-   *  Codex does; Kimi/custom do not, so they must spawn bare when no prompt flag
-   *  exists instead of receiving an invalid positional argument. */
+  /** 该 CLI 接受把初始 hive prompt 作为尾部位置参数。
+   *  Codex 支持；Kimi/custom 不支持，因此没有 prompt 标志时
+   *  它们必须裸生成，而不是收到一个无效的位置参数。 */
   positionalInitialPrompt?: boolean;
-  /** Flag to resume a prior session on respawn, given the recorded session id
-   *  (Claude `--resume <sid>`, Antigravity `--conversation <id>`). undefined = no
-   *  resume support, spawn fresh. */
+  /** 重新生成时恢复先前会话所用的标志，给定已记录的会话 id
+   *  （Claude `--resume <sid>`、Antigravity `--conversation <id>`）。undefined =
+   *  不支持恢复，全新生成。 */
   resumeFlag?: string;
-  /** Shell command that installs this provider's engine CLI when it's missing,
-   *  e.g. `npm install -g @anthropic-ai/claude-code`. When set, the missing-CLI
-   *  path may RUN it visibly in the agent terminal (after pre-spawn detection);
-   *  when undefined, the user is shown a manual instruction only and nothing is
-   *  auto-run. MUST be a trusted, hardcoded constant — never user/manifest input. */
+  /** 该 provider 的引擎 CLI 缺失时用于安装它的 shell 命令，
+   *  例如 `npm install -g @anthropic-ai/claude-code`。设置后，缺失 CLI 的
+   *  路径可在 agent 终端中可见地运行它（在生成前检测之后）；
+   *  undefined 时只向用户显示手动说明，不自动运行任何内容。
+   *  必须是可信的、硬编码的常量——绝不接受用户/清单输入。 */
   installCommand?: string;
-  /** A SELF-CONTAINED installer that needs no Node/npm at all, per platform.
+  /** 完全自包含的安装器，按平台提供，完全不需要 Node/npm。
    *
-   *  `installCommand` is `npm install -g …` for every provider, which silently
-   *  assumes npm — i.e. node — is already on the machine. When it isn't, the
-   *  missing-CLI banner prints a command that CANNOT succeed, so the user watches
-   *  an installer fail instead of an app work. Where the vendor ships a native
-   *  installer we run that instead (see buildMissingCliScript's ladder).
+   *  每个 provider 的 `installCommand` 都是 `npm install -g …`，这默许
+   *  机器上已有 npm——即 node。没有时，缺失 CLI 的横幅会打印一条
+   *  注定失败的命令，用户看到的是安装器失败而不是应用可用。厂商自带
+   *  原生安装器时我们改跑它（见 buildMissingCliScript 的阶梯）。
    *
-   *  Trusted, hardcoded constants — never user/manifest input. MUST contain no
-   *  double-quotes: the Windows form is wrapped verbatim in `cmd /d /s /c "…"`. */
+   *  可信的、硬编码的常量——绝不接受用户/清单输入。绝不能包含双引号：
+   *  Windows 形态会被原样包裹在 `cmd /d /s /c "…"` 中。 */
   nativeInstallCommand?: { posix: string; win32: string };
-  /** Optional docs URL surfaced as a manual-setup hint in the missing-CLI banner. */
+  /** 可选的文档 URL，作为手动设置提示显示在缺失 CLI 的横幅中。 */
   docsUrl?: string;
-  /** Extra argv tokens that count as an explicit permission stance (so the auto
-   *  flag is not appended). Defaults to the auto flag's own leading token. */
+  /** 被视为显式权限姿态的额外 argv 词元（因此不再追加 auto 标志）。
+   *  默认为 auto 标志自身的首词元。 */
   autoStanceTokens?: string[];
-  resumeSubcommand?: string; // CLIs that resume via a subcommand instead of a flag (Codex: `codex resume [OPTIONS] [SESSION_ID]`)
+  resumeSubcommand?: string; // 通过子命令而不是标志来恢复会话的 CLI（Codex：`codex resume [OPTIONS] [SESSION_ID]`）
 }
 
 export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
@@ -179,14 +159,14 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     autoFlag: '--permission-mode bypassPermissions',
     hiveAware: true,
     canReceiveInbox: true,
-    // Longest-context Claude variant — matches the "give Michael a bigger model"
-    // advisory and the Recommended tag on the orchestrator picker.
+    // 上下文最长的 Claude 变体——匹配 "give Michael a bigger model"
+    // 建议和编排器选择器上的 "Recommended" 标签。
     recommendedOrchestratorModel: 'claude-opus-4-8[1m]',
     resumeFlag: '--resume',
-    // Official Claude Code install (npm global). Used by the missing-CLI auto-install.
+    // Claude Code 官方安装方式（npm 全局）。用于缺失 CLI 的自动安装。
     installCommand: 'npm install -g @anthropic-ai/claude-code',
-    // Anthropic's official native installer — a standalone binary, no node/npm.
-    // The only rung of the ladder that works on a machine with no Node at all.
+    // Anthropic 官方原生安装器——独立二进制，不需要 node/npm。
+    // 是在完全没有 Node 的机器上唯一可用的阶梯档位。
     nativeInstallCommand: {
       posix: 'curl -fsSL https://claude.ai/install.sh | bash',
       win32: 'powershell -c irm https://claude.ai/install.ps1 ^| iex'
@@ -198,371 +178,99 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     label: 'Codex · GPT',
     defaultCommand: 'codex',
     commandGroups: CODEX_COMMAND_GROUPS,
-    // Auto mode: never prompt (-a never) but KEEP codex's OS sandbox, scoped to the
-    // workspace (-s workspace-write). The app used to spawn with
-    // `--dangerously-bypass-approvals-and-sandbox` for one reason only: a hive
-    // worker must write to its agent folder at <harnessHome>/hive/agents/<id>/,
-    // a different path tree from cwd, which workspace-write blocked. That is a
-    // path-layout problem, not a reason to drop the sandbox: codex's documented
-    // `--add-dir <DIR>` makes extra directories writable alongside the workspace,
-    // and the hive spawn path (hive.ts, which knows the agent dir) appends it.
-    // So: approvals off, sandbox on, hive housekeeping still works.
-    autoModeFlag: '-a never -s workspace-write',
-    autoFlag: '-a never -s workspace-write',
-    // Any of these on a command line means the user already chose a posture
-    // (including the old full bypass) — do not stack ours on top.
+    // 自动模式：从不提示（-a never），但保留 codex 的 OS 沙箱。应用过去
+    // 仅因一个原因用 `--dangerously-bypass-approvals-and-sandbox` 生成：
+    // hive worker 必须写入其位于 <harnessHome>/hive/agents/<id>/ 的
+    // agent 文件夹，这是一条与 cwd 不同的路径树，被 workspace-write
+    // 沙箱阻止。那是路径布局问题，不是放弃沙箱的理由：codex 文档化的
+    // `--add-dir <DIR>` 让额外目录与工作区一同可写，hive 的生成路径
+    // （hive.ts，知道 agent 目录）会追加它。
+    // NOTE（codex 0.151，Windows）：`-s workspace-write` 会在启动时
+    // 拒绝 `--add-dir`（"effective permissions do not allow additional
+    // writable roots"）并退出 1——agent PTY 在生成后几秒就死掉。
+    // `danger-full-access` 接受 `--add-dir` 并保留命令执行沙箱。
+    // 结论：关闭审批，开启沙箱（full-access），hive 的后勤工作仍然有效。
+    autoModeFlag: '-a never -s danger-full-access',
+    autoFlag: '-a never -s danger-full-access',
+    // 命令行上出现其中任何一个都意味着用户已选择了姿态
+    // （包括旧的完全绕过）——不要叠加我们的标志。
     autoStanceTokens: ['-a', '--ask-for-approval', '-s', '--sandbox', '--full-auto', '--dangerously-bypass-approvals-and-sandbox'],
-    // Suppresses first-run interactive prompts (directory-trust gate, installer).
+    // 抑制首次运行的交互式提示（目录信任门槛、安装器）。
     nonInteractiveEnv: { CODEX_NON_INTERACTIVE: '1' },
     supportsModel: true,
     modelFlag: '--model',
-    // Codex is NOT hiveAware in the Claude-flag sense: it has no
-    // `--append-system-prompt`/`--settings`. The hive protocol is injected as
-    // Codex's INITIAL prompt, which it takes POSITIONALLY (`codex "<prompt>"`) —
-    // hence initialPromptFlag is undefined and hive.ts appends it as a trailing arg.
+    // 在 Claude 标志意义上，Codex 不是 hiveAware：它没有
+    // `--append-system-prompt`/`--settings`。hive 协议作为
+    // Codex 的 INITIAL prompt 注入，它以位置参数接收（`codex "<prompt>"`）——
+    // 因此 initialPromptFlag 为 undefined，hive.ts 把它作为尾部参数追加。
     hiveAware: false,
-    // …but Codex DOES expose a Claude-style hooks system (hooks.json / config.toml
-    // [hooks]; PreToolUse/PostToolUse/Stop/…), so it gets full hive parity via the
-    // 'codex' bridge: a per-agent CODEX_HOME/hooks.json wired to the cth-hook shim
-    // (see hive.installCodexHooks). Stop→drain works natively (Codex's Stop honors
-    // {decision:'block',reason} = continue-with-prompt, exactly like Claude).
+    // ……但 Codex 确实暴露了 Claude 风格的 hooks 系统（hooks.json / config.toml
+    // [hooks]；PreToolUse/PostToolUse/Stop/……），因此经由 'codex' 桥获得完整的
+    // hive 对等地位：每 agent 的 CODEX_HOME/hooks.json 接入 cth-hook shim
+    // （见 hive.installCodexHooks）。Stop→排空原生可用（Codex 的 Stop 遵守
+    // {decision:'block',reason} = continue-with-prompt，与 Claude 完全相同）。
     hookBridge: 'codex',
-    // Inbox drains via the codex-hook bridge's Stop→drain (the renderer's idle
-    // inbox-wake nudge remains as a harmless fallback for an idle worker).
+    // 收件箱经由 codex-hook 桥的 Stop→排空清空（渲染器的闲置收件箱唤醒
+    // 提示仍是闲置 worker 的无害回退）。
     canReceiveInbox: true,
     initialPromptFlag: undefined,
     positionalInitialPrompt: true,
-    // Codex's long-context coding model for the orchestrator role. // TODO-verify
-    // the exact codex CLI model id (couldn't install the codex CLI to confirm).
+    // Codex 用于编排器角色的长上下文编码模型。 // TODO-verify
+    // 确切的 codex CLI 模型 id（因无法安装 codex CLI 未能确认）。
     recommendedOrchestratorModel: 'gpt-5-codex',
-    // Codex resumes via a SUBCOMMAND, not a flag: `codex resume [OPTIONS]
-    // [SESSION_ID]`. A `--resume <id>` flag does not exist, which is why restarts
-    // used to silently start a brand-new session instead of continuing.
+    // Codex 通过 SUBCOMMAND 而非标志恢复会话：`codex resume [OPTIONS]
+    // [SESSION_ID]`。不存在 `--resume <id>` 标志，这正是重启过去会
+    // 静默开启全新会话而不是继续的原因。
     resumeFlag: undefined,
     resumeSubcommand: 'resume',
-    // Official OpenAI Codex CLI install (npm global). Used by the missing-CLI auto-install.
+    // OpenAI Codex CLI 官方安装方式（npm 全局）。用于缺失 CLI 的自动安装。
     installCommand: 'npm install -g @openai/codex',
     docsUrl: 'https://github.com/openai/codex'
-  },
-  {
-    id: 'grok',
-    label: 'Grok · xAI',
-    defaultCommand: 'grok',
-    commandGroups: GROK_COMMAND_GROUPS,
-    // Grok documents bypassPermissions as the CLI/config spelling of its
-    // always-approve mode. Deny rules and lifecycle gates still take precedence.
-    autoModeFlag: '--permission-mode bypassPermissions',
-    autoFlag: '--permission-mode bypassPermissions',
-    supportsModel: true,
-    modelFlag: '--model',
-    hiveAware: false,
-    // Grok supports Claude-compatible lifecycle events but sends camelCase
-    // payloads. The bridge normalizes them before forwarding to HookServer.
-    hookBridge: 'grok',
-    canReceiveInbox: true,
-    // `grok [PROMPT]` accepts the initial hive protocol as a positional prompt.
-    positionalInitialPrompt: true,
-    // Grok resumes interactively with `grok --resume <session-id-or-title>`.
-    resumeFlag: '--resume'
   },
   {
     id: 'kimi',
     label: 'Kimi Code',
     defaultCommand: 'kimi',
     commandGroups: [],
-    // Kimi --auto handles every approval and does not stop to ask questions,
-    // matching Munder Difflin's autonomous Claude/Codex default.
+    // Kimi --auto 处理所有审批且不会停下来提问，
+    // 与 Munder Difflin 的自主 Claude/Codex 默认行为一致。
     autoModeFlag: '--auto',
     autoFlag: '--auto',
     supportsModel: true,
     modelFlag: '--model',
     hiveAware: false,
-    // Kimi's interactive TUI has no positional initial-prompt form. It supports
-    // lifecycle hooks, but Munder Difflin does not yet install a Kimi hook bridge,
-    // so mail must bounce rather than being delivered with no drain path.
-    canReceiveInbox: false
+    // Kimi 的交互式 TUI 没有位置形式的初始 prompt。它支持生命周期 hooks，
+    // 但 Munder Difflin 尚未安装 Kimi hook 桥，因此邮件必须弹回，
+    // 而不是在没有任何排空路径的情况下投递。
+    canReceiveInbox: false,
+    // Kimi 是裸交互式 TUI，既不接受位置初始 prompt 也不接受 prompt 标志
+    // （与 Crush 相同），因此协议以 seedPrompt 交回，由渲染器在启动后键入
+    // TUI 编辑器。没有它，kimi 会裸 spawn，god/kimi 智能体收不到 hive 协议。
+    seedDelivery: 'type-into-tui'
   },
   {
-    // Google's official Gemini CLI. Unlike Antigravity (`agy`), this is the
-    // open-source `@google/gemini-cli` binary and uses Gemini's native settings
-    // hooks (BeforeTool/AfterTool/BeforeAgent/AfterAgent/SessionStart).
-    id: 'gemini',
-    label: 'Gemini CLI',
-    defaultCommand: 'gemini',
-    commandGroups: [],
-    // `--yolo` is deprecated upstream; approval-mode is the current spelling.
-    autoModeFlag: '--approval-mode=yolo',
-    autoFlag: '--approval-mode=yolo',
-    supportsModel: true,
-    modelFlag: '--model',
-    hiveAware: false,
-    bridge: { kind: 'hooks', shim: 'gemini' },
-    canReceiveInbox: true,
-    // Keep the TUI alive after processing the hive protocol seed.
-    initialPromptFlag: '-i',
-    recommendedOrchestratorModel: 'pro',
-    resumeFlag: '--resume',
-    installCommand: 'npm install -g @google/gemini-cli',
-    docsUrl: 'https://github.com/google-gemini/gemini-cli'
-  },
-  {
-    id: 'antigravity',
-    label: 'Antigravity · Gemini',
-    defaultCommand: 'agy',
-    commandGroups: [],
-    autoModeFlag: '--dangerously-skip-permissions',
-    supportsModel: true,
-    modelFlag: '--model',
-    autoFlag: '--dangerously-skip-permissions',
-    hiveAware: false,
-    hookBridge: 'agy', // installAgyHooks() → ~/.gemini/.../hooks.json (translating shim)
-    canReceiveInbox: true, // via the agy-hook bridge (Stop→drain); verified agy honors hook decisions
-    initialPromptFlag: '-i', // agy --prompt-interactive: orient the session, then continue
-    recommendedOrchestratorModel: 'Gemini 3.1 Pro (High)', // agy takes the display-name label
-    resumeFlag: '--conversation' // agy: resume a previous conversation by ID
-  },
-  {
-    // qwen-code — the Qwen CLI (a gemini-cli fork) driving any OpenAI-compatible
-    // endpoint (OPENAI_BASE_URL). It has no hook surface, so it rides a PROXY
-    // bridge (bridge.kind==='proxy'), with the OpenAI usage/tool-call shape.
+    // qwen-code——Qwen CLI（gemini-cli 的分支），驱动任何 OpenAI 兼容
+    // 端点（OPENAI_BASE_URL）。它没有 hook 表面，因此走 PROXY
+    // 桥（bridge.kind==='proxy'），采用 OpenAI 用量/工具调用形态。
     id: 'qwen',
     label: 'Qwen (local available)',
     defaultCommand: 'qwen',
     commandGroups: [],
-    // gemini-cli heritage: --yolo auto-approves all actions. // TODO-verify
+    // gemini-cli 传承：--yolo 自动批准所有操作。 // TODO-verify
     autoModeFlag: '--yolo',
     supportsModel: true,
     modelFlag: '--model',
     autoFlag: '--yolo',
     hiveAware: false,
-    // SPIKE/TODO-verify: confirm qwen-code reads OPENAI_BASE_URL for its upstream
-    // ('serve' inboxDelivery is reserved for a later qwen-serve HTTP push path).
+    // SPIKE/TODO-verify：确认 qwen-code 读取 OPENAI_BASE_URL 作为其上游
+    // （'serve' inboxDelivery 预留给以后的 qwen-serve HTTP 推送路径）。
     bridge: { kind: 'proxy', api: 'openai', baseUrlEnv: 'OPENAI_BASE_URL', inboxDelivery: 'terminal' },
     canReceiveInbox: true,
-    // gemini-cli style interactive-orient flag. // TODO-verify
+    // gemini-cli 风格的交互式定向标志。 // TODO-verify
     initialPromptFlag: '-i',
-    // Qwen's long-context coder model for the orchestrator. // TODO-verify
+    // Qwen 用于编排器的长上下文编码模型。 // TODO-verify
     recommendedOrchestratorModel: 'qwen3-coder-plus',
     resumeFlag: undefined
-  },
-  {
-    // OpenCode — the TypeScript AI coding agent (opencode.ai / anomalyco/opencode,
-    // ex sst/opencode). NOT the archived Go opencode-ai/opencode (→ Crush). Run as
-    // its interactive TUI in a PTY (like codex), oriented by --prompt.
-    id: 'opencode',
-    label: 'OpenCode',
-    defaultCommand: 'opencode',
-    commandGroups: [],
-    // OpenCode's TUI exposes no skip-permissions FLAG; headless auto-approve is a
-    // config concern (permission:allow). To keep auto-mode gated behind the floor
-    // `config.autoMode` toggle (Pam guardrail #2), the permission JSON is NOT a
-    // static nonInteractiveEnv — spawnAgentCore builds OPENCODE_CONFIG_CONTENT
-    // dynamically (permission:allow only when autoMode is on; + a local provider
-    // block when a base-URL is set). So no auto flag is spliced onto the command.
-    autoModeFlag: '',
-    autoFlag: '',
-    supportsModel: true,
-    modelFlag: '--model', // value form: provider/model, e.g. anthropic/claude-sonnet-4-5
-    hiveAware: false, // no --append-system-prompt/--settings; protocol rides in via --prompt
-    // NATIVE PLUGIN bridge (god Decision 1): OpenCode has no Claude-shaped Stop hook,
-    // but its plugin API DOES expose a real lifecycle event (session.idle). A bundled
-    // per-agent plugin drains the inbox on idle and posts HIVE_SOCK payloads — the
-    // same Stop→drain semantics as codex's hooks, provider-agnostic, no traffic
-    // interception. Modeled as a `hooks` bridge with a new `opencode` shim so it
-    // reuses the existing hooks dispatch arm (installOpenCodePlugin, sibling of
-    // installCodexHooks). The config-injection proxy is the documented fallback only.
-    bridge: { kind: 'hooks', shim: 'opencode' },
-    // god-eligible. NOTE: the plugin bridge is architecturally verified (event surface
-    // + payload contract) but its live runtime (auto-load + session.idle firing +
-    // injection) is UNVERIFIED pending BYOK keys / a local LLM. The renderer idle
-    // inbox-wake nudge (useHive.ts) is the guaranteed fallback so a god still drains.
-    canReceiveInbox: true,
-    initialPromptFlag: '--prompt', // opencode --prompt "<orchestrator/worker brief>"
-    // NO recommended model — deliberately. This used to preselect
-    // `anthropic/claude-sonnet-4-5` under the comment "OpenCode's own default",
-    // which was wrong on both halves: it is not OpenCode's default, and it is a
-    // BYOK slug that resolves only for a user who has authenticated Anthropic
-    // inside OpenCode. Without that key OpenCode SILENTLY falls back to whatever
-    // it can reach (observed live on Windows: "DeepSeek V4 Flash Free" via
-    // OpenCode Zen) while every surface in this app went on reporting Claude
-    // Sonnet 4.5 — the picker said one model, the agent ran another, and nothing
-    // flagged the divergence. Undefined means buildSpawnCommand emits no
-    // `--model` at all, so OpenCode uses the model the user actually configured;
-    // every BYOK slug in the OpenCode model catalog stays one click away for
-    // whoever has the key.
-    recommendedOrchestratorModel: undefined,
-    // Capturing the TUI session id for resume is unverified; spawn fresh on respawn
-    // (protocol re-injected as the initial prompt), matching codex.
-    resumeFlag: undefined,
-    installCommand: 'npm install -g opencode-ai@latest', // trusted, hardcoded
-    // Node-free installers, for the rung that runs when npm is absent AND no Node
-    // installer could be resolved (offline / unsupported platform) — until now
-    // OpenCode had none, so that rung printed a manual hint and installed nothing.
-    // Both are trusted, hardcoded constants and contain no double-quotes (the
-    // win32 form is wrapped verbatim in `cmd /d /s /c "…"`).
-    //
-    // Unlike Claude, OpenCode ships NO standalone Windows one-liner: opencode.ai
-    // serves the POSIX install script but has no `install.ps1` (verified 404), and
-    // its docs list Chocolatey/Scoop as the Windows-native routes. `-y` because the
-    // banner runs the command unattended in the agent terminal. Honest limitation:
-    // this rung needs Chocolatey already present; when it isn't, the user sees
-    // choco's own "not recognized" error plus the banner's existing "run the
-    // command above manually" fallback — no worse off than the manual-only text.
-    nativeInstallCommand: {
-      posix: 'curl -fsSL https://opencode.ai/install | bash',
-      win32: 'choco install opencode -y'
-    },
-    docsUrl: 'https://opencode.ai/docs'
-  },
-  {
-    // Crush — Charmbracelet's Go TUI coding agent (charmbracelet/crush), successor to
-    // the archived Go opencode-ai/opencode. Non-hiveAware. Its hook surface is
-    // Claude-shaped but exposes ONLY PreToolUse today (NO Stop/SessionEnd) — so a
-    // hooks bridge can't drain on turn-end. Hence a PROXY bridge (qwen tier): a
-    // loopback sidecar observes its LLM traffic and SYNTHESIZES the Stop→drain.
-    id: 'crush',
-    label: 'Crush · Charm',
-    defaultCommand: 'crush',
-    commandGroups: [],
-    // No CODEX_NON_INTERACTIVE analogue. First-run onboarding is suppressed by the
-    // harness-written per-agent CRUSH_GLOBAL_CONFIG (provider+model+key pre-seeded),
-    // set in env at spawn by installCrushConfig — NOT via this field.
-    nonInteractiveEnv: undefined,
-    autoModeFlag: '--yolo', // -y: accept all permissions (dangerous; unsandboxed). Gated by config.autoMode.
-    autoFlag: '--yolo',
-    supportsModel: true,
-    modelFlag: '--model', // value format: provider/model-id, e.g. anthropic/claude-..., openai/gpt-4o
-    hiveAware: false,
-    // PROXY bridge. baseUrlEnv is an INTENTIONALLY INERT sentinel: Crush has NO
-    // base-URL env override, so the generic proxy env-rewrite does nothing for it.
-    // Real routing is via a per-agent CRUSH_GLOBAL_CONFIG whose provider base_url
-    // points at the loopback (installCrushConfig, special-cased in the proxy arm).
-    // Do NOT "fix" this to a real env var — it would have no effect.
-    bridge: { kind: 'proxy', api: 'openai', baseUrlEnv: 'CRUSH_PROXY_BASE_URL', inboxDelivery: 'terminal' },
-    // OpenAI-WIRE default so the out-of-box Crush god routes through the proxy
-    // cleanly (the proxy serves one wire-shape; an anthropic/* default would route to
-    // the wrong upstream — Dwight verify-crush MF1). Advisory/editable; non-OpenAI-wire
-    // Crush-via-proxy is on-device live-verify. // exact long-context id humanQA
-    recommendedOrchestratorModel: 'openai/gpt-4o',
-    // god-eligible via the proxy bridge (terminal inbox delivery on synthesized idle).
-    // Live runtime (proxy parse of Crush traffic + synthesized Stop) is UNVERIFIED
-    // pending keys; the renderer idle nudge is the guaranteed drain fallback.
-    canReceiveInbox: true,
-    // Bare `crush` is an interactive Bubble Tea TUI on a Cobra root command: the
-    // first positional is parsed as a SUBCOMMAND, so a positional seed dies with
-    // `unknown command "You are…"` (ondev-b live repro / spec-crush MF3). Crush has
-    // NO --prompt flag either. So neither flag nor positional works → deliver the
-    // protocol by TYPING it into the TUI after boot (renderer nudge path).
-    initialPromptFlag: undefined,
-    seedDelivery: 'type-into-tui',
-    resumeFlag: '--session', // Crush supports resume by id (also --continue for most-recent)
-    installCommand: 'npm install -g @charmland/crush', // trusted, hardcoded (brew/go/winget also valid)
-    docsUrl: 'https://github.com/charmbracelet/crush'
-  },
-  {
-    // Pi (Pi Coding Agent, earendil-works; npm @earendil-works/pi-coding-agent).
-    // Terminal-first, headless-driveable, 15-provider BYOK. Non-hiveAware, but has a
-    // rich pi.on(event) lifecycle (tool_call→PreToolUse, agent_end→Stop, …). Bridged
-    // via a bundled per-agent extension (installPiHooks) that posts HIVE_SOCK payloads
-    // and auto-approves tools — a `hooks` bridge with a new `pi` shim.
-    id: 'pi',
-    label: 'Pi',
-    defaultCommand: 'pi',
-    commandGroups: [],
-    // pi has NO yolo flag. `--approve` is per-run PROJECT trust (accept the cwd so pi
-    // doesn't prompt to trust the folder); the actual tool auto-allow lives INSIDE the
-    // bridge extension's tool_call handler, which respects the floor auto-state via
-    // HIVE_AUTO_APPROVE env (Pam guardrail #5). Gated by config.autoMode like the rest.
-    autoModeFlag: '--approve',
-    autoFlag: '--approve',
-    // Suppress first-run version-check / telemetry chatter in the PTY. // humanQA exact names
-    nonInteractiveEnv: { PI_SKIP_VERSION_CHECK: '1', PI_TELEMETRY: '0' },
-    supportsModel: true,
-    modelFlag: '--model', // value form: provider/model, e.g. anthropic/claude-sonnet-4-5 (thinking via :high)
-    hiveAware: false,
-    // HOOKS bridge via the new `pi` shim (installPiHooks). NOTE: only the structured
-    // `bridge` is set (NOT the legacy hookBridge) — bridgeOf returns preset.bridge
-    // first, so a hookBridge:'pi' would be dead weight + force a second union widening.
-    bridge: { kind: 'hooks', shim: 'pi' },
-    recommendedOrchestratorModel: 'anthropic/claude-sonnet-4-5',
-    // god-eligible. Live runtime (whether the extension auto-continues from agent_end,
-    // or we lean on the renderer idle nudge) is UNVERIFIED pending keys. Renderer nudge
-    // is the guaranteed drain fallback either way.
-    canReceiveInbox: true,
-    initialPromptFlag: undefined, // positional, like codex: pi "<prompt>"
-    resumeFlag: '--session',
-    // --ignore-scripts: don't run the package's postinstall on the user's machine.
-    installCommand: 'npm install -g --ignore-scripts @earendil-works/pi-coding-agent',
-    docsUrl: 'https://pi.dev/docs/latest'
-  },
-  {
-    // GitHub Copilot CLI (`copilot`, npm @github/copilot). Driven in print mode:
-    // `copilot -p "<prompt>" -s --allow-all-tools --no-ask-user [--model]`, the
-    // documented non-interactive shape (single prompt, clean stdout, exits when
-    // done). Non-hiveAware: it has no --append-system-prompt/--settings, so the
-    // hive identity+protocol rides in as the initial prompt via `-p`.
-    id: 'copilot',
-    label: 'Copilot',
-    defaultCommand: 'copilot',
-    commandGroups: [],
-    // Non-interactive autonomy: -s prints only the agent's final response (clean
-    // stdout), --allow-all-tools never blocks on a permission prompt (env:
-    // COPILOT_ALLOW_ALL), --no-ask-user disables the ask_user tool so it never
-    // stops to ask. Gated by the floor `config.autoMode` toggle like the rest.
-    autoModeFlag: '-s --allow-all-tools --no-ask-user',
-    autoFlag: '-s --allow-all-tools --no-ask-user',
-    supportsModel: true,
-    modelFlag: '--model', // e.g. claude-sonnet-4.5 (default), gpt-5.4, or 'auto'
-    hiveAware: false, // no --append-system-prompt/--settings; protocol rides in via -p
-    initialPromptFlag: '-p', // copilot -p "<orchestrator/worker brief>" runs it non-interactively
-    recommendedOrchestratorModel: 'claude-sonnet-4.5', // Copilot's default; user may pick gpt-5.4
-    // Copilot supports session resume by id (`--resume=<id>`); attached only when a
-    // prior session id was recorded (no hook bridge captures it yet → best-effort).
-    resumeFlag: '--resume',
-    // Print mode exits per turn and there is no hook bridge to drain on idle, so a
-    // copilot worker can't receive routed inbox mail (it bounces to the god).
-    canReceiveInbox: false,
-    installCommand: 'npm install -g @github/copilot', // trusted, hardcoded
-    docsUrl: 'https://docs.github.com/copilot/concepts/agents/about-copilot-cli'
-  },
-  {
-    // Cursor Agent CLI (`cursor-agent`, https://cursor.com/docs/cli). The official
-    // installer puts `cursor-agent` on PATH; `agent` is a shorter alias. Interactive
-    // TUI by default (no `-p`), so the session stays alive for hive mail via the
-    // renderer idle / work-order path — same class as Crush. Print mode (`-p`) is
-    // available for scripts but exits per turn; this preset intentionally does
-    // NOT use `-p` so Michael and workers remain god-eligible / inbox-capable.
-    // Models (including cheap gpt-5.6-luna-*) bill against Cursor credits via the
-    // logged-in CLI — there is no separate "plain OpenAI API" path for Luna.
-    id: 'cursor',
-    label: 'Cursor',
-    defaultCommand: 'cursor-agent',
-    commandGroups: [],
-    // --force/--yolo: allow tool calls without confirmations. --trust: skip the
-    // workspace trust prompt so unattended Mac Mini spawns do not stall. Gated by
-    // the floor config.autoMode toggle like every other engine.
-    autoModeFlag: '--force --trust',
-    autoFlag: '--force --trust',
-    supportsModel: true,
-    modelFlag: '--model', // e.g. gpt-5.6-luna-high, auto, composer-2.5
-    hiveAware: false,
-    // No Cursor hook bridge yet — mail delivery uses the terminal work-order /
-    // idle-nudge fallback (same honesty as Crush before its proxy is verified).
-    canReceiveInbox: true,
-    // `cursor-agent` parses early argv as Cobra-style commands (login, models, mcp, …).
-    // A long hive protocol string must NOT ride as a positional — type it into
-    // the TUI after boot instead (Crush pattern).
-    initialPromptFlag: undefined,
-    seedDelivery: 'type-into-tui',
-    recommendedOrchestratorModel: 'gpt-5.6-luna-high',
-    resumeFlag: '--resume',
-    // Official install is a curl|bash script (not npm). Prefer the native rung so
-    // a node-free machine can still self-heal. Trusted hardcoded constants only.
-    nativeInstallCommand: {
-      posix: 'curl https://cursor.com/install -fsS | bash',
-      win32: 'irm https://cursor.com/install?win32=true | iex'
-    },
-    docsUrl: 'https://cursor.com/docs/cli/install'
   },
   {
     id: 'custom',
@@ -573,7 +281,7 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     supportsModel: false,
     autoFlag: '',
     hiveAware: false,
-    canReceiveInbox: false // no inbox-drain path → mail bounces to the god
+    canReceiveInbox: false // 没有收件箱排空路径 → 邮件弹回给 god
   }
 ];
 
@@ -581,16 +289,8 @@ export function isAgentProvider(value: unknown): value is AgentProvider {
   return (
     value === 'claude' ||
     value === 'codex' ||
-    value === 'grok' ||
     value === 'kimi' ||
-    value === 'gemini' ||
-    value === 'antigravity' ||
     value === 'qwen' ||
-    value === 'opencode' ||
-    value === 'crush' ||
-    value === 'pi' ||
-    value === 'copilot' ||
-    value === 'cursor' ||
     value === 'custom'
   );
 }
@@ -607,54 +307,44 @@ export function isClaudeProvider(provider: AgentProvider | undefined): boolean {
   return provider === 'claude';
 }
 
-/** Whether this provider takes the hive's Claude-only identity injection. */
+/** 该 provider 是否接受 hive 专属的 Claude 身份注入。 */
 export function isHiveAwareProvider(provider: AgentProvider | undefined): boolean {
   return providerPreset(provider ?? 'claude').hiveAware;
 }
 
-/** Whether the router may deliver inbox mail to this provider (else bounce to
- *  the god). True when lifecycle status supports guarded idle delivery; false
- *  for hookless custom commands. */
+/** 路由是否可以向该 provider 投递收件箱邮件（否则弹回给 god）。
+ * 生命周期状态支持受保护的闲置投递时为 true；无 hook 的自定义
+ * 命令时为 false。 */
 export function canReceiveInbox(provider: AgentProvider | undefined): boolean {
   return providerPreset(provider ?? 'claude').canReceiveInbox;
 }
 
-/** The bare executable from a command string ('agy --model x' → 'agy'). */
+/** 命令串中的裸可执行文件（'agy --model x' → 'agy'）。 */
 function commandBinary(command: string | undefined): string {
   const first = (command ?? '').trim().split(/\s+/)[0] ?? '';
-  // strip a path + extension so 'C:\...\agy.exe' and '/usr/bin/claude' both map
+  // 去掉路径和扩展名，让 'C:\...\agy.exe' 与 '/usr/bin/claude' 都能映射
   const leaf = first.split(/[\\/]/).pop() ?? first;
   return leaf.replace(/\.(exe|cmd|bat|ps1)$/i, '').toLowerCase();
 }
 
-/** Infer the provider from a command (or honor an explicit override). */
+/** 从命令推断 provider（或遵从显式覆盖）。 */
 export function inferAgentProvider(command: string | undefined, explicit?: unknown): AgentProvider {
   const normalized = normalizeAgentProvider(explicit);
   if (normalized) return normalized;
   const bin = commandBinary(command);
   if (bin === 'codex') return 'codex';
-  if (bin === 'grok') return 'grok';
   if (bin === 'kimi') return 'kimi';
-  if (bin === 'gemini') return 'gemini';
-  if (bin === 'agy' || bin === 'antigravity') return 'antigravity';
   if (bin === 'qwen') return 'qwen';
-  if (bin === 'opencode') return 'opencode';
-  if (bin === 'crush') return 'crush';
-  if (bin === 'pi') return 'pi';
-  if (bin === 'copilot') return 'copilot';
-  // Cursor ships as `cursor-agent`; `agent` is a shorter alias (generic name — check last).
-  if (bin === 'cursor-agent') return 'cursor';
-  if (bin === 'agent') return 'cursor';
   if (bin === 'claude' || !bin) return 'claude';
   return 'custom';
 }
 
-/** The structured bridge descriptor for how a non-hiveAware provider receives hive
- *  lifecycle events. Returns the preset's explicit `bridge` when set (proxy tier:
- *  qwen); else derives `{kind:'hooks', shim}` from the legacy `hookBridge`
- *  (agy/codex), so those keep working untouched; else undefined (claude uses its
- *  native `--settings` path, custom has no bridge). The single accessor call sites
- *  switch on (`bridge.kind`). */
+/** 描述非 hiveAware provider 如何接收 hive 生命周期事件的结构化
+ *  bridge 描述符。设置时返回预设的显式 `bridge`（proxy 层级：qwen）；
+ *  否则从遗留 `hookBridge` 派生 `{kind:'hooks', shim}`（agy/codex），
+ *  让它们无需改动即可继续工作；否则 undefined（claude 用原生
+ *  `--settings` 路径，custom 无桥）。调用点唯一访问器
+ *  根据 `bridge.kind` 分支。 */
 export function bridgeOf(provider: AgentProvider | undefined): BridgeDescriptor | undefined {
   const preset = providerPreset(provider ?? 'claude');
   if (preset.bridge) return preset.bridge;
@@ -667,19 +357,18 @@ export function defaultCommandForProvider(provider: AgentProvider, fallback = ''
   return providerPreset(provider).defaultCommand || fallback;
 }
 
-/** Returns the preset's auto-mode CLI flag for the given provider. Empty string = no flag. */
+/** 返回给定 provider 预设的 auto-mode CLI 标志。空串 = 无标志。 */
 export function autoModeFlagForProvider(provider: AgentProvider): string {
   return providerPreset(provider).autoModeFlag ?? '';
 }
 
-/** Idempotently append a provider's auto-mode flag to an args array, honoring the
- *  user's global autoMode toggle. The renderer's Add Agent flow bakes this same
- *  flag into the command STRING before a GUI hire ever reaches the shared spawn
- *  core (buildSpawnCommand → tokenizeCommand), so `args` for a GUI spawn already
- *  contains it by the time it gets here — this is a no-op for that path. A
- *  main-only spawn (an ephemeral worker, a voice hire) never passes through that
- *  renderer step, so without this it got neither the flag nor any equivalent,
- *  leaving it in an ask-first posture no one could ever answer. */
+/** 幂等地把 provider 的 auto-mode 标志追加到 args 数组，尊重用户的
+ * 全局 autoMode 开关。渲染器的 Add Agent 流程在 GUI hire 到达共享 spawn
+ * 核心（buildSpawnCommand → tokenizeCommand）之前就把同一标志烘焙进
+ * 命令 STRING，因此 GUI spawn 的 `args` 到达此处时已包含它——对那条
+ * 路径这是空操作。仅主进程的 spawn（临时 worker、语音 hire）不会经过
+ * 那个渲染器步骤，因此没有这个函数它既得不到标志也得不到任何等价物，
+ * 只能停留在无人能回答的 ask-first 姿态。 */
 export function argsWithAutoModeFlag(args: string[], autoMode: boolean, provider: AgentProvider): string[] {
   if (!autoMode) return args;
   const flag = autoModeFlagForProvider(provider);
@@ -688,9 +377,9 @@ export function argsWithAutoModeFlag(args: string[], autoMode: boolean, provider
   return [...args, ...flag.trim().split(/\s+/)];
 }
 
-/** True when argv already states a permission posture for this provider: the
- *  auto flag's leading token, or any of the preset's `autoStanceTokens`. Token
- *  match, not substring — copilot's flag starts with `-s`. */
+/** 当 argv 已为该 provider 声明权限姿态时为 true：auto 标志的首词元，
+ *  或预设 `autoStanceTokens` 中的任意一个。词元匹配而非子串——
+ *  `-s` 开头的标志按词元匹配。 */
 export function hasAutoModeStance(args: string[], provider: AgentProvider): boolean {
   const preset = providerPreset(provider);
   const flag = preset.autoModeFlag ?? '';
@@ -699,23 +388,23 @@ export function hasAutoModeStance(args: string[], provider: AgentProvider): bool
   return args.some((a) => stance.has(a));
 }
 
-/** Returns any env vars the provider needs for non-interactive / first-run suppression. */
+/** 返回 provider 用于非交互 / 首次运行抑制所需的任何环境变量。 */
 export function nonInteractiveEnvForProvider(provider: AgentProvider): Record<string, string> {
   return providerPreset(provider).nonInteractiveEnv ?? {};
 }
 
-/** Returns the command reference groups for the given provider. */
+/** 返回给定 provider 的命令参考组。 */
 export function commandGroupsForProvider(provider: AgentProvider): CmdGroup[] {
   return providerPreset(provider).commandGroups ?? [];
 }
 
-/** Install metadata for a provider's engine CLI, consumed by the missing-CLI
- *  auto-install path. `command` is the (trusted, hardcoded) installer to run when
- *  present; when undefined the caller shows a manual hint and runs NOTHING. `label`
- *  is the friendly CLI name; `docsUrl` is an optional manual-setup link. */
+/** provider 引擎 CLI 的安装元数据，由缺失 CLI 的自动安装路径消费。
+ *  `command` 是存在时要运行的（可信、硬编码）安装器；undefined 时
+ *  调用方只显示手动提示且不运行任何内容。`label` 是友好的 CLI 名称；
+ *  `docsUrl` 是可选手动设置链接。 */
 export interface ProviderInstallInfo {
   command?: string;
-  /** A node-free installer for this platform, when the vendor ships one. */
+  /** 平台对应的无 Node 安装器，当厂商提供时。 */
   nativeCommand?: string;
   label: string;
   docsUrl?: string;

--- a/src/shared/agentRole.ts
+++ b/src/shared/agentRole.ts
@@ -1,10 +1,10 @@
 /**
- * Durable agent role vs live status.
+ * 持久的 agent 角色 vs 实时状态。
  *
- * Hive `registry.json` stores `role` (job / hire one-liner). The floor roster
- * stores the same string as `description`. Live run-state belongs on
- * `status` / `action` — never on role. Pause, idle, and Cursor "standby"
- * captions are status, not a job.
+ * Hive `registry.json` 存储 `role`（job / hire 的一句话说明）。底层花名册
+ * 把同一个字符串存储为 `description`。实时运行状态属于
+ * `status` / `action`——绝不属于 role。暂停、空闲和 Cursor 的 "standby"
+ * 说明文字是状态，不是 job。
  */
 
 const TRANSIENT_ROLE_RE = /^(on\s+)?standby$|^(idle|awaiting|paused|resumed|working|thinking|archived|starting up|reconnecting…?|running the floor|a fresh harness)$/i;
@@ -16,9 +16,9 @@ export function isDurableRole(text: string | undefined | null): boolean {
 }
 
 /**
- * Pick the job string that should survive a respawn or roster/registry sync.
- * A real hire role always beats a status-like caption. When both are durable,
- * `candidate` wins (the value the operator just set).
+ * 挑选出应在一次重生或花名册/registry 同步后存活的 job 字符串。
+ * 真实的 hire 角色总是胜过状态样的说明文字。当两者都是持久的时，
+ * `candidate` 胜出（操作员刚设置的值）。
  */
 export function preferredAgentRole(
   candidate: string | undefined | null,
@@ -34,8 +34,8 @@ export function preferredAgentRole(
   return isGod ? 'orchestrator (god)' : 'agent';
 }
 
-/** Role to send on spawn/restart. Omit a transient roster caption so the hive
- *  registry can keep the last real hire role. */
+/** 在 spawn/重启时发送的角色。省略临时的花名册说明文字，让 hive
+ *  registry 能保留上一个真实的 hire 角色。 */
 export function roleForHiveSpawn(agent: {
   description?: string;
   isGod?: boolean;

--- a/src/shared/broadcast.ts
+++ b/src/shared/broadcast.ts
@@ -1,37 +1,36 @@
 /**
- * Broadcast fan-out target selection.
+ * 广播扇出目标选择。
  *
- * Kept as a pure function (and out of `hive.ts`) so the rule is testable on its
- * own, the way `queueDelivery` / `codexRemote` are.
+ * 保持为纯函数（放在 `hive.ts` 之外），这样该规则可以像
+ * `queueDelivery` / `codexRemote` 一样独立测试。
  */
 
-/** The subset of a registry agent that fan-out actually looks at. */
+/** 扇出实际关注的 registry agent 子集。 */
 export interface BroadcastCandidate {
-  /** Michael's prep assistant — send-only, drains no inbox. */
+  /** Michael 的预备助手——仅发送，不排空收件箱。 */
   isAssistant?: boolean;
-  /** PTY tab closed; the record is retained but the agent is not live. */
+  /** PTY 标签页已关闭；记录保留，但该 agent 不再存活。 */
   archived?: boolean;
 }
 
 /**
- * The agents a `to: 'broadcast'` message fans out to.
+ * `to: 'broadcast'` 消息扇出到的目标 agents。
  *
- * Excluded: the sender itself, the send-only prep assistant (direct mail to it
- * would rot unread), and archived agents (no live PTY).
+ * 排除：发送者自身、仅发送的预备助手（直接发给它只会无人阅读而腐烂），
+ * 以及已归档的 agent（没有存活 PTY）。
  *
- * NOT excluded: providers without a hook/proxy bridge. Fan-out used to gate on
- * `canReceiveInbox`, which meant an agent on a hookless provider — `custom`,
- * i.e. any CLI the presets don't know — silently never heard a broadcast, even
- * though a DIRECT message to that same agent was delivered fine. That asymmetry
- * was the bug: `deliver` already routes a hookless target through
- * `emitTerminalHandoff` (a terminal work order) and only bounces to the god when
- * the renderer is unavailable. Fan-out now selects the same agents direct mail
- * can reach, and that existing per-target path decides HOW each one is served.
+ * 不排除：没有 hook/proxy 桥接的 provider。扇出过去以 `canReceiveInbox`
+ * 为门禁，这意味着 hookless provider——`custom`，即预设不认识的任何
+ * CLI——上的 agent 永远静默地听不到广播，尽管发给同一个 agent 的 DIRECT
+ * 消息能正常送达。那个不对称正是 bug：`deliver` 本来就会把 hookless
+ * 目标经由 `emitTerminalHandoff`（终端工单）投递，仅在渲染器不可用时
+ * 才弹回给 god。扇出现在选择与直接邮件可达的同一批 agents，由那条
+ * 既有的逐目标路径决定每个如何被服务。
  *
- * The trade-off this accepts: with the renderer down, a broadcast to N hookless
- * agents produces N bounces to the god instead of silence. That is the same
- * behaviour N direct messages already produce, and it is the loud failure —
- * nothing is dropped without the god being told.
+ * 此处接受的取舍：渲染器宕机时，发给 N 个 hookless agents 的广播
+ * 会产生 N 条弹回给 god 的消息而不是沉默，这与 N 条直接消息原本
+ * 产生的行为相同，并且这是有声的失败——不会在未告知 god 的情况下
+ * 丢弃任何消息。
  */
 export function selectBroadcastTargets(
   agents: Record<string, BroadcastCandidate | undefined>,

--- a/src/shared/claudeCommands.ts
+++ b/src/shared/claudeCommands.ts
@@ -1,17 +1,17 @@
 /**
- * Single source of truth for the Claude Code command reference.
+ * Claude Code 命令参考的唯一权威来源。
  *
- * Consumed by BOTH the renderer (the Command Center "commands" tab) and the main
- * process (rendered to `<hive>/COMMANDS.md`, which the orchestrator agent reads),
- * so the human's cheat-sheet and the agent's reference never drift.
+ * 被 renderer（Command Center 的 "commands" 标签页）和 main
+ * 进程（渲染到 `<hive>/COMMANDS.md`，编排 agent 会读取它）双方消费，
+ * 因此人的速查表与 agent 的参考永不偏离。
  *
- * Web-verified against the Claude Code docs (slash + CLI reference) for v2.1.x.
- * Curated to the broadly-useful set — aliases and trivia are intentionally omitted.
+ * 已对照 Claude Code 文档（斜杠 + CLI 参考）v2.1.x 做网络核实。
+ * 精选到广泛有用的一档——别名与琐碎内容被刻意省略。
  *
- * `kind` doubles as the scope hint an orchestrator needs:
- *   - `slash` acts ONLY on the session it's typed into (you cannot run it on
- *     another agent's terminal).
- *   - `cli` runs in a shell and can target the fleet / spawn / query.
+ * `kind` 兼任编排者需要的范围提示：
+ *   - `slash` 只作用于被敲入的那个会话（你不能在另一个 agent 的终端上运行它）。
+ *   - `cli` 在 shell 中运行，可以针对 fleet / spawn / query，
+ *     因此可以用它去定位 fleet / 派生 / 查询。
  */
 export type CmdKind = 'slash' | 'cli';
 

--- a/src/shared/codexCommands.ts
+++ b/src/shared/codexCommands.ts
@@ -1,13 +1,13 @@
 /**
- * Command reference for the OpenAI Codex CLI.
+ * OpenAI Codex CLI 的命令参考。
  *
- * Mirrors the shape of claudeCommands.ts so any component that renders a
- * command reference can switch on provider. Curated from the Codex CLI
- * reference + slash-commands docs (developers.openai.com/codex/cli/).
+ * 镜像 claudeCommands.ts 的形态，这样任何渲染命令参考的组件都可以
+ * 按提供商切换。从 Codex CLI 参考 + slash 命令文档
+ * （developers.openai.com/codex/cli/）整理而成。
  *
- * `kind` semantics match claudeCommands.ts:
- *   - `slash`  — typed inside the Codex interactive REPL session
- *   - `cli`    — shell flags / sub-commands passed at launch
+ * `kind` 语义与 claudeCommands.ts 一致：
+ *   - `slash`  — 在 Codex 交互式 REPL 会话中输入
+ *   - `cli`    — 启动时传入的 shell 标志 / 子命令
  */
 import type { CmdGroup } from './claudeCommands';
 
@@ -16,9 +16,9 @@ export const CODEX_COMMAND_GROUPS: CmdGroup[] = [
     title: 'SESSION',
     items: [
       { cmd: '/clear', kind: 'slash', desc: 'Start a fresh chat without quitting — clears the conversation context.' },
-      // Verified present in the codex 0.137.0 binary's own command table. It was
-      // missing here while providerAutomation sent it, so the two disagreed.
-      // Unlike Claude's, this one ignores any trailing focus text.
+      // 已在 codex 0.137.0 二进制自身的命令表中确认存在。此前
+      // providerAutomation 会发送它，而这里缺失，所以二者不一致。
+      // 与 Claude 的不同，这一条会忽略任何尾随的焦点文本。
       { cmd: '/compact', kind: 'slash', desc: 'Summarize the conversation so far to stay under the context limit.' },
       { cmd: '/help', kind: 'slash', desc: 'List every available slash command.' },
       { cmd: '/copy', kind: 'slash', desc: 'Copy the latest model output to the clipboard.' },
@@ -46,7 +46,7 @@ export const CODEX_COMMAND_GROUPS: CmdGroup[] = [
     title: 'APPROVALS & PERMISSIONS',
     items: [
       { cmd: 'codex --dangerously-bypass-approvals-and-sandbox', kind: 'cli', desc: 'Skip ALL approval prompts AND drop the OS sandbox (full filesystem access). Munder Difflin no longer uses this for auto mode; it keeps the sandbox and adds the hive agent folder via --add-dir.' },
-      { cmd: 'codex -a never -s workspace-write', kind: 'cli', desc: 'Never prompt for approval (-a never) but keep the sandbox scoped to the project workspace (-s workspace-write). What Munder Difflin uses for auto mode; the hive agent folder is added with --add-dir <dir>.' },
+      { cmd: 'codex -a never -s danger-full-access', kind: 'cli', desc: 'Never prompt for approval (-a never) but keep the sandbox on (-s danger-full-access, which allows --add-dir <dir>). What Munder Difflin uses for auto mode; the hive agent folder is added with --add-dir.' },
       { cmd: 'codex -a untrusted', kind: 'cli', desc: 'Only run trusted commands without asking; escalate to the user for anything else.' },
       { cmd: 'codex -s danger-full-access', kind: 'cli', desc: 'Remove all sandbox restrictions (fine-grained flag — pair with -a for full control).' }
     ]

--- a/src/shared/codexRemote.ts
+++ b/src/shared/codexRemote.ts
@@ -4,23 +4,23 @@ import { join } from 'node:path';
 export const CODEX_REMOTE_SOCKET_RELATIVE =
   'app-server-control/app-server-control.sock';
 
-/** macOS caps a Unix socket path at 104 bytes (`sun_path`), and Codex builds its
- *  control socket as `$CODEX_HOME/app-server-control/app-server-control.sock` —
- *  42 bytes of suffix. So the alias home itself must fit in ~61 bytes.
+/** macOS 把 Unix socket 路径限制在 104 字节（`sun_path`），而 Codex 把它的
+ *  控制 socket 构造成 `$CODEX_HOME/app-server-control/app-server-control.sock`——
+ *  后缀 42 字节。所以别名 home 本身必须容纳在约 61 字节内。
  *
- *  `$TMPDIR` cannot host it: macOS spells it
- *  `/var/folders/xx/<30-char-hash>/T/` (49 bytes) and the alias came out at 121
- *  — LONGER than the 118-byte real home it was introduced to shorten, so every
- *  daemon start failed with `path must be shorter than SUN_LEN`. Root the alias
- *  at a fixed short prefix instead and keep the digest to 8 hex chars: the whole
- *  socket path then lands at 60 bytes with room to spare. */
+ *  `$TMPDIR` 无法承载它：macOS 把它写成
+ *  `/var/folders/xx/<30-char-hash>/T/`（49 字节），而别名算出来是 121——
+ *  比它被引入所要缩短的那个 118 字节真实 home 还要长，所以每次
+ *  daemon 启动都以 `path must be shorter than SUN_LEN` 失败。把别名
+ *  扎根在一个固定的短前缀上，并把摘要控制在 8 个十六进制字符：
+ *  整个 socket 路径于是落在 60 字节，还有余量。 */
 export const CODEX_REMOTE_ALIAS_ROOT = '/tmp/mdc';
 
-/** Longest socket path the platform will accept, minus a small safety margin. */
+/** 平台接受的最长 socket 路径，减去一点安全余量。 */
 export const CODEX_REMOTE_SOCKET_MAX = 104;
 
-/** Keep the CODEX_HOME spelling short enough for macOS's Unix-socket limit.
- *  `tempRoot` defaults to the short fixed root; callers may override it (tests). */
+/** 把 CODEX_HOME 的拼写保持得足够短，以适配 macOS 的 Unix-socket 限制。
+ *  `tempRoot` 默认为那个短固定根；调用方可以覆盖它（测试用）。 */
 export function codexRemoteAliasPath(
   realHome: string,
   agentId: string,
@@ -33,7 +33,7 @@ export function codexRemoteAliasPath(
   return join(tempRoot, digest);
 }
 
-/** Whether a candidate home yields a control socket the platform can bind. */
+/** 候选 home 是否会产生平台能绑定的控制 socket。 */
 export function codexRemoteSocketFits(shortHome: string): boolean {
   return join(shortHome, CODEX_REMOTE_SOCKET_RELATIVE).length < CODEX_REMOTE_SOCKET_MAX;
 }
@@ -42,7 +42,7 @@ export function codexRemoteEndpoint(shortHome: string): string {
   return `unix://${join(shortHome, CODEX_REMOTE_SOCKET_RELATIVE)}`;
 }
 
-/** Global options must precede `resume`, so prepend the endpoint in all cases. */
+/** 全局选项必须位于 `resume` 之前，所以要在所有情况下都前置端点。 */
 export function withCodexRemoteArgs(args: string[], endpoint: string): string[] {
   if (args.includes('--remote')) return args;
   return ['--remote', endpoint, ...args];

--- a/src/shared/commandLine.ts
+++ b/src/shared/commandLine.ts
@@ -1,13 +1,13 @@
-/** Split a command string into argv, respecting double/single quotes so a model
- *  value with spaces (agy's `--model "Gemini 3.1 Pro (High)"`) stays one token.
- *  Quotes are stripped from the result.
+/** 把命令字符串拆分为 argv，尊重双/单引号，使含空格的模型值
+ *  （agy 的 `--model "Gemini 3.1 Pro (High)"`）保持为单个 token。
+ *  引号会从结果中剥掉。
  *
- *  Shared because BOTH sides split command lines: the renderer's spawn flows
- *  (AddAgentModal, restore, command center) and main's god-hired-worker path
- *  (processSpawnRequest). They used to carry byte-identical copies, which is an
- *  invitation for the two to drift — and a worker whose command line splits
- *  differently from the renderer's is exactly the class of silent breakage the
- *  spawn-request fix exists to prevent. */
+ *  共享是因为两侧都要拆分命令行：渲染器的 spawn 流程
+ *  （AddAgentModal、restore、命令中心）和主进程的 god 雇佣 worker 路径
+ *  （processSpawnRequest）。它们过去各持一份逐字节相同的副本，
+ *  这等于邀请两侧漂移——而一个命令行拆分方式与渲染器不同的 worker，
+ *  正是 spawn-request 修复要防止的那类静默破坏。
+ *  */
 export function tokenizeCommand(command: string): string[] {
   const out: string[] = [];
   const re = /"([^"]*)"|'([^']*)'|(\S+)/g;

--- a/src/shared/dropFonts.ts
+++ b/src/shared/dropFonts.ts
@@ -1,18 +1,18 @@
 /**
- * Self-hosted webfonts for the release-drop iframe, base64-encoded.
+ * 供 release-drop iframe 使用的自托管 webfont，base64 编码。
  *
- * The drop renders in a sandboxed iframe (srcDoc, opaque origin, CSP
- * default-src 'none'). That frame CANNOT reach a bundled font URL — no
- * same-origin, and font-src is data: only — so the design fonts have to travel
- * INSIDE the document as data: URIs. This is the drop's equivalent of the
- * app's own self-hosting (src/renderer/src/design/fonts.css): no launch-time
- * Google Fonts fetch, nothing to hang on a blocked fonts.googleapis.com.
+ * drop 渲染在沙箱 iframe 中（srcDoc、不透明源、CSP
+ * default-src 'none'）。那个 frame 无法触达打包的字体 URL——没有同源，
+ * 且 font-src 仅允许 data:——因此设计字体必须以 data: URI 的形式
+ * 内嵌进文档里。这是 drop 版的应用自身自托管
+ * （src/renderer/src/design/fonts.css）：没有启动时的 Google Fonts
+ * 请求，也没有任何东西会挂在被屏蔽的 fonts.googleapis.com 上。
  *
- * Generated from the SAME woff2 the app ships:
+ * 由应用同款 woff2 生成：
  *   - Inter    → src/renderer/src/assets/fonts/inter-latin-var.woff2 (drop --font-sans; substitutes Geist)
  *   - JetBrains Mono → …/jetbrains-mono-latin-var.woff2 (drop --font-mono, exact)
- * Both are variable (one file spans weight 400–700). Regenerate with
- * scripts/gen-drop-fonts.mjs if the woff2 change. Do not hand-edit the base64.
+ * 两者都是可变字体（一个字面覆盖 400–700 字重）。woff2 有变时用
+ * scripts/gen-drop-fonts.mjs 重新生成。不要手工编辑 base64。
  */
 
 export const DROP_FONT_WOFF2_BASE64 = {

--- a/src/shared/engineAvailability.ts
+++ b/src/shared/engineAvailability.ts
@@ -1,40 +1,40 @@
 /**
- * Can the engine a user is about to pick actually boot on this machine?
+ * 用户即将选择的引擎在这台机器上真的能启动吗？
  *
- * The onboarding wizard records Michael's engine and nothing checks it until the
- * first spawn. spawnAgentCore then runs the install ladder (cliInstall.ts), and
- * for a provider with no `installCommand` and no `nativeInstallCommand` that
- * ladder ends at the `manual` rung: a hint is printed in a terminal and the
- * orchestrator never starts. This module turns the setup catalog probe
- * (`tools:status`, which already resolves every engine binary on PATH) into one
- * answer per provider so the wizard can say so BEFORE the pick is committed.
+ * 引导向导会记录 Michael 的引擎，但在第一次 spawn 之前没有任何东西
+ * 检查它。spawnAgentCore 随后运行安装阶梯（cliInstall.ts），
+ * 对于没有 `installCommand` 也没有 `nativeInstallCommand` 的提供商，
+ * 该阶梯止步于 `manual` 这一级：终端里打印一句提示，
+ * 编排器永远不会启动。本模块把设置目录探测
+ * （`tools:status`，它已经解析了 PATH 上的每个引擎二进制）
+ * 转成每个提供商一个答案，这样向导可以在选择被提交之前就说明情况。
  *
- * Pure and electron-free on purpose so it is testable from node --test.
+ * 刻意保持纯净且不依赖 electron，以便可以用 node --test 测试。
  */
 import type { AgentProvider } from './agentProvider';
 import type { ToolStatus } from './toolCatalog';
 
 export type EngineAvailabilityState =
-  /** The binary resolves on this machine. */
+  /** 二进制在这台机器上能解析到。 */
   | 'installed'
-  /** Not here yet, but the provider ships an installer the app runs on first spawn. */
+  /** 这里还没有，但提供商带有应用在首次 spawn 时会运行的安装器。 */
   | 'installs-on-first-run'
-  /** Not here and nothing we can run: the user has to install it by hand first. */
+  /** 这里没有，而且也没有我们能运行的东西：用户得先手动安装它。 */
   | 'not-installable'
-  /** The probe did not run or did not cover this provider. Never block on this. */
+  /** 探测没有运行或没有覆盖这个提供商。绝不因此阻塞。 */
   | 'unknown';
 
 export interface EngineAvailability {
   state: EngineAvailabilityState;
-  /** Absolute path when installed. */
+  /** 已安装时的绝对路径。 */
   path: string | null;
-  /** The command the app would run (or the user could paste) to install it. */
+  /** 应用会运行（或用户可粘贴）来安装它的命令。 */
   installCommand: string;
   docsUrl?: string;
 }
 
-/** Classify one provider from the catalog probe. `statuses` is what
- *  `window.cth.toolsStatus()` returned; undefined means it has not run (yet). */
+/** 从目录探测结果分类一个提供商。`statuses` 是
+ *  `window.cth.toolsStatus()` 返回的内容；undefined 表示它（尚未）运行。 */
 export function classifyEngineAvailability(
   statuses: readonly ToolStatus[] | undefined,
   provider: AgentProvider
@@ -51,13 +51,13 @@ export function classifyEngineAvailability(
   };
 }
 
-/** Whether the wizard must refuse to move on with this engine selected. Only the
- *  proven dead end blocks; an unknown probe never locks a user out. */
+/** 向导在选中这个引擎时是否必须拒绝继续？只有
+ *  已被证明的死路会阻塞；未知的探测绝不会把用户锁在外面。 */
 export function engineBlocksOnboarding(a: EngineAvailability): boolean {
   return a.state === 'not-installable';
 }
 
-/** One short line for the badge on each engine row. */
+/** 每个引擎行徽章上的一句话。 */
 export function engineAvailabilityBadge(a: EngineAvailability): string | null {
   switch (a.state) {
     case 'installed': return 'INSTALLED';
@@ -67,9 +67,9 @@ export function engineAvailabilityBadge(a: EngineAvailability): string | null {
   }
 }
 
-/** The explanation shown under the picker when the selected engine cannot boot.
- *  Written for someone who does not know what a CLI engine is: what happened,
- *  then what to do next. */
+/** 选中引擎无法启动时，选择器下方显示的解释。
+ *  写给不了解 CLI 引擎是什么的人：先说明发生了什么，
+ *  再说明接下来该做什么。 */
 export function engineAvailabilityMessage(a: EngineAvailability, label: string): string | null {
   if (a.state !== 'not-installable') return null;
   return `${label} is not installed on this computer and the app has no installer for it, ` +

--- a/src/shared/godIdentity.ts
+++ b/src/shared/godIdentity.ts
@@ -1,18 +1,17 @@
-/** God's identity before anyone has customized it — the app's own default,
- *  not a magic string sprinkled at every spawn call site. */
+/** 任何人自定义之前 God 的身份——应用自身的默认值，
+ *  而不是散落在每个 spawn 调用点的魔法字符串。 */
 export const DEFAULT_GOD_NAME = 'Michael';
 
 /**
- * Resolve god's display name for a (re)spawn.
+ * 解析 god 在（重新）spawn 时的显示名称。
  *
- * `renameAgent()` (`store.ts`) persists a rename straight into `registry.json`
- * via `hive.ts`'s `renameAgent()` — but the god-spawn effect used to rebuild
- * god's agent object from scratch with `name: DEFAULT_GOD_NAME` hardcoded in
- * three places, so a custom name reverted to "Michael" on every app restart
- * even though the registry still had it right. Reading the persisted name
- * back here (instead of hardcoding the default) is what keeps a rename from
- * reverting. Falls back to the default only when nothing has been persisted
- * yet — a fresh hive, or a registry not yet written this run.
+ * `renameAgent()`（`store.ts`）会把重命名直接持久化到 `registry.json`
+ * （经由 `hive.ts` 的 `renameAgent()`）——但 god-spawn 效果过去会用
+ * 硬编码在三处的 `name: DEFAULT_GOD_NAME` 从头重建 god 的 agent 对象，
+ * 于是即便 registry 里保存的名称是对的，自定义名称也会在每次应用
+ * 重启时还原成 "Michael"。在这里读回持久化的名称（而不是硬编码默认值）
+ * 正是让重命名不再还原的关键。仅当尚未持久化任何内容时才回退到默认值
+ * ——全新 hive，或本次运行尚未写入 registry 的情况。
  */
 export function resolveGodName(persistedName: string | undefined | null): string {
   const trimmed = persistedName?.trim();

--- a/src/shared/heroPayload.ts
+++ b/src/shared/heroPayload.ts
@@ -1,30 +1,28 @@
 /**
- * The Settings hero card's remote payload.
+ * 设置页 hero 卡片的远程负载。
  *
- * Lives as JSON in this repo and is fetched at runtime, so plan copy and
- * sponsors can change without shipping a build. It is DATA, never markup — that
- * distinction is the whole security story here:
+ * 以 JSON 形式存放在本仓库中、运行时获取，因此方案文案和赞助商
+ * 无需发布新构建即可变更。它是 DATA，绝不是 markup——这一区分
+ * 正是整套安全论述的核心：
  *
- *   - every field is rendered by React as a text node, so it is escaped; there is
- *     no `dangerouslySetInnerHTML` anywhere on this path and adding one would
- *     turn a config file into a script-injection surface;
- *   - URLs are validated to https and opened through the existing `openExternal`
- *     bridge, which independently refuses anything that is not https;
- *   - strings are LENGTH-CAPPED, because the failure mode of unbounded remote
- *     text is not a security hole but a wrecked layout in a dialog the user
- *     cannot then use;
- *   - unknown fields are ignored and a malformed payload falls back to the baked
- *     defaults, so a bad edit degrades to "looks like it always did" rather than
- *     to an empty or broken card.
+ *   - 每个字段都由 React 作为文本节点渲染，因此会被转义；此路径上
+ *     没有任何 `dangerouslySetInnerHTML`，新增一个就会把配置文件
+ *     变成脚本注入面；
+ *   - URL 会被校验为 https，并通过既有的 `openExternal` 桥打开，
+ *     该桥会独立拒绝任何非 https 的地址；
+ *   - 字符串有长度上限，因为无界远程文本的失败模式不是安全漏洞，
+ *     而是毁掉用户无法再使用的对话框布局；
+ *   - 未知字段会被忽略，格式错误的负载会回退到内置默认值，因此
+ *     糟糕的编辑只会退化为"看起来和以前一样"，而不是空卡片或坏卡片。
  *
- * The parse is deliberately total: `parseHeroPayload` never throws and always
- * returns something renderable.
+ * 解析是刻意全量的：`parseHeroPayload` 从不抛异常，总是返回
+ * 可渲染的结果。
  */
 
 export interface HeroPlan {
   label: string;
   blurb: string;
-  /** Rendered as a button only when present AND https. */
+  /** 仅当存在且为 https 时才渲染为按钮。 */
   upgrade?: { label: string; url: string };
 }
 
@@ -36,14 +34,14 @@ export interface HeroSponsor {
 
 export interface HeroPayload {
   plan: HeroPlan;
-  /** Null renders nothing — never a "your logo here" placeholder. */
+  /** null 不渲染任何内容——绝不出现"把你的 logo 放这里"占位符。 */
   sponsor: HeroSponsor | null;
-  /** Optional one-line notice (an incident, a migration heads-up). */
+  /** 可选的一行公告（事故、迁移提醒等）。 */
   notice: string | null;
 }
 
-/** What ships in the binary. Also the fallback whenever the fetch or the parse
- *  fails, so the card is never empty and never waits on the network to render. */
+/** 随二进制发布的内容。也是任何一次获取或解析失败时的回退，
+ *  因此卡片永不空白、永不等待网络才渲染。 */
 export const DEFAULT_HERO: HeroPayload = {
   plan: {
     label: 'Local',
@@ -62,8 +60,8 @@ function str(v: unknown, cap: number): string | null {
   return t.length > cap ? `${t.slice(0, cap - 1)}…` : t;
 }
 
-/** https only. `openExternal` enforces this again at the bridge; doing it here
- *  too means a bad URL never even renders as a clickable affordance. */
+/** 仅 https。`openExternal` 会在桥层再次强制；在这里也做一遍，
+ *  意味着坏 URL 甚至永远不会渲染为可点击的控件。 */
 function httpsUrl(v: unknown): string | null {
   const s = str(v, MAX.url);
   if (!s) return null;
@@ -74,9 +72,9 @@ function httpsUrl(v: unknown): string | null {
 }
 
 /**
- * Turn whatever came off the network into a renderable payload. Any field that
- * fails validation is dropped back to its default rather than failing the whole
- * card — a broken sponsor entry should not cost the user their plan line.
+ * 把任何从网络取回的内容转换为可渲染的负载。任何未通过校验的字段
+ * 都会回退到其默认值，而不是让整张卡片失败——损坏的赞助商条目
+ * 不应让用户失去方案那一行。
  */
 export function parseHeroPayload(raw: unknown): HeroPayload {
   if (!raw || typeof raw !== 'object') return DEFAULT_HERO;
@@ -91,7 +89,7 @@ export function parseHeroPayload(raw: unknown): HeroPayload {
   if (upIn) {
     const label = str(upIn.label, MAX.label);
     const url = httpsUrl(upIn.url);
-    // Both or neither: a button with no destination is worse than no button.
+    // 两者都需或都无：没有目标的按钮比没有按钮更糟。
     if (label && url) plan.upgrade = { label, url };
   }
 

--- a/src/shared/hire.ts
+++ b/src/shared/hire.ts
@@ -1,24 +1,24 @@
 /**
- * Shareable "hires" — portable agent role templates (manifest spec v1).
+ * 可共享的 "hires"——可移植的 agent 角色模板（manifest 规范 v1）。
  *
- * A hire manifest is a small JSON document that describes a role-configured
- * agent (name, provider, model, flags, goal, budget) so it can be shared as a
- * file or hosted in a community gallery and imported with one click via the
- * `munderdifflin://hire?src=<https-url>` deep link or an in-app file picker.
+ * hire manifest 是一份小型 JSON 文档，描述一个按角色配置的 agent
+ * （name、provider、model、flags、goal、budget），因此它可以作为文件共享，
+ * 或托管在社区画廊中，并通过 `munderdifflin://hire?src=<https-url>` 深链
+ * 或应用内文件选择器一键导入。
  *
- * SECURITY MODEL — a manifest is untrusted input:
- *   - It can NEVER auto-spawn an agent. Importing only pre-fills the Add-Agent
- *     modal; the human reviews the final command and clicks spawn.
- *   - It cannot carry a raw executable/command. The spawn binary always comes
- *     from the locally configured provider preset; a manifest may only append
- *     flag-shaped arguments (validated below), which the modal shows in full.
- *   - All fields are length/shape-capped here, in one dependency-free module
- *     shared by main (deep link / file import) and renderer (prefill).
- *   - `skills` and `mcpServers` are references into the BUNDLED allowlists only —
- *     never raw specs. This is the same threat model as `commandFlags`: a manifest
- *     can never inject an arbitrary executable path, env var, or MCP spec.
- *     Write/secret MCP servers are surfaced for human consent at import, never
- *     auto-enabled (consistent with "import only pre-fills; human clicks spawn").
+ * 安全模型——manifest 是不可信输入：
+ *   - 它绝不能自动生成 agent。导入只会预填 Add-Agent 弹窗；
+ *     由人来审查最终命令并点击 spawn。
+ *   - 它不能携带原始可执行文件/命令。spawn 二进制始终来自本地配置的
+ *     provider 预设；manifest 只能追加 flag 形状的参数（下方校验），
+ *     弹窗会完整展示这些参数。
+ *   - 所有字段都在这里——这个零依赖、由 main（深链/文件导入）和 renderer
+ *     （预填）共享的模块中——做了长度/形状上限。
+ *   - `skills` 和 `mcpServers` 只能引用 BUNDLED 允许列表中的条目——
+ *     绝不是原始规范。这与 `commandFlags` 是同一威胁模型：manifest
+ *     永远不能注入任意可执行路径、环境变量或 MCP 规范。
+ *     写/密钥类 MCP 服务器在导入时呈现给人类做同意，绝不会自动启用
+ *     （与"导入只预填；人类点击 spawn"保持一致）。
  */
 
 import { mcpCatalogEntry } from './mcpCatalog';
@@ -26,58 +26,56 @@ import { MAX_AGENT_TOKEN_CAP } from './tokenCaps';
 
 export const HIRE_SPEC_V1 = 'munder-difflin/hire@1';
 
-/** Skill ids bundled in app resources (the only values a hire manifest may request
- *  in the `skills` field). A manifest can never name an arbitrary skill path —
- *  only these curated, read-only, no-secret skill ids are allowlisted. */
+/** 打包在应用资源中的 skill id（hire manifest 在 `skills` 字段中唯一可请求的值）。
+ *  manifest 永远不能指名任意的 skill 路径——
+ *  只有这些精选的、只读的、无密钥的 skill id 被列入允许列表。 */
 export const BUNDLED_SKILL_IDS: ReadonlySet<string> = new Set([
   'md-hive-sync',
   'md-fetch-summarize',
   'md-audit'
 ]);
 
-/** Providers a manifest may request ('agy' is accepted as an alias for
- *  'antigravity'). 'custom' is deliberately NOT allowed — it would let a
- *  manifest choose an arbitrary local binary. */
-export type HireProvider = 'claude' | 'antigravity' | 'codex' | 'cursor';
+/** manifest 可以请求的 provider。
+ *  'custom' 刻意不允许——那会让 manifest 挑选任意的本地二进制。 */
+export type HireProvider = 'claude' | 'codex' | 'kimi' | 'qwen';
 
 export interface HireManifest {
-  /** Spec tag; exactly `munder-difflin/hire@1` for this version. */
+  /** 规范标签；本版本恰为 `munder-difflin/hire@1`。 */
   spec: typeof HIRE_SPEC_V1;
-  /** Agent display name (also seeds the hive id). Required. */
+  /** Agent 显示名称（也作为 hive id 的种子）。必填。 */
   name: string;
-  /** One-line role, e.g. "Documentation writer" — lands in identity.md + card. */
+  /** 一行式角色描述，例如 "Documentation writer"——进入 identity.md 和卡片。 */
   description?: string;
-  /** The standing goal/mission text pre-filled into the goal field. */
+  /** 预填进 goal 字段的常驻目标/任务文本。 */
   goal?: string;
-  /** Office cast sprite id (e.g. 'pam'); unknown values fall back to default. */
+  /** Office 角色 sprite id（例如 'pam'）；未知值回退到默认。 */
   character?: string;
-  /** Accent color name (e.g. 'mint'); unknown values fall back to default. */
+  /** 强调色名称（例如 'mint'）；未知值回退到默认。 */
   accent?: string;
-  /** Which CLI the role is designed for. Default: the user's default provider. */
+  /** 该角色面向哪个 CLI。默认：用户的默认 provider。 */
   provider?: HireProvider;
-  /** Model id/label for that provider (e.g. 'claude-sonnet-4-6'). */
+  /** 该 provider 的模型 id/标签（例如 'claude-sonnet-4-6'）。 */
   model?: string;
-  /** Extra flag-shaped args appended to the locally-built spawn command. Each flag
-   *  must be in the safe-flag allowlist (see SAFE_FLAG_NAMES) and shell-metachar-free;
-   *  anything else rejects the manifest (the command stays editable post-import). */
+  /** 追加到本地构建的 spawn 命令上的额外 flag 形状参数。每个 flag 都必须
+   *  在安全 flag 允许列表（见 SAFE_FLAG_NAMES）中且不含 shell 元字符；
+   *  其他任何内容都会拒绝该 manifest（命令在导入后仍可编辑）。 */
   commandFlags?: string[];
-  /** Capability tags for the hive registry (routing hints). */
+  /** 供 hive 注册表用的能力标签（路由提示）。 */
   capabilities?: string[];
-  /** Spawn in an isolated git worktree. */
+  /** 在隔离的 git worktree 中 spawn。 */
   isolate?: boolean;
-  /** Per-agent total-token ceiling, applied to agentTokenCaps after spawn. */
+  /** 每个 agent 的 token 总额上限，spawn 后应用于 agentTokenCaps。 */
   tokenCap?: number;
-  /** Attribution shown in the import preview. */
+  /** 导入预览中显示的署名。 */
   author?: string;
-  /** Manifest home (gallery page). https only. */
+  /** manifest 主页（画廊页面）。仅 https。 */
   homepage?: string;
-  /** Bundled skill ids to activate in the agent's workspace. References into
-   *  BUNDLED_SKILL_IDS only — never raw file paths or arbitrary skill names. */
+  /** 要在 agent 工作区中激活的打包 skill id。只能引用
+   *  BUNDLED_SKILL_IDS 中的条目——绝不是原始文件路径或任意 skill 名称。 */
   skills?: string[];
-  /** Default MCP catalog ids to enable for this agent. References into the
-   *  MCP_CATALOG allowlist only — never raw specs. Safe-readonly ids are
-   *  pre-filled; write/secret ids are surfaced for human consent at import
-   *  and never auto-enabled. */
+  /** 要为该 agent 启用的默认 MCP catalog id。只能引用 MCP_CATALOG
+   *  允许列表中的条目——绝不是原始规范。安全只读 id 会预填；
+   *  写/密钥 id 在导入时呈现给人类做同意，且绝不自动启用。 */
   mcpServers?: string[];
 }
 
@@ -85,57 +83,52 @@ export interface HireValidation {
   ok: boolean;
   manifest?: HireManifest;
   errors: string[];
-  /** MCP catalog ids present in the manifest's `mcpServers` that are NOT
-   *  safe-readonly (write or secret tier). These must be surfaced to the human
-   *  for explicit consent before they are enabled — they are NEVER auto-enabled. */
+  /** manifest 的 `mcpServers` 中出现的 MCP catalog id，它们不是安全只读
+   *  （写或密钥级别）。在启用前必须呈现给人类做明确同意——它们绝不自动启用。 */
   consentRequired?: string[];
 }
 
-const PROVIDERS: readonly string[] = ['claude', 'antigravity', 'codex', 'cursor'];
+const PROVIDERS: readonly string[] = ['claude', 'codex', 'kimi', 'qwen'];
 const MAX_BYTES = 64 * 1024;
 
-/** A flag ("-x", "--flag", "--flag=value") or a bare value token that may follow
- *  a flag. Letters/digits plus a conservative punctuation set; no quotes,
- *  backticks, semicolons, pipes, ampersands, redirects, percent (cmd.exe
- *  %VAR% env-expansion), or whitespace. Args are passed to node-pty as argv
- *  (no shell), so this is defense in depth. */
+/** 一个 flag（"-x"、"--flag"、"--flag=value"）或可跟在 flag 后的裸值 token。
+ *  字母/数字加保守的标点集合；不允许引号、反引号、分号、管道、与号、
+ *  重定向、百分号（cmd.exe 的 %VAR% 环境变量展开）或空白。参数以 argv
+ *  （无 shell）传给 node-pty，因此这是纵深防御。 */
 const FLAG_RE = /^[A-Za-z0-9._\/=:,@+-]{1,100}$/;
 
-/** Allowed characters in a model id/label. Model values flow into the spawn
- *  command line (`--model <value>`), so this MUST reject shell metacharacters —
- *  on Windows a `.cmd`/`.bat` provider shim routes the command through cmd.exe,
- *  where an unquoted `&`/`|`/`^`/`<`/`>`/`(`/`)` would chain a second command.
- *  Real model ids/labels only need letters, digits, spaces, and a little
- *  punctuation: `claude-sonnet-4-6[1m]`, `Gemini 3.1 Pro (High)`. No quotes,
- *  backticks, `$`, `;`, `&`, `|`, `^`, `<`, `>`, `%`, `!`. (The command field
- *  stays editable, so a legitimate exotic value can still be typed by hand.) */
+/** 模型 id/标签中允许的字符。模型值会流入 spawn 命令行（`--model <value>`），
+ *  因此这必须拒绝 shell 元字符——在 Windows 上，`.cmd`/`.bat` provider 垫片
+ *  会把命令经由 cmd.exe 路由，在那里未加引号的 `&`/`|`/`^`/`<`/`>`/`(`/`)`
+ *  会串联出第二条命令。真实的模型 id/标签只需要字母、数字、空格和少量
+ *  标点：`claude-sonnet-4-6[1m]`、`Gemini 3.1 Pro (High)`。不允许引号、
+ *  反引号、`$`、`;`、`&`、`|`、`^`、`<`、`>`、`%`、`!`。（命令字段
+ *  保持可编辑，因此合法但稀有的值仍可手工键入。） */
 const MODEL_RE = /^[A-Za-z0-9 ._()[\]\/:@+-]{1,80}$/;
 
-/** Flags a manifest is ALLOWED to append — a default-deny ALLOWLIST.
+/** manifest 被允许追加的 flag——一个默认拒绝的 ALLOWLIST（允许列表）。
  *
- *  WHY AN ALLOWLIST: a manifest's `provider` is attacker-chosen and each CLI keeps
- *  adding flags, so a denylist of "dangerous" flags drifts and leaks (three rounds
- *  of re-review each found one more spelling that escaped — codex `-a`/`-s`, then
- *  `-c model_providers.*.base_url=…` backend-redirect credential exfil, then
- *  `--provider`). Default-deny closes the CLASS: only flags that PROVABLY cannot
- *  escalate permissions, redirect the backend / exfil credentials, read/write
- *  arbitrary files, inject prompt/config/MCP, or run commands may pass; every
- *  other flag-shaped token rejects the manifest outright.
+ *  为何用允许列表：manifest 的 `provider` 由攻击者选择，且每个 CLI 都在不断
+ *  增加 flag，因此"危险"flag 的拒绝列表会漂移并漏掉（三轮复审每次都发现
+ *  又一种漏网的拼写——codex `-a`/`-s`，然后是 `-c model_providers.*.base_url=…`
+ *  后端重定向式凭据外泄，再然后是 `--provider`）。默认拒绝关闭的是"类别"：
+ *  只有那些被证明不能提权、重定向后端/外泄凭据、读写任意文件、注入
+ *  prompt/config/MCP 或运行命令的 flag 才能通过；其他任何 flag 形状的
+ *  token 都直接拒绝该 manifest。
  *
- *  These names are the curated SAFE set, mined from the provider command
- *  references (claudeCommands.ts / codexCommands.ts) and presets
- *  (agentProvider.ts). The list is deliberately tiny — biased hard to EXCLUDE,
- *  because the spawn command stays editable after import, so a user who needs an
- *  exotic flag can add it by hand. Each is behavioral / output / a safety-cap
- *  only, with a single non-escalating value (or none):
+ *  这些名字是精选的 SAFE 集合，取自 provider 命令参考
+ *  （claudeCommands.ts / codexCommands.ts）和预设（agentProvider.ts）。
+ *  这份列表刻意很小——强烈偏向排除，因为 spawn 命令在导入后仍可编辑，
+ *  所以需要特殊 flag 的用户可以手工添加。每个都是行为/输出/安全上限类，
+ *  且只有一个（或没有）不升级的值：
  *    --model          select the model id           (claude/codex/agy modelFlag)
  *    --max-turns      cap agentic turns (runaway guard, strictly safety-↑)
  *    --output-format  headless output shape: text / json / stream-json
  *    --verbose        logging verbosity only
- *  Matched case-insensitively against the flag NAME (part before any `=`), so both
- *  `--flag value` and `--flag=value` are covered. NOTHING permission / sandbox /
- *  approval / dir / config (incl. codex `-c`) / mcp / provider / base-url /
- *  system-prompt / settings related is ever allowlisted. */
+ *  对 flag 名称（任何 `=` 之前的部分）做大小写不敏感匹配，因此 `--flag value`
+ *  和 `--flag=value` 都被覆盖。任何与权限 / sandbox / 审批 / 目录 / 配置
+ *  （含 codex `-c`）/ mcp / provider / base-url / 系统提示 / 设置相关的东西
+ *  都永不被列入允许列表。 */
 const SAFE_FLAG_NAMES: ReadonlySet<string> = new Set([
   '--model',
   '--max-turns',
@@ -143,9 +136,9 @@ const SAFE_FLAG_NAMES: ReadonlySet<string> = new Set([
   '--verbose'
 ]);
 
-/** True if a commandFlags token is an allowed flag. Handles `--x` and `--x=value`
- *  (matches the NAME before `=`, case-insensitive); short `-x` forms are not in
- *  the allowlist and so are rejected by default. */
+/** 判断 commandFlags token 是否是允许的 flag。处理 `--x` 和 `--x=value`
+ *  （匹配 `=` 前的 NAME，大小写不敏感）；短 `-x` 形式不在允许列表中，
+ *  因此默认被拒绝。 */
 function isSafeFlag(token: string): boolean {
   if (!token.startsWith('-')) return false;
   const name = token.split('=', 1)[0].toLowerCase();
@@ -156,17 +149,17 @@ function str(v: unknown): v is string { return typeof v === 'string'; }
 
 function capped(v: unknown, max: number, field: string, errors: string[], required = false): string | undefined {
   if (v === undefined || v === null) {
-    if (required) errors.push(`"${field}" is required`);
+    if (required) errors.push(`"${field}" 为必填`);
     return undefined;
   }
-  if (!str(v)) { errors.push(`"${field}" must be a string`); return undefined; }
+  if (!str(v)) { errors.push(`"${field}" 必须是字符串`); return undefined; }
   const t = v.trim();
-  if (required && !t) { errors.push(`"${field}" must not be empty`); return undefined; }
-  if (t.length > max) { errors.push(`"${field}" exceeds ${max} chars`); return undefined; }
+  if (required && !t) { errors.push(`"${field}" 不能为空`); return undefined; }
+  if (t.length > max) { errors.push(`"${field}" 超过 ${max} 个字符`); return undefined; }
   return t || undefined;
 }
 
-/** Validate an untrusted parsed JSON value into a HireManifest. Pure; no I/O. */
+/** 把不可信的已解析 JSON 值校验为 HireManifest。纯函数；无 I/O。 */
 export function validateHireManifest(raw: unknown): HireValidation {
   const errors: string[] = [];
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
@@ -185,56 +178,56 @@ export function validateHireManifest(raw: unknown): HireValidation {
   const accent = capped(o.accent, 24, 'accent', errors)?.toLowerCase();
   const model = capped(o.model, 80, 'model', errors);
   if (model !== undefined && !MODEL_RE.test(model)) {
-    errors.push('"model" contains disallowed characters (it goes onto the spawn command line; letters, digits, spaces and . _ - ( ) [ ] / : @ + only)');
+    errors.push('"model" 包含不允许的字符（它会进入 spawn 命令行；只允许字母、数字、空格以及 . _ - ( ) [ ] / : @ +）');
   }
   const author = capped(o.author, 80, 'author', errors);
   const homepage = capped(o.homepage, 300, 'homepage', errors);
 
   let provider: HireProvider | undefined;
   if (o.provider !== undefined) {
-    const p = str(o.provider) ? (o.provider === 'agy' ? 'antigravity' : o.provider) : o.provider;
+    const p = str(o.provider) ? o.provider : o.provider;
     if (str(p) && PROVIDERS.includes(p)) provider = p as HireProvider;
-    else errors.push(`"provider" must be one of ${PROVIDERS.join(', ')} (or "agy")`);
+    else errors.push(`"provider" 必须是 ${PROVIDERS.join(', ')} 之一`);
   }
 
   let commandFlags: string[] | undefined;
   if (o.commandFlags !== undefined) {
     if (!Array.isArray(o.commandFlags) || o.commandFlags.length > 16) {
-      errors.push('"commandFlags" must be an array of at most 16 items');
+      errors.push('"commandFlags" 必须是至多 16 项的数组');
     } else {
       commandFlags = [];
-      // DEFAULT-DENY: every flag-shaped token must name an allowlisted safe flag;
-      // a bare token is allowed only as the value immediately following an allowed
-      // `--flag` (so a value can never smuggle in a second, unknown flag).
-      let valueAllowed = false; // previous token was an allowed `--flag` (no inline =)
+      // DEFAULT-DENY：每个 flag 形状的 token 都必须指名一个允许列表内的安全
+      // flag；裸 token 只有在紧跟一个被允许的 `--flag` 之后才被允许
+      // （这样值永远不会夹带出第二个未知 flag）。
+      let valueAllowed = false; // 前一个 token 是被允许的 `--flag`（无内联 =）
       for (let i = 0; i < o.commandFlags.length; i++) {
         const f = o.commandFlags[i];
         if (!str(f) || !FLAG_RE.test(f)) {
-          errors.push(`commandFlags entry ${JSON.stringify(f)} is not a safe flag token`);
+          errors.push(`commandFlags 条目 ${JSON.stringify(f)} 不是安全的 flag token`);
           valueAllowed = false;
           continue;
         }
-        // The FIRST entry must be flag-shaped (defense in depth; kept explicit).
+        // 第一个条目必须是 flag 形状（纵深防御；保持显式）。
         if (i === 0 && !f.startsWith('-')) {
-          errors.push('"commandFlags" must start with a flag (e.g. "--model")');
+          errors.push('"commandFlags" 必须以一个 flag 开头（例如 "--model"）');
           valueAllowed = false;
           continue;
         }
         if (f.startsWith('-')) {
           if (!isSafeFlag(f)) {
-            errors.push(`commandFlags entry ${JSON.stringify(f)} is not in the shared-hire safe-flag list — for safety a shared hire may only embed known-harmless flags (${[...SAFE_FLAG_NAMES].join(', ')}). If you need this flag, add it by hand in the command field after importing.`);
+            errors.push(`commandFlags 条目 ${JSON.stringify(f)} 不在共享 hire 的安全 flag 列表中——出于安全，共享 hire 只能嵌入已知无害的 flag（${[...SAFE_FLAG_NAMES].join(', ')}）。如果需要该 flag，请在导入后在 command 字段里手动添加。`);
             valueAllowed = false;
             continue;
           }
           commandFlags.push(f);
-          valueAllowed = !f.includes('='); // a `--flag value` form may take one value next
+          valueAllowed = !f.includes('='); // `--flag value` 形式下一个可带一个值
         } else {
           if (!valueAllowed) {
-            errors.push(`commandFlags entry ${JSON.stringify(f)} is not allowed here (a value may only follow an allowed flag such as "--model")`);
+            errors.push(`commandFlags 条目 ${JSON.stringify(f)} 在此处不允许（值只能跟在允许的 flag 之后，例如 "--model"）`);
             continue;
           }
           commandFlags.push(f);
-          valueAllowed = false; // consume the value; no chained second value
+          valueAllowed = false; // 消费该值；不允许串联出第二个值
         }
       }
       if (commandFlags.length === 0) commandFlags = undefined;
@@ -244,7 +237,7 @@ export function validateHireManifest(raw: unknown): HireValidation {
   let capabilities: string[] | undefined;
   if (o.capabilities !== undefined) {
     if (!Array.isArray(o.capabilities) || o.capabilities.length > 12) {
-      errors.push('"capabilities" must be an array of at most 12 items');
+      errors.push('"capabilities" 必须是至多 12 项的数组');
     } else {
       capabilities = o.capabilities.filter(str).map(c => c.trim().slice(0, 40)).filter(Boolean);
       if (capabilities.length === 0) capabilities = undefined;
@@ -254,27 +247,27 @@ export function validateHireManifest(raw: unknown): HireValidation {
   let isolate: boolean | undefined;
   if (o.isolate !== undefined) {
     if (typeof o.isolate === 'boolean') isolate = o.isolate;
-    else errors.push('"isolate" must be a boolean');
+    else errors.push('"isolate" 必须是布尔值');
   }
 
   let tokenCap: number | undefined;
   if (o.tokenCap !== undefined) {
     if (typeof o.tokenCap === 'number' && Number.isInteger(o.tokenCap) && o.tokenCap > 0 && o.tokenCap <= MAX_AGENT_TOKEN_CAP) tokenCap = o.tokenCap;
-    else errors.push('"tokenCap" must be a positive integer (max 1e10)');
+    else errors.push('"tokenCap" 必须是正整数（最大 1e10）');
   }
 
-  // skills — allowlist: references into BUNDLED_SKILL_IDS only; max 8
+  // skills —— 允许列表：只引用 BUNDLED_SKILL_IDS 中的条目；最多 8 个
   let skills: string[] | undefined;
   if (o.skills !== undefined) {
     if (!Array.isArray(o.skills) || o.skills.length > 8) {
-      errors.push('"skills" must be an array of at most 8 items');
+      errors.push('"skills" 必须是至多 8 项的数组');
     } else {
       skills = [];
       for (const s of o.skills) {
-        if (!str(s) || !s.trim()) { errors.push('"skills" entries must be non-empty strings'); continue; }
+        if (!str(s) || !s.trim()) { errors.push('"skills" 条目必须是非空字符串'); continue; }
         const id = s.trim();
         if (!BUNDLED_SKILL_IDS.has(id)) {
-          errors.push(`"skills" entry ${JSON.stringify(id)} is not a bundled skill id — a hire may only reference the built-in safe skills (${[...BUNDLED_SKILL_IDS].join(', ')})`);
+          errors.push(`"skills" 条目 ${JSON.stringify(id)} 不是内置 skill id——hire 只能引用内置的安全 skills（${[...BUNDLED_SKILL_IDS].join(', ')}）`);
         } else {
           skills.push(id);
         }
@@ -283,20 +276,20 @@ export function validateHireManifest(raw: unknown): HireValidation {
     }
   }
 
-  // mcpServers — allowlist: references into MCP_CATALOG only; max 8; write/secret surfaced for consent
+  // mcpServers —— 允许列表：只引用 MCP_CATALOG 中的条目；最多 8 个；写/密钥类呈现给人类同意
   let mcpServers: string[] | undefined;
   const consentRequired: string[] = [];
   if (o.mcpServers !== undefined) {
     if (!Array.isArray(o.mcpServers) || o.mcpServers.length > 8) {
-      errors.push('"mcpServers" must be an array of at most 8 items');
+      errors.push('"mcpServers" 必须是至多 8 项的数组');
     } else {
       mcpServers = [];
       for (const s of o.mcpServers) {
-        if (!str(s) || !s.trim()) { errors.push('"mcpServers" entries must be non-empty strings'); continue; }
+        if (!str(s) || !s.trim()) { errors.push('"mcpServers" 条目必须是非空字符串'); continue; }
         const id = s.trim();
         const entry = mcpCatalogEntry(id);
         if (!entry) {
-          errors.push(`"mcpServers" entry ${JSON.stringify(id)} is not a known catalog id — a hire may only reference built-in MCP servers`);
+          errors.push(`"mcpServers" 条目 ${JSON.stringify(id)} 不是已知目录 id——hire 只能引用内置的 MCP servers`);
         } else {
           mcpServers.push(id);
           if (entry.tier !== 'safe-readonly') consentRequired.push(id);
@@ -306,7 +299,7 @@ export function validateHireManifest(raw: unknown): HireValidation {
     }
   }
 
-  if (homepage && !homepage.startsWith('https://')) errors.push('"homepage" must be https');
+  if (homepage && !homepage.startsWith('https://')) errors.push('"homepage" 必须是 https');
 
   if (errors.length > 0 || !name) return { ok: false, errors };
   return {
@@ -317,13 +310,13 @@ export function validateHireManifest(raw: unknown): HireValidation {
   };
 }
 
-/** Parse a `munderdifflin://hire?src=<https-url>` deep link. Returns the https
- *  manifest URL, or null if the link is not a well-formed hire link. */
+/** 解析 `munderdifflin://hire?src=<https-url>` 深链。返回 https
+ *  manifest URL，若链接不是格式良好的 hire 链接则返回 null。 */
 export function parseHireDeepLink(link: string): string | null {
   let u: URL;
   try { u = new URL(link); } catch { return null; }
   if (u.protocol !== 'munderdifflin:') return null;
-  // Both munderdifflin://hire?src= (host) and munderdifflin:hire?src= (path).
+  // 两种形式都接受：munderdifflin://hire?src=（host）和 munderdifflin:hire?src=（path）。
   const action = (u.host || u.pathname.replace(/^\/+/, '')).toLowerCase();
   if (action !== 'hire') return null;
   const src = u.searchParams.get('src');
@@ -334,13 +327,13 @@ export function parseHireDeepLink(link: string): string | null {
   return s.toString();
 }
 
-/** https everywhere; plain http is allowed ONLY for loopback (local gallery
- *  development) — a remote page can never point the app at an http manifest. */
+/** 一律 https；纯 http 只对回环地址（本地画廊开发）允许——远程页面永远
+ *  不能把应用指向一个 http manifest。 */
 export function isAllowedManifestUrl(u: URL): boolean {
   if (u.protocol === 'https:') return true;
   if (u.protocol !== 'http:') return false;
   return u.hostname === 'localhost' || u.hostname === '127.0.0.1' || u.hostname === '[::1]';
 }
 
-/** Byte cap shared by the deep-link fetcher and the file importer. */
+/** 深链抓取器与文件导入器共享的字节上限。 */
 export const HIRE_MAX_BYTES = MAX_BYTES;

--- a/src/shared/hireQueue.ts
+++ b/src/shared/hireQueue.ts
@@ -1,9 +1,9 @@
 import type { HireManifest } from './hire';
 
-/** Ephemeral renderer state for one human-reviewed run of imported hires. */
+/** 导入的 hires 经过一轮人工审核的临时渲染器状态。 */
 export interface HireReviewQueue {
   pending: readonly HireManifest[];
-  /** Number already spawned or skipped in this run. */
+  /** 本轮已生成或已跳过的数量。 */
   reviewed: number;
 }
 
@@ -12,7 +12,7 @@ export const EMPTY_HIRE_QUEUE: HireReviewQueue = Object.freeze({
   reviewed: 0
 });
 
-/** Append arrivals without replacing the manifest currently under review. */
+/** 追加新到达者，而不替换当前正在审核的 manifest。 */
 export function enqueueHires(
   queue: HireReviewQueue,
   incoming: readonly HireManifest[]
@@ -20,19 +20,19 @@ export function enqueueHires(
   if (incoming.length === 0) return queue;
   return {
     pending: [...queue.pending, ...incoming],
-    // A drained queue starts a new review run and therefore new progress.
+    // 排空的队列会开启一轮新的审核，因此进度也重新开始。
     reviewed: queue.pending.length === 0 ? 0 : queue.reviewed
   };
 }
 
-/** Mark exactly the head item spawned/skipped and reveal the next one. */
+/** 把头部这一项标记为已生成/已跳过，并揭示下一项。 */
 export function finishCurrentHire(queue: HireReviewQueue): HireReviewQueue {
   if (queue.pending.length === 0) return queue;
   if (queue.pending.length === 1) return EMPTY_HIRE_QUEUE;
   return { pending: queue.pending.slice(1), reviewed: queue.reviewed + 1 };
 }
 
-/** Cancel the current human-review run; unfinished manifests do not resume later. */
+/** 取消当前的人工审核流程；未完成的 manifest 之后不会恢复。 */
 export function clearHireQueue(_queue: HireReviewQueue): HireReviewQueue {
   return EMPTY_HIRE_QUEUE;
 }

--- a/src/shared/hiveNudge.ts
+++ b/src/shared/hiveNudge.ts
@@ -1,26 +1,26 @@
 /**
- * The inbox-wake nudge — the text queued for an agent that has unread hive mail,
- * and the predicate the message queue uses to keep only one of them pending.
+ * 收件箱唤醒提醒——为有未读 hive 邮件的 agent 排队的文本，
+ * 以及消息队列用来只保留其中一条待处理项的判断谓词。
  *
- * The nudge is QUEUED the moment fresh mail is seen but TYPED only once the agent
- * is idle and off cooldown, and it survives a renderer reload in the persisted
- * queue. By the time it lands, the agent has often already drained that mail and
- * filed it under `inbox/.done/` — so the nudge arrives against an inbox the agent
- * itself just emptied.
+ * 提醒在刚看到新邮件的那一刻被排队（QUEUED），但只在 agent
+ * 空闲且脱离冷却期后才被敲出（TYPED），并且它会在持久化队列中
+ * 挺过渲染器重载。等它真正落地时，agent 往往已经处理完那批邮件
+ * 并归档到 `inbox/.done/` 下了——所以提醒到达时，面对的往往是一个
+ * agent 自己刚刚清空了的收件箱。
  */
 
-/** The fixed head of every nudge; the ids that follow differ per nudge. */
+/** 每个提醒的固定开头；其后的 id 随每个提醒而异。 */
 const NUDGE_HEAD = 'You have new hive inbox message(s)';
 
 /**
- * Build the nudge, naming the messages that prompted it.
+ * 构建提醒，点名触发它的那些消息。
  *
- * The ids are diagnostic, NOT a work list: they let an agent tell "I already
- * handled this last turn" (the id sits in `inbox/.done/`) from "the harness woke
- * me for nothing", which is the distinction it otherwise cannot make and burns a
- * round-trip guessing at. The pending inbox stays authoritative — an agent that
- * has a nudge suppressed by the one-pending rule below still finds its mail by
- * reading the directory, so the text must never invite it to stop at the ids.
+ * 这些 id 是诊断性的，不是工作清单：它们让 agent 能区分
+ * "我上一轮已经处理过了"（该 id 位于 `inbox/.done/`）与
+ * "harness 白白叫醒了我"，这是它否则无法做出的区分，
+ * 且每次猜测都会浪费一次往返。待处理收件箱始终是权威——
+ * 一个提醒被下面的一条待处理规则压制的 agent，仍然会通过
+ * 读取目录找到它的邮件，所以文本绝不能在 id 处就停下。
  */
 export function inboxNudgeText(ids: string[]): string {
   const named = ids.length ? ` — at least: ${ids.join(', ')}` : '';
@@ -28,11 +28,11 @@ export function inboxNudgeText(ids: string[]): string {
 }
 
 /**
- * Is this queued text an inbox-wake nudge?
+ * 这段排队文本是不是收件箱唤醒提醒？
  *
- * Matches the fixed head only, since every nudge carries different ids — the
- * point is to recognise the COMMAND, not one instance of it. Mirrors
- * `isCompactionCommand`, and the queue's one-pending rule leans on it the same way.
+ * 只匹配固定开头，因为每个提醒携带的 id 都不同——关键在于识别
+ * 命令本身，而不是它的某个实例。镜像 `isCompactionCommand`，
+ * 队列的一条待处理规则同样依赖它。
  */
 export function isInboxNudge(text: string): boolean {
   return text.trim().startsWith(NUDGE_HEAD);

--- a/src/shared/hookEvents.ts
+++ b/src/shared/hookEvents.ts
@@ -1,4 +1,4 @@
-/** Renderer-facing hook event shared across the Electron IPC boundary. */
+/** 面向渲染器的 hook 事件，跨 Electron IPC 边界共享。 */
 export interface HookEvent {
   agentId?: string;
   event: string;
@@ -11,7 +11,7 @@ export interface HookEvent {
 
 const OPTIONAL_STRING_FIELDS = ['tool', 'notificationType', 'source', 'message'] as const;
 
-/** Validate an untrusted payload before it crosses the Electron IPC boundary. */
+/** 在不可信载荷跨过 Electron IPC 边界之前先校验它。 */
 export function validateHookEvent(value: unknown): value is HookEvent {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
 

--- a/src/shared/imageTypes.ts
+++ b/src/shared/imageTypes.ts
@@ -1,25 +1,25 @@
 /**
- * Image file detection — the ONE place that answers "is this path an image, and
- * what mime does it carry?".
+ * 图片文件检测——回答“这个路径是不是图片、携带什么 mime”的唯一切入点。
  *
- * Shared on purpose. Three call sites need the same answer and they live on
- * opposite sides of the IPC boundary: the main process stamps a mime onto the
- * bytes it reads (`fs.readFileBinary`), the IDE decides whether a click opens
- * Monaco or the image preview, and the markdown renderer decides whether an
- * `<img src>` is worth resolving. If those three ever disagree, the failure is
- * silent and confusing — a file opens as a preview that then reports "unknown
- * image", or opens in Monaco as mojibake. Keeping the table here makes
- * disagreement impossible.
+ * 刻意共享。三个调用点需要同一个答案，且它们分处 IPC 边界的两侧：
+ * 主进程为其读取的字节打上 mime 标记（`fs.readFileBinary`），
+ * IDE 决定点击打开 Monaco 还是图片预览，
+ * markdown 渲染器决定某个 `<img src>` 是否值得解析。
+ * 如果这三处产生分歧，失败是静默而令人困惑的——
+ * 文件作为预览打开却报 “unknown image”，
+ * 或作为乱码在 Monaco 中打开。把表放在这里使分歧变得不可能。
  *
- * Detection is BY EXTENSION, not by magic bytes. That is deliberate: the
- * renderer must decide how to open a file *before* it has any bytes, so a
- * content sniff isn't available at the moment the decision is made. The mime is
- * only ever used to label a `blob:` URL for the platform's own image decoder —
- * a mislabelled file simply fails to decode and shows the preview's error state,
- * it never becomes a script or a navigation.
+ * 检测按扩展名，而非魔数。这是刻意的：
+ * 渲染器必须在拿到任何字节*之前*就决定如何打开文件，
+ * 因此在做决定的时刻无法进行内容嗅探。
+ * mime 只用于给 `blob:` URL 打上标签
+ * 供平台自己的图片解码器使用——
+ * 打错标签的文件只是无法解码并显示预览的错误状态，
+ * 它永远不会变成脚本或导航。
+ *
  */
 
-/** Extension (lower-case, no dot) → mime type. */
+/** 扩展名（小写、无点）→ mime 类型。 */
 const MIME_BY_EXT: Readonly<Record<string, string>> = {
   png: 'image/png',
   jpg: 'image/jpeg',
@@ -33,13 +33,13 @@ const MIME_BY_EXT: Readonly<Record<string, string>> = {
 };
 
 /**
- * Lower-cased extension of `p` without the dot, or '' when there is none.
+ * `p` 去掉点后的小写扩展名，没有时返回 ''。
  *
- * Strips a `?query` / `#hash` first: markdown authored by an agent routinely
- * carries cache-busting suffixes (`./shot.png?v=2`), and treating `png?v=2` as
- * the extension would silently drop exactly the screenshots we want to render.
- * Only the LAST path segment is considered, so a dotted directory name
- * (`v1.2/report`) can never masquerade as an extension.
+ * 先去掉 `?query` / `#hash`：代理编写的 markdown 经常携带防缓存的
+ * 后缀（`./shot.png?v=2`），把 `png?v=2` 当作扩展名会静默丢弃
+ * 恰恰是我们想渲染的截图。
+ * 只考虑最后一个路径段，因此带点的目录名（`v1.2/report`）
+ * 永远不会冒充扩展名。
  */
 export function extensionOf(p: string): string {
   if (typeof p !== 'string') return '';
@@ -50,28 +50,28 @@ export function extensionOf(p: string): string {
   return base.slice(dot + 1).toLowerCase();
 }
 
-/** The image mime for `p`, or null when the extension isn't a known image. */
+/** `p` 的图片 mime，当扩展名不是已知图片类型时为 null。 */
 export function imageMimeForPath(p: string): string | null {
   return MIME_BY_EXT[extensionOf(p)] ?? null;
 }
 
-/** True when `p` names a raster or vector image we can render. */
+/** 当 `p` 指向我们可以渲染的位图或矢量图时为 true。 */
 export function isImagePath(p: string): boolean {
   return imageMimeForPath(p) !== null;
 }
 
 /**
- * SVG is the one image format that is ALSO source code people edit by hand.
- * Callers use this to keep a "view source" escape hatch: an .svg opens as a
- * picture (that's what you want 95% of the time) but must never become
- * un-editable, which is what routing every image straight to a read-only
- * preview would have done.
+ * SVG 是唯一一种同时也是人们手工编辑的源代码的图片格式。
+ * 调用方用它保留一个“查看源代码”的逃生口：.svg 作为图片打开
+ * （95% 的情况下这正是你想要的），但绝不能变成不可编辑——
+ * 而把所有图片直接路由到只读预览恰恰会造成这种后果。
+ *
  */
 export function isSvgPath(p: string): boolean {
   return extensionOf(p) === 'svg';
 }
 
-/** Human byte size for a status line: "864 B", "1.4 MB". */
+/** 用于状态行的人类可读字节大小：“864 B”、“1.4 MB”。 */
 export function formatBytes(n: number): string {
   if (!Number.isFinite(n) || n < 0) return '—';
   if (n < 1024) return `${n} B`;

--- a/src/shared/imeGuard.ts
+++ b/src/shared/imeGuard.ts
@@ -1,47 +1,47 @@
 /**
- * "Is this keydown just the IME talking?"
+ * “这次 keydown 只是 IME 在发声吗？”
  *
- * A CJK, Japanese or Korean user types Latin letters into an input method
- * editor, which shows a candidate list, and presses ENTER to CHOOSE a candidate.
- * That Enter is meant for the IME, not for us. Every `if (e.key === 'Enter')`
- * handler in the app used to treat it as "send", so picking a candidate fired
- * the message, ran the search, or committed the rename with half-typed text.
- * The user then had to retype in a language the app had already sent badly.
+ * 中日韩用户把拉丁字母输入到输入法编辑器里，
+ * 编辑器显示候选列表，用户按 ENTER 来*选择*候选。
+ * 这个 Enter 是给 IME 的，不是给我们的。
+ * 应用里每一个 `if (e.key === 'Enter')` 处理器过去都把它当作“发送”，
+ * 于是选候选触发了消息发送、执行了搜索、
+ * 或用敲了一半的文本提交了重命名。
+ * 用户随后不得不在应用已经胡乱发送过的语言里重新输入。
  *
- * Two signals, because neither is sufficient alone:
+ * 用两个信号，因为两者单独都不够：
  *
- *  1. `isComposing` — the DOM's own answer, true for keydowns dispatched while a
- *     composition session is open. This is the primary check. React's synthetic
- *     keyboard event does NOT re-expose it, which is why we read through
- *     `nativeEvent` first and only fall back to the object itself (for raw
- *     `KeyboardEvent` listeners, which carry it directly).
+ *  1. `isComposing` — DOM 自己的答案，对组合会话进行期间派发的 keydown
+ *     为 true。这是首要检查。React 的合成键盘事件不会重新暴露它，
+ *     因此我们先通过 `nativeEvent` 读取，
+ *     只在必要时才回退到对象本身（针对直接携带它的原始
+ *     `KeyboardEvent` 监听器）。
  *
- *  2. `keyCode === 229` — the legacy "IME is processing this key" sentinel that
- *     Chromium still reports. It covers the race at the END of a composition,
- *     where the compositionend and the confirming keydown can arrive in an order
- *     that leaves `isComposing` already false for the very Enter we must swallow.
- *     229 is never a real Enter (that is 13), so this cannot swallow a genuine
- *     keypress.
+ *  2. `keyCode === 229` — Chromium 仍会报告的“IME 正在处理这个键”的
+ *     传统哨兵值。它覆盖组合会话末尾的竞态：
+ *     compositionend 和确认的 keydown 到达顺序可能使我们要吞掉的那个
+ *     Enter 到达时 `isComposing` 已经是 false。
+ *     229 从来不是真正的 Enter（那是 13），
+ *     因此这不会吞掉一次真实的按键。
  *
- * Pure and framework-free on purpose so it is testable from `node --test`.
- */
+ * 刻意保持纯净且无框架依赖，以便能从 `node --test` 测试。
 
-/** The structural shape we need from either a React synthetic event or a raw
- *  DOM `KeyboardEvent`. Deliberately all-optional: a hand-built test double or a
- *  partially-populated event must degrade to "not composing", never throw. */
+/** 我们需要的结构形态，无论是来自 React 合成事件还是原始 DOM
+ *  `KeyboardEvent`。刻意全部可选：手工构造的测试替身或部分填充的
+ *  事件必须降级为“不在组合中”，绝不抛错。 */
 export interface ComposingKeyEvent {
   isComposing?: boolean;
   keyCode?: number;
   nativeEvent?: { isComposing?: boolean; keyCode?: number };
 }
 
-/** True when this keydown belongs to an in-flight IME composition and the
- *  handler must return WITHOUT acting. The next Enter, once composition has
- *  ended, arrives with `isComposing` false and `keyCode` 13 and is handled
- *  normally. */
+/** 当这次 keydown 属于进行中的 IME 组合、处理器必须不做任何动作直接返回时
+ *  为 true。组合结束后的下一次 Enter 会以 `isComposing` 为 false、
+ *  `keyCode` 为 13 到达，并被正常处理。
+ *  */
 export function isComposingKey(e: ComposingKeyEvent | null | undefined): boolean {
   if (!e) return false;
-  // Prefer the native event: React's SyntheticKeyboardEvent drops `isComposing`.
+  // 优先使用原生事件：React 的 SyntheticKeyboardEvent 会丢掉 `isComposing`。
   const src = e.nativeEvent ?? e;
   return src.isComposing === true || src.keyCode === 229;
 }

--- a/src/shared/integrations.ts
+++ b/src/shared/integrations.ts
@@ -1,107 +1,103 @@
 /**
- * Integrations registry — shared schema (Phase 2 foundation).
+ * Integrations registry——共享 schema（Phase 2 基础）。
  *
- * A dependency-free, importable-by-both (main + renderer) module declaring the
- * integration record/template types, their validation, and the v1 reference
- * templates. Mirrors the posture of `src/shared/mcpCatalog.ts`: NO electron / node /
- * UI imports so it can be pulled into the main process, the preload bridge, and the
- * renderer alike.
+ * 一个零依赖、主进程与渲染进程均可导入的模块，声明集成记录/模板类型、
+ * 其校验以及 v1 参考模板。与 `src/shared/mcpCatalog.ts` 的姿态一致：
+ * 不含 electron/node/UI 导入，因此可被同时拉入主进程、preload 桥和渲染进程。
  *
- * An *integration* is a labeled REST endpoint a user registers ("label it and it's
- * available"). The record carries METADATA ONLY — never the secret value, only a
- * `secretRef` handle into the encrypted secret store (see src/main/integrations.ts).
- * The loopback secret broker (src/main/integrationBroker.ts) is the ONLY place a real
- * secret is materialized, and only at forward-time inside the main process.
+ * 集成（*integration*）是用户注册的带标签 REST 端点（"给它贴个标签就能用"）。
+ * 记录只携带 METADATA——绝不包含密钥值，只有指向加密密钥库的 `secretRef`
+ * 句柄（见 src/main/integrations.ts）。回环密钥代理
+ * （src/main/integrationBroker.ts）是真实密钥唯一被实体化的地方，且仅在
+ * 主进程内的转发时刻。
  *
- * Relationship to mcpCatalog.ts: that catalog declares STDIO MCP servers; this
- * registry declares HTTP REST endpoints reached through the loopback broker — a
- * complementary transport, not a competing catalog. Where a service overlaps
- * (github/db/email/search) the labels are kept aligned.
+ * 与 mcpCatalog.ts 的关系：那个目录声明 STDIO MCP 服务器；本注册表声明
+ * 经由回环代理访问的 HTTP REST 端点——是互补的传输方式，而非竞争目录。
+ * 服务重叠处（github/db/email/search）标签保持一致。
  *
- * Full contract: hive/docs/integrations-spec.md.
+ * 完整契约：hive/docs/integrations-spec.md。
  */
 
 export type IntegrationKind = 'github' | 'custom-rest';
 
-/** How the broker injects credentials when forwarding to the integration's baseUrl.
- *  This is the ONLY auth-injection vocabulary; the secret is supplied by the broker
- *  at forward-time, never stored here. */
+/** 转发到集成 baseUrl 时代理如何注入凭据。这是唯一的认证注入词汇表；
+ *  密钥由代理在转发时提供，绝不存储于此。 */
 export type IntegrationAuthType =
-  | 'none'    // public API — inject nothing
+  | 'none'    // 公共 API——不注入任何内容
   | 'bearer'  // Authorization: Bearer <secret>
-  | 'header'  // <authHeader>: <secret>   (authHeader required)
-  | 'github'; // Authorization: Bearer <secret> + GitHub API headers
+  | 'header'  // <authHeader>: <secret>   （authHeader 必填）
+  | 'github'; // Authorization: Bearer <secret> + GitHub API 请求头
 
-/** A registered integration. METADATA ONLY — carries NO secret value, only a
- *  `secretRef` handle. Safe to persist in config.json and cross IPC to the renderer. */
+/** 已注册的集成。仅元数据——不携带任何密钥值，只有一个 `secretRef` 句柄。
+ *  可以安全地持久化到 config.json 并通过 IPC 传给渲染进程。 */
 export interface IntegrationRecord {
-  /** Stable slug, unique. See SLUG_RE. Also seeds the secretRef (`int:<id>`). */
+  /** 稳定且唯一的 slug。参见 SLUG_RE。同时是 secretRef（`int:<id>`）的种子。 */
   id: string;
-  /** Human label for the UI (<= 60 chars). */
+  /** 供 UI 显示的人类可读标签（不超过 60 字符）。 */
   label: string;
-  /** Preset family — drives default headers and UI affordances. */
+  /** 预设族——决定默认请求头和 UI 表现形式。 */
   kind: IntegrationKind;
-  /** https origin (+ optional base path). The broker forwards <baseUrl>/<path>. A
-   *  loopback http origin is allowed only for explicit local custom-rest targets. */
+  /** https 源（+ 可选基础路径）。代理转发 <baseUrl>/<path>。仅当用户显式
+   *  注册本地 custom-rest 目标时才允许回环 http 源。 */
   baseUrl: string;
-  /** How the broker injects auth when forwarding upstream. */
+  /** 向上游转发时代理如何注入认证。 */
   authType: IntegrationAuthType;
-  /** REQUIRED iff authType === 'header' — the header NAME to inject the secret under. */
+  /** 仅当 authType === 'header' 时必填——密钥注入时所用的请求头名称。 */
   authHeader?: string;
-  /** HANDLE into the encrypted secret store; NEVER the secret. Present iff
-   *  authType !== 'none'. Convention: `int:<id>`. */
+  /** 指向加密密钥库的句柄；绝不存放密钥本身。仅当 authType !== 'none'
+   *  时存在。约定：`int:<id>`。 */
   secretRef?: string;
-  /** Consent gate. A worker can reach an integration ONLY when enabled. */
+  /** 同意门槛。仅当其启用时 worker 才能访问该集成。 */
   enabled: boolean;
-  /** epoch ms. */
+  /** 纪元毫秒。 */
   createdAt: number;
-  /** epoch ms. */
+  /** 纪元毫秒。 */
   updatedAt: number;
 }
 
-/** A preset that seeds an IntegrationRecord. Dwight extends the catalog by appending
- *  to INTEGRATION_TEMPLATES — no broker or registry changes needed. */
+/** 用于播种 IntegrationRecord 的预设。Dwight 通过向 INTEGRATION_TEMPLATES
+ *  追加来扩展目录——无需改动代理或注册表。 */
 export interface IntegrationTemplate {
   kind: IntegrationKind;
-  /** Default label (user-editable). */
+  /** 默认标签（用户可编辑）。 */
   label: string;
-  /** Default origin. Empty for custom-rest (the user supplies it). */
+  /** 默认源。custom-rest 为空（由用户提供）。 */
   baseUrl: string;
   authType: IntegrationAuthType;
-  /** For authType 'header'. */
+  /** 用于 authType 'header'。 */
   authHeader?: string;
-  /** UI prompt for the secret field, e.g. "GitHub personal access token". */
+  /** 密钥字段的 UI 提示，例如 "GitHub personal access token"。 */
   secretLabel?: string;
-  /** One line: where to get the secret / what scopes it needs. */
+  /** 一行：去哪里获取密钥 / 需要什么权限范围。 */
   secretHelp?: string;
-  /** https link for the UI. */
+  /** 供 UI 使用的 https 链接。 */
   docsUrl?: string;
-  /** Default slug seed. */
+  /** 默认 slug 种子。 */
   idSuggestion: string;
 }
 
-/** Integration id: lowercase slug, 2–40 chars, no leading/trailing hyphen. */
+/** 集成 id：小写 slug，2–40 字符，无开头/结尾连字符。 */
 export const INTEGRATION_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
-/** A header name the broker may inject under (authType 'header'). */
+/** 代理可以注入的请求头名称（authType 'header'）。 */
 export const HEADER_NAME_RE = /^[A-Za-z0-9-]{1,64}$/;
 export const ALL_AUTH_TYPES: readonly IntegrationAuthType[] = ['none', 'bearer', 'header', 'github'];
 export const ALL_KINDS: readonly IntegrationKind[] = ['github', 'custom-rest'];
 
-/** The secretRef handle for an integration id (1:1). */
+/** 集成 id 的 secretRef 句柄（1:1）。 */
 export function secretRefFor(id: string): string {
   return `int:${id}`;
 }
 
-/** True iff this auth type needs a stored secret. */
+/** 该认证类型是否需要存储的密钥。 */
 export function authTypeNeedsSecret(t: IntegrationAuthType): boolean {
   return t !== 'none';
 }
 
 /**
- * Validate an integration record (the upsert gate). Mirrors validateHireManifest's
- * style: returns { ok:true } or { ok:false, error }. Fail closed — anything not
- * explicitly allowed is rejected. `createdAt`/`updatedAt` are stamped by the
- * registry, so they are not required on input.
+ * 校验集成记录（upsert 门槛）。仿照 validateHireManifest 的风格：
+ * 返回 { ok:true } 或 { ok:false, error }。默认拒绝——任何未显式允许的
+ * 内容都会被拒绝。`createdAt`/`updatedAt` 由注册表盖章，因此输入时
+ * 不要求提供。
  */
 export function validateIntegrationRecord(
   rec: unknown
@@ -145,9 +141,9 @@ export function validateIntegrationRecord(
   return { ok: true, value: { id, label, kind, baseUrl, authType, authHeader, secretRef, enabled } };
 }
 
-/** Validate a baseUrl: https origin (+ optional path), no userinfo, no traversal.
- *  A loopback http origin (127.0.0.1 / [::1] / localhost) is permitted for explicit
- *  local custom-rest targets the user registers. */
+/** 校验 baseUrl：https 源（+ 可选路径），不含用户信息，无路径穿越。
+ *  回环 http 源（127.0.0.1 / [::1] / localhost）仅对用户显式注册的
+ *  本地 custom-rest 目标允许。 */
 export function validateBaseUrl(baseUrl: string): { ok: true; url: URL } | { ok: false; error: string } {
   if (!baseUrl) return { ok: false, error: 'baseUrl is required' };
   let u: URL;
@@ -167,10 +163,9 @@ export function validateBaseUrl(baseUrl: string): { ok: true; url: URL } | { ok:
 }
 
 /**
- * Build the upstream auth headers the broker injects when forwarding. Pure — the
- * caller (the broker, in main) passes the already-decrypted secret; this function
- * never reads any store and never logs. Returns the header map to merge into the
- * outbound request (lowercased keys).
+ * 构建代理转发时注入的上游认证请求头。纯函数——调用方（主进程中的
+ * 代理）传入已解密的密钥；本函数不读取任何存储，也绝不记日志。
+ * 返回要合并到出站请求的请求头映射（键为小写）。
  */
 export function buildAuthHeaders(
   authType: IntegrationAuthType,
@@ -196,10 +191,10 @@ export function buildAuthHeaders(
 }
 
 /**
- * Join an integration baseUrl with a worker-supplied path, confining the result
- * under the baseUrl origin (NOT an open proxy). Returns null if the path would
- * escape the origin (absolute URL, host override, or traversal above the base path).
- * `pathAndQuery` is the part after `/i/<integrationId>/` including any query string.
+ * 将集成 baseUrl 与 worker 提供的路径拼接，把结果限定在 baseUrl 源之下
+ * （不是开放代理）。若路径会逃逸该源（绝对 URL、覆盖主机、或越过基础
+ * 路径的穿越）则返回 null。`pathAndQuery` 是 `/i/<integrationId>/` 之后
+ * 的部分，包括任何查询串。
  */
 export function resolveUpstreamUrl(baseUrl: string, pathAndQuery: string): URL | null {
   let base: URL;
@@ -208,16 +203,16 @@ export function resolveUpstreamUrl(baseUrl: string, pathAndQuery: string): URL |
   } catch {
     return null;
   }
-  // Reject anything that smells like an absolute target or traversal.
+  // 拒绝任何看起来像绝对目标或路径穿越的内容。
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(pathAndQuery)) return null; // scheme://...
-  if (pathAndQuery.startsWith('//')) return null; // protocol-relative host override
-  // Decode the path before the traversal check so an encoded `%2e%2e` is caught too.
+  if (pathAndQuery.startsWith('//')) return null; // 协议相对的主机覆盖
+  // 在穿越检查前先解码路径，这样编码过的 `%2e%2e` 也会被捕获。
   const pathOnly = pathAndQuery.split(/[?#]/)[0];
   let decodedPath: string;
   try { decodedPath = decodeURIComponent(pathOnly); } catch { return null; }
   if (decodedPath.split('/').some((seg) => seg === '..')) return null;
 
-  // Normalize the base path to a directory prefix, then append the worker path.
+  // 将基础路径规范化为目录前缀，然后追加 worker 路径。
   const basePath = base.pathname.endsWith('/') ? base.pathname : base.pathname + '/';
   const rel = pathAndQuery.replace(/^\/+/, '');
   let resolved: URL;
@@ -226,7 +221,7 @@ export function resolveUpstreamUrl(baseUrl: string, pathAndQuery: string): URL |
   } catch {
     return null;
   }
-  // Confine: same origin AND the resolved path stays under the base path prefix.
+  // 限定：同源，且解析后的路径保持在基础路径前缀之下。
   if (resolved.origin !== base.origin) return null;
   const confinePrefix = base.pathname.endsWith('/') ? base.pathname : base.pathname + '/';
   if (confinePrefix !== '/' && !(resolved.pathname + '/').startsWith(confinePrefix) && resolved.pathname !== base.pathname) {
@@ -235,7 +230,7 @@ export function resolveUpstreamUrl(baseUrl: string, pathAndQuery: string): URL |
   return resolved;
 }
 
-/** v1 reference templates — the two end-to-end references. Dwight appends more here. */
+/** v1 参考模板——两个端到端参考。Dwight 在此追加更多。 */
 export const INTEGRATION_TEMPLATES: IntegrationTemplate[] = [
   {
     kind: 'github',
@@ -257,11 +252,11 @@ export const INTEGRATION_TEMPLATES: IntegrationTemplate[] = [
     idSuggestion: 'my-api'
   },
 
-  // ─── First-wave YC tools (Dwight, P2) ───────────────────────────────────────
-  // Per-tool auth model + high-value endpoint catalog: hive/docs/integration-templates.md.
-  // Gmail / Google Calendar / Salesforce are intentionally NOT registered yet: they
-  // authenticate via OAuth, and IntegrationAuthType has no `oauth2` (OAuth refresh is a
-  // v1 non-goal — spec §8). They are documented under "Pending: OAuth broker".
+  // ─── 第一波 YC 工具（Dwight, P2）──────────────────────────────────────────
+  // 每个工具的认证模型 + 高价值端点目录：hive/docs/integration-templates.md。
+  // Gmail / Google Calendar / Salesforce 被有意暂不注册：它们通过 OAuth
+  // 认证，而 IntegrationAuthType 没有 `oauth2`（OAuth 刷新是 v1 非目标——
+  // spec §8）。它们被记录在 "Pending: OAuth broker" 之下。
   {
     kind: 'custom-rest',
     label: 'Linear',

--- a/src/shared/mcpCatalog.ts
+++ b/src/shared/mcpCatalog.ts
@@ -1,56 +1,53 @@
 /**
- * Default MCP server catalog (Workstream 3). A dependency-free, importable-by-both
- * (main + renderer) registry of the MCP servers Munder Difflin can wire into each
- * agent's per-session `settings.json`. Keep it free of electron/UI/node imports.
+ * 默认 MCP 服务器目录（Workstream 3）。一个零依赖、主进程与渲染进程
+ * 均可导入的注册表，登记 Munder Difflin 可以接入每个 agent 每会话
+ * `settings.json` 的 MCP 服务器。保持不含 electron/UI/node 导入。
  *
- * Tiers gate consent:
- *   - 'safe-readonly' → no secret, no destructive write OUTSIDE the agent cwd; shipped
- *                       ON by default (`defaultEnabled:true`). `filesystem`/`git` are
- *                       scoped to the agent cwd at merge time (never whole-disk).
- *   - 'write'         → can mutate state beyond the workspace; OFF by default,
- *                       consent-gated.
- *   - 'secret'        → needs an API key / token / connection string; OFF by default,
- *                       consent-gated.
+ * 层级决定同意门槛：
+ *   - 'safe-readonly' → 无密钥、不会在 agent cwd 之外做破坏性写入；默认
+ *                       开启（`defaultEnabled:true`）。`filesystem`/`git`
+ *                       在合并时限定于 agent cwd（绝不整盘）。
+ *   - 'write'         → 可以变更工作区之外的状态；默认关闭，需同意。
+ *   - 'secret'        → 需要 API 密钥/令牌/连接串；默认关闭，需同意。
  *
- * The actual merge (catalog ∩ enabled, cwd-scoping of filesystem/git, id namespacing,
- * non-fatal resolution) is Workstream 3's `buildDefaultMcpServers`/`hookSettings`
- * job — this module only declares the entries, their tiers, and the seed defaults.
+ * 真正的合并（catalog ∩ enabled、filesystem/git 的 cwd 限定、id 命名空间化、
+ * 非致命解析）是 Workstream 3 的 `buildDefaultMcpServers`/`hookSettings`
+ * 工作——本模块只声明条目、层级与种子默认值。
  *
- * NOTE: several reference servers ship as Python (uvx) rather than npm (npx). The
- * commands below reflect each server's real transport; entries that couldn't be
- * verified against an installed server are flagged `// TODO-verify`. Workstream 3
- * makes a server that fails to resolve non-fatal to the agent.
+ * 注意：若干参考服务器以 Python（uvx）而非 npm（npx）形态分发。下面的命令
+ * 反映每个服务器的真实传输方式；无法对照已安装服务器验证的条目会标记为
+ * `// TODO-verify`。Workstream 3 让解析失败的服务器对 agent 非致命。
  */
 
 export type McpTier = 'safe-readonly' | 'write' | 'secret';
 
 export interface McpCatalogEntry {
-  /** Stable catalog id (also the consent key in `config.mcpDefaults`). The merge
-   *  step namespaces the written server id (e.g. `munder-<id>`) to avoid clobbering
-   *  a user's own `~/.claude` MCP server of the same name. */
+  /** 稳定的目录 id（也是 `config.mcpDefaults` 中的同意键）。合并步骤
+   *  会为写入的服务器 id 加命名空间（如 `munder-<id>`），避免覆盖用户自己的
+   *  同名 `~/.claude` MCP 服务器。 */
   id: string;
-  /** Human label for the consent UI. */
+  /** 供同意 UI 显示的人类可读标签。 */
   label: string;
-  /** One-line description for the consent UI / hire import preview. */
+  /** 供同意 UI / hire 导入预览使用的一行描述。 */
   description: string;
-  /** The MCP stdio server launch spec. `filesystem`/`git` carry a placeholder cwd
-   *  arg that Workstream 3 replaces with the agent cwd at merge time. */
+  /** MCP stdio 服务器启动规格。`filesystem`/`git` 携带一个占位 cwd
+   *  参数，Workstream 3 在合并时用 agent cwd 替换它。 */
   spec: {
     command: string;
     args: string[];
-    /** Required env (e.g. an API token). Present only on write/secret entries; the
-     *  value is supplied via consent, never hard-coded here. */
+    /** 必需的 env（如 API 令牌）。仅存在于 write/secret 条目；值由同意
+     *  流程提供，绝不在此处硬编码。 */
     env?: Record<string, string>;
   };
   tier: McpTier;
-  /** Seed for `config.mcpDefaults[id].enabled`. Always === (tier === 'safe-readonly'). */
+  /** `config.mcpDefaults[id].enabled` 的种子值。恒等于 (tier === 'safe-readonly')。 */
   defaultEnabled: boolean;
 }
 
-/** The default MCP bundle. Safe/read-only servers are ON; anything that writes
- *  beyond the workspace or needs a secret is OFF until the user consents. */
+/** 默认 MCP 组合。安全/只读服务器开启；任何写入工作区之外或需要
+ *  密钥的服务器在用户同意前保持关闭。 */
 export const MCP_CATALOG: McpCatalogEntry[] = [
-  // ─── Safe, read-only, no-secret — shipped ON ──────────────────────────────
+  // ─── 安全、只读、无密钥——默认开启 ──────────────────────────────────────
   {
     id: 'sequential-thinking',
     label: 'Sequential Thinking',
@@ -63,7 +60,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     id: 'time',
     label: 'Time',
     description: 'Current time and timezone conversions.',
-    // Reference time server ships as Python. // TODO-verify transport (uvx vs an npm port)
+    // 参考时间服务器以 Python 形态分发。 // TODO-verify 传输方式（uvx 还是 npm 移植版）
     spec: { command: 'uvx', args: ['mcp-server-time'] },
     tier: 'safe-readonly',
     defaultEnabled: true
@@ -72,7 +69,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     id: 'fetch',
     label: 'Fetch',
     description: 'Fetch a URL and return its content as markdown (read-only HTTP GET).',
-    // Reference fetch server ships as Python. // TODO-verify transport (uvx vs an npm port)
+    // 参考 fetch 服务器以 Python 形态分发。 // TODO-verify 传输方式（uvx 还是 npm 移植版）
     spec: { command: 'uvx', args: ['mcp-server-fetch'] },
     tier: 'safe-readonly',
     defaultEnabled: true
@@ -89,8 +86,8 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     id: 'filesystem',
     label: 'Filesystem (cwd)',
     description: 'Read/edit files within the agent workspace only (scoped to cwd at spawn).',
-    // The trailing arg is the allowed root — Workstream 3 replaces this placeholder
-    // with the agent cwd at merge time so it is NEVER whole-disk.
+    // 末尾参数是允许的根目录——Workstream 3 在合并时用 agent cwd
+    // 替换此占位符，因此绝不可能是整盘。
     spec: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem', '<cwd>'] },
     tier: 'safe-readonly',
     defaultEnabled: true
@@ -99,14 +96,14 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     id: 'git',
     label: 'Git (cwd)',
     description: 'Inspect git status/log/diff for the workspace repo (scoped to cwd at spawn).',
-    // Reference git server ships as Python; `--repository <cwd>` is set at merge time.
-    // TODO-verify transport (uvx vs an npm port).
+    // 参考 git 服务器以 Python 形态分发；`--repository <cwd>` 在合并时设置。
+    // TODO-verify 传输方式（uvx 还是 npm 移植版）。
     spec: { command: 'uvx', args: ['mcp-server-git', '--repository', '<cwd>'] },
     tier: 'safe-readonly',
     defaultEnabled: true
   },
 
-  // ─── Write / secret — shipped OFF, consent-gated ──────────────────────────
+  // ─── 写入 / 密钥——默认关闭，需同意 ──────────────────────────────────────
   {
     id: 'github-token',
     label: 'GitHub',
@@ -123,7 +120,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     id: 'db',
     label: 'Database',
     description: 'Query a SQL database. Requires a connection string.',
-    // TODO-verify exact server package for the user's DB engine (Postgres assumed).
+    // TODO-verify 针对用户数据库引擎的确切服务器包（假定为 Postgres）。
     spec: {
       command: 'npx',
       args: ['-y', '@modelcontextprotocol/server-postgres'],
@@ -136,7 +133,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     id: 'email-calendar',
     label: 'Email & Calendar',
     description: 'Read/send mail and read/write calendar events. Requires account credentials.',
-    // TODO-verify provider package (Gmail/Google Calendar assumed).
+    // TODO-verify 提供商包（假定为 Gmail/Google Calendar）。
     spec: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-gsuite'], env: { GOOGLE_OAUTH_TOKEN: '' } },
     tier: 'secret',
     defaultEnabled: false
@@ -145,26 +142,26 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     id: 'search-with-key',
     label: 'Web Search',
     description: 'Keyed web search. Requires a search-provider API key.',
-    // TODO-verify provider package (Brave Search assumed).
+    // TODO-verify 提供商包（假定为 Brave Search）。
     spec: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-brave-search'], env: { BRAVE_API_KEY: '' } },
     tier: 'secret',
     defaultEnabled: false
   }
 ];
 
-/** Look up a catalog entry by id. */
+/** 按 id 查找目录条目。 */
 export function mcpCatalogEntry(id: string): McpCatalogEntry | undefined {
   return MCP_CATALOG.find((e) => e.id === id);
 }
 
-/** Whether an id is a known safe-readonly server (the only tier a hire manifest may
- *  request without surfacing for human consent — Workstream 3 validation). */
+/** id 是否为已知的 safe-readonly 服务器（hire 清单无需呈现给人类同意
+ *  即可请求的唯一层级——Workstream 3 校验）。 */
 export function isSafeReadonlyMcp(id: string): boolean {
   return mcpCatalogEntry(id)?.tier === 'safe-readonly';
 }
 
-/** Seed for `DEFAULTS.mcpDefaults` — derived from the catalog so the two never
- *  drift (safe-readonly ON, write/secret OFF). */
+/** `DEFAULTS.mcpDefaults` 的种子——由目录派生，因此两者永不漂移
+ *  （safe-readonly 开启，write/secret 关闭）。 */
 export function defaultMcpDefaults(): Record<string, { enabled: boolean }> {
   const out: Record<string, { enabled: boolean }> = {};
   for (const e of MCP_CATALOG) out[e.id] = { enabled: e.defaultEnabled };

--- a/src/shared/ossModels.ts
+++ b/src/shared/ossModels.ts
@@ -1,38 +1,38 @@
 import type { AgentProvider } from './agentProvider';
 
 /**
- * Open-source model quick-picks for the Add-Agent modal (ondev-c part-2).
+ * 添加 Agent 弹窗中的开源模型快速选择（ondev-c part-2）。
  *
- * Curated, STABLE shortlist transcribed verbatim from the verified catalog
- * `hive/shared/cli-agents/oss-models-catalog.md` §7 (frozen by Jim). Robust slugs
- * only — bleeding-edge frontier models (GLM-5.2, Kimi-K2.7) are intentionally
- * EXCLUDED from code defaults (catalog §8 = verify-live) and left to the blogs.
+ * 精心挑选的、稳定的短名单，从已验证目录
+ * `hive/shared/cli-agents/oss-models-catalog.md` §7 逐字转录（由 Jim 冻结）。
+ * 只收录稳健的 slug——前沿的尖刺模型（GLM-5.2、Kimi-K2.7）被刻意
+ * 从代码默认值中排除（目录 §8 = 上线前需实测），留给博客去讲。
  *
- * Two buckets: LOCAL (Mac-runnable via Ollama/LM Studio, no key) and THIRD-PARTY
- * OSS PROVIDER (BYOK). Every engine consumes the same upstream id; only the
- * local prefix differs (§6): OpenCode names its local provider `local`; Crush and
- * pi use `ollama`. Provider-routed slugs are identical across the three engines.
+ * 两个桶：本地（LOCAL，Mac 可通过 Ollama/LM Studio 运行，无需 key）和
+ * 第三方 OSS 提供商（THIRD-PARTY OSS PROVIDER，BYOK）。每个引擎消费
+ * 相同的上游 id；只有本地前缀不同（§6）：OpenCode 把本地提供商命名为
+ * `local`；Crush 和 pi 用 `ollama`。三个引擎中提供商路由的 slug 完全相同。
  */
 
-/** A Mac-runnable local model (Ollama tag). Slug is engine-prefixed via localSlugFor. */
+/** Mac 可运行的本地模型（Ollama tag）。slug 经 localSlugFor 加引擎前缀。 */
 export interface OssLocalPick {
   label: string;
-  /** Ollama tag — keep the colon (e.g. `gpt-oss:20b`). */
+  /** Ollama tag — 保留冒号（例如 `gpt-oss:20b`）。 */
   tag: string;
-  /** Rough minimum unified memory to run it. */
+  /** 运行它所需的大致最小统一内存。 */
   minRam: string;
 }
 
-/** A third-party OSS-provider model (BYOK). Slug used as-is across all three engines. */
+/** 第三方 OSS 提供商的模型（BYOK）。slug 在三个引擎中原样使用。 */
 export interface OssProviderPick {
   label: string;
-  /** `provider/model` slug (native provider prefix where possible). */
+  /** `provider/model` slug（尽可能使用原生提供商前缀）。 */
   slug: string;
-  /** The backend key env var this route reads (set in Settings → AI Engines). */
+  /** 此路由读取的后端 key 环境变量（在 设置 → AI 引擎 中设置）。 */
   keyEnv: string;
 }
 
-/** §7.A — Local quick-picks (Mac-runnable, no key) — Ollama tags. */
+/** §7.A — 本地快速选择（Mac 可运行，无需 key）— Ollama tags。 */
 export const OSS_LOCAL_PICKS: OssLocalPick[] = [
   { label: 'gpt-oss 20B', tag: 'gpt-oss:20b', minRam: '16 GB' },
   { label: 'Qwen3 30B-A3B', tag: 'qwen3:30b-a3b', minRam: '32 GB' },
@@ -44,7 +44,7 @@ export const OSS_LOCAL_PICKS: OssLocalPick[] = [
   { label: 'gpt-oss 120B', tag: 'gpt-oss:120b', minRam: '96 GB' }
 ];
 
-/** §7.B — Third-party OSS-provider quick-picks (BYOK). */
+/** §7.B — 第三方 OSS 提供商快速选择（BYOK）。 */
 export const OSS_PROVIDER_PICKS: OssProviderPick[] = [
   { label: 'gpt-oss 120B · Groq', slug: 'groq/openai/gpt-oss-120b', keyEnv: 'GROQ_API_KEY' },
   { label: 'Llama 3.3 70B · Groq', slug: 'groq/llama-3.3-70b-versatile', keyEnv: 'GROQ_API_KEY' },
@@ -57,19 +57,17 @@ export const OSS_PROVIDER_PICKS: OssProviderPick[] = [
   { label: 'gpt-oss 120B · OpenRouter', slug: 'openrouter/openai/gpt-oss-120b', keyEnv: 'OPENROUTER_API_KEY' }
 ];
 
-/** Engine-correct slug for a local Ollama tag (§6): OpenCode → `local/<tag>`;
- *  Crush and pi → `ollama/<tag>`. The tag keeps its colon. */
-export function localSlugFor(provider: AgentProvider, tag: string): string {
-  return provider === 'opencode' ? `local/${tag}` : `ollama/${tag}`;
+/** 本地 Ollama tag 的引擎正确 slug：`ollama/<tag>`。tag 保留其冒号。 */
+export function localSlugFor(_provider: AgentProvider, tag: string): string {
+  return `ollama/${tag}`;
 }
 
-/** Whether to surface the OSS quick-picks for this engine — the local-capable CLI
- *  engines integrated in v0.3.1. (Claude/Codex/Antigravity use their own logins.) */
+/** 是否为此引擎展示 OSS 快速选择——当前引擎集中只有 qwen 支持本地运行。 */
 export function hasOssQuickPicks(provider: AgentProvider): boolean {
-  return provider === 'opencode' || provider === 'crush' || provider === 'pi';
+  return provider === 'qwen';
 }
 
-/** Canonical blog URLs the local-setup UI hyperlinks to (ondev-c part-3). */
+/** 本地设置 UI 超链接到的权威博客 URL（ondev-c part-3）。 */
 export const OSS_BLOG_LINKS = {
   openModels: 'https://munderdiffl.in/blog/run-munder-difflin-on-open-models/',
   macMini: 'https://munderdiffl.in/blog/run-munder-difflin-on-a-mac-mini/'

--- a/src/shared/providerAutomation.ts
+++ b/src/shared/providerAutomation.ts
@@ -2,24 +2,24 @@ import type { AgentProvider } from './agentProvider';
 import { DEFAULT_COMPACTION_FOCUS } from './triggers';
 
 /**
- * Back-compat alias. The compaction focus used to be a private constant here;
- * it now lives in shared/triggers.ts as the DEFAULT VALUE of the user-editable
- * `ContextRule.message`, so the Triggers UI and this module cannot drift apart.
- * Kept exported under the old name for any consumer still reaching for it.
+ * 向后兼容别名。压缩焦点（compaction focus）曾是这里的私有常量；
+ * 现在它作为用户可编辑的 `ContextRule.message` 的默认值位于 shared/triggers.ts，
+ * 因此 Triggers UI 与本模块不会分叉。
+ * 为仍在引用它的消费者保留旧名称导出。
  */
 export const COMPACTION_FOCUS = DEFAULT_COMPACTION_FOCUS;
 
-/** What one provider's interactive TUI accepts for each context action. */
+/** 某个 provider 的交互式 TUI 为每个上下文动作接受什么。 */
 export interface ProviderContextCommands {
-  /** Summarise-in-place. `null` = no command we can type with confidence. */
+  /** 就地摘要（summarise-in-place）。`null` = 没有我们敢敲入的命令。 */
   compact: string | null;
-  /** Discard-and-restart. `null` = same. */
+  /** 丢弃并重启。`null` = 同理。 */
   clear: string | null;
   /**
-   * Whether the TUI parses text AFTER the compact command as a focus
-   * instruction. When false the focus is DROPPED rather than typed: a CLI whose
-   * slash parser ignores the remainder is harmless, but one that re-reads it as
-   * a fresh prompt would silently turn a compaction into a whole extra turn.
+   * TUI 是否把 compact 命令之后的文本解析为焦点指令。
+   * 为 false 时焦点被丢弃（DROPPED）而非敲入：斜杠解析器忽略余下部分的
+   * CLI 是无害的，但若它把余下内容当作新的 prompt 重新读取，就会静默地把
+   * 一次压缩变成整整额外一轮对话。
    */
   compactTakesFocus: boolean;
 }
@@ -31,135 +31,69 @@ const NO_CONTEXT_COMMANDS: ProviderContextCommands = {
 };
 
 /**
- * THE per-provider context-command table.
+ * 每个 provider 的上下文命令表（唯一的权威）。
  *
- * Deliberately a total `Record<AgentProvider, …>` and NOT a switch with a
- * `default:` arm — the previous switch silently answered `null` for seven of the
- * eleven providers, so auto-compaction quietly did nothing for most of the fleet
- * and nobody found out. A total record makes the compiler stop the next person
- * who adds a provider until they have actually looked its commands up.
+ * 刻意做成总表 `Record<AgentProvider, …>` 而非带 `default:` 分支的 switch——
+ * 之前的 switch 在十一个 provider 中悄悄为七个返回 `null`，导致自动压缩对
+ * 大部分 fleet 静默无效而无人察觉。总表会让编译器阻止下一个添加 provider
+ * 的人，直到他真的查过它的命令。
  *
- * `null` means "we could not establish a command we trust", NOT "we didn't
- * check". A wrong slash command typed into a live terminal is worse than no
- * command: at best it is dead text the model answers, at worst it fires some
- * other verb. Every entry below cites where it was verified — mostly by reading
- * the SHIPPED BINARY of each CLI (its own embedded command table / docs), which
- * outranks web docs because it cannot lag the installed version.
+ * `null` 表示"我们无法确立一条信任的命令"，而非"我们没查过"。
+ * 在活跃终端敲错斜杠命令比没有命令更糟：最好情况是模型回答的无效文本，
+ * 最坏会触发别的动词。下面每条都注明了在哪里验证——多数通过阅读每个 CLI
+ * 的随附二进制（其内嵌命令表/文档），它不可能落后于已装版本，因此优先级
+ * 高于网络文档。
  */
 const CONTEXT_COMMANDS: Record<AgentProvider, ProviderContextCommands> = {
-  // claudeCommands.ts:34,37 (this repo's own catalog): `/compact` takes a focus
-  // ("usage: /compact keep the auth decisions"), `/clear` starts a fresh
-  // conversation and reclaims the window.
+  // claudeCommands.ts:34,37（本仓库自带的目录）：`/compact` 接受一个焦点
+  // （"usage: /compact keep the auth decisions"），`/clear` 开启一段全新
+  // 对话并回收窗口。
   claude: { compact: '/compact', clear: '/clear', compactTakesFocus: true },
 
-  // Codex 0.137.0 binary, TUI slash-command description table:
+  // Codex 0.137.0 二进制、TUI 斜杠命令描述表：
   //   "summarize conversation to prevent hitting the context limit"  → /compact
   //   "clear the terminal and start a new chat"                      → /clear
-  // NOTE this contradicts codexCommands.ts, which lists /clear but NOT /compact.
-  // The binary is right and that catalog is incomplete (see report).
-  // compactTakesFocus stays FALSE: codex's own `Usage: /…` strings spell out an
-  // argument for every command that takes one (/goal, /raw, /mcp, /keymap,
-  // /ide, /sandbox-add-read-dir) and /compact has none.
+  // 注意这与 codexCommands.ts 矛盾，后者列出了 /clear 但没有 /compact。
+  // 二进制是对的，那个目录不全（见报告）。
+  // compactTakesFocus 保持 FALSE：codex 自己的 `Usage: /…` 字符串为每个带
+  // 参数的命令都拼出了一个参数（/goal、/raw、/mcp、/keymap、/ide、
+  // /sandbox-add-read-dir），而 /compact 没有。
   codex: { compact: '/compact', clear: '/clear', compactTakesFocus: false },
 
-  // Grok binary ships its own docs inline (04-slash-commands.md):
-  //   "/compact [context] — Compress conversation history… Optionally specify
-  //    what to preserve", example `/compact keep the auth implementation details`
-  //   "/new — Start a new session, clearing the current conversation.
-  //    Aliases: /clear"
-  // `/new` is the documented spelling (and what grokCommands.ts:13 already
-  // records), so prefer it over the alias.
-  grok: { compact: '/compact', clear: '/new', compactTakesFocus: true },
-
-  // Moonshot kimi-cli slash-command reference: `/compact` accepts appended
-  // custom instructions ("/compact preserve database-related discussions");
-  // `/clear` (alias /reset) "Clear the current session's context and start a
-  // new conversation". NB `/new` there forks a session rather than discarding.
+  // Moonshot kimi-cli 斜杠命令参考：`/compact` 接受追加的
+  // 自定义指令（"/compact preserve database-related discussions"）；
+  // `/clear`（别名 /reset）"Clear the current session's context and start a
+  // new conversation"。注意那里的 `/new` 是派生一个会话而非丢弃。
   kimi: { compact: '/compact', clear: '/clear', compactTakesFocus: true },
 
-  // antigravity.google/docs/cli/reference (Google's own command table):
-  //   "/clear  (/new)  — Clear the terminal and reset active conversation
-  //    contexts."     ← a REAL context reset, and
-  //   "Ctrl+L  cli.clear_screen — Refreshes and clears the visual terminal
-  //    buffer."       ← the screen-only one. The two are different things, so
-  // the "agy /clear only clears the screen" worry does not hold.
-  // That reference lists NO compaction verb at all (zero hits for compact /
-  // compress / summarize), and the shipped `agy` binary has no such literal
-  // either — agy compacts AUTOMATICALLY when the window fills ("# Resuming from
-  // a compaction"). Nothing to type, so: null.
-  antigravity: { compact: null, clear: '/clear', compactTakesFocus: false },
-
-  // Google Gemini CLI's command reference documents `/compress` as replacing
-  // the chat context with a summary and `/clear` as starting a clean context.
-  // `/compress` has no focus-argument contract, so never append user prose.
-  gemini: { compact: '/compress', clear: '/clear', compactTakesFocus: false },
-
-  // qwen-code's bundled cli.js, verbatim:
+  // qwen-code 自带的 cli.js，逐字引用：
   //   compressCommand = { name:"compress", altNames:["summarize"],
   //     description "Compresses the context by replacing it with a summary." }
-  //   and its action reads `context.invocation?.args` as `customInstructions`
-  //   (capped at 2000 chars) → it genuinely takes a focus.
+  //   其 action 把 `context.invocation?.args` 读作 `customInstructions`
+  //   （上限 2000 字符）→ 它确实接受一个焦点。
   //   clearCommand    = { name:"clear", altNames:["reset","new"],
   //     description "Clear conversation history and free up context." }
-  // It is `/compress`, NOT `/compact`: qwen dropped upstream gemini-cli's
-  // `compact` altName, so `/compact` would land as plain text here.
+  // 它是 `/compress`，而不是 `/compact`：qwen 丢弃了上游 gemini-cli 的
+  // `compact` 别名，因此 `/compact` 在这里只会落成纯文本。
   qwen: { compact: '/compress', clear: '/clear', compactTakesFocus: true },
 
-  // opencode binary's command registry, verbatim:
-  //   { title:"Compact session", value:"session.compact",
-  //     slash:{ name:"compact", aliases:["summarize"] }, run: … }
-  // and its own tip text "Run /compact to summarize long sessions near context
-  // limits". That `run()` calls session.summarize({sessionID,model}) and never
-  // looks at the invocation args → the focus would be silently dropped, so
-  // compactTakesFocus is false.
-  // `/clear` does NOT exist in the binary (zero literals); the fresh-session
-  // verb is `/new` — matched exactly (`t.trim().toLowerCase()==="/new"`).
-  opencode: { compact: '/compact', clear: '/new', compactTakesFocus: false },
 
-  // Crush has NO typed slash commands at all. Its own binary strings show
-  // "Summarize Session" / "New Session" as ctrl+p COMMAND-PALETTE rows, and the
-  // hint "/ or ctrl+p" means a leading `/` OPENS that palette rather than
-  // submitting a command. Typing "/compact" would filter a modal and leave it
-  // open, swallowing everything queued behind it. Nothing safe to type: null.
-  // (Crush's compact/clear are reachable only over its HTTP API.)
-  crush: NO_CONTEXT_COMMANDS,
-
-  // pi's dist/core/slash-commands.js, verbatim:
-  //   { name:"compact", description:"Manually compact the session context" }
-  //   { name:"new",     description:"Start a new session" }
-  // and docs/compaction.md: "trigger manually with `/compact [instructions]`,
-  // where optional instructions focus the summary". There is no `/clear`.
-  pi: { compact: '/compact', clear: '/new', compactTakesFocus: true },
-
-  // Copilot's INTERACTIVE mode does have `/compact [FOCUS-INSTRUCTIONS]` and
-  // `/clear` — but this app never runs it interactively. The preset spawns it in
-  // print mode (`initialPromptFlag: '-p'`, `canReceiveInbox: false`), which runs
-  // one prompt and EXITS. There is no prompt left alive to type a slash command
-  // into, so both are null by construction rather than by ignorance.
-  copilot: NO_CONTEXT_COMMANDS,
-
-  // Cursor Agent CLI (`agent`) is interactive in this preset, but its slash /
-  // command surface is not yet verified against a frozen binary catalog in-repo.
-  // Prefer null over guessing — wrong slashes into a live TUI are worse than no
-  // auto-compact. Revisit when a shipped command table is transcribed.
-  cursor: NO_CONTEXT_COMMANDS,
-
-  // An arbitrary user binary. We cannot know its command surface, and guessing
-  // means typing slashes into someone's unknown REPL.
+  // 任意用户二进制。我们无法知道它的命令表面，猜测意味着
+  // 往某个未知的 REPL 里敲斜杠。
   custom: NO_CONTEXT_COMMANDS
 };
 
-/** The full context-command entry for a provider (unknown ids degrade to none). */
+/** 某 provider 的完整上下文命令条目（未知 id 降级为 none）。 */
 export function contextCommandsForProvider(provider: AgentProvider): ProviderContextCommands {
   return CONTEXT_COMMANDS[provider] ?? NO_CONTEXT_COMMANDS;
 }
 
 /**
- * The compaction command to type, or null when this provider has none.
+ * 要敲入的压缩命令；当该 provider 没有时返回 null。
  *
- * `message` is the user-editable `ContextRule.message` (default
- * `DEFAULT_COMPACTION_FOCUS`) and is appended only where the provider's parser
- * actually reads it — see `compactTakesFocus`.
+ * `message` 是用户可编辑的 `ContextRule.message`（默认
+ * `DEFAULT_COMPACTION_FOCUS`），并且只在该 provider 的解析器真正读取它的
+ * 地方追加——参见 `compactTakesFocus`。
  */
 export function compactionCommandForProvider(
   provider: AgentProvider,
@@ -171,9 +105,9 @@ export function compactionCommandForProvider(
   return compactTakesFocus && focus ? `${compact} ${focus}` : compact;
 }
 
-/** Every distinct compaction verb this harness can type, across all providers.
- *  Derived from CONTEXT_COMMANDS rather than hand-listed, so a provider added to
- *  that table is covered here without a second edit anyone could forget. */
+/** 本 harness 跨所有 provider 能敲出的每个不同压缩动词。
+ *  从 CONTEXT_COMMANDS 派生而非手工列出，因此添加进那张表的 provider
+ *  在这里自动被覆盖，无需任何可能被忘记的第二次编辑。 */
 const COMPACT_VERBS: ReadonlySet<string> = new Set(
   Object.values(CONTEXT_COMMANDS)
     .map((c) => c.compact)
@@ -181,29 +115,26 @@ const COMPACT_VERBS: ReadonlySet<string> = new Set(
 );
 
 /**
- * Is this queued text a compaction command?
+ * 这段排队文本是不是压缩命令？
  *
- * Matches the leading VERB only, so `/compact keep the auth decisions` counts
- * while a human sentence that merely mentions compaction does not — the queue
- * carries both, and mistaking prose for a command would silently drop real work.
+ * 只匹配前导动词（VERB），因此 `/compact keep the auth decisions` 算数，
+ * 而只是提及压缩的人类句子不算——队列里两者都有，把散文误认为命令会
+ * 静默丢弃真实工作。
  *
- * Provider-agnostic on purpose: the queue is keyed by agent, not provider, and a
- * duplicate `/compact` is worth dropping regardless of which CLI is going to
- * receive it.
+ * 刻意与 provider 无关：队列按 agent 而不是 provider 键控，无论将由哪个
+ * CLI 接收，重复的 `/compact` 都值得丢弃。
  */
 export function isCompactionCommand(text: string): boolean {
   return COMPACT_VERBS.has(text.trim().split(/\s+/)[0]);
 }
 
 /**
- * The context-clearing command to type, or null when nothing typed can reach
- * this provider.
+ * 要敲入的清空上下文命令；当没有任何可敲入内容能触达该 provider 时为 null。
  *
- * Per `ContextRule.message`, a non-empty message on the CLEAR rule is "the
- * literal command to send" — an override, not a suffix. That asymmetry with
- * compact is deliberate and useful: it is the operator's escape hatch for the
- * providers this table answers `null` for, and for a CLI that renames its verb
- * between releases. Empty message = the table's own bare command.
+ * 按照 `ContextRule.message`，CLEAR 规则上的非空消息是"要发送的字面命令"——
+ * 是一个覆盖，而不是后缀。与 compact 的这种不对称是刻意且有意的：它是操作者
+ * 针对本表对某些 provider 回答 `null`、以及针对在版本间给动词改名的 CLI 的
+ * 逃生舱。空消息 = 该表自身的裸命令。
  */
 export function clearCommandForProvider(
   provider: AgentProvider,
@@ -214,8 +145,8 @@ export function clearCommandForProvider(
   return contextCommandsForProvider(provider).clear;
 }
 
-/** Claude exposes remote control as a slash command; Codex uses its daemon and
- * Kimi has no equivalent slash command. */
+/** Claude 把远程控制暴露为斜杠命令；Codex 使用其守护进程，而
+ * Kimi 没有等价的斜杠命令。 */
 export function remoteControlCommandForProvider(
   provider: AgentProvider,
   sessionName?: string
@@ -225,33 +156,27 @@ export function remoteControlCommandForProvider(
   return name ? `/remote-control ${name}` : '/remote-control';
 }
 
-/** Initial TUI output needs a short provider-specific settle before typing. */
+/** 初始 TUI 输出在敲入前需要一段短暂、provider 专属的稳定时间。 */
 export function terminalReadySettleMs(provider: AgentProvider): number {
   switch (provider) {
     case 'kimi': return 650;
-    case 'grok': return 500;
-    case 'gemini': return 500;
     case 'codex': return 500;
     default: return 400;
   }
 }
 
 /**
- * A live TUI is ready after it has produced an initial frame and had a short
- * settle period. Do not require output to become quiet: Codex can continuously
- * repaint its status line, which previously kept queued messages blocked until
- * every readiness attempt timed out.
+ * 一个存活的 TUI 在产生初始帧并经过短暂稳定期后即为就绪。
+ * 不要要求输出变安静：Codex 会不断重绘其状态行，这曾让排队的消息一直被
+ * 阻塞，直到每次就绪尝试都超时。
  *
- * `undefined` is accepted for compatibility with a renderer hot-reloaded
- * against an older main process that does not yet expose `hasOutput`.
+ * 接受 `undefined` 以兼容一个热重载的 renderer 对应尚未暴露 `hasOutput`
+ * 的旧版 main 进程。
  */
 export function terminalReadyToReceive(
   hasOutput: boolean | undefined,
   elapsedMs: number,
   provider: AgentProvider
 ): boolean {
-  if (provider === 'antigravity') {
-    return elapsedMs >= terminalReadySettleMs(provider);
-  }
   return hasOutput !== false && elapsedMs >= terminalReadySettleMs(provider);
 }

--- a/src/shared/realtimePricing.ts
+++ b/src/shared/realtimePricing.ts
@@ -1,36 +1,36 @@
 /**
- * Realtime Michael — audio token pricing for the OpenAI gpt-realtime-2 voice loop
- * (card rt-9, cost-guard). Shared so BOTH the main cost module (src/main/
- * realtimeCost.ts) and the renderer cost store (src/renderer/src/realtime/
- * costStore.ts) price from one source. Pure + dependency-free (no electron, no
- * main-only imports) so it's safe to import from either process.
+ * Realtime Michael — OpenAI gpt-realtime-2 语音循环的音频 token 定价
+ * （卡 rt-9，cost-guard）。共享一份，这样主进程成本模块（src/main/
+ * realtimeCost.ts）和渲染器成本 store（src/renderer/src/realtime/
+ * costStore.ts）都从同一个来源定价。纯净且无依赖（无 electron、无
+ * 仅主进程可用的导入），因此从任一进程导入都安全。
  *
- * Pricing (locked plan / board): gpt-realtime-2 AUDIO tokens bill at $32 per 1M
- * input and $64 per 1M output. A voice turn is dominated by audio; text tokens
- * (instructions, tool args) and cached tokens are cheaper. We deliberately price
- * ALL input/output tokens at the audio rate: for a cost GUARD a conservative
- * UPPER bound is the safe choice (warn early rather than under-count), and it uses
- * only the authoritative audio numbers rather than guessing text/cache rates. The
- * raw token counts are surfaced alongside the dollar figure so it stays auditable.
+ * 定价（锁定套餐/董事会）：gpt-realtime-2 的 AUDIO token 按每 1M
+ * 输入 $32、每 1M 输出 $64 计费。语音轮次以音频为主；文本 token
+ * （指令、工具参数）和缓存 token 更便宜。我们刻意把所有输入/输出
+ * token 都按音频费率定价：对成本 GUARD 而言，保守的
+ * 上界（UPPER bound）是安全之选（宁可提前告警也不低估），而且
+ * 它只使用权威的音频数字，而不是猜测文本/缓存费率。原始 token 计数
+ * 会与美元金额一并呈现，以便保持可审计。
  */
 
 /**
- * The realtime voice model Talk connects to. Lives HERE, in shared, because it is
- * named in user-facing Settings copy as well as used by the main-process mint —
- * a model string duplicated across a process boundary is one that eventually
- * disagrees with itself, and the half users read is the half nobody notices is
- * stale. `src/main/realtime.ts` re-exports this as its own REALTIME_MODEL.
+ * Talk 连接的实时语音模型。它放在这里、放在 shared 中，是因为它既出现在
+ * 面向用户的设置文案里，又被主进程的 mint 使用——跨进程边界重复的模型字符串，
+ * 最终总有一份会与自己不一致，而用户读到的那一半
+ * 正是没人会注意已经过期的那一半。`src/main/realtime.ts`
+ * 把它作为自己的 REALTIME_MODEL 重新导出。
  */
 export const REALTIME_MODEL = 'gpt-realtime-2.1';
 
-/** USD per 1,000,000 audio tokens (gpt-realtime-2). */
+/** 每 1,000,000 音频 token 的美元价格（gpt-realtime-2）。 */
 export const REALTIME_AUDIO_INPUT_PER_MTOK = 32;
 export const REALTIME_AUDIO_OUTPUT_PER_MTOK = 64;
 
 /**
- * A usage delta as reported by the realtime session. Accepts both the SDK's
- * camelCase (`inputTokens`) and the raw realtime API's snake_case
- * (`input_tokens`) so the caller can forward whatever shape it has.
+ * 实时会话报告的使用量增量。同时接受 SDK 的 camelCase（`inputTokens`）
+ * 和实时 API 原生的 snake_case（`input_tokens`），
+ * 这样调用方可以直接转发自己拥有的任何形态。
  */
 export interface RealtimeUsage {
   inputTokens?: number;
@@ -41,7 +41,7 @@ export interface RealtimeUsage {
   total_tokens?: number;
 }
 
-/** Pull input/output token counts out of either casing; missing ⇒ 0. */
+/** 从两种大小写中取出输入/输出 token 计数；缺失 ⇒ 0。 */
 export function normalizeRealtimeUsage(u: RealtimeUsage | null | undefined): {
   inputTokens: number;
   outputTokens: number;
@@ -54,9 +54,9 @@ export function normalizeRealtimeUsage(u: RealtimeUsage | null | undefined): {
 }
 
 /**
- * USD cost for ONE realtime usage delta. Conservative upper bound: every input
- * token is priced at the audio-input rate and every output token at the
- * audio-output rate (see file header).
+ * 一次实时使用增量的 USD 成本。保守上界：每个输入
+ * token 按音频输入费率定价，每个输出 token 按
+ * 音频输出费率定价（见文件头）。
  */
 export function computeRealtimeUsd(u: RealtimeUsage | null | undefined): number {
   const { inputTokens, outputTokens } = normalizeRealtimeUsage(u);
@@ -66,7 +66,7 @@ export function computeRealtimeUsd(u: RealtimeUsage | null | undefined): number 
   );
 }
 
-/** Compact USD formatter: <$1 shows cents (e.g. $0.42), else 2dp (e.g. $12.30). */
+/** 紧凑的美元格式化：< $1 显示分（例如 $0.42），否则两位小数（例如 $12.30）。 */
 export function formatUsd(n: number): string {
   if (!isFinite(n) || n <= 0) return '$0.00';
   if (n < 0.01) return '<$0.01';

--- a/src/shared/releaseDrop.ts
+++ b/src/shared/releaseDrop.ts
@@ -1,44 +1,41 @@
 /**
- * RELEASE DROPS — a full-bleed, authored "what's new" moment instead of a corner
- * toast with three clipped bullets.
+ * RELEASE DROPS —— 一段整版、精心编排的"新功能"时刻，而不是角落里
+ * 只有三条被截断项目的气泡提示。
  *
- * The author writes ordinary HTML inside a marked block in the GitHub release
- * body. Everything between the markers is the drop; the rest of the body stays
- * plain markdown for people reading the release on github.com, who should still
- * get a sensible page. A release with no drop block falls back to the existing
- * digest toast, so this is purely additive — no release has to change.
+ * 作者在 GitHub release 正文中一个标记块内编写普通 HTML。
+ * 标记之间的内容就是这段 drop；正文其余部分对在 github.com 上阅读 release
+ * 的人来说仍是普通 markdown，他们应该还能看到一页合理的页面。没有 drop 块
+ * 的 release 会回退到现有的摘要气泡，因此这纯粹是增量式的——没有任何
+ * release 必须改动。
  *
  *   <!-- drop -->
  *   <section class="hero"> … any HTML/CSS, <img>, <video> … </section>
  *   <!-- /drop -->
  *
- * ── Why this file is paranoid ──────────────────────────────────────────────
- * This renders REMOTE, AUTHOR-CONTROLLED markup inside the app. The renderer it
- * would otherwise land in has `window.cth` bridged onto it — spawnPty,
- * writeFileText, updateConfig. Script execution in that context is not a bug,
- * it is arbitrary code execution on the user's machine with the app's full
- * authority, reachable by anyone who can publish a release (or MITM the fetch).
+ * ── 为何此文件如此多疑 ──────────────────────────────────────────────
+ * 它会在应用内部渲染远程、作者控制的标记。否则它会落入的 renderer 上桥接
+ * 着 `window.cth`——spawnPty、writeFileText、updateConfig。在该上下文中执行
+ * 脚本不是 bug，而是在用户的机器上以应用的完整权限执行任意代码，任何能
+ * 发布 release（或对请求做中间人攻击）的人都能触达。
  *
- * So the drop NEVER runs in the app's renderer. It is handed to an iframe whose
- * sandbox grants exactly one thing — `allow-popups` — and, inside that, a CSP of
- * `default-src 'none'` that blocks scripts independently. Two unrelated
- * mechanisms, either sufficient alone. `allow-scripts` must NEVER be added
- * alongside `allow-same-origin`: that pair lets the frame reach out and remove
- * its own sandbox.
+ * 因此 drop 绝不在应用的 renderer 中运行。它被交给一个 iframe，其 sandbox
+ * 只授予一件事——`allow-popups`——并且在其内部还有一条 `default-src 'none'`
+ * 的 CSP，独立地封锁脚本。两个互不相关的机制，单独任何一个都足够。
+ * `allow-scripts` 绝不能与 `allow-same-origin` 一起加：那一对会让 frame
+ * 够到外面并移除自己的 sandbox。
  *
- * Why `allow-popups` and nothing else. The modal deliberately carries no buttons
- * of its own, so the actions a release wants to offer are authored here as
- * ordinary `<a target="_blank">` links. A popup is the weakest possible way to
- * honour one: the frame cannot navigate itself or the top window, it can only
- * ASK for a new window, and main's setWindowOpenHandler denies the window and
- * hands the URL to the OS browser only when it is http(s). No script runs, on
- * either side. A same-frame `<a href>` without target="_blank" still does
- * nothing, which is correct — the drop must never be able to replace itself.
+ * 为什么是 `allow-popups` 而不是别的。该弹窗刻意不携带任何自己的按钮，
+ * 因此 release 想提供的动作在这里被编写成普通的 `<a target="_blank">` 链接。
+ * 弹窗是兑现它的最弱方式：frame 不能导航自己或顶层窗口，它只能请求一个
+ * 新窗口，而 main 的 setWindowOpenHandler 会拒绝该窗口，并且只在它是
+ * http(s) 时才把 URL 交给操作系统浏览器。两边都不会运行脚本。没有
+ * target="_blank" 的同 frame `<a href>` 仍然什么都不做，这是正确的——
+ * drop 绝不能能够替换自身。
  *
- * What works, which is everything a launch page actually needs: images, video,
- * audio, web fonts, gradients, transforms, keyframe animations, grid, and
- * target="_blank" links out. What does not: scripts, forms, same-frame or
- * top-level navigation, and any URL scheme other than http and https.
+ * 什么能工作，也就是一个发布页真正需要的全部：图片、视频、音频、web 字体、
+ * 渐变、变换、关键帧动画、grid，以及指向外部的 target="_blank" 链接。
+ * 什么不能：脚本、表单、同 frame 或顶层导航，以及 http 和 https 之外的
+ * 任何 URL scheme。
  */
 
 import { DROP_FONT_WOFF2_BASE64 } from './dropFonts';
@@ -47,10 +44,10 @@ const DROP_OPEN = '<!-- drop -->';
 const DROP_CLOSE = '<!-- /drop -->';
 
 /**
- * Pull the authored HTML out of a release body, or null when there is none.
- * Deliberately literal: an exact marker pair, first opener to the next closer.
- * Anything unbalanced returns null and the caller falls back to the digest —
- * a half-parsed drop would render as broken markup in front of every user.
+ * 从 release 正文中取出作者编写的 HTML；没有时返回 null。
+ * 刻意保持字面：一对精确的标记，从第一个开始标记到下一个结束标记。
+ * 任何不平衡都返回 null，由调用方回退到摘要——
+ * 半解析的 drop 会在每个用户面前渲染成损坏的标记。
  */
 export function extractDropHtml(body: string | null | undefined): string | null {
   if (typeof body !== 'string') return null;
@@ -64,43 +61,40 @@ export function extractDropHtml(body: string | null | undefined): string | null 
 }
 
 /**
- * Defence in depth ONLY — the sandbox and the CSP are the real controls.
+ * 只是纵深防御——sandbox 和 CSP 才是真正的控制。
  *
- * This exists because a CSP typo or a future `allow-scripts` would otherwise be
- * a single point of failure, not because a regex is a competent HTML sanitizer:
- * it is not, and nothing here should ever be relied on as one. It removes the
- * shapes that would be most damaging if the primary controls ever lapsed.
+ * 它的存在是因为 CSP 拼写错误或未来的 `allow-scripts` 否则会成为单点故障，
+ * 而不是因为正则能胜任 HTML 清理器：它不能，这里的东西也绝不能被当作清理器
+ * 依赖。它移除的是若主控制失效时最具破坏性的那些形态。
  */
 function stripActiveContent(html: string): string {
   return html
     .replace(/<script\b[\s\S]*?<\/script\s*>/gi, '')
     .replace(/<script\b[^>]*\/?>/gi, '')
-    // on*= handlers, quoted or bare. Blocked by CSP too (inline handlers are
-    // script, and script-src falls back to default-src 'none').
+    // on*= 处理器，带引号或裸写。同样被 CSP 封锁（内联处理器属于 script，
+    // 而 script-src 回退到 default-src 'none'）。
     .replace(/\son[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
-    // A remote `@import` is RENDER-BLOCKING: the frame paints nothing until the
-    // stylesheet resolves, and on a network where fonts.googleapis.com is blocked
-    // (China) that is a TCP timeout — tens of seconds of white screen. The
-    // tightened CSP (style-src 'unsafe-inline', font-src data:) already fails such
-    // a fetch FAST rather than letting it hang, but we also drop the rule outright
-    // so the frame never even tries and no CSP-violation is logged. Only REMOTE
-    // imports go — a `data:` import blocks on nothing and stays. The design fonts
-    // are self-hosted in FRAME_FONT_CSS, so an author's `var(--font-sans)` /
-    // `var(--font-mono)` renders correctly with zero network either way.
+    // 远程 `@import` 会阻塞渲染：frame 在样式表解析完成前什么都不画，
+    // 而在 fonts.googleapis.com 被屏蔽（中国）的网络上那就是一次 TCP 超时——
+    // 几十秒的白屏。收紧的 CSP（style-src 'unsafe-inline'，font-src data:）
+    // 已经会让这样的请求快速失败而不是让它挂起，但我们也直接把这条规则去掉，
+    // 让 frame 根本不去尝试，并且不记录任何 CSP 违规。只有远程的 import 被
+    // 去掉——`data:` 的 import 不依赖任何东西，保留下来。设计字体在
+    // FRAME_FONT_CSS 中自托管，因此作者的 `var(--font-sans)` / `var(--font-mono)`
+    // 无论怎样都零网络地正确渲染。
     //
-    // Two forms, and both consume the WHOLE statement: the url may hold its own
-    // `;` (a font url is `…wght@400;500;600…`), so a naive `[^;]*` would stop
-    // inside the url and leave a tail of broken CSS behind.
+    // 两种形式，且都消费整条语句：url 可能自带 `;`（字体 url 形如
+    // `…wght@400;500;600…`），所以朴素的 `[^;]*` 会在 url 内部停下，
+    // 在身后留下一段损坏的 CSS。
     .replace(/@import\s+(?:url\(\s*)?(["'])https?:\/\/(?:(?!\1)[\s\S])*\1\s*\)?\s*[^;]*;?/gi, '')
     .replace(/@import\s+url\(\s*https?:\/\/[^)]*\)\s*[^;]*;?/gi, '');
 }
 
-/** The design fonts, self-hosted as `data:` URIs so the frame needs no network.
- *  Inter answers `--font-sans` (the drop's declared substitute for Geist) and
- *  JetBrains Mono answers `--font-mono` exactly; both are variable, so one face
- *  each spans weight 400–700. `font-display: swap` means text paints in the
- *  fallback immediately and reflows when the face is ready — but the face is a
- *  data: URI, so "ready" is the same tick and there is nothing to wait on. */
+/** 设计字体，以 `data:` URI 自托管，因此 frame 无需网络。
+ *  Inter 对应 `--font-sans`（drop 声明的 Geist 替身），JetBrains Mono 精确
+ *  对应 `--font-mono`；两者都是可变字体，因此一个字面各覆盖 400–700 字重。
+ *  `font-display: swap` 意味着文本先以回退字体绘制，字体就绪后再回流——但字体
+ *  是 data: URI，所以"就绪"与初始绘制在同一帧，没有任何需要等待的东西。 */
 const FRAME_FONT_CSS = `
   @font-face {
     font-family: 'Inter';
@@ -118,15 +112,11 @@ const FRAME_FONT_CSS = `
   }
 `;
 
-/** Design tokens mirrored into the frame. The drop cannot read the app's CSS
- *  variables across the origin boundary, so the ones worth having are restated
- *  here — an author writing `var(--ink)` gets the app's palette for free, while
- *  a fully bespoke drop can ignore them entirely. */
+/** 镜像进 frame 的设计令牌。drop 无法跨源读取应用的 CSS 变量，
+ *  所以把值得有的这些重述在这里——写 `var(--ink)` 的作者免费获得应用的调色板，
+ *  而完全自定的 drop 可以完全忽略它们。 */
 const FRAME_BASE_CSS = `
-  /* The landing site palette (docs/DESIGN.md §2): warm paper, near-black ink,
-     one yellow CTA, sky for a highlighted phrase, maroon for the brand. Square
-     corners and hard offset shadows are the look; --radius is 0 on purpose.
-     --accent and --line are kept as aliases so older drops still resolve. */
+  /* 着陆页调色板（docs/DESIGN.md §2）：暖纸底色、近黑色墨色、一枚黄色 CTA、天蓝色高亮短语、酒红色品牌色。方角 + 硬偏移阴影是视觉基调；--radius 故意设为 0。--accent 和 --line 保留为别名，让老 drop 仍可解析。 */
   :root {
     --paper: #FFFDF7;
     --cream: #F5F2E8;
@@ -162,15 +152,11 @@ const FRAME_BASE_CSS = `
     font-family: var(--font-sans);
     font-size: 15px; line-height: 1.55;
     -webkit-font-smoothing: antialiased;
-    /* The frame owns scrolling: the modal chrome around it stays put while a
-       tall drop scrolls, which is what makes a long launch page workable in a
-       fixed-height dialog. */
+    /* frame 独占滚动：外层弹窗 chrome 保持静止，drop 内容在内部滚动——这正是长发布页能在固定高度对话框中可行用的原因。 */
     overflow-x: hidden;
   }
 
-  /* The default layout. An author who writes nothing but semantic HTML, an
-     eyebrow, an h1, a lede, a <ul class="features">, gets the designed result
-     without writing a line of CSS. Everything here is overridable. */
+  /* 默认布局。作者只需写语义化 HTML——一个 eyebrow、一个 h1、一段 lede、一个 <ul class="features">——即可获得设计效果，无需写一行 CSS。此处所有样式均可覆盖。 */
   .drop { padding: var(--pad); max-width: 780px; margin: 0 auto; }
 
   .eyebrow {
@@ -198,13 +184,12 @@ const FRAME_BASE_CSS = `
   a:hover { color: var(--maroon); }
   hr { border: none; border-top: 2px solid var(--ink); margin: 2.2em 0; }
 
-  /* Feature list: stacked rows, each with its own media block. */
+  /* 特性列表：堆叠行，每行带独立媒体块。 */
   ul.features { list-style: none; padding: 0; margin: 0; display: grid; gap: clamp(28px, 5vw, 48px); }
   ul.features > li { display: grid; gap: 14px; }
   ul.features p { color: var(--ink-dim); margin: 0; max-width: 58ch; }
 
-  /* Media. Images, video and the placeholder all share one silhouette so a drop
-     built with placeholders looks identical once real assets land. */
+  /* 媒体元素。图片、视频和占位符共用同一轮廓，这样用占位符搭建的 drop 在真实资源就位后外观完全一致。 */
   img, video, canvas, svg, .placeholder {
     display: block; width: 100%; max-width: 100%; height: auto;
     border-radius: 0; border: var(--border);
@@ -212,8 +197,7 @@ const FRAME_BASE_CSS = `
   figure { margin: 0; }
   figcaption { font-family: var(--font-mono); font-size: 12px; color: var(--ink-faint); margin-top: 10px; }
 
-  /* Drop-in placeholder: <div class="placeholder" data-label="Hero"></div>
-     Pure CSS, so it needs no asset and cannot 404 in front of a user. */
+  /* 即插即用占位符：<div class="placeholder" data-label="Hero"></div> 纯 CSS 实现，无需任何资源，对用户永远不可能 404。 */
   .placeholder {
     aspect-ratio: 16 / 9;
     display: flex; align-items: center; justify-content: center;
@@ -226,11 +210,7 @@ const FRAME_BASE_CSS = `
   .placeholder.square { aspect-ratio: 1 / 1; }
   .placeholder.wide { aspect-ratio: 21 / 9; }
 
-  /* Deliberately NOT theme-aware. A drop is an authored artifact, a launch page
-     rather than app chrome, and it must look the same for everyone who receives
-     it. An automatic dark inversion silently recolours a design the author never
-     saw and wrecks any image chosen against a light ground. A drop that WANTS
-     dark styles it explicitly. */
+  /* 故意不做主题适配。drop 是作者创作的作品，是发布页而非应用 chrome，它必须对所有接收者看起来一样。自动的深色反转会悄无声息地重绘作者从未见过的配色方案，毁掉任何针对浅色背景选择的图片。想要深色的 drop 显式声明即可。 */
   @media (prefers-reduced-motion: reduce) {
     * { animation-duration: .01ms !important; transition-duration: .01ms !important; }
   }
@@ -238,24 +218,22 @@ const FRAME_BASE_CSS = `
 
 
 /**
- * The v0.4.4 release page — and the reference for what a drop can be.
+ * v0.4.4 的 release 页面——也是 drop 能做到什么的参照。
  *
- * Six pages with working Back/Next, built WITHOUT a line of JavaScript, because
- * the frame runs under `sandbox=""` and nothing in it will ever execute. The deck
- * is radio inputs plus `:checked ~` sibling selectors: a <label for> is a real
- * click target, checking a radio is not scripting, and CSS does the paging.
- * Verified in a real sandboxed iframe, not assumed.
+ * 六个页面带可用的 Back/Next，不用一行 JavaScript 构建，因为 frame 运行在
+ * `sandbox=""` 下，里面永远不会执行任何东西。翻页器是 radio input 加
+ * `:checked ~` 兄弟选择器：`<label for>` 是真正的点击目标，勾选 radio 不是
+ * 脚本，分页由 CSS 完成。在真实的沙箱 iframe 里验证过，不是想当然。
  *
- * The nav is repeated inside each page rather than shared, so each page names its
- * own neighbours and no selector has to compute "current + 1".
+ * 导航在每页内重复而不是共享，这样每页自己指名相邻页，任何选择器都不必
+ * 计算"当前 + 1"。
  *
- * Every page is sized to FIT the square modal without scrolling — a page that
- * scrolls cuts a sentence in half at the fold, which is what a launch page must
- * never do. That constraint is why the closing note is its own page rather than
- * the tail of the list.
+ * 每页的尺寸都正好放进方形弹窗而不滚动——滚动的页面会在折线处把句子切成
+ * 两半，这是一个发布页绝不能做的事。正因为这个约束，结束语才是独立的一页，
+ * 而不是列表的尾巴。
  *
- * Kept as the simulate payload so `updateSimulate({ drop: true })` renders
- * exactly what ships in the release body.
+ * 保留为 simulate 载荷，这样 `updateSimulate({ drop: true })` 渲染出的
+ * 正是 release 正文里发布的内容。
  */
 export const DEFAULT_DROP_HTML = `<style>
   html, body { height: 100%; }
@@ -318,8 +296,7 @@ export const DEFAULT_DROP_HTML = `<style>
   .card h2 { margin: 10px 0 .2em; font-size: 1.15rem; }
   .card p { margin: 0; color: var(--ink-soft); font-size: 13.5px; }
   .split { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; align-items: start; }
-  /* 16:10, not 4:3 — the taller ratio pushed the second row past the fold, and a
-     drop page that scrolls cuts a sentence in half at the boundary. */
+  /* 16:10 而非 4:3——更高的比例让第二行越过折叠线，而一个会滚动的 drop 页会在边界处把句子切成两半。 */
   .split .placeholder { aspect-ratio: 16 / 10; }
 </style>
 
@@ -511,41 +488,36 @@ export const DEFAULT_DROP_HTML = `<style>
 </div>`;
 
 /**
- * Wrap authored HTML into a complete, self-contained document for `srcdoc`.
+ * 把作者编写的 HTML 包装成一份完整、自包含的 `srcdoc` 文档。
  *
- * The CSP is the load-bearing line. `default-src 'none'` means an omitted
- * directive denies rather than allows, so script-src, connect-src, frame-src and
- * object-src are all closed without being named. Only the media a launch page
- * needs is opened back up, and only over https or data:.
+ * CSP 是承重的那一行。`default-src 'none'` 意味着省略的指令是被拒绝而非
+ * 允许，因此 script-src、connect-src、frame-src 和 object-src 无需点名即全部
+ * 关闭。只有发布页需要的媒体被重新打开，且只通过 https 或 data:。
  */
 export function buildDropSrcDoc(html: string): string {
   const csp = [
     "default-src 'none'",
     'img-src https: data: blob:',
     'media-src https: data: blob:',
-    // style-src drops `https:`: authored `<style>` is 'unsafe-inline', but a
-    // REMOTE stylesheet or `@import url(https://…)` is denied. That is the fix
-    // for the white screen — a remote font stylesheet is render-blocking, and
-    // permitting it means the frame hangs on a slow or blocked
-    // fonts.googleapis.com (China: a TCP timeout of white). Denied by CSP, the
-    // same import FAILS FAST and the frame paints immediately in the fallback.
+    // style-src 去掉 `https:`：作者编写的 `<style>` 是 'unsafe-inline'，但远程
+    // 样式表或 `@import url(https://…)` 被拒绝。那就是白屏的修复——远程字体
+    // 样式表会阻塞渲染，允许它就意味着 frame 会挂在一个慢速或被屏蔽的
+    // fonts.googleapis.com 上（中国：白色的 TCP 超时）。被 CSP 拒绝后，同样的
+    // import 会快速失败，frame 立即用回退字体绘制。
     "style-src 'unsafe-inline'",
-    // font-src drops `https:` too: fonts are self-hosted as data: URIs
-    // (FRAME_FONT_CSS), so nothing legitimate needs the network, and a remote
-    // @font-face src can no longer stall a paint.
+    // font-src 也去掉 `https:`：字体以 data: URI 自托管（FRAME_FONT_CSS），
+    // 因此没有任何合法东西需要网络，远程 @font-face src 也无法再拖住一次绘制。
     'font-src data:'
-    // No script-src, no connect-src, no form-action: default-src 'none' denies
-    // them. Spelled out here so a future edit has to remove a comment to widen it.
+    // 没有 script-src、connect-src、form-action：default-src 'none' 会拒绝
+    // 它们。在这里写明，这样未来的编辑必须删掉一条注释才能放宽它们。
     //
-    // The CSP `sandbox` directive is deliberately NOT listed: it is ignored when
-    // delivered via <meta> (header-only, per spec), so including it would read as
-    // a third control while doing nothing. The iframe's own sandbox attribute is
-    // the real one.
+    // CSP 的 `sandbox` 指令刻意不列出：通过 <meta> 交付时它会被忽略（按规范
+    // 仅限头部），所以写上它会被读作第三个控制却什么都不做。iframe 自己的
+    // sandbox 属性才是真正的那个。
   ].join('; ');
-  // No remote <link>/<preconnect> to a font CDN: the design fonts are inlined as
-  // data: URIs below, so the frame reaches the network for NOTHING at load. This
-  // is the drop's version of the app's own "fonts ship inside" fix — the same
-  // render-blocking Google Fonts fetch, killed in the same way.
+  // 没有指向字体 CDN 的远程 <link>/<preconnect>：设计字体以下方的 data: URI
+  // 内联，因此 frame 在加载时完全不为任何东西触网。这是 drop 版的应用自身
+  // "字体内嵌"修复——同样是渲染阻塞的 Google Fonts 请求，用同样的方式消灭。
   return `<!doctype html>
 <html>
 <head>

--- a/src/shared/releaseNotes.ts
+++ b/src/shared/releaseNotes.ts
@@ -1,49 +1,44 @@
 /**
- * Release-note digest — turns a GitHub release body into 3-5 short lines.
+ * 发布说明摘要——把 GitHub 发布正文提炼成 3-5 行短句。
  *
- * The updater has always carried `notes` (electron-updater's
- * `info.releaseNotes`, i.e. the release body) on the `available` /
- * `downloaded` / `available-manual` states, and the UI has always thrown it
- * away. The update toast is the only notification this app ever raises, so the
- * one moment we have someone's attention we were spending on a version number.
+ * 更新器一直在 `available` / `downloaded` / `available-manual` 状态上携带
+ * `notes`（electron-updater 的 `info.releaseNotes`，即发布正文），而 UI 一直
+ * 把它扔掉。更新 toast 是本应用唯一升起的通知，因此我们仅有的吸引注意力的
+ * 时刻，过去却只用来显示版本号。
  *
- * Why this is not just `body.slice(0, 280)`:
+ * 为什么不能只是 `body.slice(0, 280)`：
  *
- *   1. The body is RELEASE.md (see .github/workflows/release.yml → `body_path`),
- *      which is ~200 lines: a tagline, a link, download tables for three
- *      platforms, build-from-source instructions, a "Previously" list. The
- *      actual news sits under a `## What's new in <version>` heading a third of
- *      the way down. Taking "the first lines" of that body gives you the
- *      product tagline — text the user has already read. So when the body has a
- *      "what's new" heading we start there, and stop at the next heading or
- *      horizontal rule so we don't bleed into "Still new in 0.4.2".
+ *   1. 正文是 RELEASE.md（见 .github/workflows/release.yml → `body_path`），
+ *      约 200 行：一句口号、一个链接、三个平台的下载表、从源码构建的说明、
+ *      一份"Previously"列表。真正的新闻位于三分之一处
+ *      `## What's new in <version>` 标题之下。取正文的"前几行"只会得到产品
+ *      口号——用户早已读过的文字。因此当正文有 "what's new" 标题时我们从
+ *      那里开始，并在下一个标题或水平分隔线处停下，以免渗进
+ *      "Still new in 0.4.2"。
  *
- *   2. It is markdown, and the toast renders plain text. Links have to collapse
- *      to their label (a raw `https://github.com/...` eats the whole budget),
- *      images and badges have to disappear entirely, and emphasis markers have
- *      to go — but ONLY when they are emphasis. `DO_NOT_TRACK` and `first_run`
- *      are real strings in this project's release notes and must survive.
+ *   2. 它是 markdown，而 toast 渲染纯文本。链接必须坍缩为其标签（裸的
+ *      `https://github.com/...` 会吃掉整个预算），图片和徽章必须整体消失，
+ *      强调标记也必须去掉——但 ONLY 当它们是强调时。`DO_NOT_TRACK` 和
+ *      `first_run` 是本项目发布说明中的真实字符串，必须存活。
  *
- *   3. Release bullets wrap across source lines. Splitting on `\n` and clipping
- *      would cut a sentence at the author's line break, which is arbitrary, so
- *      continuation lines are folded back into their bullet before clipping.
+ *   3. 发布列表项跨越源码行换行。按 `\n` 切分再裁剪会在作者换行处切断句子，
+ *      那是任意的，因此续行在裁剪前被折回其列表项。
  *
- * Deliberately pure and electron-free (same contract as updateState.ts): no DOM,
- * no `window`, no imports. The toast and the Settings block both call it, and
- * test/release-notes.test.cjs pins the behaviour without booting anything.
+ * 刻意保持纯净且与 electron 无关（与 updateState.ts 契约相同）：无 DOM、
+ * 无 `window`、无导入。toast 和 Settings 块都会调用它，
+ * test/release-notes.test.cjs 在不启动任何东西的情况下钉住行为。
  */
 
-/** At most this many lines in the digest — a toast, not a changelog. */
+/** 摘要中至多这么多行——是 toast，不是更新日志。 */
 export const RELEASE_NOTES_MAX_BULLETS = 5;
-/** Total character budget across all lines. Sized so the 340px toast stays
- *  roughly six lines tall even before the block's own scroll clamp. */
+/** 所有行共享的总字符预算。按让 340px 的 toast 大约保持六行高来定，即便在
+ *  块自身的滚动钳制之前。 */
 export const RELEASE_NOTES_MAX_CHARS = 280;
-/** No single line may hog the whole budget. Tuned against this project's own
- *  release notes, whose bullets lead with a bolded sentence and then explain
- *  themselves for another two lines: 110 keeps the lead plus a clause, and
- *  leaves room for the two or three bullets after it. */
+/** 任何单行都不得独占整个预算。针对本项目自己的发布说明调校——其列表项以
+ *  加粗的句子开头，然后再用两行展开解释：110 能保住引导句加一个从句，并为
+ *  其后的两三个列表项留出空间。 */
 export const RELEASE_NOTES_MAX_BULLET_CHARS = 110;
-/** Below this, a clipped tail is unreadable ("Icons are nat…") — stop instead. */
+/** 低于此值时，被裁剪的尾部不可读（"Icons are nat…"）——改为不裁。 */
 const MIN_PARTIAL_CHARS = 40;
 
 export interface ReleaseNotesOptions {
@@ -54,55 +49,51 @@ export interface ReleaseNotesOptions {
 
 const FENCE_RE = /^\s{0,3}(?:```|~~~)/;
 const HEADING_RE = /^\s{0,3}#{1,6}\s+/;
-/** `---`, `***`, `___` (and spaced variants). Checked BEFORE the bullet test,
- *  because `- - -` is a rule and `- x` is a bullet. */
+/** `---`、`***`、`___`（及带空格变体）。在列表项测试之前检查，因为
+ *  `- - -` 是分隔线而 `- x` 是列表项。 */
 const RULE_RE = /^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/;
 const BULLET_RE = /^\s*(?:[-*+]|\d{1,2}[.)])\s+/;
 const TABLE_ROW_RE = /^\s*\|/;
-/** Setext underline (`====` under a title) — structure, never content. */
+/** Setext 下划线（标题下的 `====`）——是结构，绝非内容。 */
 const SETEXT_RE = /^\s{0,3}=+\s*$/;
 const WHATS_NEW_RE = /^\s{0,3}#{1,6}\s+.*what[’']?s\s+new/i;
-/** GitHub appends this to auto-generated bodies; it is a URL, not news. */
+/** GitHub 会把它追加到自动生成的正文；它是 URL，不是新闻。 */
 const FULL_CHANGELOG_RE = /^\s*\**\s*full\s+changelog\s*\**\s*:/i;
 const BARE_URL_RE = /^\s*<?https?:\/\/\S+>?\s*$/i;
 
 /**
- * GitHub's releases.atom feed carries the release body as RENDERED HTML, not as
- * the markdown that produced it, and electron-updater falls back to that feed
- * whenever the channel yml has no releaseNotes. So this parser has to survive
- * HTML even though every one of its tests fed it markdown.
+ * GitHub 的 releases.atom feed 以 RENDERED HTML（而非生成它的 markdown）携带
+ * 发布正文，且只要频道 yml 没有 releaseNotes，electron-updater 就会回退到该
+ * feed。因此这个解析器即便其每个测试喂的都是 markdown，也得能对付 HTML。
  *
- * Untreated, rendered HTML has no `##` headings, so the what's-new section is
- * never found and the bullet scan takes over. In OUR body the only line that
- * looks like a markdown bullet is `* { box-sizing: border-box; }` from the
- * <style> block, because `*` followed by a space IS the bullet syntax. The
- * shipped toast said exactly that and nothing else.
+ * 不做处理时，渲染出的 HTML 没有 `##` 标题，因此 what's-new 段落永远找不到，
+ * 列表项扫描接过控制权。在我们的正文里唯一看起来像 markdown 列表项的
+ * 是 <style> 块里的 `* { box-sizing: border-box; }`，因为 `*` 后跟空格就是
+ * 列表项语法。当时发布的 toast 展示的正是它，别无其他。
  *
- * Belt and braces only: the real fix is releaseInfo.releaseNotesFile in
- * electron-builder.yml, which puts markdown in the yml so the feed is never
- * read. This just makes a future release that forgets the yml degrade to
- * something correct rather than to CSS.
+ * 只是双保险：真正的修复是 electron-builder.yml 里的
+ * releaseInfo.releaseNotesFile，它把 markdown 放进 yml，因此 feed 永远不会被
+ * 读取。这里只是让未来某次忘记该 yml 的发布降级成正确内容，而不是降级成 CSS。
  */
 const STYLE_SCRIPT_RE = /<(style|script)\b[^>]*>[\s\S]*?<\/\1>/gi;
 const HTML_HEADING_RE = /^\s*<h[1-6]\b[^>]*>/i;
 const HTML_LI_RE = /^\s*<li\b[^>]*>/i;
-/** Only the apostrophe forms, decoded early so WHATS_NEW_RE still matches
- *  `<h2>What&#39;s new</h2>`. Deliberately NOT &lt;/&gt;, which would
- *  manufacture tags out of escaped text. */
+/** 只处理撇号形式，提前解码以便 WHATS_NEW_RE 仍能匹配
+ *  `<h2>What&#39;s new</h2>`。刻意不处理 &lt;/&gt;，那会把转义文本制成标签。 */
 const APOS_ENTITY_RE = /&(?:#0*39|#x0*27|apos|rsquo|lsquo);/gi;
 
-/** A heading in either syntax. */
+/** 两种语法之一中的标题。 */
 function isHeadingLine(line: string): boolean {
   return HEADING_RE.test(line) || HTML_HEADING_RE.test(line);
 }
 
-/** The what's-new heading in either syntax. */
+/** 两种语法之一中的 what's-new 标题。 */
 function isWhatsNewLine(line: string): boolean {
   if (WHATS_NEW_RE.test(line)) return true;
   return HTML_HEADING_RE.test(line) && /what[’']?s\s+new/i.test(line);
 }
 
-/** The bullet marker this line opens with, in either syntax, or null. */
+/** 该行以哪种列表项标记开头（两种语法之一），或 null。 */
 function bulletPrefix(line: string): string | null {
   if (RULE_RE.test(line)) return null;
   const md = line.match(BULLET_RE);
@@ -112,52 +103,52 @@ function bulletPrefix(line: string): string | null {
 }
 
 /**
- * Markdown → plain text for one already-joined line.
+ * 为一行已连接的行做 markdown → 纯文本。
  *
- * Exported for the tests: this is where every "the toast showed a raw URL"
- * class of bug lives, and it is far easier to pin here than through the digest.
+ * 为测试导出：所有"toast 显示了裸 URL"类 bug 都在这里，在此钉住比经由摘要
+ * 钉住容易得多。
  */
 export function stripMarkdown(md: string): string {
   return String(md ?? '')
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')            // images/badges: gone entirely
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')         // inline links → their label
-    .replace(/\[([^\]]*)\]\[[^\]]*\]/g, '$1')        // reference links → their label
-    .replace(/<https?:\/\/[^>]*>/g, '')              // autolinks: the URL is noise here
-    .replace(/<[^>\s][^>]*>/g, '')                   // stray inline HTML
-    .replace(/`([^`]*)`/g, '$1')                     // inline code, backticks only
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')            // 图片/徽章：整体消失
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')         // 行内链接 → 其标签
+    .replace(/\[([^\]]*)\]\[[^\]]*\]/g, '$1')        // 引用链接 → 其标签
+    .replace(/<https?:\/\/[^>]*>/g, '')              // 自动链接：这里的 URL 是噪音
+    .replace(/<[^>\s][^>]*>/g, '')                   // 游离的行内 HTML
+    .replace(/`([^`]*)`/g, '$1')                     // 行内代码，仅反引号
     .replace(/\*\*\*([^*]+)\*\*\*/g, '$1')
     .replace(/\*\*([^*]+)\*\*/g, '$1')
-    // Struck-through text is retracted, not emphasised — "on ~~Windows~~ macOS"
-    // must not come out as "on Windows macOS".
+    // 删除线文本是收回，不是强调——"on ~~Windows~~ macOS" 绝不能变成
+    // "on Windows macOS"。
     .replace(/~~[^~]+~~/g, '')
-    // Single-marker emphasis needs the word-boundary guards, otherwise
-    // `DO_NOT_TRACK` and `agent_spawned` come out mangled.
+    // 单标记强调需要词边界守卫，否则 `DO_NOT_TRACK` 和 `agent_spawned`
+    // 会被弄乱。
     .replace(/(?<![\w*])\*([^*\n]+)\*(?!\w)/g, '$1')
     .replace(/(?<![\w_])__([^_\n]+)__(?!\w)/g, '$1')
     .replace(/(?<![\w_])_([^_\n]+)_(?!\w)/g, '$1')
-    .replace(/^\s{0,3}#{1,6}\s*/, '')                // a heading marker that slipped through
+    .replace(/^\s{0,3}#{1,6}\s*/, '')                // 漏网的标题标记
     .replace(/&nbsp;/g, ' ')
     .replace(/\s+/g, ' ')
-    .replace(/^[\s—–:.,;·-]+/, '')         // leading orphan punctuation from a stripped link
+    .replace(/^[\s—–:.,;·-]+/, '')         // 剥离链接后遗留的行首孤标点
     .trim();
 }
 
-/** Anything with at least one word character and enough of it to be a sentence. */
+/** 至少含一个单词字符、且足够构成一句话的内容。 */
 function isMeaningful(text: string): boolean {
   return text.length >= 3 && /[A-Za-z0-9]/.test(text);
 }
 
 /**
- * Drop everything that is markup rather than prose: fenced code, HTML comments,
- * download/checksum tables, blockquote wrappers and GitHub's `[!NOTE]` markers.
- * Blockquotes are unwrapped rather than dropped — this project's release notes
- * put real caveats ("Appearance only. No functional change") inside one.
+ * 丢弃一切属于标记而非散文的东西：围栏代码、HTML 注释、下载/校验和表、
+ * 块引用包装和 GitHub 的 `[!NOTE]` 标记。块引用是解包而非丢弃——本项目的
+ * 发布说明把真实的注意事项（"Appearance only. No functional change"）放在
+ * 块引用内。
  */
 function usableLines(body: string): string[] {
   const out: string[] = [];
   let inFence = false;
-  // Whole blocks, before any line splitting: a <style> body is CSS on every one
-  // of its lines, and one of those lines parses as a markdown bullet.
+  // 在任何按行切分之前先处理整块：<style> body 的每一行都是 CSS，而其中
+  // 有一行会被解析成 markdown 列表项。
   const cleaned = body
     .replace(/\r\n?/g, '\n')
     .replace(STYLE_SCRIPT_RE, '')
@@ -179,11 +170,10 @@ function usableLines(body: string): string[] {
 }
 
 /**
- * The slice of the body that is actually "what's new".
+ * 正文中真正属于 "what's new" 的那一段。
  *
- * Starts after the first `what's new` heading when there is one, otherwise at
- * the top; either way headings and rules are skipped while we're still in the
- * preamble and END the section once content has been collected.
+ * 存在 `what's new` 标题时从其后开始，否则从顶部开始；无论哪种情况，还在
+ * 前言的阶段会跳过标题和分隔线，一旦收集到内容，标题和分隔线就结束该段。
  */
 function firstSection(lines: string[]): string[] {
   const marker = lines.findIndex(isWhatsNewLine);
@@ -203,13 +193,11 @@ function firstSection(lines: string[]): string[] {
 }
 
 /**
- * Fold the section into digest items.
+ * 把该段折成摘要项。
  *
- * Bullets win when the section has any: a changelog's bullets ARE the summary,
- * and the paragraph above them is usually scene-setting that would eat two of
- * the five slots. A release with no bullets at all falls back to its
- * paragraphs, so a one-line "Fixes the crash on launch." body still says
- * something.
+ * 段落里有列表项时列表项优先：更新日志的列表项本身就是摘要，其上的段落通常
+ * 只是铺垫，会吃掉五个槽位中的两个。完全没有列表项的发布回退到其段落，因此
+ * 一行 "Fixes the crash on launch." 正文也仍能说点东西。
  */
 function collectItems(section: string[]): string[] {
   const bullets: string[] = [];
@@ -232,7 +220,7 @@ function collectItems(section: string[]): string[] {
       current = [line.slice(bullet.length)];
       currentIsBullet = true;
     } else if (current.length > 0) {
-      current.push(line.trim());   // a wrapped continuation of the item above
+      current.push(line.trim());   // 上面一项的折行续句
     } else {
       current = [line.trim()];
       currentIsBullet = false;
@@ -243,7 +231,7 @@ function collectItems(section: string[]): string[] {
   return bullets.length > 0 ? bullets : prose;
 }
 
-/** Clip to `max` chars on a word boundary, ellipsis included in the count. */
+/** 按词边界裁剪到 `max` 字符，省略号计入字数。 */
 function clip(text: string, max: number): string {
   if (text.length <= max) return text;
   const cut = text.slice(0, max - 1);
@@ -253,11 +241,10 @@ function clip(text: string, max: number): string {
 }
 
 /**
- * Parse a GitHub release body into a short "What's new" digest.
+ * 把 GitHub 发布正文解析成简短 "What's new" 摘要。
  *
- * Returns `[]` — never a placeholder — for a missing, empty, or
- * structure-only body, so callers can render nothing at all rather than an
- * empty heading. Most releases in the wild have no usable body.
+ * 对缺失、空或仅结构的正文返回 `[]`——绝不返回占位符——因此调用方可渲染
+ * 空内容，而不是一个空标题。野生的大多数发布都没有可用正文。
  */
 export function summarizeReleaseNotes(
   body: string | null | undefined,
@@ -275,8 +262,8 @@ export function summarizeReleaseNotes(
   for (const item of items) {
     if (out.length >= maxBullets) break;
     const room = Math.min(maxBulletChars, maxChars - used);
-    // The first line always gets rendered (clipped if it must be); after that a
-    // stub too short to read is worse than one bullet fewer.
+    // 第一行总是渲染（必要时裁剪）；此后，太短而无法阅读的残条还不如少一条
+    // 列表项。
     if (out.length > 0 && room < MIN_PARTIAL_CHARS) break;
     const text = clip(item, Math.max(room, 1));
     out.push(text);

--- a/src/shared/taskLedger.ts
+++ b/src/shared/taskLedger.ts
@@ -1,28 +1,28 @@
 /**
- * Non-destructive edits to the task ledger (`hive/tasks.json`).
+ * 对任务台账（`hive/tasks.json`）的非破坏性编辑。
  *
- * The ledger is a HAND-WRITTEN file: the god appends whatever fields a card
- * needs — `result` (the verbatim Slack reply posted back to the user), `repo`,
- * `scope`, `origin`, `deliverable`, `commit`, `blockedOn`, `notes` — none of
- * which the renderer's display model knows about. Several UI surfaces write the
- * ledger back after a small edit (answer a question, move a card, dismiss one),
- * and `hive:writeTasks` replaces the file wholesale. So any writer holding a
- * partial model of a card silently DELETED every field it didn't know about,
- * on EVERY card on the board, the moment the user touched one of them.
+ * 台账是手工编写的文件：god 会追加一张卡片需要的任何字段——
+ * `result`（原样发回给用户的 Slack 回复）、`repo`、`scope`、`origin`、
+ * `deliverable`、`commit`、`blockedOn`、`notes`——renderer 的显示模型
+ * 对这些一无所知。多个 UI 面在小型编辑后会把台账写回（回答问题、
+ * 移动卡片、关闭一张），而 `hive:writeTasks` 会整体替换该文件。因此
+ * 任何持有卡片部分模型的写入者，在用户触碰其中一张卡片的瞬间，
+ * 都会静默地删掉它不知道的每一个字段——
+ * 而且是在看板上每一张卡片上。
  *
- * Two rules fix that, and both live here so main and the renderer share them:
+ * 两条规则解决这个问题，且都写在这里，让 main 与 renderer 共享：
  *
- *   - `mergeTaskLedger` — the persistence-side backstop. A card the writer
- *     didn't fully describe keeps the fields it already had on disk.
- *   - `patchTaskInLedger` — the caller-side rule. Edit the RAW ledger entry
- *     rather than re-serializing a display model, so a normalizing parser can't
- *     overwrite a field it coerced (a string `priority` re-emitted as a number).
+ *   - `mergeTaskLedger` —— 持久化侧的兜底。写入者未完整描述的卡片
+ *     会保留磁盘上已有的字段。
+ *   - `patchTaskInLedger` —— 调用侧规则。编辑台账的 RAW 条目，
+ *     而不是重新序列化显示模型，这样规范化解析器就无法覆盖它强转过的字段
+ *     （字符串 `priority` 被重新输出为数字）。
  *
- * Deletion deliberately still works: a card absent from the incoming list is
- * gone. Merging protects fields, never card membership.
+ * 删除仍然刻意生效：入站列表中缺失的卡片即被移除。
+ * 合并保护的是字段，绝不是卡片的成员资格。
  */
 
-/** One raw ledger entry as it sits on disk — an object of unknown fields. */
+/** 一条磁盘上原始台账条目的样子——一个未知字段的对象。 */
 type RawTask = Record<string, unknown>;
 
 function isRawTask(value: unknown): value is RawTask {
@@ -35,20 +35,20 @@ function idOf(value: unknown): string | null {
 }
 
 /**
- * Fold `incoming` over `existing`, matching cards by `id`.
+ * 把 `incoming` 折叠到 `existing` 上，按 `id` 匹配卡片。
  *
- * The result is `incoming` — its order, and its membership, so removing a card
- * from the list still deletes it. What survives the fold are the fields on the
- * matching on-disk card that `incoming` does not mention.
+ * 结果是 `incoming`——它的顺序、它的成员资格，因此从列表中移除一张
+ * 卡片仍然会删除它。在折叠中存活下来的是匹配的磁盘卡片上
+ * `incoming` 未提及的字段。
  *
- * A field the caller DOES send wins, including an explicit `null` — that's the
- * way to clear one. A shallow merge cannot express "delete this key", and it
- * shouldn't: writers here are partial models, so a missing key means "I don't
- * know about this", never "remove it".
+ * 调用方确实发送的字段获胜，包括显式的 `null`——
+ * 那是清空某个字段的方式。浅合并无法表达"删除这个键"，也不应该：
+ * 这里的写入者是部分模型，因此缺失的键意味着"我不知道这个"，
+ * 绝不是"删掉它"。
  *
- * Entries without a string `id` (a malformed card the god hand-wrote) pass
- * through untouched — there is no key to merge them on, and dropping them would
- * lose data the same way this function exists to prevent.
+ * 没有字符串 `id` 的条目（god 手写出的畸形卡片）原样通过——
+ * 没有键可供合并，丢弃它们会丢失
+ * 本函数要防止的同一类数据。
  */
 export function mergeTaskLedger(existing: unknown, incoming: unknown): unknown[] {
   const incomingList = Array.isArray(incoming) ? incoming : [];
@@ -67,15 +67,14 @@ export function mergeTaskLedger(existing: unknown, incoming: unknown): unknown[]
 }
 
 /**
- * Apply `patch` to one card in a RAW ledger array, leaving every other card —
- * and every other field of the patched card — byte-identical.
+ * 把 `patch` 应用到 RAW 台账数组中的一张卡片上，让其他每张卡片——
+ * 以及被打补丁卡片的其他每个字段——都保持逐字节不变。
  *
- * This is what a UI edit should write. Re-serializing the display model instead
- * feeds the ledger a normalized card: `parseTasks` coerces a hand-written
- * `priority: "high"` to the number `3` and re-emits `dependsOn: []` for a card
- * that spells the key `deps`, and those coercions are real values, so they beat
- * `mergeTaskLedger` and land on disk. Patching the raw entry never produces
- * them in the first place.
+ * 这才是 UI 编辑应该写入的东西。改为重新序列化显示模型，会喂给台账
+ * 一张规范化卡片：`parseTasks` 会把手工写的 `priority: "high"` 强转为
+ * 数字 `3`，并对拼写为 `deps` 键的卡片重新输出 `dependsOn: []`，而这些
+ * 强转是真实的值，所以它们能压过 `mergeTaskLedger` 并落到磁盘。补丁
+ * 原始条目则从一开始就不会产生它们。
  */
 export function patchTaskInLedger(
   rawTasks: unknown,

--- a/src/shared/terminalPaths.ts
+++ b/src/shared/terminalPaths.ts
@@ -1,60 +1,60 @@
 /**
- * What a ⌘-clicked path token in terminal output should DO.
+ * 终端输出中 ⌘-点击的路径令牌应该做什么（DO）。
  *
- * v0.3.4 shipped this for markdown only: `*.md` in agent output became a link
- * that opened the rendered preview. Everything else in the same line stayed
- * dead text, so a printed `src/main/updater.ts` was something you had to
- * retype into the file tree by hand.
+ * v0.3.4 只为 markdown 实现了这一点：agent 输出里的 `*.md` 变成了链接，
+ * 点击会打开渲染后的预览。同一行的其他内容仍是死文本，
+ * 所以打印出来的 `src/main/updater.ts` 得靠你手动
+ * 重新输入到文件树里。
  *
- * Three outcomes, and the split is about what we can HONESTLY do with the file:
+ * 三种结果，划分标准是我们能诚实地（HONESTLY）对文件做什么：
  *
- *   preview → markdown. There is a renderer for it, and reading is the point.
- *   edit    → source and config we can put in Monaco without lying about it.
- *   reveal  → everything else: images, archives, binaries, PDFs, unknown
- *             extensions, directories. We open the OS file browser at the
- *             file's parent instead of pretending to understand the bytes.
+ *   preview → markdown。它有渲染器，而阅读正是其意义所在。
+ *   edit    → 可以放进 Monaco 且不撒谎的源码和配置。
+ *   reveal  → 其余一切：图片、归档、二进制、PDF、未知
+ *             扩展名、目录。我们在文件的父目录打开 OS 文件浏览器，
+ *             而不是假装理解这些字节。
  *
- * WHY REVEAL RATHER THAN OPEN. The token comes from AGENT OUTPUT, which is
- * hostile input. Handing an arbitrary path to the OS "open with default app"
- * call would let a line of terminal text become an execution: a printed
- * `installer.dmg`, `payload.app`, or `.desktop` file is one ⌘-click from
- * running. Revealing only ever opens a file browser, so the worst an agent can
- * do by printing a path is show you a folder you could already reach yourself.
- * That is why this module never returns an "open" verdict for an unknown type.
+ * 为什么 REVEAL 而不 OPEN。令牌来自 AGENT OUTPUT，这是
+ * 不可信输入。把任意路径交给 OS 的"用默认应用打开"
+ * 调用，会让一行终端文本变成一次执行：打印出来的
+ * `installer.dmg`、`payload.app` 或 `.desktop` 文件距离真正运行
+ * 只差一次 ⌘-点击。Reveal 只会打开文件浏览器，所以 agent
+ * 打印路径所能造成的最坏后果，是给你看一个你自己本来就能访问的文件夹。
+ * 这正是本模块对未知类型绝不返回"open"判定（verdict）的原因。
  *
- * MATCHING IS THE HARD PART, not classifying. Anchoring on a known extension
- * (what the markdown version did) cannot see `report.pdf` — and `report.pdf` is
- * exactly the case that needs reveal. Opening the match up to ANY extension
- * instead drags in every version string and decimal on the line: `v0.4.5`,
- * `1.5`, `electron 43.0`. The rule that separates them is below.
+ * 难点在于匹配（MATCHING），而不是分类。锚定已知扩展名
+ * （markdown 版的做法）看不到 `report.pdf`——而 `report.pdf`
+ * 恰恰是需要 reveal 的情况。把匹配放开到任意扩展名，
+ * 反而会把行里的每个版本号和十进制数都拖进来：`v0.4.5`、
+ * `1.5`、`electron 43.0`。区分它们的规则见下方。
  */
 
 import { isImagePath } from './imageTypes';
 
-/** Extensions that open in the markdown preview. */
+/** 在 markdown 预览中打开的扩展名。 */
 const PREVIEW_EXTS = new Set(['md', 'markdown']);
 
 /**
- * Extensions we are willing to put in the editor. Deliberately a list rather
- * than "anything that isn't binary": a wrong guess here opens a font or a
- * sqlite file as mojibake, and the reveal fallback is a strictly better answer
- * for anything we are not sure about.
+ * 我们愿意放进编辑器的扩展名。刻意用列表而非
+ * "任何非二进制的东西"：在这里猜错会把字体或
+ * sqlite 文件当作乱码打开，而对任何我们没有把握的东西，
+ * reveal 回退都是严格更优的答案。
  */
 const EDIT_EXTS = new Set([
-  // source
+  // 源码
   'ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs', 'mts', 'cts',
   'py', 'rb', 'go', 'rs', 'java', 'kt', 'kts', 'swift', 'c', 'h', 'cc', 'cpp',
   'hpp', 'cs', 'php', 'lua', 'pl', 'r', 'scala', 'clj', 'ex', 'exs', 'erl',
   'dart', 'zig', 'hs', 'ml', 'vue', 'svelte', 'astro',
-  // shell
+  // shell 脚本
   'sh', 'bash', 'zsh', 'fish', 'ps1', 'bat', 'cmd',
-  // markup and style
+  // 标记与样式
   'html', 'htm', 'css', 'scss', 'sass', 'less', 'xml', 'xsl',
-  // data and config
+  // 数据与配置
   'json', 'jsonc', 'json5', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf',
   'env', 'properties', 'lock', 'gradle', 'tf', 'tfvars', 'graphql', 'gql',
   'proto', 'sql', 'csv', 'tsv',
-  // plain text
+  // 纯文本
   'txt', 'text', 'log', 'diff', 'patch', 'gitignore', 'dockerignore',
   'editorconfig', 'npmrc', 'nvmrc'
 ]);
@@ -62,10 +62,10 @@ const EDIT_EXTS = new Set([
 export type PathAction = 'preview' | 'edit' | 'reveal';
 
 /**
- * Lower-cased extension of the last path segment, or '' when there is none.
- * Local rather than imported from imageTypes so a `?query` suffix cannot reach
- * a filesystem call: terminal tokens are filesystem paths, and a literal `?` in
- * a filename is legal on every platform we ship.
+ * 最后一个路径段的小写扩展名，没有则返回 ''。
+ * 在这里本地实现而不是从 imageTypes 导入，这样 `?query` 后缀就不会
+ * 触及文件系统调用：终端令牌是文件系统路径，而文件名中字面的 `?`
+ * 在我们发布的每个平台上都是合法的。
  */
 function extOf(token: string): string {
   const base = token.split(/[/\\]/).pop() ?? '';
@@ -75,26 +75,26 @@ function extOf(token: string): string {
 }
 
 /**
- * Candidate path tokens in one line of terminal output.
+ * 一行终端输出里的候选路径令牌。
  *
- * The extension must START WITH A LETTER and run 1-8 more alphanumerics. That
- * single constraint is what keeps `v0.4.5`, `1.5`, and `0.92` out: their
- * "extension" is digits. `node_modules/.bin` has no extension and is caught by
- * the separator rule in `isPathToken` instead.
+ * 扩展名必须以字母开头（START WITH A LETTER），后面再跟 1-8 个字母数字。
+ * 正是这一条约束把 `v0.4.5`、`1.5` 和 `0.92` 挡在外面：它们的
+ * "扩展名"是数字。`node_modules/.bin` 没有扩展名，改由
+ * `isPathToken` 里的分隔符规则捕获。
  *
- * The leading `X:\` group exists because `:` cannot be in the body class (it
- * would swallow the `:line` suffix). Without the group the match on
- * `C:\Users\x\a.ts` starts at the backslash, and a drive-less `\Users\x\a.ts`
- * then looks RELATIVE and gets joined onto the agent's cwd.
+ * 开头的 `X:\` 分组存在是因为 `:` 不能出现在主体字符类里（否则会
+ * 吞掉 `:line` 后缀）。没有这个分组时，`C:\Users\x\a.ts` 的匹配会从
+ * 反斜杠开始，而无盘符的 `\Users\x\a.ts` 看起来就变成"相对路径"，
+ * 会被拼接到 agent 的 cwd 上。
  */
 const PATH_TOKEN_RE = /(?:[A-Za-z]:[\\/])?[A-Za-z0-9_@.~/\\+-]*[A-Za-z0-9_@~/\\+-]\.[A-Za-z][A-Za-z0-9]{0,7}(?::\d+)?/g;
 
-/** A fresh matcher. The regex is stateful (`g`), so callers must never share one. */
+/** 返回一个全新的匹配器。该正则是有状态的（`g`），所以调用方绝不能共享一个。 */
 export function pathTokenMatcher(): RegExp {
   return new RegExp(PATH_TOKEN_RE.source, 'g');
 }
 
-/** Strip shell/prose wrapping and any trailing `:line` from a raw match. */
+/** 从原始匹配中剥掉 shell/散文包裹以及末尾的 `:line`。 */
 export function stripPathToken(raw: string): string {
   return raw
     .replace(/^["'`([<]+/, '')
@@ -103,13 +103,13 @@ export function stripPathToken(raw: string): string {
 }
 
 /**
- * Is this token worth underlining at all?
+ * 这个令牌是否值得加下划线？
  *
- * A token qualifies when it carries an extension we KNOW, or when it contains a
- * path separator. The separator clause is what lets `docs/report.pdf` and
- * `/tmp/dump.bin` reach the reveal branch while a bare `electron.43` on a prose
- * line stays dead text. It is a heuristic and it is meant to be: the cost of a
- * false positive is one underline that stats to nothing and does nothing.
+ * 令牌在携带我们认识的扩展名、或包含路径分隔符时才算合格。
+ * 分隔符条款让 `docs/report.pdf` 和 `/tmp/dump.bin` 能进入 reveal
+ * 分支，而散文行里光秃秃的 `electron.43` 仍保持死文本。
+ * 这是启发式，而且本应如此：误报的代价只是一条统计到空、
+ * 什么都不做的下划线。
  */
 export function isPathToken(token: string): boolean {
   const ext = extOf(token);
@@ -119,14 +119,14 @@ export function isPathToken(token: string): boolean {
 }
 
 /**
- * What ⌘-click should do with `token`.
+ * ⌘-点击应该对 `token` 做什么。
  *
- * Images resolve to `reveal` on purpose. The app HAS an image viewer (the IDE
- * routes there), but a terminal click is a navigation gesture: you clicked a
- * path because you want to get to the file, and Finder is where you can then
- * drag, rename, or open it with the tool you actually wanted. Change this to
- * 'preview' if that reading turns out to be wrong; the classifier is the only
- * place that decides.
+ * 图片刻意解析为 `reveal`。应用确实有图片查看器(IDE 会路由过去),
+ * 但终端点击是一种导航手势:你点击路径是因为你想到达那个文件,
+ * 而 Finder 里你可以随后拖动、重命名或用你真正想要的工具打开它。
+ * 如果这个解读被证明是错的,把它改成 'preview' 即可;
+ * 分类器是唯一决定
+ * 它去向的地方。
  */
 export function classifyPathToken(token: string): PathAction {
   const ext = extOf(token);

--- a/src/shared/tokenCaps.ts
+++ b/src/shared/tokenCaps.ts
@@ -1,2 +1,2 @@
-/** Highest accepted per-agent token ceiling across manifests and config IPC. */
+/** 所有清单与配置 IPC 中每个 agent 可接受的最高 token 上限。 */
 export const MAX_AGENT_TOKEN_CAP = 10_000_000_000;

--- a/src/shared/toolCatalog.ts
+++ b/src/shared/toolCatalog.ts
@@ -1,19 +1,19 @@
 /**
- * The setup catalog — every EXTERNAL tool the harness can use, what it buys the
- * user, and how to install it on this platform.
+ * 安装目录——harness 能使用的每一个 EXTERNAL（外部）工具、它能给用户
+ * 带来什么、以及如何在本平台安装。
  *
- * Why this file exists: the app ships as one Electron bundle, but several of its
- * best features are thin wrappers over tools that live outside it — mempalace for
- * semantic memory, uv to install mempalace, git for worktrees, and one CLI per
- * agent engine. Every one of them degrades SILENTLY when absent (that is the
- * deliberate design — `memory.start()` is a documented no-op without mempalace),
- * which is friendly right up until the user cannot tell "off" from "broken" and
- * has no single place that says which is which. This catalog is that place.
+ * 本文件为何存在：应用作为一个 Electron 包分发，但它的几个最佳特性
+ * 只是对包外工具的薄封装——mempalace 提供语义记忆、uv 安装 mempalace、
+ * git 提供工作树、每个代理引擎各有一个 CLI。其中任何一个缺失时都会
+ * 静默降级（这是刻意设计——没有 mempalace 时 `memory.start()` 是文档化的
+ * 空操作），这在用户能区分“关闭”和“损坏”之前都是友好的，
+ * 但之后用户就没有单一地方能说明哪个是哪个。本目录就是那个地方。
  *
- * The engine rows are DERIVED from AGENT_PROVIDER_PRESETS rather than restated
- * here: those presets already carry `defaultCommand`, `installCommand`,
- * `nativeInstallCommand` and `docsUrl`, and a second hand-maintained copy would
- * drift the moment a provider is added.
+ * 引擎行是从 AGENT_PROVIDER_PRESETS 派生而来，而不是在这里重述：
+ * 那些预设已经携带 `defaultCommand`、`installCommand`、
+ * `nativeInstallCommand` 和 `docsUrl`，再来一份手工维护的副本
+ * 会在添加提供方的那一刻开始漂移。
+ *
  */
 
 import { AGENT_PROVIDER_PRESETS } from './agentProvider';
@@ -21,25 +21,25 @@ import { AGENT_PROVIDER_PRESETS } from './agentProvider';
 export type ToolKind = 'prerequisite' | 'memory' | 'engine';
 
 export interface ToolSpec {
-  /** Stable row id. For a probed binary this is also the name we look up. */
+  /** 稳定的行 id。对于被探测的二进制，这也是我们要查找的名称。 */
   id: string;
-  /** The executable to probe on PATH, or null when presence is derived some
-   *  other way (mempalace comes from the memory subsystem's own status). */
+  /** 要在 PATH 上探测的可执行文件；当存在性以其他方式得出时为 null
+   *  （mempalace 来自记忆子系统自身的状态）。 */
   bin: string | null;
   label: string;
   kind: ToolKind;
-  /** One line, benefit-framed: what the user LOSES without it. */
+  /** 一行、以收益角度表述：没有它用户会失去什么。 */
   why: string;
-  /** Part of "set up everything". Everything else is opt-in. */
+  /** 属于“一键设置全部”。其余都是可选的。 */
   essential: boolean;
-  /** Install command per platform. Empty string = no scripted install. */
+  /** 按平台的安装命令。空字符串 = 无脚本化安装。 */
   install: { posix: string; win32: string };
-  /** Shown when there is no scripted install, or as extra context. */
+  /** 没有脚本化安装时显示，或作为额外上下文。 */
   note?: string;
   docsUrl?: string;
 }
 
-/** Base rows — the non-engine tools. Engines are appended by `toolCatalog()`. */
+/** 基础行——非引擎工具。引擎由 `toolCatalog()` 追加。 */
 const BASE_TOOLS: ToolSpec[] = [
   {
     id: 'uv',
@@ -50,15 +50,15 @@ const BASE_TOOLS: ToolSpec[] = [
     essential: true,
     install: {
       posix: 'curl -LsSf https://astral.sh/uv/install.sh | sh',
-      // PowerShell, not cmd.exe: astral ships install.ps1 for Windows and there
-      // is no .bat equivalent. Quoted so it survives being pasted into either.
+      // 是 PowerShell 而非 cmd.exe：astral 为 Windows 提供 install.ps1，
+      // 没有对应的 .bat。加引号以便粘贴到两者中任一个都能生效。
       win32: 'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"'
     },
     docsUrl: 'https://docs.astral.sh/uv/'
   },
   {
     id: 'mempalace',
-    bin: null, // presence comes from MemoryStatus.available, not a PATH probe
+    bin: null, // 存在性来自 MemoryStatus.available，而非 PATH 探测
     label: 'MemPalace — semantic memory',
     kind: 'memory',
     why: 'Meaning-based recall across everything your agents have learned. Without it they still keep plain markdown notes, but cannot search them by meaning.',
@@ -89,9 +89,9 @@ const BASE_TOOLS: ToolSpec[] = [
     kind: 'prerequisite',
     why: 'Runs the npm-installed agent engines (OpenCode, and Claude Code on machines without the native build).',
     essential: false,
-    // Deliberately no scripted command: the app already ships a checksum-verified
-    // Node installer (nodeInstall.ts) that runs automatically when an engine needs
-    // one. Printing a rival curl|sh here would compete with it.
+    // 刻意不提供脚本化命令：应用已内置一个经校验和验证的
+    // Node 安装器（nodeInstall.ts），当某个引擎需要时会自动运行。
+    // 在这里打印一个竞品的 curl|sh 会与它竞争。
     install: { posix: '', win32: '' },
     note: 'The app installs this for you when an engine needs it — nothing to do by hand.',
     docsUrl: 'https://nodejs.org'
@@ -99,12 +99,12 @@ const BASE_TOOLS: ToolSpec[] = [
 ];
 
 /**
- * The full catalog for a platform. `platform` is a `process.platform` value; only
- * win32 vs everything-else matters.
+ * 针对某个平台的完整目录。`platform` 是 `process.platform` 值；
+ * 只有 win32 与其余所有平台的区别才重要。
  */
 export function toolCatalog(): ToolSpec[] {
   const engines: ToolSpec[] = AGENT_PROVIDER_PRESETS
-    // `custom` is whatever the user typed — there is nothing to detect or install.
+    // `custom` 是用户随意输入的——没有什么可探测或安装的。
     .filter((p) => p.id !== 'custom' && !!p.defaultCommand)
     .map((p) => ({
       id: `engine:${p.id}`,
@@ -112,8 +112,8 @@ export function toolCatalog(): ToolSpec[] {
       label: p.label,
       kind: 'engine' as const,
       why: `Agent engine — ${p.defaultCommand}.`,
-      // Claude Code is the recommended engine and the only one the floor assumes
-      // by default, so it is the one engine "set up everything" will install.
+      // Claude Code 是推荐引擎，也是基线默认假定的唯一引擎，
+      // 因此它是“一键设置全部”会安装的那一个。
       essential: p.id === 'claude',
       install: {
         posix: p.installCommand ?? p.nativeInstallCommand?.posix ?? '',
@@ -124,24 +124,24 @@ export function toolCatalog(): ToolSpec[] {
   return [...BASE_TOOLS, ...engines];
 }
 
-/** A catalog row plus what we found on THIS machine. */
+/** 一条目录行加上我们在本机上找到的内容。 */
 export interface ToolStatus extends ToolSpec {
   found: boolean;
-  /** Absolute path when found, or null. */
+  /** 找到时的绝对路径，或 null。 */
   path: string | null;
-  /** Extra live context — e.g. "palace initialised", a version string. */
+  /** 额外的实时上下文——例如 “palace initialised”、版本字符串。 */
   detail?: string;
-  /** `install` already resolved for the running platform. */
+  /** 已按运行平台解析好的 `install`。 */
   installCommand: string;
 }
 
 /**
- * The prompt handed to Michael by "ask Michael to set up everything".
+ * “让 Michael 一键设置全部”时交给 Michael 的提示词。
  *
- * Written as an explicit contract rather than a wish: name the exact commands so
- * he does not have to guess or search, tell him to VERIFY rather than assume, and
- * make the ordering dependency (uv before mempalace) explicit — an orchestrator
- * that installs mempalace first just fails and reports failure.
+ * 写成一份显式契约而不是一个愿望：点出确切的命令让他不必猜测或搜索，
+ * 告诉他去 VERIFY（验证）而不是假定，并把安装顺序依赖（先 uv 后
+ * mempalace）写明——先装 mempalace 的编排器只会失败并报告失败。
+ *
  */
 export function setupPrompt(missing: ToolStatus[]): string {
   if (missing.length === 0) return '';

--- a/src/shared/triggers.ts
+++ b/src/shared/triggers.ts
@@ -1,29 +1,29 @@
 /**
- * TRIGGERS — every way the God orchestrator gets woken up without a human typing.
+ * 触发器——God 编排器在无需人工输入的情况下被唤醒的各种方式。
  *
- * This module is the single contract shared by main, preload and renderer. Four
- * trigger types live under one roof:
+ * 本模块是 main、preload 和 renderer 共享的单一契约。四种触发类型同处一室：
  *
- *   schedules  — recurring dispatched missions (the pre-existing `ScheduledMission`;
- *                still owned by config.missions, surfaced under Triggers)
- *   context    — auto-compaction / auto-clearing of agent terminal context
- *   webhook    — inbound HTTP from arbitrary callers, one entry per endpoint
- *   org        — inbound peer messages from teammates' clone nodes (UI only for now)
+ *   schedules  — 周期性派发的任务（既有的 `ScheduledMission`；
+ *                仍归 config.missions 所有，在 Triggers 下展示）
+ *   context    — 代理终端上下文的自动压缩 / 自动清除
+ *   webhook    — 来自任意调用方的入站 HTTP，每个端点一条记录
+ *   org        — 来自队友克隆节点的入站对等消息（目前仅 UI）
  *
- * The webhook and org types both admit an outside party, so both share one
- * `TriggerMode` gate and both write to one `TriggerHistoryEntry` ledger.
+ * webhook 和 org 两种类型都接受外部一方，因此二者共享同一个
+ * `TriggerMode` 门控，并都写入同一个 `TriggerHistoryEntry` 台账。
+ *
  */
 
-/* ────────────────────────────── behaviour gate ───────────────────────────── */
+/* ────────────────────────────── 行为门控 ───────────────────────────── */
 
 /**
- * How much an external sender is trusted.
+ * 外部发送方被信任的程度。
  *
- *   strict              — every inbound message waits for the operator's approval.
- *   allow-all           — everything flows straight through: messages, directives
- *                         and communication alike.
- *   communication-only  — informational traffic flows; anything that asks the hive
- *                         to *act* (a directive) waits for approval.
+ *   strict              — 每条入站消息都等待操作员批准。
+ *   allow-all           — 一切直接放行：消息、指令和沟通类内容一律通过。
+ *   communication-only  — 信息性流量直接通过；任何要求 hive *行动*
+ *                         （指令）的内容等待批准。
+ *
  */
 export type TriggerMode = 'strict' | 'allow-all' | 'communication-only';
 
@@ -36,71 +36,71 @@ export const TRIGGER_MODES: { value: TriggerMode; label: string; blurb: string }
 export const DEFAULT_TRIGGER_MODE: TriggerMode = 'strict';
 
 /**
- * What an inbound message is asking for. A *directive* wants the hive to do work;
- * *communication* is informational (a status question, an FYI, a reply).
- * Senders may declare it; `classifyInboundKind` guesses when they don't.
+ * 一条入站消息在要求什么。*directive*（指令）要求 hive 做工作；
+ * *communication*（沟通）是信息性的（状态询问、通知、回复）。
+ * 发送方可声明它；未声明时由 `classifyInboundKind` 猜测。
  */
 export type InboundKind = 'directive' | 'communication';
 
-/** Resolve a mode + kind into whether the message may be routed without a human. */
+/** 根据 mode + kind 判定消息是否可在无人工的情况下被路由。 */
 export function isAutoAllowed(mode: TriggerMode, kind: InboundKind): boolean {
   if (mode === 'allow-all') return true;
   if (mode === 'communication-only') return kind === 'communication';
-  return false; // strict
+  return false; // strict 模式
 }
 
 /**
- * Best-effort guess at intent when the payload doesn't declare `kind`.
+ * 当载荷未声明 `kind` 时，对意图尽最大努力猜测。
  *
- * Deliberately conservative: anything we aren't confident is chatter is treated as
- * a directive, because mis-labelling a directive as communication is what lets
- * unapproved work through in `communication-only` mode. Callers who care should
- * send an explicit `kind`.
+ * 刻意保持保守：任何我们不确定是闲聊的内容都当作指令处理，
+ * 因为把指令误标为沟通正是让未经批准的工作在 `communication-only`
+ * 模式下溜过去的途径。在乎的调用方应发送显式的 `kind`。
+ *
  */
 export function classifyInboundKind(text: string): InboundKind {
   const t = text.trim().toLowerCase();
   if (!t) return 'communication';
-  // A leading question with no imperative reads as someone asking, not tasking.
+  // 以疑问词开头且无祈使语气的句子，读作有人在询问而非派活。
   const asksOnly = /^(what|how|when|where|who|why|is|are|do|does|did|can|could|status|any)\b/.test(t)
     && t.endsWith('?')
     && !/\b(fix|build|ship|deploy|run|write|create|add|remove|delete|refactor|implement|update|merge|revert)\b/.test(t);
   return asksOnly ? 'communication' : 'directive';
 }
 
-/* ──────────────────────────── context trigger ────────────────────────────── */
+/* ──────────────────────────── 上下文触发器 ────────────────────────────── */
 
 /**
- * One half of the context trigger (compact, or clear). Both the *message* sent to
- * the agent and the *conditions* that fire it are user-editable — that is the whole
- * point of surfacing this as a trigger rather than leaving it hardcoded.
+ * 上下文触发器的一半（compact 或 clear）。发送给代理的 *message*
+ * 和触发它的 *conditions* 都是用户可编辑的——这正是把它作为触发器
+ * 暴露出来而不是写死代码的全部意义。
  *
- * A run fires for an agent when BOTH conditions hold:
- *   - at least `everyMs` has elapsed since the last run, and
- *   - that agent's context is at least `minContextPct` full.
- * `minContextPct` of 0 disables the pressure gate (time alone fires it).
+ * 当两个条件都成立时，某个代理会触发一次运行：
+ *   - 距上次运行至少经过了 `everyMs`，且
+ *   - 该代理的上下文已至少用到 `minContextPct`。
+ * `minContextPct` 为 0 时禁用压力门控（仅靠时间触发）。
  */
 export interface ContextRule {
   enabled: boolean;
-  /** Minimum wall-clock gap between runs. */
+  /** 两次运行之间的最小墙钟间隔。 */
   everyMs: number;
-  /** Percent (0-100) of the context window that must be used before firing. */
+  /** 触发前必须已使用的上下文窗口百分比（0-100）。 */
   minContextPct: number;
   /**
-   * Separate, lower bar for very large context windows (~1M tokens), where a
-   * smaller *fraction* is still an enormous absolute amount of text.
+   * 针对超大上下文窗口（约 1M token）单独设置的更低门槛，
+   * 因为此时更小的*占比*仍是巨大的绝对文本量。
    */
   minContextPctLargeWindow: number;
   /**
-   * For `compact`: extra focus text appended to the provider's compaction command,
-   * on the providers that read trailing text (codex and opencode ignore it, so it
-   * is dropped for them rather than typed as stray input).
+   * 对 `compact`：附加到提供方压缩命令之后的额外焦点文本，
+   * 适用于会读取尾部文本的提供方（codex 和 opencode 忽略它，
+   * 因此对它们丢弃而不作为游离输入键入）。
    *
-   * For `clear`: a literal command that OVERRIDES the provider's own clear verb.
-   * That override doubles as the escape hatch for providers we deliberately map to
-   * nothing — Crush (palette-only), Copilot (print mode), and custom binaries —
-   * where the operator knows their CLI and we don't.
+   * 对 `clear`：一条覆盖提供方自身 clear 动词的字面命令。
+   * 该覆盖同时充当我们刻意映射为无操作——Crush（仅调色板）、
+   * Copilot（打印模式）和自定义二进制——的提供方的逃生口，
+   * 这些情况下操作员了解自己的 CLI 而我们不了解。
    *
-   * Empty string = send the provider's bare command.
+   * 空字符串 = 发送提供方的裸命令。
    */
   message: string;
 }
@@ -111,31 +111,31 @@ export interface ContextTriggerConfig {
 }
 
 /**
- * The focus text that has always ridden along with `/compact`. Preserved verbatim
- * as the default so upgrading users see no behaviour change beyond the cadence.
+ * 始终随 `/compact` 一起发送的焦点文本。作为默认值原样保留，
+ * 让升级用户在节奏之外看不到任何行为变化。
  */
 export const DEFAULT_COMPACTION_FOCUS =
   'Keep the current task, recent decisions, open questions, and file paths in play. Drop resolved tangents.';
 
 /**
- * Defaults are deliberately TWICE the old cadence and TWICE the previously
- * documented pressure bar.
+ * 默认值刻意设为旧节奏的两倍、旧文档压力门槛的两倍。
  *
- * History: `main/config.ts` documented a 30% / 20% context gate that was never
- * actually implemented — every live agent got compacted on every tick, hourly.
- * This makes the gate real and sets it at 2x, so compaction now costs an agent
- * half as many interruptions.
+ * 历史：`main/config.ts` 曾文档化一个 30% / 20% 的上下文门控，但从未真正
+ * 实现——每个在线代理都在每个 tick 被压缩，每小时一次。这里让门控变为真实
+ * 并设为 2 倍，使压缩现在只给代理造成一半的打扰。
  *
- * Auto-clear ships DISABLED. `/clear` is destructive — it discards context rather
- * than summarising it, and the codebase already gates the manual verb behind a
- * spoken confirm word. Turning it on is an explicit operator choice.
+ * 自动清除默认关闭。`/clear` 是破坏性的——它丢弃上下文而不是总结它，
+ * 代码库也早已把手动命令关在需要口头确认词的门后。开启它是操作员的
+ * 显式选择。
+ *
+ *
  */
 export const DEFAULT_CONTEXT_TRIGGER: ContextTriggerConfig = {
   compact: {
     enabled: true,
-    everyMs: 7_200_000, // 2h — was 1h
-    minContextPct: 60, // was a documented-but-unenforced 30
-    minContextPctLargeWindow: 40, // was a documented-but-unenforced 20
+    everyMs: 7_200_000, // 2h — 之前是 1h
+    minContextPct: 60, // 之前是文档化但未强制执行的 30
+    minContextPctLargeWindow: 40, // 之前是文档化但未强制执行的 20
     message: DEFAULT_COMPACTION_FOCUS
   },
   clear: {
@@ -147,31 +147,31 @@ export const DEFAULT_CONTEXT_TRIGGER: ContextTriggerConfig = {
   }
 };
 
-/* ──────────────────────────── webhook triggers ───────────────────────────── */
+/* ──────────────────────────── Webhook 触发器 ───────────────────────────── */
 
 /**
- * One inbound endpoint. Several may exist at once; they are multiplexed over a
- * single HTTP server + tunnel and told apart by the `id` in the request path, so
- * adding a webhook costs no extra port and no extra tunnel.
+ * 一个入站端点。可同时存在多个；它们在单个 HTTP 服务器 + 隧道上多路复用，
+ * 通过请求路径中的 `id` 区分，因此添加 webhook 不额外占用端口、不额外
+ * 占用隧道。
  *
- * `secret` is per-endpoint: revoking one caller never disturbs the others.
+ * `secret` 按端点独立：吊销一个调用方绝不会影响其他调用方。
  */
 export interface WebhookTrigger {
   id: string;
   name: string;
-  /** Shared secret the caller echoes in `x-md-webhook-secret`. Never logged. */
+  /** 调用方在 `x-md-webhook-secret` 中回显的共享密钥。从不记录。 */
   secret: string;
   enabled: boolean;
   mode: TriggerMode;
-  /** User-editable JSON Schema (serialised) that inbound bodies are checked against. */
+  /** 用户可编辑的 JSON Schema（序列化形式），入站请求体将按其校验。 */
   schema: string;
   createdAt: number;
 }
 
 /**
- * The default contract for an inbound POST. Users may edit this per webhook to
- * match whatever the calling system already emits; `message` is the only field the
- * router truly needs.
+ * 入站 POST 的默认契约。用户可按每个 webhook 编辑它以匹配调用系统
+ * 已产出的内容；`message` 是路由真正需要的唯一字段。
+ *
  */
 export const DEFAULT_WEBHOOK_SCHEMA_OBJECT = {
   type: 'object',
@@ -190,14 +190,14 @@ export const DEFAULT_WEBHOOK_SCHEMA_OBJECT = {
 
 export const DEFAULT_WEBHOOK_SCHEMA = JSON.stringify(DEFAULT_WEBHOOK_SCHEMA_OBJECT, null, 2);
 
-/* ────────────────────────── organisation trigger ─────────────────────────── */
+/* ────────────────────────── 组织触发器 ─────────────────────────── */
 
 /**
- * Peer-to-peer messaging between teammates' installs. Each teammate runs their own
- * Munder Difflin; setting an org key lets their instance address yours.
+ * 队友各自安装之间的对等消息。每位队友运行自己的 Munder Difflin；
+ * 设置组织密钥后，他们的实例即可寻址到你的实例。
  *
- * UI + persistence only for now — the transport service does not exist yet, so
- * nothing reads `apiKey` beyond the settings surfaces that display it.
+ * 目前仅 UI + 持久化——传输服务尚不存在，因此除了展示它的设置界面外，
+ * 没有任何东西读取 `apiKey`。
  */
 export interface OrgTriggerConfig {
   apiKey: string;
@@ -211,31 +211,31 @@ export const DEFAULT_ORG_TRIGGER: OrgTriggerConfig = {
   mode: DEFAULT_TRIGGER_MODE
 };
 
-/** Copy shown under the org key field. Kept here so Settings and Triggers agree. */
+/** 组织密钥字段下方展示的文案。放在这里使设置页和触发器保持一致。 */
 export const CLONE_NODE_BLURB =
   'Set an organisation key and your teammates can message your clone node — the copy of '
   + 'Munder Difflin running on your machine. Each teammate runs their own, so an org key '
   + 'is how two installs find each other.';
 
-/* ──────────────────────────── trigger history ────────────────────────────── */
+/* ──────────────────────────── 触发器历史 ────────────────────────────── */
 
 /**
- * One line in the ledger. Both directions are recorded so the operator can read a
- * conversation as a conversation: what they sent us, and what we said back.
- * `correlationId` ties our outbound reply to the inbound that prompted it.
+ * 台账中的一行。两个方向都被记录，操作员可以把对话当对话读：
+ * 他们发来什么，我们又回了什么。`correlationId` 把我们的出站回复
+ * 与促成它的入站消息绑定在一起。
  */
 export interface TriggerHistoryEntry {
   id: string;
   source: 'webhook' | 'org';
-  /** Which webhook (or which peer) — `WebhookTrigger.id` for webhooks. */
+  /** 哪个 webhook（或哪个对端）——webhook 时为 `WebhookTrigger.id`。 */
   sourceId: string;
-  /** Display name at the time of the event, so history survives a rename/delete. */
+  /** 事件发生时的显示名，使历史在重命名/删除后仍然可用。 */
   sourceName: string;
   direction: 'inbound' | 'outbound';
-  /** The other party: who sent it to us, or who we sent it to. */
+  /** 另一方：谁发给我们，或我们发给了谁。 */
   peer: string;
   title?: string;
-  /** Full message body — never truncated at rest; the UI decides how much to show. */
+  /** 完整消息正文——存盘时永不截断；显示多少由 UI 决定。 */
   body: string;
   kind: InboundKind;
   decision?: 'auto-allowed' | 'pending' | 'approved' | 'rejected';
@@ -244,17 +244,17 @@ export interface TriggerHistoryEntry {
   at: number;
 }
 
-/** Ledger cap. Oldest entries are dropped past this so the file can't grow forever. */
+/** 台账上限。超过此数后最旧的条目会被丢弃，文件才不会无限增长。 */
 export const TRIGGER_HISTORY_LIMIT = 500;
 
-/* ───────────────────────── minimal schema validation ─────────────────────── */
+/* ───────────────────────── 最小化 Schema 校验 ─────────────────────── */
 
 /**
- * A deliberately small JSON-Schema subset checker — `type`, `required`,
- * `properties`, `enum`. The project has no validation dependency and inbound
- * webhook bodies do not justify adding one; anything this doesn't understand is
- * ignored rather than treated as a failure, so an exotic user schema degrades to
- * "accept" instead of locking the caller out of their own endpoint.
+ * 一个刻意保持精简的 JSON-Schema 子集校验器——`type`、`required`、
+ * `properties`、`enum`。项目没有校验依赖，入站 webhook 请求体也不值得
+ * 引入一个；任何它不理解的内容都被忽略而不是当作失败，
+ * 因此一个奇怪的用户 schema 会退化为“接受”，而不会把调用方锁在
+ * 他们自己的端点之外。
  */
 export function validateAgainstSchema(
   value: unknown,
@@ -282,7 +282,7 @@ export function validateAgainstSchema(
     const props = isPlainObject(s.properties) ? s.properties : {};
     for (const [key, sub] of Object.entries(props)) {
       const v = (value as Record<string, unknown>)[key];
-      if (v === undefined) continue; // absent optionals are fine; `required` covers the rest
+      if (v === undefined) continue; // 缺失的可选字段没问题；其余由 `required` 覆盖
       const r = validateAgainstSchema(v, sub);
       if (!r.ok) return { ok: false, error: `${key}: ${r.error}` };
     }
@@ -300,7 +300,7 @@ function matchesType(value: unknown, type: string): boolean {
     case 'array': return Array.isArray(value);
     case 'object': return isPlainObject(value);
     case 'null': return value === null;
-    default: return true; // unknown type keyword — don't fail the caller over it
+    default: return true; // 未知的类型关键字——别因此让调用方失败
   }
 }
 

--- a/src/shared/updateState.ts
+++ b/src/shared/updateState.ts
@@ -1,33 +1,30 @@
 /**
- * Auto-update status model + presentation mapping.
+ * 自动更新状态模型 + 呈现映射。
  *
- * Deliberately electron-free: main (src/main/updater.ts) produces these states
- * from electron-updater events, the toolbar badge
- * (src/renderer/src/components/UpdateBadge.tsx) renders them, and the rules that
- * matter — which state wins when two arrive out of order, what the button says
- * and does — live here where they can be unit-tested without booting Electron.
+ * 刻意与 electron 无关：主进程（src/main/updater.ts）从 electron-updater 事件
+ * 产出这些状态，工具栏徽章（src/renderer/src/components/UpdateBadge.tsx）渲染
+ * 它们，而关键规则——两个状态乱序到达时哪一个胜出、按钮说什么做什么——都在
+ * 这里，无需启动 Electron 即可单元测试。
  */
 
 export type UpdateStatus =
-  /** Nothing known yet (fresh window, or dev build where we never check). */
+  /** 尚无所知（新窗口，或从不检查的开发构建）。 */
   | { state: 'idle' }
   | { state: 'checking' }
   | { state: 'not-available' }
   | { state: 'available'; version: string; notes?: string }
   | { state: 'downloading'; version: string; percent: number }
   | { state: 'downloaded'; version: string; notes?: string }
-  /** This install can't self-update (win-portable, or the native path failed):
-   *  notify-only, link to the release page. `reason` is the underlying error.
-   *  `notes` is the release body — the notify-only poll already reads the same
-   *  `releases/latest` JSON that carries it, so the toast can show "what's new"
-   *  here too without a second request. */
+  /** 此安装无法自我更新（win-portable，或原生路径失败）：仅通知，链接到发布
+   *  页。`reason` 是底层错误。`notes` 是发布正文——仅通知轮询已经读取同一份
+   *  携带它的 `releases/latest` JSON，因此 toast 在这里无需第二次请求也能
+   *  显示 "what's new"。 */
   | { state: 'available-manual'; version: string; url: string; reason?: string; notes?: string;
-      /** Direct asset for THIS platform/arch, when the release has one. The
-       *  modal's primary button downloads it; without it the button falls back
-       *  to the releases page. */
+      /** 本平台/架构的直接资源（发布存在时）。模态框主按钮下载它；没有它
+       *  按钮回退到发布页。 */
       downloadUrl?: string }
-  /** First launch after the version moved: `version` is the one now RUNNING and
-   *  `notes` its release body, so the renderer can show that release's page. */
+  /** 版本变更后的首次启动：`version` 是当前正在 RUNNING 的版本，`notes` 是
+   *  它的发布正文，渲染进程可以展示该版本的发布页。 */
   | { state: 'just-updated'; version: string; notes?: string }
   | { state: 'error'; message: string };
 
@@ -35,9 +32,8 @@ export type UpdateAction = 'none' | 'check' | 'download' | 'restart' | 'open-rel
 
 export const REPO = 'chaitanyagiri/munder-difflin';
 
-/** The installer for THIS machine in the release tagged v{version}, by the
- *  names electron-builder.yml produces. Used when a status carries no
- *  `downloadUrl` of its own (the native updater path never does). */
+/** 发布中针对 THIS 机器的安装包，按 electron-builder.yml 生成的名称。当
+ *  状态本身不携带 `downloadUrl` 时使用（原生更新器路径从不携带）。 */
 export function installerUrl(version: string, platform: string, arch: string): string {
   const v = version.replace(/^v/, '');
   const file = platform === 'darwin' ? `Munder-Difflin-${v}-mac-${arch}.dmg`
@@ -46,17 +42,16 @@ export function installerUrl(version: string, platform: string, arch: string): s
   return `https://github.com/${REPO}/releases/download/v${v}/${file}`;
 }
 
-/** The newer release a status knows about, or null. Every state that names a
- *  version newer than the running one counts, whatever the updater is doing
- *  with it: the manual path is always on offer. */
+/** 状态已知的较新发布，或 null。任何提及比运行版本新的状态的版本都算，
+ *  无论更新器正在对它做什么：手动路径始终可用。 */
 export function pendingVersion(status: UpdateStatus | null, current: string): string | null {
   if (!status || !('version' in status)) return null;
   if (status.state === 'just-updated') return null;
   return isNewer(status.version, current) ? status.version : null;
 }
 
-/** Where a manual download of `status`'s release goes: the asset the release
- *  itself named when it did, else the conventional installer URL. */
+/** `status` 的发布的手动下载指向哪里：发布本身命名了资源时用它，否则用
+ *  约定俗成的安装包 URL。 */
 export function manualDownloadUrl(status: UpdateStatus, platform: string, arch: string): string | null {
   if (!('version' in status) || status.state === 'just-updated') return null;
   if (status.state === 'available-manual' && status.downloadUrl) return status.downloadUrl;
@@ -64,17 +59,17 @@ export function manualDownloadUrl(status: UpdateStatus, platform: string, arch: 
 }
 
 export interface UpdateBadgeView {
-  /** Extra text beside the version, or null to show the version alone. */
+  /** 版本旁附加的文字，或 null 表示只显示版本。 */
   label: string | null;
-  /** What a click does. 'none' renders the badge non-interactive. */
+  /** 点击做什么。'none' 使徽章不可交互。 */
   action: UpdateAction;
   tone: 'idle' | 'busy' | 'ready' | 'warn';
-  /** Tooltip — the only place the underlying error is ever surfaced verbatim. */
+  /** 悬停提示——底层错误唯一被逐字呈现的地方。 */
   title: string;
   busy: boolean;
 }
 
-/** `1.2.3` / `v1.2.3` -> [1,2,3]; null for anything that isn't semver-ish. */
+/** `1.2.3` / `v1.2.3` -> [1,2,3]；任何不是类 semver 的返回 null。 */
 export function parseVersion(v: string): [number, number, number] | null {
   const m = String(v ?? '').trim().replace(/^v/, '').match(/^(\d+)\.(\d+)\.(\d+)/);
   return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
@@ -91,28 +86,26 @@ export function isNewer(candidate: string, current: string): boolean {
 }
 
 /**
- * Should the "what's new" release drop open on this launch?
+ * 本次启动是否应打开 "what's new" 发布页？
  *
- * `previous` is the `last-run-version` stamp (null when the file does not
- * exist), `current` is the running version.
+ * `previous` 是 `last-run-version` 印记（文件不存在时为 null），`current` 是
+ * 运行版本。
  *
- * The drop used to require a stamp to already be present, which meant it fired
- * for almost nobody: the stamp AND its reader shipped in the same release, so
- * no earlier install had the file, `previous` read null on the upgrade INTO
- * that release, and a genuinely fresh install had nothing either.
+ * 过去该页要求印记已经存在，这意味着它对几乎没人触发：印记和它的读取器在
+ * 同一个发布中上线，因此升级进该发布时更早的安装没有这个文件，`previous`
+ * 读到 null，而真正的新装也什么都没有。
  *
- *   - same version relaunch  -> false. Seen once is seen.
- *   - never run before       -> true.  The fresh-install case that was missing.
- *   - version moved forward  -> true.  The ordinary upgrade.
- *   - version moved BACKWARD -> false. A downgrade has nothing new to announce.
+ *   - 同版本重启        -> false。看过一次就是看过。
+ *   - 从未运行过        -> true。  曾经缺失的新装场景。
+ *   - 版本向前移动      -> true。  普通升级。
+ *   - 版本向后移动      -> false。降级没有新东西可宣布。
  *
- * Note the forward test is "not a downgrade", not `isNewer(current, previous)`.
- * `isNewer` compares major.minor.patch only and discards `-rc.N`, so a second
- * RC of the same version (0.4.7-rc.1 -> 0.4.7-rc.2) is neither newer nor older;
- * asking "is this a downgrade?" lets that case through DELIBERATELY (a new
- * build does have new notes) while still refusing a real downgrade. Doing it
- * here rather than by teaching `isNewer` about prereleases keeps the change off
- * the badge/pending state machine, which reads `isNewer` for other decisions.
+ * 注意前向测试是"不是降级"，而非 `isNewer(current, previous)`。`isNewer`
+ * 只比较 major.minor.patch 并丢弃 `-rc.N`，因此同一版本的第二 RC
+ * （0.4.7-rc.1 -> 0.4.7-rc.2）既非更新也非更旧；问"这是降级吗？"刻意放行
+ * 该情形（新构建确实有新说明），同时仍拒绝真正的降级。在这里实现而不是教
+ * `isNewer` 认识预发布版本，使徽章/待处理状态机保持不变，因为它为其他决策
+ * 读取 `isNewer`。
  */
 export function shouldShowReleaseDrop(previous: string | null, current: string): boolean {
   if (previous === current) return false;
@@ -120,16 +113,15 @@ export function shouldShowReleaseDrop(previous: string | null, current: string):
   return !isNewer(previous, current);
 }
 
-/** Download percentages arrive as floats and, on a resumed/differential
- *  download, occasionally out of range. Clamp so the UI can't render `-0%`
- *  or `104%`. */
+/** 下载百分比以浮点数到达，并在恢复/差异下载时偶尔越界。钳制，让 UI 无法
+ *  渲染 `-0%` 或 `104%`。 */
 export function clampPercent(n: number): number {
   if (!Number.isFinite(n)) return 0;
   return Math.max(0, Math.min(100, Math.round(n)));
 }
 
-/** How far along the update pipeline a state is. A later stage is never
- *  replaced by an earlier one for the SAME version — see `reduceStatus`. */
+/** 状态在更新管线中走到多远。对同一版本，更晚的阶段绝不会被更早的取代
+ *  —— 见 `reduceStatus`。 */
 function rank(s: UpdateStatus): number {
   switch (s.state) {
     case 'idle': return 0;
@@ -149,38 +141,35 @@ function versionOf(s: UpdateStatus): string | null {
 }
 
 /**
- * Fold a new status into the current one.
+ * 把新状态折进当前状态。
  *
- * The rule that matters: once an update is staged, the 6-hourly re-check (or a
- * manual "check now") must NOT wipe the "restart to update" affordance out from
- * under the user — `checking` / `not-available` / a transient `error` are all
- * lower-rank and lose. A genuinely NEWER version always wins, so a long-running
- * app that sees 0.3.7 while 0.3.6 is staged moves forward rather than sticking.
+ * 关键规则：一旦更新已就绪，6 小时一次的复查（或手动 "check now"）绝不能把
+ * "重启即可更新"的提示从用户眼前抹掉——`checking` / `not-available` / 一次
+ * 性 `error` 的等级都更低，会输。新的版本总是胜出，因此一个运行了很久、在
+ * 0.3.6 就绪时看到 0.3.7 的应用会向前推进，而不是卡住。
  */
 export function reduceStatus(prev: UpdateStatus | null, next: UpdateStatus): UpdateStatus {
   if (!prev) return next;
   const pv = versionOf(prev);
   const nv = versionOf(next);
-  if (pv && nv && isNewer(nv, pv)) return next;   // a newer release supersedes
-  if (pv && nv && pv !== nv) return next;         // different (e.g. rolled back) release
+  if (pv && nv && isNewer(nv, pv)) return next;   // 更新的版本取代
+  if (pv && nv && pv !== nv) return next;         // 不同（如回滚）的版本
   return rank(next) >= rank(prev) ? next : prev;
 }
 
 /**
- * What the toolbar badge shows and does for a given status.
+ * 给定状态时工具栏徽章显示什么、做什么。
  *
- * `currentVersion` is the running app's version — it is always rendered next to
- * the logo, so every one of these views is "v0.3.6" plus at most one extra chip.
+ * `currentVersion` 是运行中应用的版本——它总是显示在 logo 旁边，因此这里的
+ * 每个视图都是 "v0.3.6" 加至多一个额外标签。
  */
 export function describeUpdate(status: UpdateStatus | null, currentVersion: string): UpdateBadgeView {
   const v = currentVersion;
-  // The title-bar badge is the MANUAL path, always: click downloads the
-  // installer and the user replaces the app. Auto-update (download, restart)
-  // lives in Settings -> Updates. So any state that names a newer release reads
-  // the same here, whatever the background updater is doing with it.
+  // 标题栏徽章始终是 MANUAL 路径：点击下载安装包并由用户自行替换应用。
+  // 自动更新（下载、重启）位于 Settings -> Updates。因此任何提及较新版本的
+  // 状态在这里读取方式相同，无论后台更新器正在对它做什么。
   if (status?.state === 'downloading') {
-    // Settings started the automatic download; the chip reports progress and
-    // nothing else, so the two paths are not raced against each other.
+    // Settings 启动了自动下载；标签只报告进度，别无其他，两条路径互不竞争。
     return {
       label: `downloading ${clampPercent(status.percent)}%`, action: 'none', tone: 'busy', busy: true,
       title: `Downloading v${status.version}… ${clampPercent(status.percent)}%`
@@ -188,11 +177,10 @@ export function describeUpdate(status: UpdateStatus | null, currentVersion: stri
   }
   const pending = pendingVersion(status, v);
   if (pending) {
-    // When the native updater has staged the update, the badge drives the SAME
-    // auto-update the Settings pane does: restart to install once it is
-    // downloaded, or kick the download while it is 'available'. Manual download
-    // is reserved for 'available-manual', the notify-only fallback where the
-    // native updater could NOT fetch it, so the user replaces the app by hand.
+    // 当原生更新器已就绪更新时，徽章驱动与 Settings 窗格相同的自动更新：
+    // 下载完成后重启安装，或在 'available' 时启动下载。手动下载保留给
+    // 'available-manual'——原生更新器无法取回的仅通知回退——此时用户手工
+    // 替换应用。
     if (status?.state === 'downloaded') {
       return {
         label: `v${pending} · restart`, action: 'restart', tone: 'ready', busy: false,
@@ -222,7 +210,7 @@ export function describeUpdate(status: UpdateStatus | null, currentVersion: stri
       };
     case 'not-available':
     case 'just-updated':
-      // A check has confirmed it, so say so. Idle (no check yet) stays bare.
+      // 检查已确认，如实说明。Idle（尚未检查）保持空白。
       return { label: 'latest', action: 'check', tone: 'idle', busy: false, title: `v${v} is the latest version — click to check again` };
     case 'idle':
     default:
@@ -231,12 +219,11 @@ export function describeUpdate(status: UpdateStatus | null, currentVersion: stri
 }
 
 export interface UpdateSettingsView {
-  /** Headline: the version that matters right now — yours, or the one waiting. */
+  /** 标题：此刻重要的版本——你的，或等待中的那个。 */
   headline: string;
-  /** One sentence of explanation. Carries the verbatim error when there is one. */
+  /** 一句话说明。有错误时逐字携带该错误。 */
   detail: string;
-  /** Primary button label, or null while the updater is mid-flight and there is
-   *  nothing useful to press. */
+  /** 主按钮标签，更新器进行中且没有可点的东西时为 null。 */
   button: string | null;
   action: UpdateAction;
   busy: boolean;
@@ -244,14 +231,12 @@ export interface UpdateSettingsView {
 }
 
 /**
- * What the Settings → General "Updates" block shows and does.
+ * 给定状态时 Settings → General 的 "Updates" 块显示什么、做什么。
  *
- * Separate from `describeUpdate` on purpose. The toolbar chip has room for two
- * words and has to stay quiet when nothing is happening, so its idle state says
- * nothing at all; Settings is where someone goes *to ask*, so every state gets a
- * full sentence and — outside the two mid-flight states — a button. The states
- * and the transitions between them are shared, which is the part that has to
- * stay in sync.
+ * 有意与 `describeUpdate` 分开。工具栏标签只有两个词的空间，无事发生时必须
+ * 保持安静，因此它的空闲态什么都不说；Settings 是*主动询问*的去处，因此每个
+ * 状态都有完整句子，并且在两个进行中状态之外都有按钮。状态及其之间的转移是
+ * 共享的——那是必须保持同步的部分。
  */
 export function describeUpdateSettings(
   status: UpdateStatus | null,
@@ -320,8 +305,7 @@ export function describeUpdateSettings(
   }
 }
 
-/** What to do with the installer once it has downloaded, per platform. Shown
- *  on the title-bar badge's hover card and in the notice after the click. */
+/** 安装包下载后按平台该怎么做。显示在标题栏徽章的悬停卡片以及点击后的提示里。 */
 export function manualInstallSteps(platform: string): { os: string; steps: string[] } {
   if (platform === 'darwin') {
     return {

--- a/src/shared/weeklySchedule.ts
+++ b/src/shared/weeklySchedule.ts
@@ -1,55 +1,55 @@
 /**
- * WEEKLY SCHEDULES — "every Monday and Thursday at 09:00" instead of
- * "every 86400000 ms".
+ * 每周日程 — 用"每周一和周四的 09:00"来表达，而不是
+ * "每 86400000 毫秒"。
  *
- * A `ScheduledMission` has always fired on a fixed interval, which cannot say
- * "weekday mornings": an interval drifts relative to the clock, and a 24h one
- * started at 15:00 fires at 15:00 forever. This module adds the other shape.
- * When a mission carries a valid `weekly`, that REPLACES its interval; the
- * interval is left on the record untouched so switching back restores it.
+ * `ScheduledMission` 一直按固定间隔触发，这无法表达"工作日早晨"：
+ * 间隔相对时钟会漂移，而且在 15:00 启动的 24 小时间隔会永远
+ * 在 15:00 触发。本模块补充另一种形态。当任务带有有效的
+ * `weekly` 时，它 REPLACES 该间隔；记录上的间隔保持原样不动，
+ * 这样切回时能恢复。
  *
- * Pure and import-free on purpose, so the test loader can take it directly and
- * the scheduler's arithmetic is testable without a clock or a config file.
+ * 刻意保持纯净且无导入，测试加载器可以直接引用它，
+ * 调度器的运算可以在没有时钟或配置文件的情况下测试。
  *
- * ── Everything here is LOCAL time, deliberately ────────────────────────────
- * "09:00 on Monday" means 09:00 where the user is sitting, which is the only
- * reading a person expects. That is why the next occurrence is built with the
- * Date(y, m, d, h, min) constructor rather than by adding milliseconds: adding
- * 7 * 86400000 across a daylight-saving boundary lands an hour off, while
- * re-constructing from calendar fields lands on the same wall clock. On a
- * spring-forward day a time that does not exist (02:30 in most of the US) rolls
- * forward the way the platform rolls it, which is the standard behaviour and
- * the one every other scheduler produces too.
+ * ── 这里的一切时间都是本地时间，刻意如此 ────────────────────────────
+ * "周一 09:00" 指的是用户所在时区的 09:00，这是人们唯一
+ * 会期望的解读。这就是为什么下一次触发是用
+ * `Date(y, m, d, h, min)` 构造器而不是毫秒加法构建的：
+ * 跨夏令时边界加 `7 * 86400000` 会偏差一小时，而
+ * 从日历字段重建则会落在同一个墙上时钟上。在春季拨快的
+ * 一天里，不存在的时间（美国大部分地区的 02:30）会
+ * 按平台的方式向前滚动，这是标准行为，也是其他所有
+ * 调度器都会产生的行为。
  */
 
 export interface WeeklySchedule {
-  /** 0 = Sunday … 6 = Saturday. Empty means "not a weekly schedule". */
+  /** 0 = 周日 … 6 = 周六。空数组表示"不是每周日程"。 */
   days: number[];
-  /** Minutes since local midnight, 0..1439. */
+  /** 自本地午夜起的分钟数，0..1439。 */
   minute: number;
 }
 
-export const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-/** Initials for the 7-button picker. Two Ts and two Ss — the position carries
- *  the meaning, and every calendar in the world does the same. */
-export const WEEKDAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+export const WEEKDAY_LABELS = ['周日', '周一', '周二', '周三', '周四', '周五', '周六'];
+/** 7 按钮选择器的首字母。两个 T 和两个 S——由位置承载含义，
+ *  世界上每个日历都是这么做的。 */
+export const WEEKDAY_INITIALS = ['日', '一', '二', '三', '四', '五', '六'];
 
 /**
- * How long after a MISSED slot the mission still fires.
+ * 错过（MISSED）时段后任务仍然触发的最长等待时间。
  *
- * A laptop asleep at 09:00 and opened at 10:30 should still get its 09:00 run;
- * one closed on Friday and opened on Monday should not get Friday's. Six hours
- * splits those two cases about where a person would. This matches what the
- * interval scheduler already does (it clamps a negative remaining time to zero
- * and fires on boot), so the two kinds of schedule behave the same way after a
- * sleep rather than one of them silently skipping.
+ * 一台在 09:00 睡眠、10:30 打开的笔记本仍应得到它 09:00 的运行；
+ * 一台周五关闭、周一打开的笔记本则不应补跑周五的。六个小时
+ * 大约落在人们会划分这两类情况的界限附近。这与间隔调度器
+ * 已有的行为一致（它把负的剩余时间钳制为零并在启动时触发），
+ * 因此两类日程在睡眠后的行为相同，而不是其中一个
+ * 静默跳过。
  */
 export const WEEKLY_CATCHUP_MS = 6 * 60 * 60 * 1000;
 
-/** Validate and canonicalise. Returns null for anything that is not a usable
- *  weekly schedule — no days, a bad day number, a minute outside the day — so
- *  every caller has exactly one check to make. Days come back sorted and
- *  de-duplicated, so two schedules that mean the same thing compare equal. */
+/** 校验并规范化。对任何不可用的每周日程返回 null——没有天数、
+ *  无效的星期数、超出一天的分钟数——这样每个调用方都只需做一次检查。
+ *  天数会排序并去重返回，因此两个含义相同的日程比较结果
+ *  相等。 */
 export function normalizeWeekly(w: unknown): WeeklySchedule | null {
   if (!w || typeof w !== 'object') return null;
   const raw = w as { days?: unknown; minute?: unknown };
@@ -63,28 +63,28 @@ export function normalizeWeekly(w: unknown): WeeklySchedule | null {
   return { days, minute };
 }
 
-/** "09:00". Zero-padded 24h, because a schedule an operator is reading back
- *  should not need an am/pm second look. */
+/** "09:00"。24 小时制补零，因为操作员回读的日程
+ *  不应还需要再看一眼上午/下午。 */
 export function formatMinute(minute: number): string {
   const h = Math.floor(minute / 60);
   const m = minute % 60;
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
 }
 
-/** Human summary for a row: "weekdays at 09:00", "Mon, Thu at 14:30". */
+/** 供人阅读的摘要行："weekdays at 09:00"、"Mon, Thu at 14:30"。 */
 export function formatWeekly(w: unknown): string {
   const n = normalizeWeekly(w);
-  if (!n) return 'no days picked';
+  if (!n) return '未选择任何日子';
   const at = formatMinute(n.minute);
   const key = n.days.join(',');
-  if (key === '0,1,2,3,4,5,6') return `every day at ${at}`;
-  if (key === '1,2,3,4,5') return `weekdays at ${at}`;
-  if (key === '0,6') return `weekends at ${at}`;
-  return `${n.days.map((d) => WEEKDAY_LABELS[d]).join(', ')} at ${at}`;
+  if (key === '0,1,2,3,4,5,6') return `每天 ${at}`;
+  if (key === '1,2,3,4,5') return `工作日 ${at}`;
+  if (key === '0,6') return `周末 ${at}`;
+  return `${n.days.map((d) => WEEKDAY_LABELS[d]).join('、')} ${at}`;
 }
 
-/** Build the local instant for `minute` on the day `offset` days from `from`.
- *  Calendar-field construction, not millisecond arithmetic — see the DST note. */
+/** 为距 `from` 起 `offset` 天的那一天、在 `minute` 时刻构建本地时刻。
+ *  使用日历字段构造，而非毫秒运算——参见 DST 注释。 */
 function slotAt(from: Date, offset: number, minute: number): Date {
   return new Date(
     from.getFullYear(), from.getMonth(), from.getDate() + offset,
@@ -92,9 +92,9 @@ function slotAt(from: Date, offset: number, minute: number): Date {
   );
 }
 
-/** The first matching slot STRICTLY after `nowMs`, or null if there are no days.
- *  Eight candidates is always enough: the worst case is one day a week whose
- *  slot has already passed today, which lands on offset 7. */
+/** 严格晚于 `nowMs` 的第一个匹配时段，若无可用天数则返回 null。
+ *  八个候选总是够用：最坏情况是每周一天、其时段今天已过，
+ *  那会落在偏移 7 上。 */
 export function nextWeeklyFireMs(w: unknown, nowMs: number): number | null {
   const n = normalizeWeekly(w);
   if (!n) return null;
@@ -108,8 +108,8 @@ export function nextWeeklyFireMs(w: unknown, nowMs: number): number | null {
   return null;
 }
 
-/** The most recent matching slot at or before `nowMs`, or null. Used only to
- *  decide whether a slot was MISSED while the app was not running. */
+/** 最接近的、在 `nowMs` 之前（含）的匹配时段，或 null。仅用于
+ *  判断应用未运行期间是否有时段被错过（MISSED）。 */
 export function previousWeeklyFireMs(w: unknown, nowMs: number): number | null {
   const n = normalizeWeekly(w);
   if (!n) return null;
@@ -124,14 +124,14 @@ export function previousWeeklyFireMs(w: unknown, nowMs: number): number | null {
 }
 
 /**
- * How long the scheduler should wait before firing this mission, or null when
- * the schedule is not usable.
+ * 调度器在触发此任务前应等待多久，日程不可用时
+ * 返回 null。
  *
- * Zero means "fire now": a slot passed while we were not watching, it is recent
- * enough to still be worth running, and we have not already run it. That last
- * clause is what `lastFiredAt` is for — without it, re-arming the scheduler
- * (which happens on every save of ANY mission) would re-fire a mission that
- * already ran minutes ago.
+ * 零表示"立即触发"：我们未监控时有一个时段已过，它足够新、
+ * 仍值得运行，而且我们尚未运行过。最后一个条件就是
+ * `lastFiredAt` 的作用——没有它，重新武装调度器
+ * （对任意任务每次保存都会发生）会重新触发一个
+ * 几分钟前已经运行过的任务。
  */
 export function weeklyDelayMs(w: unknown, nowMs: number, lastFiredAt = 0): number | null {
   const n = normalizeWeekly(w);


### PR DESCRIPTION
## Summary

Localize the codebase for Simplified Chinese users and fix terminal rendering issues on CJK systems:

### Localization
- Translate comments across `src/main`, `src/renderer`, `src/shared` to Simplified Chinese
- Add `src/main/l10n.ts`: minimal main-process localizer keyed on OS locale (renderer keeps full i18next)
- Sync `zh-CN`/`en`/`ar` locale catalogs

### Terminal fixes (CJK + qwen)
- Add `Sarasa Mono SC`, `PingFang SC`, `Microsoft YaHei` to terminal font stack so CJK renders legibly
- Fix duplicate/interleaved output: qwen legacy erase-lines flags + enqueueWrite write-flush throttle
- Debounce pty resize (140ms) to stop overlapping repaints

## Scope
- `src/**` only (219 files, comments + the fixes above)
- No docs, no version bump, no build artifacts

## Notes
- Verified the build compiles on Windows (electron-vite)
- Test file untouched (LF line endings preserved)

### Before

![Before: UI in English](https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/main/docs/pr-evidence/before-en.png)

### After

![After: same screen with 简体中文 selected in Settings → General](https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/main/docs/pr-evidence/after-zh.png)