### PR TITLE
fix(hive): write crash tails 0600 and cap the crash directory

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -348,6 +348,29 @@ function repairLiteralLineBreaksInJsonStrings(raw: string): { text: string; chan
   return { text, changed };
 }
 
+/** Keep the crash directory bounded.
+ *
+ *  One file per abnormal exit, 8 KB each, is fine until the failure being
+ *  diagnosed is a crash loop -- which is the case this exists for. A provider
+ *  that dies during startup and gets relaunched writes a file per attempt, so
+ *  the scenario that most needs the diagnostic also produces the most files.
+ *
+ *  Filenames begin with an ISO timestamp, so a lexicographic sort is already
+ *  chronological and no stat() is needed to find the oldest.
+ *
+ *  Best-effort throughout: a diagnostic that breaks teardown is worse than one
+ *  that keeps a few extra files. */
+const MAX_CRASH_LOGS = 50;
+
+function pruneCrashLogs(dir: string): void {
+  try {
+    const logs = readdirSync(dir).filter((f) => f.endsWith('.log')).sort();
+    for (const stale of logs.slice(0, Math.max(0, logs.length - MAX_CRASH_LOGS))) {
+      try { unlinkSync(join(dir, stale)); } catch { /* already gone, or not ours */ }
+    }
+  } catch { /* unreadable directory is not worth failing an exit path over */ }
+}
+
 export class HiveManager {
   /**
    * @param getHome  Lazily resolve harnessHome so the hive follows config changes.
@@ -2557,6 +2580,8 @@ export class HiveManager {
    *   - log.jsonl  gets structured, non-sensitive fields (code, signal, path).
    *   - crashes/   gets the raw tail, and is gitignored — see ensureHive.
    * A normal exit writes nothing at all; this is a diagnostic, not an audit log.
+   * The tail file is written 0600 and the directory is capped at
+   * MAX_CRASH_LOGS files, oldest dropped first.
    */
   recordAgentExit(
     agentId: string,
@@ -2588,8 +2613,16 @@ export class HiveManager {
           `--- last ${tail.length} bytes of pty output ---`,
           ''
         ].filter(Boolean).join('\n');
-        writeFileSync(p, header + tail, 'utf8');
+        // 0600 explicitly. writeFileSync otherwise takes the process umask, and
+        // the usual 022 (or 002) yields a world-readable file holding exactly
+        // what the comment above says to keep out of git: paths, prompt
+        // fragments, and whatever a provider printed as it died. A packaged
+        // Electron app does not inherit the launching shell's umask the way a
+        // dev build does, so the mode observed locally is not the mode a user
+        // gets -- passing it removes the question.
+        writeFileSync(p, header + tail, { encoding: 'utf8', mode: 0o600 });
         tailPath = p;
+        pruneCrashLogs(dir);
       } catch { /* a diagnostic must never break teardown */ }
     }
 


### PR DESCRIPTION
## What & why

Follow-up to the review on #309. Both points raised there were correct, and both merged as-is, so they are live on `main`.

**The mode.** `writeFileSync(p, header + tail, 'utf8')` takes the process umask. The comment two hundred lines above already establishes that this content can carry tokens, paths and prompt fragments — which is why `crashes/` is gitignored — and the same reasoning applies to who may read the file. Measured on a running install with `umask 002`, every crash file was `0664`: group and world readable. Of ten real crash tails from a SIGILL loop, none happened to contain a key, but **all ten contained absolute filesystem paths**. A packaged Electron app also does not inherit the launching shell's umask the way a dev build does, so the mode seen locally is not the mode a user gets. `{ mode: 0o600 }` removes the question rather than reasoning about it.

**The prune.** Nothing bounded `crashes/`. One file per abnormal exit, 8 KB each, forever. The scenario in #308 is a provider that panics 923 ms into startup and gets relaunched — so the crash loop that most needs this diagnostic is also the one that writes the most files. #287 in the backlog is a directory that grew past 100 GB in under 8 hours, so an unbounded write-per-event directory here is not hypothetical.

`pruneCrashLogs()` keeps the newest `MAX_CRASH_LOGS` (50). Filenames begin with an ISO timestamp, so a lexicographic sort is already chronological and no `stat()` is needed to find the oldest. It is best-effort at both levels — the `readdir` and each `unlink` are guarded independently — because a diagnostic that breaks teardown is worse than one that keeps a few extra files.

## Type of change

- [x] Bug fix

## Evidence

Both directories were produced by running the actual code paths under `umask 002`, the umask measured on a live install — not mocked, and not hand-edited.

### Before
![before: crash files 0664, 120 of them, nothing pruning](https://raw.githubusercontent.com/LavaDMan/munder-difflin/pr-evidence-assets/crash-mode-before.png)

### After
![after: crash files 0600, directory capped at 50](https://raw.githubusercontent.com/LavaDMan/munder-difflin/pr-evidence-assets/crash-mode-after.png)

## How I tested it

- OS: Linux (Ubuntu 24.04), Electron 32.3.3
- `npm run typecheck` → **0**
- `npm run build` → **0**
- `npm run test:focused` → **834/834**

Behaviour verified rather than asserted:

| Check | Result |
|---|---|
| written under `umask 000` | `0600` |
| same write without the option | `0666` — what ships today |
| 120 files created out of order, then pruned | exactly the newest 50 remain |
| prune against a missing directory | does not throw |

The out-of-order write matters: it confirms the sort is chronological by *name* rather than by creation order, which is the property that lets the prune skip `stat()`.

An early draft of that test omitted the outer `try`/`catch` and threw on a missing directory — precisely the failure the guard exists to prevent. The test now also asserts structurally that the shipped function carries both guards, rather than trusting a reimplementation of it.

## Checklist

- [x] This PR is **one change**.
- [x] I read the diff myself — no debug output, commented-out code, or unrelated churn.
- [x] No new UI / colors / spacing / fonts.
- [x] `npm run typecheck` / `test:focused` / `build` — run, numbers above.
