### PR TITLE
Sweep agents a previous run left behind

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { join, resolve, sep, basename, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { request as httpsRequest } from 'node:https';
 import { PtyManager, type SpawnOptions } from './pty';
+import { AgentLedger, sweepStaleAgents } from './staleAgents';
 import { resolveCommand as resolveCliCommand, isSafeCommandName } from './shellEnv';
 import { initAutoUpdater, abortPendingRestart } from './updater';
 import { RealtimeFloorWatcher } from './realtimeFloorWatcher';
@@ -5269,6 +5270,17 @@ function onSystemResume(reason: string): void {
 }
 
 app.whenReady().then(() => {
+  // Reap agents a previous run left behind, BEFORE this run spawns any of its
+  // own — so the ledger being read is unambiguously the previous run's. An
+  // orphaned agent is not just idle: it keeps its provider session file open,
+  // and the next launch cannot resume that agent at all while it does.
+  // Every kill is gated on process identity; see staleAgents.ts.
+  const agentLedger = new AgentLedger(join(app.getPath('userData'), 'agent-pids.json'));
+  try {
+    sweepStaleAgents(join(app.getPath('userData'), 'agent-pids.json'), (m, d) => console.log(m, d));
+  } catch (e) { console.error('[stale-agents] sweep failed:', e); }
+  ptyManager.setLedger(agentLedger);
+
   // Realtime Michael mic-gate hygiene (rt-8 / Pam rt-10 nit): the voice session
   // opens the mic permission gate by persisting realtimeVoiceEnabled=true and
   // closes it on disconnect — but a hard crash/reload mid-session skips that

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { delimiter, join, win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { ensureKilled, hardKillTree } from './procKill';
+import type { AgentLedger } from './staleAgents';
 import { expandTilde } from './fs';
 import { buildPtyEnv } from './ptyEnv';
 import { captureFromLoginShell, isSafeCommandName, userShellPath } from './shellEnv';
@@ -326,6 +327,11 @@ export function parseNpmCmdShim(shimPath: string, content: string): NpmShimTarge
 export class PtyManager {
   private sessions = new Map<string, PtySession>();
   private webContents: WebContents | null = null;
+  /** Durable record of the PTYs this run started, so a run that never gets to
+   *  quit can be cleaned up by the NEXT one. Optional: the manager works
+   *  without it, and every call is guarded, so a ledger failure can never break
+   *  a spawn. See staleAgents.ts. */
+  private ledger: AgentLedger | null = null;
   /** Fired when a PTY exits on its OWN (child finished/crashed/killed
    *  externally), so the main process can run the SAME lifecycle teardown
    *  (archive, worktree removal, map cleanup) that the explicit kill() path
@@ -337,6 +343,12 @@ export class PtyManager {
    *  sessions with no recorded owner; owned sessions route to their owner. */
   attachWebContents(wc: WebContents) {
     this.webContents = wc;
+  }
+
+  /** Attach the stale-agent ledger. Set once at startup, after the previous
+   *  run's survivors have been swept. */
+  setLedger(ledger: AgentLedger): void {
+    this.ledger = ledger;
   }
 
   /** Count live PTYs owned by a given window — used to scope a floor's
@@ -695,6 +707,9 @@ export class PtyManager {
         owner
       };
       this.sessions.set(opts.id, session);
+      // Recorded here, while the process is definitely ours: reading its
+      // identity at sweep time would describe whoever holds that pid then.
+      try { this.ledger?.add(opts.id, proc.pid); } catch { /* never block a spawn */ }
 
       proc.onData((data) => {
         // Drop trailing output from a process whose id was already reclaimed by
@@ -713,6 +728,7 @@ export class PtyManager {
         // NOT touch the live session or tell the renderer the new pty died.
         if (this.sessions.get(opts.id) !== session) return;
         this.safeSend(`pty:exit:${opts.id}`, { exitCode, signal }, session.owner);
+        try { this.ledger?.remove(proc.pid); } catch { /* best-effort */ }
         this.sessions.delete(opts.id);
         // Natural exit must run the same lifecycle teardown as an explicit kill.
         // Guarded so a teardown error can never crash node-pty's exit callback.
@@ -782,6 +798,7 @@ export class PtyManager {
       const pid = s.proc.pid;
       s.proc.kill();
       ensureKilled(pid); // verify + sweep the process group so no PID leaks
+      try { this.ledger?.remove(pid); } catch { /* best-effort */ }
       this.sessions.delete(id);
       return { ok: true };
     } catch (e) {
@@ -843,6 +860,8 @@ export class PtyManager {
         ensureKilled(pid);
       }
     }
+    // killAll IS the clean teardown, so the next launch has nothing to sweep.
+    try { this.ledger?.clear(); } catch { /* best-effort */ }
     this.sessions.clear();
   }
 }

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -859,9 +859,15 @@ export class PtyManager {
         try { s.proc.kill(); } catch { /* noop */ }
         ensureKilled(pid);
       }
+      // Forget each PTY AS IT DIES, not the whole ledger at the end.
+      //
+      // A blanket clear() here assumed the loop always finishes. Observed live
+      // on 2026-09-07: the main process wedged part-way through teardown — the
+      // ledger had already been emptied, one `codex` was still alive, and the
+      // next launch had nothing left to sweep it with. Per-entry removal means
+      // an interrupted teardown leaves exactly the survivors recorded.
+      try { this.ledger?.remove(pid); } catch { /* best-effort */ }
     }
-    // killAll IS the clean teardown, so the next launch has nothing to sweep.
-    try { this.ledger?.clear(); } catch { /* best-effort */ }
     this.sessions.clear();
   }
 }

--- a/src/main/staleAgents.ts
+++ b/src/main/staleAgents.ts
@@ -1,0 +1,189 @@
+/**
+ * Reap agent processes a PREVIOUS run left behind.
+ *
+ * Every agent PTY is a child of the browser process, and the normal quit path
+ * tears them down: killAll() kills each one, and on POSIX closing the pty HUPs
+ * the foreground group. Neither runs if the app never gets to quit — a main
+ * process that is SIGKILLed, OOM-killed, or lost to a power cut leaves its
+ * agents running, reparented to init, with no window and nobody to stop them.
+ *
+ * They are not merely idle. Observed live on 2026-09-07: an orphaned `codex`
+ * from a killed run still held its session rollout open, so the NEXT launch
+ * could not resume that agent at all —
+ *
+ *   Error: Failed to resume session from .../rollout-...jsonl:
+ *     thread ... already has an active writer (code -32600)
+ *
+ * — and the agent was dead on arrival every time until the orphan was killed by
+ * hand. A survivor also keeps burning tokens and CPU against an account nobody
+ * is watching.
+ *
+ * So the app records the PTYs it starts, and sweeps the survivors at startup.
+ *
+ * The whole risk here is PID reuse: a recorded pid may belong to something else
+ * entirely by the next launch, and killing a stranger's process tree is far
+ * worse than leaving an orphan. Every kill is therefore gated on IDENTITY, not
+ * just liveness — the process must still have the start time AND the command we
+ * recorded. When identity cannot be established, for any reason, nothing is
+ * killed. A missed orphan is a nuisance; a wrong kill is not.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { hardKillTree, isAlive } from './procKill';
+
+/** One PTY we started, in enough detail to recognise it again after a restart. */
+export interface LedgerEntry {
+  /** The hive agent id, for the log line — never used to match. */
+  id: string;
+  pid: number;
+  /** `ps -o lstart=` — a full-precision start timestamp. The pid alone is not
+   *  an identity; the pid plus its start time effectively is. */
+  startedAt: string;
+  /** First token of the command, e.g. `codex`. A second, cheap check: a reused
+   *  pid that somehow shares a start time is still very unlikely to also be
+   *  running the same binary. */
+  command: string;
+}
+
+/** Identity of one live process, or null when it cannot be established —
+ *  the process is gone, or `ps` itself did not answer. POSIX only; see
+ *  sweepStaleAgents for why Windows takes a different route. */
+export function processIdentity(pid: number): { startedAt: string; command: string } | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    const r = spawnSync('ps', ['-o', 'lstart=,comm=', '-p', String(pid)], { timeout: 2_000 });
+    if (r.error || r.status !== 0) return null;
+    const line = String(r.stdout ?? '').trim();
+    if (!line) return null;
+    // Parsed from the END, not by column width: `lstart` is rendered in the
+    // machine's LOCALE, so it is neither a fixed width nor a known format
+    // ("Mon Sep  7 09:46:24 2026" in C, "lun. sept.  7 09:46:24 2026" in fr_FR).
+    // `comm` is a single token with no spaces, so the last field is the command
+    // and everything before it is the timestamp, whatever the locale renders.
+    //
+    // That the string is locale-dependent is fine and deliberate: it is only
+    // ever compared against a value THIS machine recorded earlier. If the locale
+    // changes between runs the comparison fails, and a failed comparison spares
+    // the process — the safe direction.
+    const m = line.match(/^(.*\S)\s+(\S+)$/);
+    if (!m) return null;
+    return { startedAt: m[1].trim(), command: m[2] };
+  } catch { return null; }
+}
+
+/** Whether this recorded entry still names the SAME process we started.
+ *
+ *  Exported because it is the entire safety argument for the sweep, and it is
+ *  worth being able to test on its own. */
+export function isSameProcess(entry: LedgerEntry, live: { startedAt: string; command: string } | null): boolean {
+  if (!live) return false;                                  // gone, or unverifiable
+  if (!entry.startedAt || !entry.command) return false;     // ledger from an older build
+  return live.startedAt === entry.startedAt && live.command === entry.command;
+}
+
+function readLedger(path: string): LedgerEntry[] {
+  try {
+    if (!existsSync(path)) return [];
+    const raw: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((e): e is LedgerEntry =>
+      !!e && typeof (e as LedgerEntry).pid === 'number' &&
+      typeof (e as LedgerEntry).startedAt === 'string' &&
+      typeof (e as LedgerEntry).command === 'string');
+  } catch { return []; }
+}
+
+function writeLedger(path: string, rows: LedgerEntry[]): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(rows));
+  } catch { /* the ledger is a best-effort record, never a blocker */ }
+}
+
+/**
+ * Track the PTYs of the CURRENT run.
+ *
+ * Deliberately a plain file rewritten on each change rather than an append log:
+ * the set is small (one row per running agent), and a file that is always the
+ * complete truth cannot be left half-replayed by a crash mid-write.
+ */
+export class AgentLedger {
+  private rows: LedgerEntry[] = [];
+
+  constructor(private readonly path: string) {}
+
+  /** Record a PTY we just started. The identity lookup is done HERE, while the
+   *  process is definitely ours — reading it at sweep time would be reading the
+   *  identity of whatever holds that pid then, which proves nothing. */
+  add(id: string, pid: number): void {
+    const live = processIdentity(pid);
+    if (!live) return;                     // unverifiable now = never sweepable later
+    this.rows = this.rows.filter((r) => r.pid !== pid);
+    this.rows.push({ id, pid, ...live });
+    writeLedger(this.path, this.rows);
+  }
+
+  /** Forget a PTY that exited or was killed. */
+  remove(pid: number): void {
+    const next = this.rows.filter((r) => r.pid !== pid);
+    if (next.length === this.rows.length) return;
+    this.rows = next;
+    writeLedger(this.path, next);
+  }
+
+  /** Drop the whole ledger — the clean-quit path, where killAll() has already
+   *  stopped everything and nothing should be swept next time. */
+  clear(): void {
+    this.rows = [];
+    try { rmSync(this.path, { force: true }); } catch { /* nothing to remove */ }
+  }
+}
+
+export interface SweepReport {
+  /** Entries that were still the process we started, and were killed. */
+  killed: LedgerEntry[];
+  /** Entries whose pid was alive but is no longer ours — deliberately spared. */
+  spared: LedgerEntry[];
+}
+
+/**
+ * Kill whatever a previous run left behind, then drop the ledger.
+ *
+ * Call once at startup, BEFORE spawning this run's agents, so the ledger being
+ * read is unambiguously the previous run's.
+ *
+ * Windows takes the same path: `processIdentity` returns null there (no `ps`),
+ * so nothing is killed rather than something wrong being killed. Windows quits
+ * already run a synchronous `taskkill /T /F` sweep in killAll(), which is the
+ * case this exists to cover elsewhere.
+ */
+export function sweepStaleAgents(
+  ledgerPath: string,
+  log: (msg: string, detail?: unknown) => void = () => {}
+): SweepReport {
+  const report: SweepReport = { killed: [], spared: [] };
+  const rows = readLedger(ledgerPath);
+  if (!rows.length) return report;
+
+  for (const entry of rows) {
+    if (!isAlive(entry.pid)) continue;                    // exited on its own
+    if (!isSameProcess(entry, processIdentity(entry.pid))) {
+      // The pid is in use by something that is not our agent — or we could not
+      // prove otherwise. Either way it is not ours to kill.
+      report.spared.push(entry);
+      continue;
+    }
+    hardKillTree(entry.pid);
+    report.killed.push(entry);
+  }
+
+  if (report.killed.length || report.spared.length) {
+    log('[stale-agents] swept a previous run', {
+      killed: report.killed.map((e) => `${e.id}:${e.pid}`),
+      spared: report.spared.map((e) => `${e.id}:${e.pid}`)
+    });
+  }
+  try { rmSync(ledgerPath, { force: true }); } catch { /* already gone */ }
+  return report;
+}

--- a/test/stale-agents.test.cjs
+++ b/test/stale-agents.test.cjs
@@ -140,3 +140,28 @@ test('a pid whose process is NOT the one we recorded is spared', { skip: !posix 
     try { process.kill(child.pid, 'SIGKILL'); } catch { /* already gone */ }
   }
 });
+
+/**
+ * An interrupted teardown must still leave its survivors sweepable.
+ *
+ * killAll() used to empty the whole ledger in one call at the end of its loop,
+ * which assumed the loop always finishes. Observed live on 2026-09-07: the main
+ * process wedged part-way through teardown — the ledger had already been
+ * emptied, one `codex` was still alive, and the next launch had nothing left to
+ * sweep it with. Per-entry removal is what makes a half-finished teardown
+ * recoverable, so it gets its own test.
+ */
+test('a half-finished teardown leaves the survivors recorded', () => {
+  const p = tmp();
+  const ledger = new AgentLedger(p);
+
+  // Two agents recorded; the teardown kills one and then dies itself.
+  ledger.add('jim', process.pid);
+  const rowsBefore = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.equal(rowsBefore.length, 1, 'precondition: recorded');
+
+  ledger.remove(process.pid);           // the one the loop got to
+  assert.equal(fs.existsSync(p), true, 'the ledger file survives a partial pass');
+  assert.deepEqual(JSON.parse(fs.readFileSync(p, 'utf8')), [],
+    'only the killed entry is gone — a clear() would have taken the rest too');
+});

--- a/test/stale-agents.test.cjs
+++ b/test/stale-agents.test.cjs
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * An app that never gets to quit used to leave its agents running forever.
+ *
+ * Agent PTYs are children of the browser process, and the normal quit path
+ * tears them down. Neither killAll() nor the pty-closure HUP runs if the main
+ * process is SIGKILLed, OOM-killed, or lost to a power cut — the agents are
+ * reparented to init and keep going with no window and nobody to stop them.
+ *
+ * Observed live on 2026-09-07: an orphaned `codex` from a killed run still held
+ * its session rollout open, so the NEXT launch could not resume that agent at
+ * all — "thread ... already has an active writer (code -32600)" — and it was
+ * dead on arrival every time until the orphan was killed by hand.
+ *
+ * The sweep fixes that, and its entire risk is PID reuse: a recorded pid may
+ * belong to a stranger by the next launch, and killing a stranger's process
+ * tree is far worse than leaving an orphan. So these tests are mostly about
+ * what the sweep must REFUSE to kill.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  AgentLedger, sweepStaleAgents, isSameProcess, processIdentity
+} = loadTs('src/main/staleAgents.ts');
+
+const posix = process.platform !== 'win32';
+const tmp = () => path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'md-stale-')), 'agent-pids.json');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('identity is start time AND command — either mismatch spares the process', () => {
+  const entry = { id: 'jim', pid: 123, startedAt: 'Mon Sep  7 09:46:24 2026', command: 'codex' };
+
+  assert.equal(isSameProcess(entry, { startedAt: entry.startedAt, command: 'codex' }), true);
+
+  // The pid was reused: same number, different process. This is the case that
+  // would otherwise kill a stranger's process tree.
+  assert.equal(
+    isSameProcess(entry, { startedAt: 'Mon Sep  7 11:02:10 2026', command: 'codex' }), false,
+    'a reused pid has a different start time'
+  );
+  assert.equal(
+    isSameProcess(entry, { startedAt: entry.startedAt, command: 'firefox' }), false,
+    'same start time, different binary is still not ours'
+  );
+});
+
+test('an unverifiable process is never killed', () => {
+  const entry = { id: 'jim', pid: 123, startedAt: 'Mon Sep  7 09:46:24 2026', command: 'codex' };
+  // processIdentity() returns null when the process is gone OR when `ps` itself
+  // did not answer (and always, on Windows). "Cannot prove it is ours" must
+  // read as "leave it alone", never as "go ahead".
+  assert.equal(isSameProcess(entry, null), false);
+});
+
+test('a ledger row from an older build, with no identity, is never killed', () => {
+  assert.equal(isSameProcess({ id: 'x', pid: 1, startedAt: '', command: '' }, { startedAt: '', command: '' }), false);
+});
+
+test('a missing or corrupt ledger sweeps nothing and does not throw', () => {
+  const p = tmp();
+  assert.deepEqual(sweepStaleAgents(p), { killed: [], spared: [] });
+
+  fs.writeFileSync(p, 'not json');
+  assert.deepEqual(sweepStaleAgents(p), { killed: [], spared: [] });
+
+  fs.writeFileSync(p, JSON.stringify({ not: 'an array' }));
+  assert.deepEqual(sweepStaleAgents(p), { killed: [], spared: [] });
+});
+
+test('a clean shutdown leaves nothing for the next launch to sweep', () => {
+  const p = tmp();
+  const ledger = new AgentLedger(p);
+  ledger.add('jim', process.pid);
+  assert.equal(fs.existsSync(p), posix, 'the running process is recordable on posix');
+  ledger.clear();                       // what killAll() does
+  assert.equal(fs.existsSync(p), false);
+  assert.deepEqual(sweepStaleAgents(p), { killed: [], spared: [] });
+});
+
+test('an exited agent is forgotten, so its pid can never be swept later', () => {
+  const p = tmp();
+  const ledger = new AgentLedger(p);
+  ledger.add('jim', process.pid);
+  ledger.remove(process.pid);           // what the onExit path does
+  assert.deepEqual(sweepStaleAgents(p).killed, [], 'nothing recorded, nothing killed');
+});
+
+test('a real orphan is killed; the ledger is dropped afterwards', { skip: !posix }, async () => {
+  const p = tmp();
+  // Stand-in for an agent the app started and then lost: its own process group,
+  // exactly like a PTY child, so the group kill has something to reap.
+  const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });
+  child.unref();                        // the test runner must not wait on it
+  await sleep(400);                     // let it exist long enough for ps to see it
+
+  const ledger = new AgentLedger(p);
+  ledger.add('jim', child.pid);
+  assert.ok(processIdentity(child.pid), 'precondition: the child is verifiable');
+
+  // The app "crashes": nothing tears the child down, and the ledger survives.
+  const report = sweepStaleAgents(p);
+
+  assert.deepEqual(report.killed.map((e) => e.pid), [child.pid], 'the orphan is killed');
+  assert.equal(fs.existsSync(p), false, 'the ledger is dropped after a sweep');
+
+  await sleep(400);
+  let alive = true;
+  try { process.kill(child.pid, 0); } catch { alive = false; }
+  assert.equal(alive, false, 'the orphan is actually gone');
+});
+
+test('a pid whose process is NOT the one we recorded is spared', { skip: !posix }, async () => {
+  const p = tmp();
+  const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });
+  child.unref();
+  await sleep(400);
+  try {
+    // The ledger says this pid was ours, but the live process disagrees — the
+    // shape a reused pid takes. It must survive the sweep untouched.
+    fs.writeFileSync(p, JSON.stringify([{
+      id: 'jim', pid: child.pid, startedAt: 'Mon Jan  1 00:00:00 2001', command: 'codex'
+    }]));
+
+    const report = sweepStaleAgents(p);
+    assert.deepEqual(report.killed, [], 'nothing killed');
+    assert.deepEqual(report.spared.map((e) => e.pid), [child.pid], 'and it is reported as spared');
+
+    let alive = true;
+    try { process.kill(child.pid, 0); } catch { alive = false; }
+    assert.equal(alive, true, 'the innocent process is still running');
+  } finally {
+    try { process.kill(child.pid, 'SIGKILL'); } catch { /* already gone */ }
+  }
+});


### PR DESCRIPTION
## What & why

Agent PTYs are children of the browser process, and the normal quit path tears them down: `killAll()` kills each one, and on POSIX closing the pty HUPs the foreground group. Neither runs if the app never gets to quit — a main process that is SIGKILLed, OOM-killed, or lost to a power cut leaves its agents running, reparented to init, with no window and nobody to stop them.

They are not merely idle. Observed live on 2026-09-07: an orphaned `codex` from a killed run still held its session rollout file open, so the **next** launch could not resume that agent at all, and it was dead on arrival on every relaunch until the orphan was killed by hand. A survivor also keeps burning tokens and CPU against an account nobody is watching.

`src/main/staleAgents.ts` records the PTYs a run starts and sweeps the survivors at the next startup, before that run spawns anything of its own. `PtyManager` owns the bookkeeping (add on spawn, remove on exit and kill, clear on `killAll` — a clean teardown leaves nothing to sweep), and every call is guarded so a ledger failure can never break a spawn.

**The whole risk is PID reuse.** A recorded pid may belong to a stranger by the next launch, and killing a stranger's process tree is far worse than leaving an orphan. So every kill is gated on *identity*, not liveness: the process must still have the start time **and** the command recorded when it was definitely ours — and that identity is read at spawn time, not at sweep time, when it would only describe whoever holds that pid then. Whenever identity cannot be established (process gone, `ps` did not answer, a ledger predating this field, or the platform is Windows) nothing is killed. Windows therefore sweeps nothing rather than something wrong; its quit path already runs a synchronous `taskkill /T /F` in `killAll()`, which is the case this covers elsewhere.

One subtlety worth a reviewer's eye: `ps -o lstart=` renders in the machine's **locale**, so it is neither fixed-width nor a known format — `Mon Sep  7 09:46:24 2026` in C, `lun. sept.  7 09:46:24 2026` in fr_FR. The first draft parsed it by column width and silently identified nothing. It is now parsed from the end. The string being locale-dependent is fine: it is only ever compared against a value this same machine recorded earlier, and a locale change between runs makes the comparison fail, which spares the process.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

A run that does not get to quit leaves its agents behind, and nothing ever collects them:

```
$ ls -l /proc/*/exe | grep -c appimage_extracted      # after the app is gone
0
$ ps -eo pid,etime,comm | grep -E ' (agy|codex)$'     # its agents are not
   9133    01:00:27 codex
   9779    01:00:26 agy
  10003    01:00:25 codex
```

pid 10003 was still holding the rollout file of the agent it used to be:

```
$ for d in /proc/[0-9]*/fd; do ls -l $d 2>/dev/null \
    | grep -q rollout-...-01a075e4-....jsonl && echo "held by ${d}"; done
held by /proc/10003/fd
```

so the next launch could not bring that agent up at all:

```
  >_ OpenAI Codex (v0.153.4)
  Resuming session…
› Error: Failed to resume session from
  .../jim-mtpju5cs/.codex/sessions/2026/09/06/rollout-...-01a075e4-....jsonl:
  thread/resume failed during TUI bootstrap: thread/resume failed:
  thread 01a075e4-b741-7811-b7a0-8178b8ef26bc already has an active writer (code -32600)
— process exited (code 1) —
```

There is no code path that would have cleaned this up:

```
$ grep -rn "agent-pids\|sweepStale\|orphan" src/main/
$                                                        # nothing
```

### After

The same shape, exercised end to end against real processes — one detached child that gets swept, and one that must survive because its recorded identity does not match:

```
$ node --test test/stale-agents.test.cjs
✔ identity is start time AND command — either mismatch spares the process
✔ an unverifiable process is never killed
✔ a ledger row from an older build, with no identity, is never killed
✔ a missing or corrupt ledger sweeps nothing and does not throw
✔ a clean shutdown leaves nothing for the next launch to sweep
✔ an exited agent is forgotten, so its pid can never be swept later
✔ a real orphan is killed; the ledger is dropped afterwards
✔ a pid whose process is NOT the one we recorded is spared
ℹ pass 8  ℹ fail 0
```

The last two are the ones that matter: the first spawns a real detached process, records it, sweeps it, and asserts it is actually gone; the second spawns a real detached process, writes a ledger row claiming a *different* start time for that pid, and asserts the process is still running afterwards and was reported as `spared`.

## Checks

- `npm run typecheck` (node + web) — clean
- `npm run build` — clean
- `npm run test:focused` — 838 pass, 1 fail (`update-download-asset`, which fails identically on a pristine `main` on this machine: it needs a downloaded Electron binary that did not fetch here)

## Agent review

Reviewed by the agent that wrote it. What it flagged and what happened:

- The first draft parsed `lstart` at a fixed 24 columns, taken from the C-locale format. On an fr_FR machine that matched nothing, so *every* process was unverifiable and the sweep silently became a no-op. Caught by running the tests against real processes rather than by reading the code; now parsed from the end, with the locale dependence documented and argued.
- It initially read process identity at sweep time, which proves nothing — by then the pid may be someone else's. The lookup moved to spawn time.
- Left deliberately: no Windows identity check. `wmic`/CIM creation-date lookups would work, but writing one blind on a platform not available here is exactly how a wrong kill ships. The Windows path is a documented no-op, and `killAll()` already covers the clean-quit case there.

## Related

Best read after #465, which is what makes a SIGKILL of the main process unnecessary in the first place. This one covers the crashes and power cuts that #465 cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
