### PR TITLE
Add a floor switcher, and give floors distinct titles

### DIFF
--- a/src/main/floors.ts
+++ b/src/main/floors.ts
@@ -1,0 +1,68 @@
+/**
+ * Telling floors apart, and moving between them.
+ *
+ * Floors already run in parallel — each window owns its own PTYs (routed by
+ * `PtySession.owner`), and `backgroundThrottling: false` keeps an occluded
+ * floor's heartbeat loops running. What was missing was any way to *reach* a
+ * particular one.
+ *
+ * Two things stood in the way, and only the first is obvious:
+ *
+ *  1. Nothing listed the open floors. The app menu is built once at startup, so
+ *     even a static list would have gone stale on the first `New Floor`.
+ *
+ *  2. Every floor was called "Munder Difflin". `createWindow` passes
+ *     `title: 'Munder Difflin — Floor'`, but `src/renderer/index.html` carries
+ *     `<title>Munder Difflin</title>`, and in Electron the PAGE title wins as
+ *     soon as it loads — silently, with no error. Verified on 2026-09-07: every
+ *     open window reported the same title to the compositor, so the window
+ *     manager's own switcher could not distinguish them either. Setting the
+ *     title at construction is therefore not enough; it has to be re-applied
+ *     after load and defended against `page-title-updated`.
+ *
+ * Numbering is by POSITION, not by a stable id, so the numbers stay dense as
+ * floors come and go and always match what the switcher menu shows. A floor
+ * being renumbered when an earlier one closes is the same behaviour browser tabs
+ * have, and it keeps `Ctrl+Alt+2` meaning "the second one in the list".
+ */
+
+/** The primary window keeps the bare product name — it is the one users think
+ *  of as "the app", and renaming it to "Floor 1" would be a downgrade. */
+export const PRIMARY_TITLE = 'Munder Difflin';
+
+/** Title for the window at `index` in floor order (0 = primary). */
+export function floorTitle(index: number): string {
+  return index === 0 ? PRIMARY_TITLE : `${PRIMARY_TITLE} — Floor ${index + 1}`;
+}
+
+/** Menu label for the window at `index`. Numbered so the row reads the same way
+ *  as the accelerator that reaches it. */
+export function floorMenuLabel(index: number): string {
+  return `${index + 1}  ${floorTitle(index)}`;
+}
+
+/** Accelerator for the nth floor, or undefined past what we can bind.
+ *
+ *  `CmdOrCtrl+Alt+<n>` rather than the browser-style `CmdOrCtrl+<n>`: a menu
+ *  accelerator is claimed before the focused element sees the key, and these
+ *  windows are mostly full of agent TUIs. Ctrl+1..9 is plausible input for a
+ *  TUI; Ctrl+Alt+1..9 is not. (This is the same concern that made the Edit
+ *  menu's clipboard items `registerAccelerator: false`, arrived at from the
+ *  other direction: there the fix was to leave the key alone, here it is to
+ *  choose a key nothing else wants.) */
+export function floorAccelerator(index: number): string | undefined {
+  return index < 9 ? `CmdOrCtrl+Alt+${index + 1}` : undefined;
+}
+
+/**
+ * Index of the floor to move to when cycling.
+ *
+ * Wraps in both directions, so a two-floor setup can be flipped between with one
+ * key held down. `current` of -1 (nothing focused, or a window not in the list)
+ * enters at the first floor going forward and the last going back.
+ */
+export function cycleFloorIndex(current: number, count: number, dir: 1 | -1): number {
+  if (count <= 0) return -1;
+  if (current < 0 || current >= count) return dir === 1 ? 0 : count - 1;
+  return (current + dir + count) % count;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { join, resolve, sep, basename, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { request as httpsRequest } from 'node:https';
 import { PtyManager, type SpawnOptions } from './pty';
+import { floorTitle, floorMenuLabel, floorAccelerator, cycleFloorIndex } from './floors';
 import { resolveCommand as resolveCliCommand, isSafeCommandName } from './shellEnv';
 import { initAutoUpdater, abortPendingRestart } from './updater';
 import { RealtimeFloorWatcher } from './realtimeFloorWatcher';
@@ -344,6 +345,24 @@ let mainWindow: BrowserWindow | null = null;
 /** Every open window (primary + floors). A registry, not a single handle, so
  *  multi-window lifecycle (focus tracking, quit fan-out) is correct. */
 const allWindows = new Set<BrowserWindow>();
+
+/** Open windows in floor order: the primary first, then floors oldest-first.
+ *  A Set has insertion order and createWindow adds the primary first, so this is
+ *  simply the live set minus anything already torn down. */
+function floorOrder(): BrowserWindow[] {
+  return [...allWindows].filter((w) => !w.isDestroyed());
+}
+
+/** Re-apply every window's numbered title and rebuild the switcher menu.
+ *
+ *  Called on open AND on close: numbering is positional, so closing floor 2
+ *  renumbers whatever was floor 3, and a stale menu would point at a window that
+ *  no longer exists. */
+function refreshFloors(): void {
+  const wins = floorOrder();
+  wins.forEach((w, i) => { try { w.setTitle(floorTitle(i)); } catch { /* torn down mid-pass */ } });
+  if (readConfig().multiWindow) installAppMenu();
+}
 /** Monotonic floor counter → a stable, unique session partition per floor so
  *  each floor's renderer state (localStorage: agents, queues, selection) is
  *  isolated from every other window's. */
@@ -2320,6 +2339,13 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   const wc = win.webContents;
 
   allWindows.add(win);
+  // src/renderer/index.html carries <title>Munder Difflin</title>, and in
+  // Electron the PAGE title overrides the BrowserWindow one the moment it
+  // loads — silently. Without this every floor reports the same title to the
+  // compositor and neither our switcher nor the window manager's can tell them
+  // apart (verified 2026-09-07). Refuse the page's title and re-apply ours.
+  win.on('page-title-updated', (e) => { e.preventDefault(); });
+  win.webContents.on('did-finish-load', () => { refreshFloors(); });
   // Global timer events follow the user — the most-recently-focused window is
   // primary. The primary is also seeded synchronously so boot events route now.
   win.on('focus', () => { mainWindow = win; });
@@ -2371,7 +2397,7 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   }
 
 
-  win.once('ready-to-show', () => win.show());
+  win.once('ready-to-show', () => { win.show(); refreshFloors(); });
 
   // Never opens a window; hands the URL to the OS browser instead.
   //
@@ -2433,6 +2459,9 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
 
   win.on('closed', () => {
     allWindows.delete(win);
+    // Numbering is positional, so a close renumbers every later floor and the
+    // switcher menu still lists a window that no longer exists.
+    refreshFloors();
     // A closed floor must not leave its terminals running headless. (Natural
     // onExit teardown — archive + worktree cleanup — still runs per PTY.)
     if (isFloor) { try { ptyManager.killByOwner(wc); } catch { /* best-effort */ } }
@@ -2449,6 +2478,13 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
 /** Open a new floor window — gated by the multiWindow flag. Returns the window,
  *  or null when the feature is off (the entry points are hidden in that case,
  *  but the IPC stays defensive). */
+/** Move focus one floor forward or back, wrapping at both ends. */
+function focusFloorBy(dir: 1 | -1): void {
+  const wins = floorOrder();
+  const next = wins[cycleFloorIndex(wins.findIndex((w) => w.isFocused()), wins.length, dir)];
+  if (next && !next.isDestroyed()) { next.show(); next.focus(); }
+}
+
 function openFloor(): BrowserWindow | null {
   if (!readConfig().multiWindow) return null;
   return createWindow({ floor: true });
@@ -2502,6 +2538,34 @@ function installAppMenu(): void {
       ]
     },
     { role: 'viewMenu' },
+    // The floor switcher. Rebuilt by refreshFloors() on every open/close, which
+    // is the only way it can stay true: the menu is otherwise built once.
+    {
+      label: 'Floors',
+      submenu: [
+        ...floorOrder().map((w, i) => ({
+          label: floorMenuLabel(i),
+          accelerator: floorAccelerator(i),
+          // `type: 'checkbox'` rather than 'radio': radio items in an Electron
+          // submenu group take the FIRST item's state when none is checked,
+          // which would mark floor 1 as current no matter which had focus.
+          type: 'checkbox' as const,
+          checked: w.isFocused(),
+          click: () => { if (!w.isDestroyed()) { w.show(); w.focus(); } }
+        })),
+        { type: 'separator' as const },
+        {
+          label: 'Next Floor',
+          accelerator: 'CmdOrCtrl+Alt+Right',
+          click: () => focusFloorBy(1)
+        },
+        {
+          label: 'Previous Floor',
+          accelerator: 'CmdOrCtrl+Alt+Left',
+          click: () => focusFloorBy(-1)
+        }
+      ]
+    },
     { role: 'windowMenu' }
   ];
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -353,15 +353,35 @@ function floorOrder(): BrowserWindow[] {
   return [...allWindows].filter((w) => !w.isDestroyed());
 }
 
+let floorRefreshQueued = false;
+
 /** Re-apply every window's numbered title and rebuild the switcher menu.
  *
  *  Called on open AND on close: numbering is positional, so closing floor 2
  *  renumbers whatever was floor 3, and a stale menu would point at a window that
- *  no longer exists. */
+ *  no longer exists.
+ *
+ *  DEFERRED, and that is the whole point of the indirection. The trigger for a
+ *  rebuild is usually `New Floor`, whose click handler is a MENU ITEM of the
+ *  very menu being replaced: calling Menu.setApplicationMenu() from inside that
+ *  click's own call stack tears the menu out from under the item still being
+ *  activated. Observed live on 2026-09-07 — Ctrl+Shift+N opened the floor and
+ *  then took the whole app down, cleanly and silently, while the same keystroke
+ *  on a build without this rebuild worked fine. setImmediate lets the click
+ *  unwind first; the flag coalesces the burst (ready-to-show and
+ *  did-finish-load both fire) into one rebuild. */
 function refreshFloors(): void {
-  const wins = floorOrder();
-  wins.forEach((w, i) => { try { w.setTitle(floorTitle(i)); } catch { /* torn down mid-pass */ } });
-  if (readConfig().multiWindow) installAppMenu();
+  if (floorRefreshQueued) return;
+  floorRefreshQueued = true;
+  setImmediate(() => {
+    floorRefreshQueued = false;
+    const wins = floorOrder();
+    wins.forEach((w, i) => { try { w.setTitle(floorTitle(i)); } catch { /* torn down mid-pass */ } });
+    if (!readConfig().multiWindow) return;
+    // A menu that fails to build must not take the app with it: without the
+    // guard the throw escapes into Electron's event loop.
+    try { installAppMenu(); } catch (e) { console.error('[floors] menu rebuild failed:', e); }
+  });
 }
 /** Monotonic floor counter → a stable, unique session partition per floor so
  *  each floor's renderer state (localStorage: agents, queues, selection) is

--- a/test/floor-switcher.test.cjs
+++ b/test/floor-switcher.test.cjs
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * Floors already ran in parallel — each window owns its own PTYs, and
+ * `backgroundThrottling: false` keeps an occluded floor's heartbeat loops
+ * running. What was missing was any way to reach a particular one.
+ *
+ * The non-obvious half of that: every floor was called "Munder Difflin".
+ * `createWindow` passes `title: 'Munder Difflin — Floor'`, but
+ * src/renderer/index.html carries `<title>Munder Difflin</title>`, and in
+ * Electron the PAGE title wins as soon as it loads — silently, with no error.
+ * Verified on 2026-09-07 against a running build: every open window reported the
+ * same title to the compositor, so the window manager's own switcher could not
+ * tell them apart either. That is why the fix re-applies the title after load
+ * and refuses `page-title-updated`, rather than trusting the constructor.
+ *
+ * These tests pin the naming and the cycling, which is where the behaviour lives.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const {
+  PRIMARY_TITLE, floorTitle, floorMenuLabel, floorAccelerator, cycleFloorIndex
+} = loadTs('src/main/floors.ts');
+
+test('the primary keeps the bare product name; floors are numbered from 2', () => {
+  // Renaming the primary to "Floor 1" would be a downgrade — it is the window
+  // users think of as "the app".
+  assert.equal(floorTitle(0), PRIMARY_TITLE);
+  assert.equal(floorTitle(1), 'Munder Difflin — Floor 2');
+  assert.equal(floorTitle(2), 'Munder Difflin — Floor 3');
+});
+
+test('every floor gets a DISTINCT title — the whole point of the change', () => {
+  const titles = [0, 1, 2, 3].map(floorTitle);
+  assert.equal(new Set(titles).size, titles.length, 'titles must be unique');
+});
+
+test('the menu row reads the same way as the key that reaches it', () => {
+  assert.equal(floorMenuLabel(0), `1  ${PRIMARY_TITLE}`);
+  assert.equal(floorAccelerator(0), 'CmdOrCtrl+Alt+1');
+  assert.equal(floorMenuLabel(1), '2  Munder Difflin — Floor 2');
+  assert.equal(floorAccelerator(1), 'CmdOrCtrl+Alt+2');
+});
+
+test('accelerators stop at 9 rather than binding nonsense', () => {
+  assert.equal(floorAccelerator(8), 'CmdOrCtrl+Alt+9');
+  assert.equal(floorAccelerator(9), undefined, 'a 10th floor is clickable, not bound');
+});
+
+test('the accelerator avoids keys an agent TUI might want', () => {
+  // A menu accelerator is claimed BEFORE the focused element sees the key, and
+  // these windows are mostly full of agent TUIs. Ctrl+1 is plausible TUI input;
+  // Ctrl+Alt+1 is not. Browser-style Ctrl+<n> would have stolen keystrokes.
+  for (let i = 0; i < 9; i++) {
+    assert.match(floorAccelerator(i), /^CmdOrCtrl\+Alt\+[1-9]$/);
+  }
+});
+
+test('cycling wraps in both directions', () => {
+  assert.equal(cycleFloorIndex(0, 3, 1), 1);
+  assert.equal(cycleFloorIndex(2, 3, 1), 0, 'forward past the end wraps to the first');
+  assert.equal(cycleFloorIndex(0, 3, -1), 2, 'back past the start wraps to the last');
+  // Two floors held down on one key must flip, not stick.
+  assert.equal(cycleFloorIndex(0, 2, 1), 1);
+  assert.equal(cycleFloorIndex(1, 2, 1), 0);
+});
+
+test('cycling with nothing focused enters at the near end', () => {
+  // findIndex returns -1 when no window is focused, or when the focused window
+  // is not one of ours. Entering the list must still do something sensible.
+  assert.equal(cycleFloorIndex(-1, 3, 1), 0);
+  assert.equal(cycleFloorIndex(-1, 3, -1), 2);
+  assert.equal(cycleFloorIndex(99, 3, 1), 0, 'an index past the end is treated the same');
+});
+
+test('cycling with no windows reports nothing to focus', () => {
+  assert.equal(cycleFloorIndex(0, 0, 1), -1);
+  assert.equal(cycleFloorIndex(-1, 0, -1), -1);
+});


### PR DESCRIPTION
## What & why

Floors already ran in parallel — each window owns its own PTYs (routed by `PtySession.owner`), and `backgroundThrottling: false` keeps an occluded floor's heartbeat loops running even behind a lock screen. What was missing was any way to *reach* a particular one.

Two things stood in the way, and only the first is obvious.

**1. Nothing listed the open floors.** `installAppMenu()` is called once at startup, so even a static list would have gone stale on the first `New Floor`.

**2. Every floor was called "Munder Difflin".** `createWindow` passes `title: 'Munder Difflin — Floor'`, but `src/renderer/index.html` carries `<title>Munder Difflin</title>`, and in Electron the **page** title wins as soon as it loads — silently, with no error. Setting it in the constructor was never enough. Verified against a running build on 2026-09-07: every open window reported the same title to the compositor, so the window manager's own switcher could not tell them apart either.

`src/main/floors.ts` owns the naming and the cycling as pure functions; `index.ts` wires them:

- `page-title-updated` is refused and the title re-applied after load, so the page can no longer stomp it.
- `refreshFloors()` renumbers every window and rebuilds the menu on open **and** on close — numbering is positional, so closing floor 2 renumbers floor 3, and a stale menu would point at a window that is gone.
- A `Floors` menu lists the open windows, checkmarks the focused one, and binds each to `CmdOrCtrl+Alt+<n>`, plus `CmdOrCtrl+Alt+Left/Right` to cycle.

Two choices worth a reviewer's eye:

- **The accelerator is `CmdOrCtrl+Alt+<n>`, not the browser-style `CmdOrCtrl+<n>`.** A menu accelerator is claimed before the focused element sees the key, and these windows are mostly full of agent TUIs. `Ctrl+1` is plausible TUI input; `Ctrl+Alt+1` is not. This is the same concern that made the Edit menu's clipboard items `registerAccelerator: false`, arrived at from the other direction — there the fix was to leave the key alone, here it is to pick a key nothing else wants.
- **The rows are `type: 'checkbox'`, not `'radio'`.** Radio items in an Electron submenu group take the first item's state when none is checked, which would mark floor 1 as current no matter which window had focus.

Numbering is positional rather than by a stable id, so the numbers stay dense and always match what the menu shows — the same behaviour browser tabs have. The primary keeps the bare product name; renaming it to "Floor 1" would be a downgrade.

No change to how floors run. Cross-platform: no platform-specific code, `CmdOrCtrl` throughout, and the menu itself is already gated on the existing `multiWindow` flag.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

Two windows open (primary + one `New Floor`), as the compositor sees them:

```
$ hyprctl clients -j | jq -r '.[] | select(.class|test("munder";"i")) | .title'
Munder Difflin
Munder Difflin
```

Identical. Nothing in the app lists them either — the menu is `File / Edit / View / Window`, with no floor entry anywhere:

```
$ grep -n "role: 'viewMenu'" -A2 src/main/index.ts
    { role: 'viewMenu' },
    { role: 'windowMenu' }
  ];
```

So the only way to reach a specific floor is to guess from the window manager's list of identically-named windows.

### After

Titles are distinct and numbered, and the naming/cycling is pinned by tests:

```
$ node --test test/floor-switcher.test.cjs
✔ the primary keeps the bare product name; floors are numbered from 2
✔ every floor gets a DISTINCT title — the whole point of the change
✔ the menu row reads the same way as the key that reaches it
✔ accelerators stop at 9 rather than binding nonsense
✔ the accelerator avoids keys an agent TUI might want
✔ cycling wraps in both directions
✔ cycling with nothing focused enters at the near end
✔ cycling with no windows reports nothing to focus
ℹ pass 8  ℹ fail 0
```

The menu gains a `Floors` submenu that tracks the open windows:

```
Floors
  ✓ 1  Munder Difflin                Ctrl+Alt+1
    2  Munder Difflin — Floor 2      Ctrl+Alt+2
    3  Munder Difflin — Floor 3      Ctrl+Alt+3
    ─────────────────────────────
    Next Floor                       Ctrl+Alt+→
    Previous Floor                   Ctrl+Alt+←
```

Closing floor 2 renumbers floor 3 to 2 and rebuilds the list, so the numbers, the titles and the accelerators never disagree.

## Checks

- `npm run typecheck` (node + web) — clean
- `npm run build` — clean
- `npm run test:focused` — 838 pass, 1 fail (`update-download-asset`, which fails identically on a pristine `main` on this machine: it needs a downloaded Electron binary that did not fetch here)

## Agent review

Reviewed by the agent that wrote it. What it flagged and what happened:

- The first draft only changed the `title:` option in `createWindow`, which does nothing — the page title overrides it on load. Caught by checking the live window titles rather than by reading the constructor.
- It initially reached for browser-style `Ctrl+<n>`, which would have stolen keystrokes from the agent TUIs that fill these windows. There is a test for the key shape now, precisely because the wrong choice is invisible until someone loses a keystroke mid-run.
- Radio menu items looked like the natural fit for "which floor is current" and were wrong for it; checkbox items are used instead.
- Left deliberately: no in-window floor switcher UI, and no per-floor agent scoping. The on-disk hive is process-global and floors share it (as documented on the `multiWindow` flag) — changing that is a much larger design question than a switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LZ5q4m4TzEX1xzoFtt2na
