### PR TITLE
feat(models): ship a model without shipping a build, and add Fable 5.1 / GPT-6 Astra / Gemini 3.7 Flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ All notable changes to this project are documented here. The format is based on
   reasoning levels; Cursor gets its own build of the two it carries. Every id was read out of the
   CLI that will be invoked with it — `codex-rs/models-manager/models.json`, `agy models`,
   `cursor-agent models`, and the installed `claude` binary — rather than guessed from a name.
+  **GPT-6 Astra needs Codex 0.153.1 or newer.** The slug landed in that release, so an older
+  `codex` on your machine will reject it when the agent spawns; update Codex first. The catalog's
+  version bounds cover the app, not the CLI it launches, so this is a prerequisite rather than
+  something the picker can hide for you.
 - **A new model no longer needs a release.** The pickers now read
   [`docs/model-catalog.json`](docs/model-catalog.json) on `main`, fetched at runtime and cached for
-  six hours, so adding a model is one line in one file on GitHub and every installed copy picks it
-  up. The catalog compiled into the build stays the floor: it is what renders offline, on first
+  six hours, so adding a model is one line in one file on GitHub rather than a build. The check runs
+  at startup, not on a timer: an installed copy picks a new model up the next time it launches with
+  a cached copy older than six hours, and an app left open does not change under you.
+  The catalog compiled into the build stays the floor: it is what renders offline, on first
   launch, and whenever the remote copy is missing, unreadable, or announces a schema this build does
   not know. A provider present in the remote copy replaces that provider's list; a provider it does
   not mention keeps the built-in one, so a bad edit costs a list rather than a picker. The payload is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Fable 5.1, GPT-6 Astra, and Gemini 3.7 Flash in the model pickers.** Claude Code gets
+  `claude-fable-5-1`, Codex gets `gpt-6-astra`, and Antigravity gets Gemini 3.7 Flash at all three
+  reasoning levels; Cursor gets its own build of the two it carries. Every id was read out of the
+  CLI that will be invoked with it — `codex-rs/models-manager/models.json`, `agy models`,
+  `cursor-agent models`, and the installed `claude` binary — rather than guessed from a name.
+- **A new model no longer needs a release.** The pickers now read
+  [`docs/model-catalog.json`](docs/model-catalog.json) on `main`, fetched at runtime and cached for
+  six hours, so adding a model is one line in one file on GitHub and every installed copy picks it
+  up. The catalog compiled into the build stays the floor: it is what renders offline, on first
+  launch, and whenever the remote copy is missing, unreadable, or announces a schema this build does
+  not know. A provider present in the remote copy replaces that provider's list; a provider it does
+  not mention keeps the built-in one, so a bad edit costs a list rather than a picker. The payload is
+  data and never markup, and a model id is length-capped and stripped of control characters before it
+  can reach a `--model` flag on a spawn command line. Same mechanism as the Settings hero card.
+
 ## [0.4.6] — 2026-08-27
 
 **The release that speaks your language and updates itself.** The interface runs in Chinese and

--- a/docs/hires/models.json
+++ b/docs/hires/models.json
@@ -1,17 +1,21 @@
 {
   "_comment": "Source of truth for model suggestions on the site. Update by hand or run: python3 scripts/build-data.py --sync-models (scrapes upstream's config.ts and merges). Manifests may use ANY model string - these are suggestions, not validation.",
-  "updated": "2026-06-10",
+  "updated": "2026-09-04",
   "claude": [
     "claude-opus-4-8",
     "claude-opus-4-8[1m]",
     "claude-sonnet-4-6",
     "claude-haiku-4-5-20251001",
     "claude-fable-5",
+    "claude-fable-5-1",
     "claude-sonnet-4-6[1m]"
   ],
   "antigravity": [
     "Gemini 3.1 Pro (High)",
     "Gemini 3.1 Pro (Low)",
+    "Gemini 3.7 Flash (High)",
+    "Gemini 3.7 Flash (Medium)",
+    "Gemini 3.7 Flash (Low)",
     "Gemini 3.5 Flash (High)",
     "Gemini 3.5 Flash (Medium)",
     "Gemini 3.5 Flash (Low)",
@@ -19,5 +23,10 @@
     "Claude Opus 4.6 (Thinking)",
     "GPT-OSS 120B (Medium)"
   ],
-  "codex": []
+  "codex": [
+    "gpt-6-astra",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna"
+  ]
 }

--- a/docs/model-catalog.json
+++ b/docs/model-catalog.json
@@ -1,4 +1,7 @@
 {
+  "_comment": "The agent model pickers. Edited HERE, on main, and fetched by every installed copy of the app at runtime, so a new model ships WITHOUT a release. Data only, never markup: every field renders as escaped text and `id` is length-capped before it reaches a --model flag. Unknown fields are ignored; a provider whose entries are all malformed falls back to the list compiled into the build (src/shared/modelCatalog.json), so a bad edit costs a list, never a picker.",
+  "_howToAddAModel": "Add one line to the right provider array: {\"id\": \"<the exact --model value>\", \"label\": \"<what the picker shows>\"}. `id` is what the CLI is invoked with, so copy it from that CLI's own list (`codex` models.json, `agy models`, `cursor-agent models`, `claude --model`). Omit `id` entirely for a 'pass no --model flag' row. Optional `minAppVersion` / `maxAppVersion` are INCLUSIVE app-version bounds for a model only some releases can run; a prerelease counts as its release (0.4.6-rc.1 is 0.4.6). Apps refresh within 6 hours of a push to main.",
+  "_schema": "version MUST stay 1 until the shape changes; a build ignores a catalog whose version it does not know, which is what stops a future schema from half-applying to an old build.",
   "version": 1,
   "providers": {
     "claude": [

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -725,8 +725,9 @@ export function resetConfig(): HarnessConfig {
   return withTriggerDefaults({ ...DEFAULTS });
 }
 
-/** Model ids by tier (Lane A #6.4). Kept in sync with AGENT_MODELS in
- *  src/renderer/src/store/config.ts. */
+/** Model ids by tier (Lane A #6.4). Kept in sync with the claude list in
+ *  src/shared/modelCatalog.json, which `agentModels()` in
+ *  src/renderer/src/store/config.ts reads. */
 const MODEL_GOD = 'claude-opus-4-8';                  // orchestration — highest capability
 const MODEL_WORKER = 'claude-sonnet-4-6';             // general execution
 const MODEL_HELPER = 'claude-haiku-4-5-20251001';     // narrow, cheap helpers
@@ -741,7 +742,7 @@ export interface RoleHint {
 
 /** Default model for an agent given its role (Lane A #6.4): Opus for the god,
  *  Haiku for narrow helpers (triage / routing / verification / formatting),
- *  Sonnet for general workers. Returns a model id (matching AGENT_MODELS) or
+ *  Sonnet for general workers. Returns a model id (matching the catalog) or
  *  undefined to fall back to the CLI default. This is only a DEFAULT — an
  *  explicit per-agent model selection always wins. */
 export function modelForRole(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -83,6 +83,7 @@ import { detectNodeVersion, nodeIsUsable, resolveNodeInstaller } from './nodeIns
 import { toolCatalog, type ToolStatus } from '../shared/toolCatalog';
 import { listLocalSkills, loadCatalog, installSkill, uninstallSkill, type LocalSkill } from './skills';
 import { loadHero } from './hero';
+import { loadModelCatalog } from './modelCatalog';
 import {
   CODEX_REMOTE_SOCKET_RELATIVE,
   codexRemoteAliasPath,
@@ -3458,6 +3459,14 @@ ipcMain.handle('hive:patchAgentRole', (_evt, id: unknown, role: unknown) => {
 ipcMain.handle('hero:payload', async (_evt, force: unknown) =>
   loadHero(join(app.getPath('userData'), 'hero.json'), { force: force === true }));
 
+// ─── IPC: model catalog (remote data, cached) ───────────────────────────────
+/** The agent model presets, fetched from docs/model-catalog.json on main so a
+ *  new model reaches installed copies without a release. Validated in
+ *  shared/modelCatalogPayload; a null catalog means "keep the baked one". */
+const MODEL_CATALOG_CACHE = () => join(app.getPath('userData'), 'model-catalog.json');
+ipcMain.handle('models:catalog', async (_evt, force: unknown) =>
+  loadModelCatalog(MODEL_CATALOG_CACHE(), { force: force === true }));
+
 // ─── IPC: skills (installed locally, and the browsable catalog) ─────────────
 /** Skills the CLIs on this machine can already use. Scans the registered repos
  *  plus the agent's own cwd, so a project-scoped skill shows up where it applies. */
@@ -5188,6 +5197,12 @@ app.whenReady().then(() => {
     appVersion: app.getVersion(),
     enabled: readConfig().telemetryEnabled !== false
   });
+
+  // Warm the model catalog cache before any picker opens. The renderer reads
+  // the same cache over IPC on load; doing the network hop here means the file
+  // is already fresh on disk by the time a modal is opened, and a failure is
+  // silent by construction (the baked catalog is the floor).
+  void loadModelCatalog(MODEL_CATALOG_CACHE()).catch(() => { /* never fatal */ });
 
   // A cold-start deep link (Windows/Linux) rides in on OUR argv.
   const startupHireLink = process.argv.find((a) => a.startsWith('munderdifflin://'));

--- a/src/main/modelCatalog.ts
+++ b/src/main/modelCatalog.ts
@@ -1,0 +1,74 @@
+/**
+ * Fetch + cache the REMOTE model catalog.
+ *
+ * Same shape as the hero payload and the skills catalog: served from cache when
+ * fresh, refetched otherwise, and NEVER fatal. A failed fetch falls back to the
+ * cached copy, and a missing cache falls back to null — which the renderer reads
+ * as "keep the catalog compiled into this build".
+ *
+ * The point of this file: shipping a model was a build. Now it is an edit to
+ * docs/model-catalog.json on main, which every installed copy picks up within
+ * the TTL. The baked catalog stays the floor, so the pickers are never empty and
+ * never wait on the network.
+ */
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { getText } from './fetchText';
+import { parseModelCatalog, type ModelCatalog } from '../shared/modelCatalogPayload';
+
+const CATALOG_URL =
+  'https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/main/docs/model-catalog.json';
+
+/** Models ship on a human timescale, and a stale list costs the user nothing —
+ *  every command field in the app stays editable. Six hours matches the hero
+ *  payload; a launch after that refreshes in the background. */
+const TTL_MS = 6 * 60 * 60 * 1000;
+
+export interface RemoteCatalogResult {
+  /** null = nothing usable came back; the caller keeps its baked catalog. */
+  catalog: ModelCatalog | null;
+  /** 0 when nothing has ever been fetched. */
+  fetchedAt: number;
+  /** True when this is a cached or absent copy rather than a fresh fetch. */
+  stale: boolean;
+}
+
+export async function loadModelCatalog(
+  cachePath: string,
+  opts: { force?: boolean } = {}
+): Promise<RemoteCatalogResult> {
+  let cached: { catalog: ModelCatalog; fetchedAt: number } | null = null;
+  try {
+    if (existsSync(cachePath)) {
+      const read = JSON.parse(readFileSync(cachePath, 'utf8'));
+      // Re-validate on READ, not only on fetch. The cache is a file on disk that
+      // a previous build wrote; a schema bump or a hand-edit must not reach the
+      // pickers unchecked just because it once passed.
+      const catalog = parseModelCatalog(read?.catalog);
+      if (catalog && typeof read.fetchedAt === 'number') {
+        cached = { catalog, fetchedAt: read.fetchedAt };
+      }
+    }
+  } catch { cached = null; }
+
+  if (cached && !opts.force && Date.now() - cached.fetchedAt < TTL_MS) {
+    return { catalog: cached.catalog, fetchedAt: cached.fetchedAt, stale: false };
+  }
+
+  try {
+    const body = await getText(CATALOG_URL, { timeoutMs: 8000 });
+    // Parse the JSON and the SHAPE separately: valid JSON that is not a catalog
+    // must fall back, not reach a picker as undefined rows.
+    const catalog = parseModelCatalog(JSON.parse(body));
+    if (!catalog) throw new Error('not a model catalog');
+    const payload = { catalog, fetchedAt: Date.now() };
+    try {
+      mkdirSync(dirname(cachePath), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify(payload));
+    } catch { /* the cache is an optimisation, not the feature */ }
+    return { ...payload, stale: false };
+  } catch {
+    if (cached) return { catalog: cached.catalog, fetchedAt: cached.fetchedAt, stale: true };
+    return { catalog: null, fetchedAt: 0, stale: true };
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,8 @@ import type { ToolStatus } from '../shared/toolCatalog';
 export type { ToolStatus } from '../shared/toolCatalog';
 import type { HeroPayload } from '../shared/heroPayload';
 export type { HeroPayload } from '../shared/heroPayload';
+import type { ModelCatalog } from '../shared/modelCatalogPayload';
+export type { ModelCatalog, CatalogModel } from '../shared/modelCatalogPayload';
 import type { HookEvent } from '../shared/hookEvents';
 export type { HookEvent } from '../shared/hookEvents';
 import type { LocalSkill, CatalogSkill } from '../main/skills';
@@ -788,6 +790,12 @@ const api = {
   /** Settings hero payload — plan + sponsor, fetched from the repo and cached. */
   heroPayload: (force?: boolean): Promise<{ hero: HeroPayload; fetchedAt: number; stale: boolean }> =>
     ipcRenderer.invoke('hero:payload', force),
+  /** The remote model catalog — the agent model presets, fetched from the repo
+   *  and cached, so a new model needs a JSON edit rather than a release. A null
+   *  catalog means the renderer keeps the list compiled into the build. */
+  modelCatalog: (force?: boolean): Promise<{
+    catalog: ModelCatalog | null; fetchedAt: number; stale: boolean;
+  }> => ipcRenderer.invoke('models:catalog', force),
   /** Skills already installed for the coding agents on this machine. */
   skillsLocal: (cwd?: string): Promise<LocalSkill[]> => ipcRenderer.invoke('skills:local', cwd),
   /** The browsable skills catalog (cached; `force` re-fetches). */

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AGENT_MODELS, type HarnessConfig } from '@/store/config';
+import { agentModels, type HarnessConfig } from '@/store/config';
 import { useStore } from '@/store/store';
 import {
   CLONE_NODE_BLURB,
@@ -1203,7 +1203,7 @@ export function SettingsModal({ config, onClose, initialSection }: SettingsModal
                             {t('settings.agentsModels.defaultModelDesc', { godName })}
                           </span>
                           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                            {AGENT_MODELS.map((m) => (
+                            {agentModels().map((m) => (
                               <button
                                 key={m.label}
                                 onClick={() => { if (m.id) void saveDefaultModel(m.id); }}

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -14,6 +14,7 @@ import type {
 } from '@shared/triggers';
 import { isNewer } from '@shared/updateState';
 import modelCatalog from '@shared/modelCatalog.json';
+import type { CatalogModel, ModelCatalog } from '@shared/modelCatalogPayload';
 
 export {
   AGENT_PROVIDER_PRESETS,
@@ -162,10 +163,12 @@ export interface ModelOption {
   label: string;
 }
 
-/** One row of the model catalog. `minAppVersion` / `maxAppVersion` are INCLUSIVE
- *  app-version bounds: the model is offered while the running build sits inside
- *  them, and null (or an absent key) means unbounded in that direction. That is
- *  what lets a release introduce or retire a model without a code change.
+/** The catalog row + catalog types now live in shared/, because the MAIN
+ *  process validates the remote copy against the same shape before it crosses
+ *  the bridge. `minAppVersion` / `maxAppVersion` are INCLUSIVE app-version
+ *  bounds: the model is offered while the running build sits inside them, and
+ *  null (or an absent key) means unbounded in that direction. That is what lets
+ *  a release introduce or retire a model without a code change.
  *
  *  PRERELEASES COUNT AS THEIR RELEASE. The comparison is major.minor.patch only
  *  (`isNewer` discards a `-rc.N` suffix), so `minAppVersion: '0.4.6'` IS offered
@@ -173,18 +176,7 @@ export interface ModelOption {
  *  count as that release, it matches the update badge's own comparison, and the
  *  alternative would hide a new model from exactly the testers meant to
  *  exercise it. Bound a model to the release, not to its rc. */
-interface CatalogModel {
-  /** absent = use the CLI default (no --model flag) */
-  id?: string;
-  label: string;
-  minAppVersion?: string | null;
-  maxAppVersion?: string | null;
-}
-
-interface ModelCatalog {
-  version: number;
-  providers: Record<string, CatalogModel[]>;
-}
+export type { CatalogModel, ModelCatalog } from '@shared/modelCatalogPayload';
 
 /** The model presets every provider picker offers.
  *
@@ -241,7 +233,65 @@ interface ModelCatalog {
  *  - kimi: managed Kimi Code aliases accepted by `kimi --model <alias>`.
  *  - custom: no presets at all; the command field is the whole interface.
  */
-const CATALOG: ModelCatalog = modelCatalog;
+const BAKED: ModelCatalog = modelCatalog;
+
+/** The catalog the pickers actually read. Starts as the baked copy and is
+ *  replaced, per provider, when the remote copy arrives from main. `let`, not
+ *  `const`, is the whole mechanism: everything below reads it through a
+ *  function call, so a refresh reaches the next render with no plumbing. */
+let CATALOG: ModelCatalog = BAKED;
+
+/** Merge a validated remote catalog over the baked one.
+ *
+ *  Per PROVIDER, not per model: a provider present in the remote copy replaces
+ *  that provider's list outright, and a provider the remote copy does not
+ *  mention keeps the list this build shipped with. That means docs/model-catalog
+ *  .json can carry only the providers being changed, and a provider dropped from
+ *  it degrades to the built-in list rather than to an empty picker.
+ *
+ *  Returns whether anything actually changed, so the caller can skip a pointless
+ *  event on the overwhelmingly common "nothing new" path. */
+export function applyRemoteModelCatalog(remote: ModelCatalog | null): boolean {
+  const next: ModelCatalog = remote
+    ? { version: BAKED.version, providers: { ...BAKED.providers, ...remote.providers } }
+    : BAKED;
+  if (JSON.stringify(next) === JSON.stringify(CATALOG)) return false;
+  CATALOG = next;
+  return true;
+}
+
+/** Fired on `window` after the catalog changes, so a surface holding a rendered
+ *  list can re-read it. Pickers that call `modelsForProvider()` during render
+ *  pick the change up on their next render either way. */
+export const MODEL_CATALOG_EVENT = 'cth:model-catalog';
+
+/** Ask main for the remote catalog and apply it. Safe to call repeatedly; the
+ *  network hop is main's problem and it is cached there behind a TTL.
+ *
+ *  Called once when this module loads inside the app (below). Kept exported so a
+ *  Settings action can force a refresh, and so the tests can drive it. */
+export async function refreshModelCatalog(force = false): Promise<boolean> {
+  try {
+    const bridge = (globalThis as { cth?: { modelCatalog?: (force?: boolean) => Promise<{ catalog: ModelCatalog | null }> } }).cth;
+    if (!bridge?.modelCatalog) return false;
+    const { catalog } = await bridge.modelCatalog(force);
+    const changed = applyRemoteModelCatalog(catalog);
+    if (changed && typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(MODEL_CATALOG_EVENT));
+    }
+    return changed;
+  } catch {
+    // The baked catalog is already rendering. A failed refresh is not an error
+    // the user has any action for, so it is not one they get told about.
+    return false;
+  }
+}
+
+// Fire once on load. The pickers all call modelsForProvider() during render, so
+// the usual case — main pre-warmed the cache at startup, this resolves in a few
+// ms, no modal is open yet — needs no subscription at all. A catalog that lands
+// while a picker is already open reaches it on that picker's next render.
+if (typeof window !== 'undefined') void refreshModelCatalog();
 
 declare const __APP_VERSION__: string | undefined;
 
@@ -293,8 +343,12 @@ export function modelsForProvider(provider: AgentProvider): ModelOption[] {
   return modelsForProviderAtVersion(provider, runningAppVersion());
 }
 
-/** The Claude presets, for the surfaces that only ever offer Claude models. */
-export const AGENT_MODELS: ModelOption[] = modelsForProvider('claude');
+/** The Claude presets, for the surfaces that only ever offer Claude models.
+ *  A FUNCTION, not a const array: a const would be captured at module load and
+ *  would still be showing the baked list after a remote refresh landed. */
+export function agentModels(): ModelOption[] {
+  return modelsForProvider('claude');
+}
 
 /** Providers shown in the Command Center's cross-provider model picker.
  *  God must remain on a provider with a working inbox drain; otherwise switching

--- a/src/shared/modelCatalogPayload.ts
+++ b/src/shared/modelCatalogPayload.ts
@@ -1,0 +1,154 @@
+/**
+ * The model catalog's shape, and the total parser for the REMOTE copy of it.
+ *
+ * There are two copies of this catalog and they do different jobs:
+ *
+ *   - `src/shared/modelCatalog.json` is compiled INTO the build. It is what the
+ *     pickers show offline, on first launch, and whenever the remote copy is
+ *     missing or unreadable. Shipping a model here still means shipping a build.
+ *   - `docs/model-catalog.json` in this repo is fetched at runtime from
+ *     raw.githubusercontent. Editing that one file on GitHub puts a new model in
+ *     every installed copy of the app within the TTL, with no release.
+ *
+ * The remote copy is DATA, never markup — same contract as the Settings hero
+ * payload (src/shared/heroPayload.ts), for the same reasons:
+ *
+ *   - every field lands in a React `<option>` as a text node, so it is escaped;
+ *   - `id` is spliced into an agent's spawn command line as the `--model` value,
+ *     so it is LENGTH-CAPPED and NEWLINE-FREE. A model id is a slug, and letting
+ *     an unbounded remote string reach a command line is the one genuinely sharp
+ *     edge on this path;
+ *   - a `version` that is not the schema this build understands is REJECTED
+ *     whole, so a future schema change cannot half-apply to an old build;
+ *   - unknown fields are ignored and anything malformed falls back to the baked
+ *     catalog, so a bad edit degrades to "the models this build shipped with"
+ *     rather than to an empty picker.
+ *
+ * `parseModelCatalog` never throws. It returns null for "nothing usable here,
+ * keep what you have", never a partially-built catalog.
+ */
+
+/** One row of the catalog. `minAppVersion` / `maxAppVersion` are INCLUSIVE app
+ *  version bounds; null (or an absent key) means unbounded in that direction.
+ *  See the long note on the filter in src/renderer/src/store/config.ts. */
+export interface CatalogModel {
+  /** absent = use the CLI default (no --model flag) */
+  id?: string;
+  label: string;
+  minAppVersion?: string | null;
+  maxAppVersion?: string | null;
+}
+
+export interface ModelCatalog {
+  version: number;
+  providers: Record<string, CatalogModel[]>;
+}
+
+/** The only schema version this build can read. A remote catalog announcing
+ *  anything else is ignored in full — that is the escape hatch that lets the
+ *  shape change later without breaking every shipped build in the field. */
+export const CATALOG_SCHEMA_VERSION = 1;
+
+const MAX = {
+  /** A model id is a slug or a display name agy echoes back; nothing legitimate
+   *  is anywhere near this long, and it ends up on a command line. */
+  id: 120,
+  label: 60,
+  /** Provider keys are the ids in AGENT_PROVIDER_PRESETS. */
+  key: 40,
+  version: 24,
+  providers: 40,
+  models: 60
+};
+
+/** A single-line, trimmed, capped string — or null if there is nothing usable.
+ *  Control characters are neutralised rather than escaped: an id carrying a
+ *  newline or a NUL would be a command-line splice, and a label carrying one
+ *  would break the option row. Neither has a legitimate reason to contain one. */
+function str(value: unknown, cap: number): string | null {
+  if (typeof value !== 'string') return null;
+  // Control characters are replaced, not stripped, so two words never fuse.
+  const clean = value.replace(/[\u0000-\u001f\u007f]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!clean) return null;
+  return clean.length > cap ? clean.slice(0, cap) : clean;
+}
+
+/** A version bound. Kept as a plain capped string — the comparison in config.ts
+ *  is already total and treats anything unparseable as "no bound". */
+function bound(value: unknown): string | null {
+  return str(value, MAX.version);
+}
+
+/** One catalog row, or null if it cannot be rendered. A row with no label is
+ *  dropped: an option the user cannot read is worse than a missing option. */
+function parseModel(raw: unknown): CatalogModel | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const label = str(o.label, MAX.label);
+  if (!label) return null;
+  const model: CatalogModel = { label };
+  // An absent OR empty id means "pass no --model flag", which is a real option
+  // several providers carry. Only a non-empty string becomes an id.
+  const id = str(o.id, MAX.id);
+  if (id) model.id = id;
+  const min = bound(o.minAppVersion);
+  const max = bound(o.maxAppVersion);
+  if (min) model.minAppVersion = min;
+  if (max) model.maxAppVersion = max;
+  return model;
+}
+
+/** A provider key: the ids the app already knows, or a new one a later release
+ *  will know. Restricted to slug characters so a stray key cannot collide with
+ *  an object prototype member when the map is indexed. */
+function parseKey(key: string): string | null {
+  if (key.length > MAX.key) return null;
+  if (!/^[a-z][a-z0-9_-]*$/i.test(key)) return null;
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') return null;
+  return key;
+}
+
+/**
+ * Turn whatever came off the network into a catalog, or null.
+ *
+ * A provider survives only if its value is an array AND either that array was
+ * empty (a deliberate "offer nothing", which is what `custom` is) or at least
+ * one of its rows parsed. A provider whose rows ALL failed is dropped entirely,
+ * so a mangled entry costs the user that provider's remote list and they fall
+ * back to the models the build shipped with — never an empty picker.
+ */
+export function parseModelCatalog(raw: unknown): ModelCatalog | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const o = raw as Record<string, unknown>;
+  if (o.version !== CATALOG_SCHEMA_VERSION) return null;
+  if (!o.providers || typeof o.providers !== 'object' || Array.isArray(o.providers)) return null;
+
+  const providers: Record<string, CatalogModel[]> = Object.create(null);
+  let kept = 0;
+  for (const [rawKey, rawList] of Object.entries(o.providers as Record<string, unknown>)) {
+    if (kept >= MAX.providers) break;
+    const key = parseKey(rawKey);
+    if (!key || !Array.isArray(rawList)) continue;
+
+    const models: CatalogModel[] = [];
+    // The same id twice would render two identical options and make the picker
+    // look broken. First one wins, as it does in the baked catalog.
+    const seen = new Set<string>();
+    for (const entry of rawList.slice(0, MAX.models)) {
+      const model = parseModel(entry);
+      if (!model) continue;
+      const dedupe = model.id ?? '';
+      if (seen.has(dedupe)) continue;
+      seen.add(dedupe);
+      models.push(model);
+    }
+    if (models.length === 0 && rawList.length > 0) continue;
+    providers[key] = models;
+    kept += 1;
+  }
+
+  if (kept === 0) return null;
+  // Object.create(null) has no prototype, which is the point above, but it also
+  // is not a plain object for structuredClone across the IPC boundary.
+  return { version: CATALOG_SCHEMA_VERSION, providers: { ...providers } };
+}

--- a/test/model-catalog-remote.test.cjs
+++ b/test/model-catalog-remote.test.cjs
@@ -1,0 +1,200 @@
+'use strict';
+
+/**
+ * The REMOTE model catalog: the parser that guards the network payload, and the
+ * overlay that merges it onto the list compiled into the build.
+ *
+ * The failure this file exists to prevent: a bad edit to docs/model-catalog.json
+ * on main reaching every installed copy of the app and emptying a picker — or
+ * worse, putting an attacker-shaped string on an agent's spawn command line. The
+ * parser is total by contract, so every case below asserts the FALLBACK, not an
+ * exception.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+const baked = require('../src/shared/modelCatalog.json');
+
+const { parseModelCatalog, CATALOG_SCHEMA_VERSION } =
+  loadTs('src/shared/modelCatalogPayload.ts');
+const { applyRemoteModelCatalog, modelsForProvider, agentModels } =
+  loadTs('src/renderer/src/store/config.ts');
+
+const ok = (providers) => ({ version: CATALOG_SCHEMA_VERSION, providers });
+
+/** Every test that changes the live catalog must put it back, or the next file
+ *  in the run inherits a catalog that never shipped. */
+test.afterEach(() => applyRemoteModelCatalog(null));
+
+// ─── the parser ─────────────────────────────────────────────────────────────
+
+test('a well-formed catalog parses to exactly what it says', () => {
+  const parsed = parseModelCatalog(ok({
+    claude: [{ id: 'claude-fable-5-1', label: 'Fable 5.1' }],
+    codex: [{ label: 'CLI default' }, { id: 'gpt-6-astra', label: 'GPT-6 Astra' }]
+  }));
+  assert.deepEqual(parsed, {
+    version: 1,
+    providers: {
+      claude: [{ label: 'Fable 5.1', id: 'claude-fable-5-1' }],
+      codex: [{ label: 'CLI default' }, { label: 'GPT-6 Astra', id: 'gpt-6-astra' }]
+    }
+  });
+});
+
+test('the shipped remote file is itself a valid catalog', () => {
+  // docs/model-catalog.json is what actually goes over the wire. If it does not
+  // survive its own parser, every app in the field silently keeps the baked list
+  // and nobody finds out until a model is missing.
+  const remote = require('../docs/model-catalog.json');
+  const parsed = parseModelCatalog(remote);
+  assert.ok(parsed, 'docs/model-catalog.json must parse');
+  assert.deepEqual(
+    Object.keys(parsed.providers).sort(),
+    Object.keys(baked.providers).sort(),
+    'the remote file should cover the same providers as the baked one'
+  );
+});
+
+test('the remote file and the baked file agree on every model', () => {
+  // They are seeded from each other. Drift here means a fresh install shows one
+  // list for a few hours and a different one after the first refresh, which
+  // reads as a bug in the picker rather than as two files out of sync.
+  const remote = require('../docs/model-catalog.json');
+  assert.deepEqual(remote.providers, baked.providers);
+});
+
+test('a version this build does not know is rejected whole', () => {
+  assert.equal(parseModelCatalog({ version: 2, providers: { claude: [{ label: 'X' }] } }), null);
+  assert.equal(parseModelCatalog({ providers: { claude: [{ label: 'X' }] } }), null);
+  assert.equal(parseModelCatalog({ version: '1', providers: { claude: [{ label: 'X' }] } }), null);
+});
+
+test('anything that is not a catalog falls back rather than throwing', () => {
+  for (const junk of [null, undefined, 0, 'catalog', [], [{ label: 'X' }], {},
+    ok(null), ok([]), ok('claude')]) {
+    assert.equal(parseModelCatalog(junk), null, JSON.stringify(junk) ?? String(junk));
+  }
+});
+
+test('a row with no readable label is dropped, not rendered blank', () => {
+  const parsed = parseModelCatalog(ok({
+    claude: [{ id: 'no-label' }, { label: '   ' }, { label: 42 }, { id: 'kept', label: 'Kept' }]
+  }));
+  assert.deepEqual(parsed.providers.claude, [{ label: 'Kept', id: 'kept' }]);
+});
+
+test('an id is never allowed to carry a newline onto a command line', () => {
+  // The id is spliced in as the --model value. A newline or a NUL is the one
+  // input on this path with teeth, so it is neutralised rather than passed on.
+  const parsed = parseModelCatalog(ok({
+    claude: [{ id: 'gpt-6-astra\n--dangerously-skip-permissions', label: 'Nice\u0000 model' }]
+  }));
+  const [model] = parsed.providers.claude;
+  assert.ok(!/[\u0000-\u001f\u007f]/.test(model.id), model.id);
+  assert.ok(!/[\u0000-\u001f\u007f]/.test(model.label), model.label);
+  assert.equal(model.id, 'gpt-6-astra --dangerously-skip-permissions');
+});
+
+test('ids and labels are length-capped', () => {
+  const parsed = parseModelCatalog(ok({
+    claude: [{ id: 'x'.repeat(500), label: 'y'.repeat(500) }]
+  }));
+  const [model] = parsed.providers.claude;
+  assert.equal(model.id.length, 120);
+  assert.equal(model.label.length, 60);
+});
+
+test('an empty id means "pass no --model flag", the same as no id at all', () => {
+  const parsed = parseModelCatalog(ok({ codex: [{ id: '', label: 'CLI default' }] }));
+  assert.deepEqual(parsed.providers.codex, [{ label: 'CLI default' }]);
+});
+
+test('a duplicated id renders once', () => {
+  const parsed = parseModelCatalog(ok({
+    claude: [{ id: 'a', label: 'First' }, { id: 'a', label: 'Second' }, { label: 'No id' }]
+  }));
+  assert.deepEqual(parsed.providers.claude.map((m) => m.label), ['First', 'No id']);
+});
+
+test('a provider whose rows all fail is dropped, an empty one is honoured', () => {
+  const parsed = parseModelCatalog(ok({
+    claude: [{ nope: true }, 'not an object'],   // all rows fail → drop the key
+    custom: [],                                  // deliberately offers nothing
+    grok: [{ id: 'grok-4.6', label: 'Grok 4.6' }]
+  }));
+  assert.deepEqual(Object.keys(parsed.providers).sort(), ['custom', 'grok']);
+  assert.deepEqual(parsed.providers.custom, []);
+});
+
+test('a provider key that is not a slug never reaches the map', () => {
+  const parsed = parseModelCatalog(ok({
+    '__proto__': [{ id: 'x', label: 'X' }],
+    'has space': [{ id: 'x', label: 'X' }],
+    '9lives': [{ id: 'x', label: 'X' }],
+    claude: [{ id: 'x', label: 'X' }]
+  }));
+  assert.deepEqual(Object.keys(parsed.providers), ['claude']);
+  assert.equal(Object.prototype.hasOwnProperty.call({}, 'polluted'), false);
+});
+
+test('version bounds survive the parse', () => {
+  const parsed = parseModelCatalog(ok({
+    claude: [{ id: 'x', label: 'X', minAppVersion: '0.4.7', maxAppVersion: null }]
+  }));
+  assert.deepEqual(parsed.providers.claude, [{ label: 'X', id: 'x', minAppVersion: '0.4.7' }]);
+});
+
+// ─── the overlay ────────────────────────────────────────────────────────────
+
+test('a remote provider replaces that list; the others keep the baked one', () => {
+  const before = modelsForProvider('codex');
+  assert.ok(applyRemoteModelCatalog(parseModelCatalog(ok({
+    claude: [{ id: 'claude-next-9', label: 'Next 9' }]
+  }))));
+  assert.deepEqual(modelsForProvider('claude'), [{ id: 'claude-next-9', label: 'Next 9' }]);
+  assert.deepEqual(modelsForProvider('codex'), before, 'codex was not in the remote copy');
+});
+
+test('the Claude-only surfaces read the overlay, not a snapshot', () => {
+  // agentModels() is a function precisely because a const array would have been
+  // captured at module load and would still be showing the baked list here.
+  applyRemoteModelCatalog(parseModelCatalog(ok({
+    claude: [{ id: 'claude-next-9', label: 'Next 9' }]
+  })));
+  assert.deepEqual(agentModels(), [{ id: 'claude-next-9', label: 'Next 9' }]);
+});
+
+test('clearing the overlay restores the models the build shipped with', () => {
+  applyRemoteModelCatalog(parseModelCatalog(ok({ claude: [{ id: 'x', label: 'X' }] })));
+  assert.equal(applyRemoteModelCatalog(null), true);
+  assert.deepEqual(
+    modelsForProvider('claude').map((m) => m.id),
+    baked.providers.claude.map((m) => m.id)
+  );
+});
+
+test('applying the same catalog twice reports no change', () => {
+  const remote = parseModelCatalog(ok({ claude: [{ id: 'x', label: 'X' }] }));
+  assert.equal(applyRemoteModelCatalog(remote), true);
+  assert.equal(applyRemoteModelCatalog(remote), false, 'no pointless re-render event');
+});
+
+test('the version filter still runs over remote entries', () => {
+  applyRemoteModelCatalog(parseModelCatalog(ok({
+    claude: [
+      { id: 'always', label: 'Always' },
+      { id: 'later', label: 'Later', minAppVersion: '99.0.0' }
+    ]
+  })));
+  // No __APP_VERSION__ define outside a build, so the filter fails open and
+  // offers both — the deliberate "never hide every model" behaviour.
+  assert.deepEqual(modelsForProvider('claude').map((m) => m.id), ['always', 'later']);
+  globalThis.__APP_VERSION__ = '0.4.6';
+  try {
+    assert.deepEqual(modelsForProvider('claude').map((m) => m.id), ['always']);
+  } finally {
+    delete globalThis.__APP_VERSION__;
+  }
+});

--- a/test/model-catalog.test.cjs
+++ b/test/model-catalog.test.cjs
@@ -12,13 +12,20 @@ const {
   runningAppVersion
 } = loadTs('src/renderer/src/store/config.ts');
 
-/** Every model the pickers offered while the lists were hardcoded TypeScript
- *  arrays, as `[id, label]` pairs — the providers whose full list no other test
- *  pins (provider-config.test.cjs pins codex/grok/kimi/gemini/custom). Moving
- *  the lists into JSON must not change one byte of what a user sees, and these
- *  literals are the only record of what shipped before the move. */
+/** Exactly what each picker offers, as `[id, label]` pairs — the providers
+ *  whose full list no other test pins (provider-config.test.cjs pins
+ *  codex/grok/kimi/gemini/custom).
+ *
+ *  This started as the record of what the hardcoded TypeScript arrays offered
+ *  before they moved into JSON, and it keeps that job: the ids here are the
+ *  exact `--model` values the CLIs are invoked with, so a typo in the catalog is
+ *  a model that silently fails to spawn. Adding a model means adding it here
+ *  too, ON PURPOSE — that is the point of the list, not friction to route
+ *  around. It pins the BAKED catalog; the remote overlay is tested separately in
+ *  model-catalog-remote.test.cjs. */
 const SHIPPED = {
   claude: [
+    ["claude-fable-5-1", "Fable 5.1"],
     ["claude-fable-5", "Fable 5"],
     ["claude-opus-5", "Opus 5 · 1M"],
     ["claude-opus-4-8", "Opus 4.8"],
@@ -32,6 +39,9 @@ const SHIPPED = {
     [undefined, "CLI default"],
     ["Gemini 3.1 Pro (High)", "Gemini 3.1 Pro · High"],
     ["Gemini 3.1 Pro (Low)", "Gemini 3.1 Pro · Low"],
+    ["Gemini 3.7 Flash (High)", "Gemini 3.7 Flash · High"],
+    ["Gemini 3.7 Flash (Medium)", "Gemini 3.7 Flash · Med"],
+    ["Gemini 3.7 Flash (Low)", "Gemini 3.7 Flash · Low"],
     ["Gemini 3.5 Flash (High)", "Gemini 3.5 Flash · High"],
     ["Gemini 3.5 Flash (Medium)", "Gemini 3.5 Flash · Med"],
     ["Gemini 3.5 Flash (Low)", "Gemini 3.5 Flash · Low"],
@@ -88,6 +98,8 @@ const SHIPPED = {
     ["gpt-5.6-luna-high", "GPT-5.6 Luna 1M High (cheap)"],
     ["gpt-5.6-sol-medium", "GPT-5.6 Sol 1M"],
     ["gpt-5.6-sol-high", "GPT-5.6 Sol 1M High"],
+    ["gemini-3.7-flash-high", "Gemini 3.7 Flash"],
+    ["claude-fable-5-1-thinking-high", "Fable 5.1 1M Thinking (no ZDR)"],
     ["composer-2.5", "Composer 2.5"],
     ["composer-2.5-fast", "Composer 2.5 Fast"],
     ["gpt-5.2", "GPT-5.2"],
@@ -115,7 +127,7 @@ const BOUNDED = {
 
 const ids = (models) => models.map((model) => model.id);
 
-test('the pickers offer exactly the models that shipped before the catalog', () => {
+test('the pickers offer exactly the models the catalog names', () => {
   for (const [provider, expected] of Object.entries(SHIPPED)) {
     assert.deepEqual(
       modelsForProvider(provider).map((model) => [model.id, model.label]),

--- a/test/provider-config.test.cjs
+++ b/test/provider-config.test.cjs
@@ -87,7 +87,7 @@ test('model picker options stay provider-specific', () => {
   );
   assert.deepEqual(
     modelsForProvider('codex').map((model) => model.id),
-    [undefined, 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']
+    [undefined, 'gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']
   );
   assert.deepEqual(
     modelsForProvider('grok').map((model) => model.id),


### PR DESCRIPTION
Adding a model meant editing renderer source, type-checking it and cutting a release. It is now **one line in [`docs/model-catalog.json`](docs/model-catalog.json) on `main`**: the pickers fetch that file at runtime.

**When it actually lands, precisely.** There is no timer. The check runs once at startup (a prewarm in `app.whenReady()` plus one call when the renderer loads), so a new model appears on the next app launch whose cached copy is older than six hours. An app left open does not change under the user.

**This does not reach anyone already on 0.4.6.** The reader is *in this PR*; a build that predates it cannot fetch a file it does not know about. The three models below arrive the normal way, in the release that carries this change. The mechanism pays off from the model after them.

## The mechanism is the one the hero card already uses

Not a new one. `src/main/hero.ts` already fetches `docs/hero.json` from raw.githubusercontent through `src/main/fetchText.ts`, validates the shape in a total parser, and caches under userData behind a six hour TTL. Applied here:

| File | What it does |
|---|---|
| `src/shared/modelCatalogPayload.ts` | Catalog types (lifted out of the renderer so main validates against the same shape) + `parseModelCatalog`, which never throws and returns `null` for "keep what you have" |
| `src/main/modelCatalog.ts` | Fetch, cache, and **re-validate the cache on read**. The cache is a file a previous build wrote; a schema bump or a hand edit must not reach a picker unchecked just because it once passed |
| `src/main/index.ts` | IPC `models:catalog`, plus a prewarm in `app.whenReady()` so the cache is fresh before any modal opens |
| `src/preload/index.ts` | The bridge |
| `docs/model-catalog.json` | The file you actually edit |

**The baked catalog stays the floor.** It renders offline, on first launch, and whenever the remote copy is missing, unreadable, or announces a schema version this build does not know. The merge is **per provider**: a provider the remote copy names replaces that list, one it omits keeps the built-in list. A bad edit costs a list, never a picker.

**The payload is data, never markup.** Every field lands in an `<option>` as an escaped text node, and a model id is length-capped and stripped of control characters before it can reach a `--model` flag on a spawn command line. That is the one genuinely sharp edge on this path, and it has a test.

`AGENT_MODELS` becomes `agentModels()`. A const array is captured at module load and would still be showing the baked list after a refresh landed.

## The three new models

Every id was read off the CLI that will be invoked with it, not inferred from a name.

| Model | Provider | id | Source |
|---|---|---|---|
| Fable 5.1 | claude | `claude-fable-5-1` | present in the installed `claude` binary. No `[1m]` variant exists |
| GPT-6 Astra | codex | `gpt-6-astra` | `codex-rs/models-manager/models.json` at `rust-v0.153.2` |
| Gemini 3.7 Flash | antigravity | `Gemini 3.7 Flash (High/Medium/Low)` | `agy models` |
| both | cursor | `gemini-3.7-flash-high`, `claude-fable-5-1-thinking-high` | `cursor-agent models` |

### Two things a reviewer should know

1. **GPT Astra is GPT-6 Astra**, released 3 September 2026, and codex only learned the slug in **0.153.1**. An older codex will reject it. The catalog's `minAppVersion` / `maxAppVersion` bound the *app* version, not the CLI version, so this cannot be expressed as a bound. The command field stays editable and the CLI reports the bad slug, which is the documented degradation.
2. **`agy models` now prints `slug<TAB>label`.** The catalog uses agy's display label as the id, which is the existing verified convention, but if that form ever stops being accepted it breaks every antigravity entry, not only the new ones. Worth a follow-up check.

## Testing

- `test/model-catalog-remote.test.cjs`, 18 tests: junk payloads, an unknown schema version, prototype pollution through a provider key, the command-line splice, the length caps, dedupe, and every fallback path.
- The `SHIPPED` literals in `test/model-catalog.test.cjs` and the codex ids in `test/provider-config.test.cjs` are updated **on purpose**. They pin the exact `--model` values the CLIs are invoked with, so a typo there is a model that silently fails to spawn. Adding a model means adding it there too.
- `npm run typecheck` clean, full `node --test test/*.test.cjs` exit 0 on this branch.

## How to add a model after this lands

Add one line to the right provider array in `docs/model-catalog.json`, push to `main`, done:

```json
{ "id": "<the exact --model value>", "label": "<what the picker shows>" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKx1g6LQ6Mmzto5BRY8zLT

