### PR TITLE
Recover from renderer death instead of freezing forever

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { join, resolve, sep, basename, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { request as httpsRequest } from 'node:https';
 import { PtyManager, type SpawnOptions } from './pty';
+import { installWindowHealth, installProcessHealth, logQuitPromptDecision } from './rendererHealth';
 import { resolveCommand as resolveCliCommand, isSafeCommandName } from './shellEnv';
 import { initAutoUpdater, abortPendingRestart } from './updater';
 import { RealtimeFloorWatcher } from './realtimeFloorWatcher';
@@ -2319,6 +2320,18 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   // reference stays valid as the per-PTY ownership key.
   const wc = win.webContents;
 
+  // Renderer liveness. Installed BEFORE the first load so a crash during load
+  // is caught too. A dead renderer used to leave this window mapped and frozen
+  // forever, with the compositor's "Terminate" — which kills the whole agent
+  // tree — as the user's only way out. See rendererHealth.ts.
+  installWindowHealth(win, {
+    label: isFloor ? 'floor' : 'primary',
+    // A reload keeps the same webContents object, so PTY ownership and the
+    // default sink stay valid; re-assert the sink anyway so the primary's
+    // routing survives even if that ever stops being true.
+    onReloaded: (next) => { if (!isFloor) ptyManager.attachWebContents(next); }
+  });
+
   allWindows.add(win);
   // Global timer events follow the user — the most-recently-focused window is
   // primary. The primary is also seeded synchronously so boot events route now.
@@ -2409,6 +2422,9 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
     // Primary window: existing app-wide quit warning (renderer modal).
     const count = ptyManager.list().length;
     if (count === 0) return;
+    // Same wedge as before-quit: with no renderer to draw the warning, cancelling
+    // the close leaves a window that can never be closed. Let it go instead.
+    if (!logQuitPromptDecision(win, 'window-close')) return;
     e.preventDefault();
     win.focus();
     wc.send('app:closeRequested', { ptyCount: count });
@@ -5269,6 +5285,11 @@ function onSystemResume(reason: string): void {
 }
 
 app.whenReady().then(() => {
+  // GPU/utility deaths are recorded, not acted on: Chromium respawns them, but
+  // when a renderer dies moments later the ORDER of the two is the diagnosis —
+  // and a packaged launch has stdout on /dev/null, so nothing else keeps it.
+  installProcessHealth();
+
   // Realtime Michael mic-gate hygiene (rt-8 / Pam rt-10 nit): the voice session
   // opens the mic permission gate by persisting realtimeVoiceEnabled=true and
   // closes it on disconnect — but a hard crash/reload mid-session skips that
@@ -5355,11 +5376,17 @@ app.on('before-quit', (e) => {
   if (allowQuit) return;
   const count = ptyManager.list().length;
   if (count === 0) return;
+  // The confirmation is a RENDERER modal, so it can only be asked for when a
+  // renderer is alive to draw it. Cancelling the quit without one wedges the
+  // app permanently: `app:closeRequested` goes nowhere, nothing ever sets
+  // allowQuit, and every later quit — including a SIGTERM — is swallowed the
+  // same way. Observed live on 2026-09-07: after the renderer died, the frozen
+  // window could not be closed by any means short of SIGKILL. With no one to
+  // ask, quit; the teardown path still stops the PTYs cleanly.
+  if (!logQuitPromptDecision(mainWindow, 'before-quit')) return;
   e.preventDefault();
-  if (mainWindow) {
-    mainWindow.focus();
-    mainWindow.webContents.send('app:closeRequested', { ptyCount: count });
-  }
+  mainWindow.focus();
+  mainWindow.webContents.send('app:closeRequested', { ptyCount: count });
 });
 
 // Every window loads the config once at start-up, so tell them all when a

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -34,6 +34,14 @@ export function withHiveRuntimeFallback(path: string, hiveRoot?: string): string
  *  agents cost kilobytes, not megabytes. */
 const TAIL_MAX = 8192;
 
+/** Output coalescing (see `flushOutput`). One animation frame: long enough to
+ *  collapse a TUI's redraw burst into a single IPC message, short enough that
+ *  typing still echoes instantly. */
+const OUTPUT_FLUSH_MS = 16;
+/** Flush immediately once this much has accumulated, so a large burst (a build
+ *  log, a `cat` of a big file) is never held back by the timer. */
+const OUTPUT_FLUSH_BYTES = 64 * 1024;
+
 /** What the exit handler is told about a process that just died. Passed by
  *  value because the session is deleted from the map before the handler runs. */
 export interface PtyExitInfo {
@@ -70,6 +78,11 @@ interface PtySession {
   /** True after the child has emitted at least one frame. Automation waits for
    *  this before typing, so startup prompts cannot outrun the TUI subscription. */
   hasOutput: boolean;
+  /** Output accumulated since the last flush, and the timer that will send it.
+   *  See `flushOutput` for why the stream is coalesced rather than forwarded
+   *  chunk-for-chunk. */
+  pending: string;
+  flushTimer: NodeJS.Timeout | null;
 }
 
 export interface SpawnOptions {
@@ -358,6 +371,10 @@ export class PtyManager {
           s.proc.kill();
           ensureKilled(pid);
         } catch { /* already gone */ }
+        // The sink is closing with the window: cancel the flush rather than
+        // aim it at a webContents that is about to be destroyed.
+        if (s.flushTimer) { clearTimeout(s.flushTimer); s.flushTimer = null; }
+        s.pending = '';
         void id;
       }
     }
@@ -377,6 +394,36 @@ export class PtyManager {
    *  PTY fires onExit asynchronously — by then app.quit() may have destroyed the
    *  window, and `.send()` on a destroyed webContents throws "Object has been
    *  destroyed", which surfaces as the main-process crash dialog. Guard it. */
+  /** Buffer a chunk and make sure a flush is scheduled.
+   *
+   *  node-pty emits one callback per read, and an agent CLI redrawing a TUI
+   *  produces a long train of tiny writes. Forwarding each one as its own
+   *  `pty:data:<id>` cost a structured clone, an IPC hop and a separate
+   *  renderer main-thread task PER CHUNK — for every session at once, whether
+   *  or not its terminal was even on screen. With a handful of busy agents that
+   *  is enough main-thread work to starve the renderer: the office floor stops
+   *  painting and the window stops answering the compositor's ping.
+   *
+   *  Coalescing changes only the packaging, never the bytes or their order. */
+  private queueOutput(session: PtySession, chunk: string): void {
+    session.pending += chunk;
+    if (session.pending.length >= OUTPUT_FLUSH_BYTES) { this.flushOutput(session); return; }
+    if (session.flushTimer) return;
+    session.flushTimer = setTimeout(() => this.flushOutput(session), OUTPUT_FLUSH_MS);
+    // A pending flush must never hold the process open at quit.
+    session.flushTimer.unref?.();
+  }
+
+  /** Send everything buffered for a session as one message. Safe to call at any
+   *  time, including on an already-drained or already-dead session. */
+  private flushOutput(session: PtySession): void {
+    if (session.flushTimer) { clearTimeout(session.flushTimer); session.flushTimer = null; }
+    const data = session.pending;
+    if (!data) return;
+    session.pending = '';
+    this.safeSend(`pty:data:${session.id}`, data, session.owner);
+  }
+
   private safeSend(channel: string, payload: unknown, target?: WebContents | null): void {
     // Route to the session's owner window when known (multi-window: keeps each
     // floor's stream private); fall back to the default attached sink otherwise.
@@ -692,7 +739,9 @@ export class PtyManager {
         lastOutputAt: Date.now(),
         hasOutput: false,
         tail: '',
-        owner
+        owner,
+        pending: '',
+        flushTimer: null
       };
       this.sessions.set(opts.id, session);
 
@@ -705,13 +754,16 @@ export class PtyManager {
         // Keep only the trailing window; slice AFTER appending so a single
         // oversized write still leaves us its end (the part that explains a death).
         session.tail = (session.tail + data).slice(-TAIL_MAX);
-        // Route to the session's owner window (multi-window owner routing).
-        this.safeSend(`pty:data:${opts.id}`, data, session.owner);
+        // Coalesced rather than sent per chunk — see flushOutput().
+        this.queueOutput(session, data);
       });
       proc.onExit(({ exitCode, signal }) => {
         // Stale exit from a process whose id was reclaimed (kill()+respawn) — do
         // NOT touch the live session or tell the renderer the new pty died.
         if (this.sessions.get(opts.id) !== session) return;
+        // Ordering: whatever the process printed on its way out must reach the
+        // terminal BEFORE the exit banner, so drain the buffer first.
+        this.flushOutput(session);
         this.safeSend(`pty:exit:${opts.id}`, { exitCode, signal }, session.owner);
         this.sessions.delete(opts.id);
         // Natural exit must run the same lifecycle teardown as an explicit kill.
@@ -782,6 +834,9 @@ export class PtyManager {
       const pid = s.proc.pid;
       s.proc.kill();
       ensureKilled(pid); // verify + sweep the process group so no PID leaks
+      // Deliver the last buffered bytes (they may be the reason it was killed),
+      // then make sure no timer outlives the session.
+      this.flushOutput(s);
       this.sessions.delete(id);
       return { ok: true };
     } catch (e) {

--- a/src/main/rendererHealth.ts
+++ b/src/main/rendererHealth.ts
@@ -1,0 +1,311 @@
+import { app, dialog, type BrowserWindow, type WebContents } from 'electron';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Renderer liveness: detection, diagnosis and bounded recovery.
+ *
+ * Observed live on 2026-09-07 (v0.4.6, packaged AppImage, Hyprland/Wayland):
+ * the app ran a five-agent hive for ~25 minutes, then the compositor put up
+ * "An application Munder Difflin is not responding — Terminate / Wait". At that
+ * point `/proc` held the browser process, both zygotes, the GPU process and the
+ * network service — and NO renderer at all. The window stayed mapped, showing
+ * the office background of its last painted frame; the main process was still
+ * fine, still routing (hive `log.jsonl` was being appended seconds later).
+ *
+ * The renderer had died and NOTHING in the app noticed: `createWindow` bound no
+ * `render-process-gone`, no `unresponsive`, and `app` bound no
+ * `child-process-gone`. A dead renderer therefore left a permanently frozen
+ * window with no reload path, and the only exit the user is offered is the
+ * compositor's "Terminate" — which kills the browser process and takes the
+ * whole running hive (every agent PTY is its child) down with it.
+ *
+ * Nothing was recoverable after the fact either: a packaged launch from a
+ * .desktop file has stdout/stderr on /dev/null, so every `console.error` is
+ * discarded, and no crashpad handler was attached, so the death left no dump.
+ *
+ * This module closes that hole:
+ *   - it records renderer/child-process deaths and hangs to a file under
+ *     userData, the one place a packaged build can actually be read back from;
+ *   - it reloads a crashed renderer automatically, under a strict budget, so a
+ *     crash loop can never turn into a reload loop;
+ *   - once the budget is spent, or while the renderer is merely wedged, it
+ *     offers recovery through a native dialog — a route that does not require
+ *     killing the process tree the hive lives in.
+ */
+
+/** Reasons that mean the renderer died on us and a reload is the right answer.
+ *
+ *  `killed` belongs here, which is not obvious: Chromium reports it for ANY
+ *  signal death, so it covers the kernel OOM killer and an external `kill` —
+ *  the very cases a user most needs recovered — not just a deliberate teardown.
+ *  Verified against Electron on 2026-09-07: SIGKILL to the render process
+ *  reports `{ reason: 'killed', exitCode: 9 }`. Deliberate teardown is already
+ *  excluded by `clean-exit` and by the isDestroyed() guard on the window, so
+ *  treating `killed` as a crash cannot resurrect a window we meant to close. */
+const RECOVERABLE_REASONS = new Set([
+  'crashed',
+  'oom',
+  'killed',
+  'abnormal-exit',
+  'launch-failed',
+  'integrity-failure'
+]);
+
+/** Whether a `render-process-gone` reason should be recovered from. Exported so
+ *  the classification is testable on its own — it is the single decision that
+ *  separates "the window comes back" from "the window is frozen forever". */
+export function shouldRecoverFrom(reason: string): boolean {
+  return RECOVERABLE_REASONS.has(reason);
+}
+
+/** At most this many automatic reloads inside {@link BUDGET_WINDOW_MS}. Past
+ *  that we stop and ask, because a renderer that dies immediately on every
+ *  load would otherwise spin forever, burning CPU next to a live hive. */
+export const BUDGET_LIMIT = 3;
+export const BUDGET_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * Rolling-window allowance for automatic reloads.
+ *
+ * Pure and clock-injectable so the budget can be tested without Electron: the
+ * interesting property (a crash loop is bounded, but a machine left running for
+ * hours still recovers from an occasional crash) is a property of this class,
+ * not of the event wiring.
+ */
+export class ReloadBudget {
+  private readonly stamps: number[] = [];
+
+  constructor(
+    private readonly limit: number = BUDGET_LIMIT,
+    private readonly windowMs: number = BUDGET_WINDOW_MS,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  /** Whether one more automatic reload is allowed right now. Read-only. */
+  allows(): boolean {
+    return this.live().length < this.limit;
+  }
+
+  /** Consume one reload. Returns false (and consumes nothing) when spent. */
+  take(): boolean {
+    const live = this.live();
+    if (live.length >= this.limit) return false;
+    live.push(this.now());
+    this.replace(live);
+    return true;
+  }
+
+  /** Reloads used inside the current window — for the diagnostic record. */
+  used(): number {
+    return this.live().length;
+  }
+
+  private live(): number[] {
+    const cutoff = this.now() - this.windowMs;
+    return this.stamps.filter((t) => t > cutoff);
+  }
+
+  private replace(next: number[]): void {
+    this.stamps.length = 0;
+    this.stamps.push(...next);
+  }
+}
+
+/**
+ * Windows whose renderer we have SEEN die and not come back.
+ *
+ * Electron keeps the WebContents object alive after its render process dies, so
+ * `isDestroyed()` stays false. `isCrashed()` is meant to report it, but relying
+ * on it alone was not enough in practice: measured against Electron 32 on
+ * 2026-09-07, a window whose renderer had been killed still passed an
+ * isCrashed()-only guard, and the app stayed unquittable. Our own observation of
+ * `render-process-gone` is authoritative, so record it and consult that first.
+ *
+ * A WeakSet, so a closed window is not kept alive by the bookkeeping.
+ */
+const deadRenderers = new WeakSet<BrowserWindow>();
+
+/** Called from the liveness wiring as the renderer dies and comes back. */
+export function markRendererDead(win: BrowserWindow): void { deadRenderers.add(win); }
+export function markRendererAlive(win: BrowserWindow): void { deadRenderers.delete(win); }
+
+/**
+ * Whether a window still has a renderer that could draw a modal and answer.
+ *
+ * Both quit paths cancel the quit and ask the renderer to confirm; asking a dead
+ * one cancels the quit forever, since nothing ever answers and nothing sets the
+ * allow-quit latch. Observed live on 2026-09-07: after the renderer died the
+ * frozen window could not be closed by any means short of SIGKILL, SIGTERM
+ * included.
+ */
+export function canPromptRenderer(win: BrowserWindow | null): win is BrowserWindow {
+  if (!win || win.isDestroyed()) return false;
+  if (deadRenderers.has(win)) return false;
+  const wc = win.webContents;
+  return !wc.isDestroyed() && !wc.isCrashed();
+}
+
+/** The same decision, reported for the log — a quit that does not happen is
+ *  otherwise completely silent, which is what made this hard to see. */
+export function logQuitPromptDecision(
+  win: BrowserWindow | null,
+  where: string
+): win is BrowserWindow {
+  const ok = canPromptRenderer(win);
+  logHealthEvent('quit-prompt', {
+    where,
+    willPrompt: ok,
+    hasWindow: !!win,
+    marked: !!win && !win.isDestroyed() && deadRenderers.has(win),
+    crashed: !!win && !win.isDestroyed() && !win.webContents.isDestroyed() && win.webContents.isCrashed()
+  });
+  return ok;
+}
+
+/** Where the diagnostics land. Under userData because that is the only
+ *  directory a packaged build reliably owns AND the user can be pointed at. */
+export function healthLogPath(): string {
+  return join(app.getPath('userData'), 'logs', 'renderer-health.log');
+}
+
+/** Append one line of diagnostics. Best-effort in every sense: this runs on
+ *  paths that are already degraded, so it must never throw and never block on
+ *  anything that could itself be wedged. */
+export function logHealthEvent(event: string, detail: Record<string, unknown> = {}): void {
+  const line = `${new Date().toISOString()} ${event} ${JSON.stringify(detail)}\n`;
+  // Still echo to the console: a `npm run dev` session has a real stdout, and
+  // that is where a developer looks first.
+  console.error(`[renderer-health] ${line.trimEnd()}`);
+  try {
+    const file = healthLogPath();
+    mkdirSync(join(file, '..'), { recursive: true });
+    appendFileSync(file, line);
+  } catch { /* diagnostics must never be the thing that breaks */ }
+}
+
+/** How long a window may stay unresponsive before we stop assuming it is a
+ *  passing hitch and offer the user a way out. Chromium fires 'unresponsive'
+ *  well before a compositor does, so this is deliberately patient. */
+const HANG_PROMPT_AFTER_MS = 20_000;
+
+interface WindowHealthOptions {
+  /** Label for the record — the primary window and floors are worth telling
+   *  apart when reading the log back. */
+  label: string;
+  /** Re-attached after a reload by the caller that owns the routing tables. */
+  onReloaded?: (wc: WebContents) => void;
+}
+
+/**
+ * Wire liveness handling onto one window. Idempotent per window: call it once,
+ * from createWindow, right after the BrowserWindow exists.
+ */
+export function installWindowHealth(win: BrowserWindow, opts: WindowHealthOptions): void {
+  const { label } = opts;
+  const budget = new ReloadBudget();
+  let hangTimer: NodeJS.Timeout | null = null;
+  let hangPromptOpen = false;
+
+  const clearHangTimer = (): void => {
+    if (hangTimer) { clearTimeout(hangTimer); hangTimer = null; }
+  };
+
+  const reload = (why: string): void => {
+    if (win.isDestroyed()) return;
+    logHealthEvent('reload', { label, why, used: budget.used() });
+    try {
+      win.webContents.reload();
+      opts.onReloaded?.(win.webContents);
+    } catch (e) {
+      logHealthEvent('reload-failed', { label, why, error: String(e) });
+    }
+  };
+
+  // A renderer that is gone can no longer be asked anything — recover it, or
+  // record precisely why we chose not to.
+  win.webContents.on('render-process-gone', (_e, details) => {
+    clearHangTimer();
+    markRendererDead(win);
+    const { reason, exitCode } = details;
+    logHealthEvent('render-process-gone', { label, reason, exitCode });
+
+    if (!shouldRecoverFrom(reason)) return;             // deliberate teardown
+    if (win.isDestroyed()) return;
+
+    if (budget.take()) { reload(`render-process-gone:${reason}`); return; }
+
+    // Budget spent: the renderer is dying faster than it can load. Stop the
+    // loop and hand the decision over, WITHOUT taking the hive down.
+    logHealthEvent('reload-budget-exhausted', { label, reason, exitCode });
+    void dialog.showMessageBox(win, {
+      type: 'error',
+      buttons: ['Reload window', 'Leave it'],
+      defaultId: 0,
+      cancelId: 1,
+      message: 'The Munder Difflin window keeps crashing.',
+      detail:
+        `The interface crashed ${BUDGET_LIMIT} times in a row (${reason}). Your agents are ` +
+        'still running — this window is the only thing affected.\n\n' +
+        `Diagnostics: ${healthLogPath()}`
+    }).then(({ response }) => { if (response === 0) reload('user:after-budget'); });
+  });
+
+  // A wedged renderer is still alive, so give it room to come back on its own;
+  // only a hang long enough for the compositor to flag it gets a prompt.
+  win.on('unresponsive', () => {
+    logHealthEvent('unresponsive', { label });
+    clearHangTimer();
+    hangTimer = setTimeout(() => {
+      hangTimer = null;
+      if (win.isDestroyed() || hangPromptOpen) return;
+      hangPromptOpen = true;
+      logHealthEvent('unresponsive-prompt', { label, afterMs: HANG_PROMPT_AFTER_MS });
+      void dialog.showMessageBox(win, {
+        type: 'warning',
+        buttons: ['Reload window', 'Keep waiting'],
+        defaultId: 1,
+        cancelId: 1,
+        message: 'The Munder Difflin window has stopped responding.',
+        detail:
+          'Your agents keep running either way — reloading only rebuilds the ' +
+          'interface. Closing the window from the desktop instead would stop ' +
+          'every running agent.\n\n' +
+          `Diagnostics: ${healthLogPath()}`
+      }).then(({ response }) => {
+        hangPromptOpen = false;
+        if (response === 0) reload('user:unresponsive');
+      }).catch(() => { hangPromptOpen = false; });
+    }, HANG_PROMPT_AFTER_MS);
+  });
+
+  // A renderer that finished loading is alive again — whether it was reloaded
+  // by us, by the user, or by a navigation.
+  win.webContents.on('did-finish-load', () => { markRendererAlive(win); });
+  win.webContents.on('did-start-loading', () => { markRendererAlive(win); });
+
+  win.on('responsive', () => {
+    clearHangTimer();
+    logHealthEvent('responsive', { label });
+  });
+
+  win.on('closed', clearHangTimer);
+}
+
+/**
+ * Record deaths of the processes a window depends on but does not own — the GPU
+ * process and the utility services. These do not freeze the UI by themselves
+ * (Chromium respawns them), but when the renderer dies shortly afterwards the
+ * order of events is the whole diagnosis, and it is currently unrecorded.
+ */
+export function installProcessHealth(): void {
+  app.on('child-process-gone', (_e, details) => {
+    logHealthEvent('child-process-gone', {
+      type: details.type,
+      reason: details.reason,
+      exitCode: details.exitCode,
+      serviceName: details.serviceName,
+      name: details.name
+    });
+  });
+}

--- a/test/pty-output-coalescing.test.cjs
+++ b/test/pty-output-coalescing.test.cjs
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * PTY output used to reach the renderer one node-pty read at a time.
+ *
+ * `proc.onData` fires once per read, and an agent CLI redrawing its TUI emits a
+ * long train of tiny writes. Each one became its own `pty:data:<id>` — a
+ * structured clone, an IPC hop and a separate renderer main-thread task, per
+ * chunk, for every live session at once, whether or not that terminal was even
+ * on screen. Observed live on 2026-09-07: five agents, one of them pegged at
+ * ~97% CPU for 25 minutes, and a window the compositor eventually declared
+ * unresponsive.
+ *
+ * The fix coalesces a session's output into one message per frame. What it must
+ * NOT do is change the stream, so these tests pin all four properties:
+ *   1. a burst of chunks collapses into a single IPC message;
+ *   2. the bytes and their order survive coalescing exactly;
+ *   3. a large burst is flushed on size rather than held for the timer;
+ *   4. output still precedes the exit banner — a process's dying words must not
+ *      land after the "process exited" line.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const Module = require('node:module');
+
+// node-pty is a native module rebuilt for Electron's ABI; electron itself is a
+// binary. Neither is needed to exercise the buffering, so stub both.
+let lastFake = null;
+function makeFakeProc() {
+  const proc = {
+    pid: 4242,
+    _data: null,
+    _exit: null,
+    onData(cb) { proc._data = cb; },
+    onExit(cb) { proc._exit = cb; },
+    write() {},
+    resize() {},
+    kill() {}
+  };
+  lastFake = proc;
+  return proc;
+}
+
+const stubs = new Map([
+  ['node-pty', { spawn: () => makeFakeProc() }],
+  ['electron', { app: { getPath: () => os.tmpdir() } }]
+]);
+const origResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+  if (stubs.has(request)) return request;
+  return origResolve.call(this, request, ...rest);
+};
+const origLoad = Module._load;
+Module._load = function (request, ...rest) {
+  if (stubs.has(request)) return stubs.get(request);
+  return origLoad.call(this, request, ...rest);
+};
+
+const loadTs = require('./load-ts.cjs');
+const { PtyManager } = loadTs('src/main/pty.ts');
+
+/** A stand-in for a window's webContents that just records what was sent. */
+function recorder() {
+  const sent = [];
+  return { sent, isDestroyed: () => false, send: (channel, payload) => sent.push({ channel, payload }) };
+}
+
+const tick = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Spawn one session against the fake pty. `node` is used because spawn()
+ *  resolves the command for real before handing it to (stubbed) node-pty. */
+function spawnSession(mgr, wc, id = 'sess-1') {
+  const res = mgr.spawn({ id, cwd: os.tmpdir(), command: 'node' }, wc);
+  assert.equal(res.ok, true, `spawn failed: ${res.error}`);
+  assert.ok(lastFake && lastFake._data, 'expected the manager to subscribe to pty output');
+  return lastFake;
+}
+
+test('a burst of chunks becomes ONE ipc message, bytes and order intact', async () => {
+  const mgr = new PtyManager();
+  const wc = recorder();
+  const proc = spawnSession(mgr, wc);
+
+  const chunks = ['\x1b[2J', 'Building', ' ', 'the', ' ', 'floor', '...\r\n'];
+  for (const c of chunks) proc._data(c);
+
+  assert.equal(wc.sent.length, 0, 'nothing is sent synchronously — that is the point');
+  await tick(40);
+
+  const data = wc.sent.filter((m) => m.channel === 'pty:data:sess-1');
+  assert.equal(data.length, 1, `expected 1 coalesced message, got ${data.length}`);
+  assert.equal(data[0].payload, chunks.join(''), 'coalescing must not alter the stream');
+});
+
+test('a large burst flushes on size instead of waiting for the timer', async () => {
+  const mgr = new PtyManager();
+  const wc = recorder();
+  const proc = spawnSession(mgr, wc, 'big');
+
+  // Over the 64 KiB threshold: a build log must not be held back by a frame timer.
+  proc._data('x'.repeat(64 * 1024 + 1));
+  const immediate = wc.sent.filter((m) => m.channel === 'pty:data:big');
+  assert.equal(immediate.length, 1, 'an oversized burst is flushed at once');
+  assert.equal(immediate[0].payload.length, 64 * 1024 + 1);
+});
+
+test("a process's dying output still precedes its exit banner", async () => {
+  const mgr = new PtyManager();
+  const wc = recorder();
+  const proc = spawnSession(mgr, wc, 'dying');
+
+  // The whole reason the tail is kept: the last bytes explain the death. They
+  // are worthless if the terminal prints them after "process exited".
+  proc._data('error: cannot find module\r\n');
+  proc._exit({ exitCode: 1, signal: undefined });
+
+  const channels = wc.sent.map((m) => m.channel);
+  const dataAt = channels.indexOf('pty:data:dying');
+  const exitAt = channels.indexOf('pty:exit:dying');
+  assert.notEqual(dataAt, -1, 'buffered output must be flushed on exit, not dropped');
+  assert.notEqual(exitAt, -1, 'the exit event must still be delivered');
+  assert.ok(dataAt < exitAt, 'output must arrive before the exit banner');
+  assert.equal(wc.sent[dataAt].payload, 'error: cannot find module\r\n');
+});

--- a/test/renderer-health.test.cjs
+++ b/test/renderer-health.test.cjs
@@ -1,0 +1,191 @@
+'use strict';
+
+/**
+ * A dead renderer used to be invisible to the app, and permanent.
+ *
+ * Observed live on 2026-09-07 (v0.4.6, packaged AppImage, Hyprland/Wayland):
+ * after ~25 minutes running a five-agent hive, the compositor raised
+ * "Munder Difflin is not responding". `/proc` held the browser process, both
+ * zygotes, the GPU process and the network service — and no renderer at all.
+ * The window stayed mapped on its last painted frame while the main process
+ * carried on routing the hive. `createWindow` bound no 'render-process-gone'
+ * and no 'unresponsive', so nothing reloaded the window and nothing recorded
+ * the death; the compositor's "Terminate" was the user's only way out, and it
+ * would have killed every agent PTY along with the browser process.
+ *
+ * These tests pin the properties that make the recovery safe:
+ *   1. an occasional crash always gets an automatic reload;
+ *   2. a crash LOOP cannot become a reload loop — the budget is finite;
+ *   3. the budget is a rolling window, so a long-lived session recovers again
+ *      later instead of being permanently spent;
+ *   4. deliberate teardown ('clean-exit', 'killed') is never "recovered" — a
+ *      window we meant to close must not be resurrected.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+// rendererHealth.ts imports `electron` at module scope for the wiring half of
+// the file. The pure half under test needs none of it, so resolve the bare
+// specifier to a stub rather than dragging the real binary in.
+const stubs = new Map([['electron', {
+  app: { getPath: () => path.join(require('node:os').tmpdir(), 'md-health-test'), on: () => {} },
+  dialog: { showMessageBox: async () => ({ response: 1 }) }
+}]]);
+const origResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+  if (stubs.has(request)) return request;
+  return origResolve.call(this, request, ...rest);
+};
+const origLoad = Module._load;
+Module._load = function (request, ...rest) {
+  if (stubs.has(request)) return stubs.get(request);
+  return origLoad.call(this, request, ...rest);
+};
+
+const loadTs = require('./load-ts.cjs');
+const {
+  ReloadBudget, BUDGET_LIMIT, BUDGET_WINDOW_MS,
+  canPromptRenderer, shouldRecoverFrom, markRendererDead, markRendererAlive
+} = loadTs('src/main/rendererHealth.ts');
+
+/** A budget on a clock we control, so the rolling window is testable without
+ *  waiting ten real minutes. */
+function budgetAt(clock) {
+  return new ReloadBudget(BUDGET_LIMIT, BUDGET_WINDOW_MS, () => clock.now);
+}
+
+test('a crashed renderer is reloaded — the window is never left frozen', () => {
+  const clock = { now: 0 };
+  const budget = budgetAt(clock);
+  assert.equal(budget.allows(), true);
+  assert.equal(budget.take(), true, 'the first crash must always be recovered');
+});
+
+test('a crash loop cannot become a reload loop', () => {
+  const clock = { now: 0 };
+  const budget = budgetAt(clock);
+  for (let i = 0; i < BUDGET_LIMIT; i++) {
+    assert.equal(budget.take(), true, `reload ${i + 1} is within budget`);
+    clock.now += 500; // a renderer dying immediately on load
+  }
+  assert.equal(budget.allows(), false);
+  assert.equal(budget.take(), false, 'past the budget we stop and ask instead');
+  assert.equal(budget.used(), BUDGET_LIMIT);
+});
+
+test('the budget is a rolling window, not a lifetime quota', () => {
+  const clock = { now: 0 };
+  const budget = budgetAt(clock);
+  for (let i = 0; i < BUDGET_LIMIT; i++) budget.take();
+  assert.equal(budget.take(), false, 'spent inside the window');
+
+  // A session left running for hours must still recover from a later, unrelated
+  // crash — otherwise the first bad minute disables recovery for the whole day.
+  clock.now += BUDGET_WINDOW_MS + 1;
+  assert.equal(budget.used(), 0, 'old crashes age out of the window');
+  assert.equal(budget.take(), true, 'a later crash is recovered again');
+});
+
+test('reload accounting only counts what it consumed', () => {
+  const clock = { now: 0 };
+  const budget = budgetAt(clock);
+  budget.allows();
+  budget.allows();
+  assert.equal(budget.used(), 0, 'allows() must be read-only');
+  budget.take();
+  assert.equal(budget.used(), 1);
+});
+
+/**
+ * The quit wedge, same root cause.
+ *
+ * Both quit paths (app 'before-quit' and the primary window's 'close') cancel
+ * the quit and ask the RENDERER to draw the "you have running terminals"
+ * warning. With the renderer dead there is nobody to answer: nothing sets the
+ * allow-quit latch, so every later quit is cancelled the same way. Observed
+ * live on 2026-09-07 — the frozen window survived SIGTERM and needed SIGKILL.
+ *
+ * The trap is that Electron keeps the WebContents object alive after its render
+ * process dies, so the obvious guard (`isDestroyed()`) still reports false. Only
+ * `isCrashed()` tells the truth, which is exactly what these tests pin.
+ */
+
+/** Minimal stand-in for a BrowserWindow: only the three flags the guard reads. */
+function fakeWin({ destroyed = false, wcDestroyed = false, crashed = false } = {}) {
+  return {
+    isDestroyed: () => destroyed,
+    webContents: { isDestroyed: () => wcDestroyed, isCrashed: () => crashed }
+  };
+}
+
+test('a healthy window is still asked to confirm the quit', () => {
+  assert.equal(canPromptRenderer(fakeWin()), true);
+});
+
+test('a CRASHED renderer is not asked — this is the SIGTERM wedge', () => {
+  // isDestroyed() stays false after the render process dies; only isCrashed()
+  // reports it. A guard that checked destruction alone would still cancel the
+  // quit here, and the window would stay unclosable.
+  const win = fakeWin({ crashed: true });
+  assert.equal(win.isDestroyed(), false, 'precondition: the window object survives');
+  assert.equal(win.webContents.isDestroyed(), false, 'precondition: so does the WebContents');
+  assert.equal(canPromptRenderer(win), false, 'a crashed renderer cannot answer, so do not ask');
+});
+
+test('a torn-down window or WebContents is not asked either', () => {
+  assert.equal(canPromptRenderer(fakeWin({ destroyed: true })), false);
+  assert.equal(canPromptRenderer(fakeWin({ wcDestroyed: true })), false);
+  assert.equal(canPromptRenderer(null), false, 'no window at all: quit, do not hang');
+});
+
+/**
+ * Which deaths get recovered.
+ *
+ * 'killed' is the one that matters and the one that is easy to get wrong. It
+ * reads like deliberate teardown, but Chromium reports it for ANY signal death
+ * — the kernel OOM killer included, which is the likeliest way a renderer dies
+ * under a busy hive. Verified against Electron on 2026-09-07: SIGKILL to the
+ * render process reports { reason: 'killed', exitCode: 9 }. An earlier draft of
+ * this fix excluded it, and the window stayed frozen exactly as before.
+ */
+test("'killed' is recovered — it is what an OOM kill reports", () => {
+  assert.equal(shouldRecoverFrom('killed'), true);
+});
+
+test('genuine crashes are recovered', () => {
+  for (const reason of ['crashed', 'oom', 'abnormal-exit', 'launch-failed', 'integrity-failure']) {
+    assert.equal(shouldRecoverFrom(reason), true, `${reason} should be recovered`);
+  }
+});
+
+test('a clean exit is NOT "recovered" — that window meant to close', () => {
+  assert.equal(shouldRecoverFrom('clean-exit'), false);
+});
+
+/**
+ * Our own observation of the death is what the guard trusts first.
+ *
+ * isCrashed() is documented to report a dead render process, but relying on it
+ * alone was not enough in practice: measured against Electron 32 on 2026-09-07,
+ * a window whose renderer had been SIGKILLed still passed an isCrashed()-only
+ * guard, so the quit was cancelled and the app stayed unquittable — the exact
+ * bug this was meant to fix. `render-process-gone` is a fact we witness, so the
+ * guard consults that record before asking Electron.
+ */
+test('a window marked dead is not prompted, even if isCrashed() lies', () => {
+  const win = fakeWin();                       // isCrashed() === false
+  assert.equal(canPromptRenderer(win), true, 'precondition: it looks healthy');
+  markRendererDead(win);
+  assert.equal(canPromptRenderer(win), false, 'our own observation wins');
+});
+
+test('a reloaded renderer is prompted again', () => {
+  const win = fakeWin();
+  markRendererDead(win);
+  assert.equal(canPromptRenderer(win), false);
+  markRendererAlive(win);                      // did-finish-load after a reload
+  assert.equal(canPromptRenderer(win), true, 'recovery must restore the warning');
+});


### PR DESCRIPTION
## What & why

A renderer crash left the app permanently frozen, silent, and unkillable.

Observed live on 2026-09-07 (v0.4.6, packaged AppImage, Hyprland/Wayland): after ~25 minutes running a five-agent hive, the compositor raised "Munder Difflin is not responding". `/proc` held the browser process, both zygotes, the GPU process and the network service — and **no renderer at all**. The window stayed mapped on its last painted frame while the main process carried on routing the hive; `hive/log.jsonl` was still being appended seconds later.

Three gaps turned one renderer crash into a dead end:

1. **Nothing noticed.** `createWindow` bound no `render-process-gone` and no `unresponsive`; `app` bound no `child-process-gone`. Recovery from outside is not possible either — a compositor will not give focus to a non-responding surface, so the `View > Reload` the menu already provides is unreachable. That leaves the compositor's "Terminate", and every agent PTY is a child of the browser process, so it takes the whole running hive down with it.
2. **Nothing was recorded.** A packaged launch from a `.desktop` file has stdout/stderr on `/dev/null`, so every `console.error` is discarded, and no crashpad handler was attached, so the death left no dump.
3. **The app could no longer quit.** Both quit paths cancel the quit and ask the *renderer* to draw the "you have running terminals" warning. With no renderer, nothing answers, nothing sets the allow-quit latch, and every later quit is cancelled the same way — the frozen window survived `SIGTERM` and needed `SIGKILL`.

Two traps worth flagging for review, both found by measuring rather than reading docs:

- Electron reports a renderer killed by a signal as `reason: 'killed'`, **including an OOM kill**. An earlier draft of this fix treated `killed` as deliberate teardown and did not recover from it — the window stayed frozen exactly as before. `test/renderer-health.test.cjs` pins this.
- `webContents.isCrashed()` alone was not a sufficient liveness guard: measured against Electron 32, a window whose renderer had been SIGKILLed still passed an `isCrashed()`-only check, so the quit was still cancelled. The fix trusts our own observation of `render-process-gone` first.

### Changes

- `src/main/rendererHealth.ts` — wires renderer liveness onto every window. A crashed renderer is reloaded automatically under a rolling budget (3 per 10 minutes) so a crash loop can never become a reload loop; past the budget, and for a hang long enough that a compositor would flag it, a native dialog offers the reload instead — a route that does not require killing the process tree the hive lives in. Deaths and hangs are recorded to `userData/logs/renderer-health.log`. GPU/utility deaths are logged too: when a renderer dies moments later, the order of the two is the diagnosis.
- `logQuitPromptDecision()` guards both quit paths, so a quit is only ever cancelled when a renderer is alive to answer the prompt — and the decision is logged, because a quit that does not happen is otherwise completely silent.
- `src/main/pty.ts` — coalesces PTY output. `proc.onData` fires once per read, and an agent CLI redrawing its TUI emits a long train of tiny writes. Each one became its own `pty:data:<id>`: a structured clone, an IPC hop and a separate renderer main-thread task, per chunk, for every live session at once, whether or not that terminal was even on screen. With one agent pegged at ~97% CPU that is enough main-thread work to starve the renderer, which is the most likely trigger of the freeze above. Output is now flushed one message per frame, immediately past 64 KiB so a large burst is never held back, and drained before `pty:exit` so a process's dying words cannot land after its exit banner. Bytes and order are unchanged.

Cross-platform: no platform-specific code, no new paths built by hand, provider-neutral (nothing here knows which CLI is running). No UI beyond two native dialogs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

The failure as it happens on `main`. The window is mapped and painting its last frame, but the bundle has no renderer process, nothing was logged, and the main process is demonstrably still alive and working:

```
$ ls -l /proc/*/exe | grep appimage_extracted     # every process in the bundle
  pid 7304    (browser)
  pid 7307    --type=zygote
  pid 7308    --type=zygote
  pid 7310    --type=zygote
  pid 7432    --type=gpu-process
  pid 7522    --type=utility
  -> no --type=renderer: the renderer is gone

$ hyprctl clients                                  # the window is still mapped
  munder-difflin | Munder Difflin | mapped = True

$ ls ~/.config/munder-difflin/logs/                # nothing was recorded
  ls: cannot access '.../logs/': No such file or directory

$ tail -1 ~/HarnessAgents/hive/log.jsonl           # the main process is fine
  last hive event: 2026-09-07 10:36:56
```

On screen at that moment: the window painted its `backgroundColor` (`#FFF8E7`) and the office skyline, plus the browser-drawn menu bar — and nothing else. No sidebar, no agents, no terminal. (Screenshots are attached in a follow-up comment.)

And the quit wedge (defect 3):

```
$ kill 7091 7304      # SIGTERM
  still alive: pid 7304
$ kill -9 7304        # only SIGKILL ends it
```

The suite is red on the coalescing behaviour:

```
$ node --test test/pty-output-coalescing.test.cjs
✖ a burst of chunks becomes ONE ipc message, bytes and order intact
  Expected 1 coalesced message, got 7
ℹ pass 2  ℹ fail 1
```

### After

The same failure, provoked on the fixed build — the renderer killed exactly the way it died on its own:

```
$ kill -9 285779                                   # the renderer

$ cat ~/.config/munder-difflin/logs/renderer-health.log
  2026-09-07T10:10:20.163Z render-process-gone {"label":"primary","reason":"killed","exitCode":9}
  2026-09-07T10:10:20.164Z reload {"label":"primary","why":"render-process-gone:killed","used":1}

$ ls -l /proc/*/exe | grep appimage_extracted      # a fresh renderer, 1 ms later
  pid 285268  (browser)
  pid 285284  --type=zygote
  pid 285285  --type=zygote
  pid 285287  --type=zygote
  pid 285430  --type=gpu-process
  pid 285767  --type=utility
  pid 307763  --type=renderer
```

On screen: the office floor is fully back — sidebar, all four agents, live terminal — with no user action, and the hive never stopped. (Screenshots attached in a follow-up comment.)

The suite is green:

```
$ node --test test/renderer-health.test.cjs test/pty-output-coalescing.test.cjs
ℹ pass 15  ℹ fail 0
```

## Checks

- `npm run typecheck` (node + web) — clean
- `npm run build` — clean
- `npm run test:focused` — 845 pass, 1 fail (`update-download-asset`, which fails identically on a pristine `main` on this machine: it needs a downloaded Electron binary that did not fetch here)
- Verified end to end against a locally built AppImage of this branch, on Hyprland/Wayland.

## Agent review

Reviewed by the agent that wrote it; the two findings it produced were fixed rather than shipped, and both are in the tests:

- it initially classified `killed` as deliberate teardown, which silently disabled recovery for the OOM case — caught by running the real build, not by reading the diff;
- the `isCrashed()`-only quit guard passed review but failed in the running app, so the guard now trusts our own `render-process-gone` observation first.

Left deliberately unchanged: the coalescing window is a fixed 16 ms rather than adaptive, and `HANG_PROMPT_AFTER_MS` is a fixed 20 s. Both are judgement calls that want real-world numbers before being made clever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LZ5q4m4TzEX1xzoFtt2na
