### PR TITLE
fix(breaker): count work in the agent's own directory as progress

### DIFF
--- a/src/main/breaker.ts
+++ b/src/main/breaker.ts
@@ -13,7 +13,8 @@
  *   (a) Oscar's usage samples via UsageProvider [Seam 1] — for cost + token velocity;
  *   (b) hook events (repeated identical tool calls, api_error storms) — fed in by
  *       HookServer through recordToolUse/recordError;
- *   (c) file-mtime no-progress — passed per-agent by the beat as `progressing`.
+ *   (c) file-mtime no-progress — passed per-agent by the beat as `progressing`
+ *       (coordination files) and `lastWorkAt` (the agent's own workspace).
  *
  * Velocity is the DIFF of consecutive cumulative samples (Δoutput/Δt), never a
  * single sample treated as an increment.
@@ -54,6 +55,13 @@ export interface BreakerInput {
   sample: AgentUsageSample | null;
   /** Did the agent make coordination progress recently (file-mtime signal)? */
   progressing: boolean;
+  /** When the agent's own WORKING DIRECTORY last changed, or omitted when the
+   *  caller cannot tell. Coordination and work are different things: an agent
+   *  can spend twenty minutes editing files, running a build and committing
+   *  without touching a single hive message, and `progressing` answers only
+   *  the first question. Optional, so a caller with no workspace notion for an
+   *  agent omits it and nothing about that agent changes. */
+  lastWorkAt?: number;
 }
 
 const LEVELS: BreakerLevel[] = ['healthy', 'steering', 'constrained', 'stopped'];
@@ -332,7 +340,17 @@ export class CircuitBreaker {
         // arms above still backstop). Debounced: fires only after
         // NO_PROGRESS_BEATS consecutive beats, so a one-beat blip never steers.
         const toolActive = nowMs - s.lastDistinctToolAt < PROGRESS_TOOL_WINDOW_MS;
-        if (!input.progressing && !toolActive) {
+        // A recently-changed working directory is progress too. The question
+        // this arm asks is "is this agent doing anything"; until now it asked
+        // "is this agent COORDINATING". The paths behind `progressing` are the
+        // inbox, the outbox and memory.md - every one of them messaging or
+        // memory, none of them where work lands. An agent that edits, builds
+        // and commits touches none of them and reads as wedged. Same window as
+        // the tool clock, because it answers the same question over the same
+        // span of time.
+        const workActive = typeof input.lastWorkAt === 'number' && input.lastWorkAt > 0
+          && nowMs - input.lastWorkAt < PROGRESS_TOOL_WINDOW_MS;
+        if (!input.progressing && !toolActive && !workActive) {
           s.noProgressBeats += 1;
           if (s.noProgressBeats >= NO_PROGRESS_BEATS) {
             return { tripping: true, reason: 'no-progress: generating tokens without coordinating (stale log/files)' };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1033,6 +1033,47 @@ function lastCoordinationAt(agentId: string): number {
   return Math.max(...times);
 }
 
+/** Newest mtime of the agent's OWN WORKING DIRECTORY — the work
+ *  `lastCoordinationAt` cannot see. 0 when there is nothing to read.
+ *
+ *  Provider neutral by construction: `cwd` is the agent's registry entry, the
+ *  same field every supported CLI is spawned into, and none of the paths below
+ *  is specific to any one of them. An agent whose `cwd` is not a git checkout
+ *  simply falls back to the directory's own mtime; an agent with no `cwd` at
+ *  all returns 0 and behaves exactly as it does today.
+ *
+ *  Cheap by construction: a handful of `stat` calls on fixed paths, never a
+ *  directory walk. This runs for every agent on every beat, and a working
+ *  directory can hold hundreds of thousands of files. Git is what makes it
+ *  affordable — each of these is rewritten by ordinary work:
+ *
+ *    cwd                  a file or directory added or removed at the top level
+ *    .git/index           any `git add`, `git status`, `git checkout`
+ *    .git/logs/HEAD       the reflog: commit, checkout, reset, merge, rebase
+ *    .git/FETCH_HEAD      fetch and pull
+ *    .git/packed-refs     and `.git/refs/remotes`: a push updating a tracking ref
+ *
+ *  Its honest limit: editing a file deep in the tree while running no git
+ *  command moves none of these. That case is already covered by the breaker's
+ *  own distinct-tool clock, so the two signals are complementary rather than
+ *  redundant — this one exists for the window where tool events do not reach
+ *  the breaker but the work is unmistakably real.
+ */
+function lastWorkAt(agentId: string): number {
+  const cwd = hive.registry().agents[agentId]?.cwd;
+  if (!cwd) return 0;
+  const times: number[] = [0];
+  const pushMtime = (p: string): void => { try { times.push(statSync(p).mtimeMs); } catch { /* missing */ } };
+  pushMtime(cwd);
+  const git = join(cwd, '.git');
+  pushMtime(join(git, 'index'));
+  pushMtime(join(git, 'logs', 'HEAD'));
+  pushMtime(join(git, 'FETCH_HEAD'));
+  pushMtime(join(git, 'refs', 'remotes'));
+  pushMtime(join(git, 'packed-refs'));
+  return Math.max(...times);
+}
+
 /** PTY id owning a given agent id, or undefined. */
 function ptyForAgent(agentId: string): string | undefined {
   for (const [ptyId, a] of ptyToAgent) if (a === agentId) return ptyId;
@@ -1173,7 +1214,10 @@ function runBreakerBeat(progressWindowMs: number): void {
     inputs.push({
       agentId: id,
       sample,
-      progressing: now - lastCoordinationAt(id) < progressWindowMs || now - lastSpanAt < progressWindowMs
+      progressing: now - lastCoordinationAt(id) < progressWindowMs || now - lastSpanAt < progressWindowMs,
+      // Work, as distinct from coordination. The breaker decides what to do
+      // with it; the beat only reports it.
+      lastWorkAt: lastWorkAt(id)
     });
   }
   for (const d of breaker.tick(inputs, now)) {

--- a/test/breaker.test.cjs
+++ b/test/breaker.test.cjs
@@ -54,8 +54,8 @@ const T0 = 1_000_000_000_000; // fixed epoch base so tests are deterministic
 const BEAT = 30_000;
 
 /** Run one beat for a single agent; returns its decision. */
-function beat(b, id, s, progressing, now) {
-  return b.tick([{ agentId: id, sample: s, progressing }], now)[0];
+function beat(b, id, s, progressing, now, lastWorkAt) {
+  return b.tick([{ agentId: id, sample: s, progressing, lastWorkAt }], now)[0];
 }
 
 // ── regression: pre-existing trips still fire ────────────────────────────────
@@ -176,6 +176,46 @@ test('recent distinct tool calls exempt the no-progress trip', () => {
   b.recordToolUse('a', 'Read', { file: 'y' }, T0 + 2 * BEAT - 1000);
   const d = beat(b, 'a', sample('a', T0 + 2 * BEAT, 9000), false, T0 + 2 * BEAT);
   assert.equal(d.state.level, 'healthy', `reason: ${d.state.reason}`);
+});
+
+// -- fix 4: the agent's own working directory counts as progress ------------
+//
+// `progressing` is computed from coordination files only - inbox, outbox and
+// memory.md. An agent editing, building and committing touches none of them,
+// so a working agent read as wedged. These three pin the whole behaviour: it
+// counts, staleness still trips, and a caller that reports nothing is
+// unaffected.
+
+test('a recently changed working directory counts as progress', () => {
+  const b = makeBreaker();
+  // No coordination, no tool events - only the workspace moving. This is the
+  // shape that misfired: real work, invisible to every signal the arm had.
+  beat(b, 'a', sample('a', T0, 0), false, T0, T0 - 1000);
+  beat(b, 'a', sample('a', T0 + BEAT, 5000), false, T0 + BEAT, T0 + BEAT - 1000);
+  const d = beat(b, 'a', sample('a', T0 + 2 * BEAT, 9000), false, T0 + 2 * BEAT, T0 + 2 * BEAT - 1000);
+  assert.equal(d.state.level, 'healthy', `reason: ${d.state.reason}`);
+});
+
+test('a STALE working directory still trips the no-progress arm', () => {
+  const b = makeBreaker();
+  const stale = T0 - 10 * 60_000; // older than PROGRESS_TOOL_WINDOW_MS
+  beat(b, 'a', sample('a', T0, 0), false, T0, stale);
+  beat(b, 'a', sample('a', T0 + BEAT, 5000), false, T0 + BEAT, stale);
+  const d = beat(b, 'a', sample('a', T0 + 2 * BEAT, 9000), false, T0 + 2 * BEAT, stale);
+  assert.equal(d.state.level, 'steering', `reason: ${d.state.reason}`);
+  assert.match(d.state.reason, /no-progress/);
+});
+
+test('an ABSENT lastWorkAt behaves exactly as before', () => {
+  const b = makeBreaker();
+  // A caller with no workspace notion for this agent omits the field entirely.
+  // Nothing about that agent may change, or the fix would alter behaviour for
+  // every provider that reports nothing.
+  beat(b, 'a', sample('a', T0, 0), false, T0);
+  beat(b, 'a', sample('a', T0 + BEAT, 5000), false, T0 + BEAT);
+  const d = beat(b, 'a', sample('a', T0 + 2 * BEAT, 9000), false, T0 + 2 * BEAT);
+  assert.equal(d.state.level, 'steering', `reason: ${d.state.reason}`);
+  assert.match(d.state.reason, /no-progress/);
 });
 
 test('REPEATED identical tool calls do not count as progress', () => {


### PR DESCRIPTION
## What & why

The no-progress arm asks "is this agent doing anything", but the signal it reads answers "is this agent **coordinating**". `lastCoordinationAt` takes the newest mtime of five paths — `inbox`, `inbox/.done`, `outbox`, `outbox/.sent`, `memory.md` — every one of them messaging or memory, and none of them where work lands. An agent that spends twenty minutes editing files, running a build and committing touches none of them, so a working agent reads as wedged and gets steered.

`BreakerInput` gains an optional `lastWorkAt`, which the no-progress arm treats exactly as it already treats the existing distinct-tool clock, over the same window. The beat supplies it from the agent's registry `cwd` plus a few git paths beneath it: six `stat` calls on fixed paths, never a directory walk, because this runs for every agent on every beat and a working directory can hold hundreds of thousands of files.

**Two source files for one change, and it is deliberate.** `lastCoordinationAt` lives in `index.ts`, but `test/breaker.test.cjs` transpiles `breaker.ts` standalone — so a fix written entirely in `index.ts` could not be proven by the existing seam. The *decision* is therefore in `breaker.ts` (testable) and the *collection* in `index.ts`, about twenty lines. That is the minimum shape in which the change can be demonstrated, not a second change riding along.

**Provider neutral by construction.** `cwd` is the field every supported CLI is spawned into; there is no provider check anywhere in the diff. An agent with no `cwd` returns 0 and behaves exactly as it does today, and one whose `cwd` is not a git checkout falls back to the directory's own mtime. A guard below pins that.

Refs #441 — this fixes one of the three defects described there and deliberately leaves the other two alone. They are separate changes and belong in separate pull requests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

No UI. The observable behaviour is the trip itself, so the evidence is the guard failing with the production reason string and then passing — the same three tests in both runs, only the fix differing.

### Before

The three new guards run against `breaker.ts` **without** the fix. The first fails with the reason the arm actually emits. Complete output of the run, 18 ok and 1 FAIL, exit 1:

<img width="1124" height="866" alt="BEFORE" src="https://github.com/user-attachments/assets/b2cb0316-09be-4408-982d-656521318ece" />

```
$ git checkout origin/main -- src/main/breaker.ts   # revert the fix, keep the new guards
$ node test/breaker.test.cjs

  ok  repeated identical tool calls trip the loop arm
  ok  error storm trips
  ok  token velocity spike trips on the second sample
  ok  no-progress does NOT trip on a single beat (debounce)
  ok  sustained no-progress still trips (second consecutive beat)
  ok  a progressing beat resets the no-progress debounce
  ok  compaction exempts the no-progress trip
  ok  compaction exempts the velocity trip
  ok  trips resume after compaction end + trailing grace
  ok  compaction safety cap: exemption expires even without PostCompact
  ok  recordCompactEnd without a compaction in flight is a no-op
  ok  recent distinct tool calls exempt the no-progress trip
FAIL  a recently changed working directory counts as progress
      reason: no-progress: generating tokens without coordinating (stale log/files)
  ok  a STALE working directory still trips the no-progress arm
  ok  an ABSENT lastWorkAt behaves exactly as before
  ok  REPEATED identical tool calls do not count as progress
  ok  huge identical Write inputs still register as repeats (loop arm)
  ok  huge inputs differing early still count as distinct calls
  ok  a healthy beat de-escalates one level

exit=1
```

### After

The same file and the same guards with the fix applied. Complete output, 19 ok and 0 FAIL, exit 0:

<img width="908" height="806" alt="AFTER" src="https://github.com/user-attachments/assets/14de2a35-58ea-4c65-9d0c-f252faf7e65d" />

```
$ node test/breaker.test.cjs

  ok  repeated identical tool calls trip the loop arm
  ok  error storm trips
  ok  token velocity spike trips on the second sample
  ok  no-progress does NOT trip on a single beat (debounce)
  ok  sustained no-progress still trips (second consecutive beat)
  ok  a progressing beat resets the no-progress debounce
  ok  compaction exempts the no-progress trip
  ok  compaction exempts the velocity trip
  ok  trips resume after compaction end + trailing grace
  ok  compaction safety cap: exemption expires even without PostCompact
  ok  recordCompactEnd without a compaction in flight is a no-op
  ok  recent distinct tool calls exempt the no-progress trip
  ok  a recently changed working directory counts as progress
  ok  a STALE working directory still trips the no-progress arm
  ok  an ABSENT lastWorkAt behaves exactly as before
  ok  REPEATED identical tool calls do not count as progress
  ok  huge identical Write inputs still register as repeats (loop arm)
  ok  huge inputs differing early still count as distinct calls
  ok  a healthy beat de-escalates one level

exit=0
```

The two guards that pass in **both** runs are the point: they assert *unchanged* behaviour, so a green there before and after is what shows the signal discriminates rather than merely moves. `an ABSENT lastWorkAt behaves exactly as before` is the provider-neutrality guard.

## How I tested it

- **OS:** Windows 11, Node 24. **The checkout lives under a path containing a space**, which `CONTRIBUTING.md` names as a shipped-bug source — typecheck, build and the full suite all ran from there. `path.join` throughout the change, no hand-built separators.
- **Steps:**
  1. `node test/breaker.test.cjs` with the fix reverted and the new guards present, giving the failure above.
  2. Restored the fix, `node test/breaker.test.cjs`, 19 ok and 0 FAIL.
  3. `npm run typecheck`, green, both the node and web projects.
  4. `npm run build`, green.
  5. `npm run test:focused`, **two failures, both pre-existing and unrelated to this change**: `quit-sweep.electron.test.cjs` and `update-download-asset.test.cjs`. I confirmed that rather than assuming it — stashed the three files, re-ran on a clean tree, got the same two. One of them is itself a path-with-a-space mismatch on this machine. Flagging it rather than ticking the box.

## Review notes

Running an agent over my own diff, as `CONTRIBUTING.md` asks, including what it flagged that I chose to leave:

1. **`.git/refs/remotes` is a directory**, so its mtime moves when a ref file is created or removed, not when an existing one is updated in place. A push to an already-tracked branch may not move it. `logs/HEAD` and `index` cover the commit and the staging that precede any push, so the signal still fires — but the path list is less complete than it looks, and the code says so rather than implying otherwise.
2. **Six `stat` calls per agent per beat.** Trivial on a local disk; six round trips on a network or virtualised filesystem. I accepted that against the alternative, a recursive newest-file scan, which is far worse in exactly that environment.
3. **A deep file edit with no git command moves none of these paths.** A real limit, stated in the comment. The existing distinct-tool clock already covers that case, which is why the two signals are complementary rather than redundant.
4. **No new trust boundary:** the change reads mtimes only, of paths beneath a `cwd` the app already spawns processes into. No writes, no user input, no new surface.

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes — two pre-existing failures, unrelated; see "How I tested it".
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — there is no new UI.
- [x] If I added art, it's my own or compatibly licensed — no art.

