### PR TITLE
Slack media: outbound file upload + inbound download fix + thread reply-ledger

### DIFF
--- a/resources/md-slack-reply.cjs
+++ b/resources/md-slack-reply.cjs
@@ -10,16 +10,25 @@
  * Slack's chat.postMessage. The token never appears here, in the prompt, or in
  * any transcript.
  *
+ * On a SUCCESSFUL post it also UPSERTS the bot-thread follow-ledger
+ * (`slack-bot-threads.json`, alongside the app config in userData) that
+ * `md-slack-poller.cjs` reads to decide which threads to pull replies for. This
+ * is what makes a user's later THREAD REPLY reach the bot with no @-mention:
+ * conversations.history only returns top-level messages, so a thread is only
+ * followed if it's in this ledger. Every agent/god reply goes through THIS CLI,
+ * so writing the ledger here (rather than relying on the MD main process) is what
+ * guarantees the ledger actually exists. The ledger holds channel + thread
+ * timestamps ONLY — never a token. A ledger write failure never breaks the reply.
+ *
  * Usage:
  *   node md-slack-reply.cjs --channel C123 --thread 1700000000.000100 --text "..."
- *   (optional) --config /abs/path/to/slack-reply.json
- *
- * The discovery file is located via, in order: --config, then the
- * MD_SLACK_REPLY_CONFIG env var (injected into every agent by main).
+ *   (optional) --config /abs/path/to/slack-reply.json   (else MD_SLACK_REPLY_CONFIG)
+ *   (optional) --ledger /abs/path/to/slack-bot-threads.json  (else alongside config)
  */
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 const http = require('node:http');
 
 /** Parse `--key value` and `--key=value` pairs from argv. */
@@ -43,58 +52,127 @@ function fail(msg) {
   process.exit(1);
 }
 
-const args = parseArgs(process.argv.slice(2));
-const channel = args.channel;
-const thread = args.thread || args.thread_ts;
-const text = args.text;
-
-if (!channel || !thread || !text || text === true) {
-  fail('required: --channel <id> --thread <ts> --text "<message>"');
+/** Numeric max of two Slack decimal-string timestamps (either may be undefined). */
+function tsMaxStr(a, b) {
+  if (!a) return b;
+  if (!b) return a;
+  return Number(b) > Number(a) ? b : a;
 }
 
-const configPath = args.config || process.env.MD_SLACK_REPLY_CONFIG;
-if (!configPath) {
-  fail('cannot locate the reply endpoint: set MD_SLACK_REPLY_CONFIG or pass --config');
+/** Resolve the follow-ledger path: --ledger, else alongside the discovery config
+ *  (MD userData) — the SAME dir `md-slack-poller.cjs` resolves the ledger in, so
+ *  the writer here and the reader there always agree. */
+function resolveLedgerPath(args, configPath) {
+  if (args && args.ledger && args.ledger !== true) return args.ledger;
+  return path.join(path.dirname(configPath), 'slack-bot-threads.json');
 }
 
-let cfg;
-try {
-  cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-} catch (e) {
-  fail(`reply endpoint not running (could not read ${configPath}): ${e.message}`);
-}
-if (!cfg || typeof cfg.port !== 'number' || typeof cfg.token !== 'string') {
-  fail(`malformed reply config at ${configPath}`);
-}
-
-const body = JSON.stringify({ channel, thread_ts: thread, text });
-const req = http.request(
-  {
-    method: 'POST',
-    host: '127.0.0.1',
-    port: cfg.port,
-    path: '/reply',
-    headers: {
-      'content-type': 'application/json',
-      'content-length': Buffer.byteLength(body),
-      'x-md-reply-token': cfg.token
-    }
-  },
-  (res) => {
-    const chunks = [];
-    res.on('data', (c) => chunks.push(c));
-    res.on('end', () => {
-      const raw = Buffer.concat(chunks).toString('utf8');
-      let json = {};
-      try { json = JSON.parse(raw); } catch { /* non-JSON body */ }
-      if (res.statusCode === 200 && json.ok) {
-        process.stdout.write('Posted reply to Slack thread.\n');
-        process.exit(0);
-      }
-      fail(`reply failed (HTTP ${res.statusCode}): ${json.error || raw || 'unknown error'}`);
-    });
+/**
+ * Upsert one bot-participated thread into the ledger the poller reads. Merges
+ * with existing entries (never drops others), keeps the NEWEST `lastBotTs`, and
+ * writes atomically with 0600 perms (mirrors the poller's saveState). Shape
+ * matches what `md-slack-poller.cjs` `loadBotThreadRoots` expects:
+ *   { "threads": { "<root_ts>": { "channel": "C…", "lastBotTs": "<ts>", … } } }
+ * `botMsgTs` (the bot's posted message ts, from the loopback reply response) is
+ * the baseline the poller uses so it forwards only replies NEWER than the bot's
+ * reply; when unknown it falls back to the thread root ts. NEVER throws — a
+ * ledger error must not break a reply that already posted.
+ * @returns {boolean} true when the ledger was written.
+ */
+function upsertBotThread(ledgerPath, { channel, thread_ts, botMsgTs }) {
+  if (!channel || !thread_ts) return false;
+  try {
+    let data = { threads: {} };
+    try {
+      const parsed = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'));
+      if (parsed && typeof parsed === 'object' && parsed.threads && typeof parsed.threads === 'object') data = parsed;
+    } catch { /* missing or corrupt → start fresh, preserving nothing we can't read */ }
+    if (!data.threads || typeof data.threads !== 'object') data.threads = {};
+    const prev = data.threads[thread_ts] || {};
+    data.threads[thread_ts] = {
+      channel,
+      lastBotTs: tsMaxStr(prev.lastBotTs, botMsgTs || thread_ts),
+      ts: thread_ts,
+      updated: Date.now(),
+    };
+    const tmp = `${ledgerPath}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+    fs.renameSync(tmp, ledgerPath);
+    return true;
+  } catch (e) {
+    process.stderr.write(`md-slack-reply: warning — could not update follow-ledger: ${e.message}\n`);
+    return false;
   }
-);
-req.on('error', (e) => fail(`could not reach reply endpoint: ${e.message}`));
-req.write(body);
-req.end();
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const channel = args.channel;
+  const thread = args.thread || args.thread_ts;
+  const text = args.text;
+
+  if (!channel || !thread || !text || text === true) {
+    fail('required: --channel <id> --thread <ts> --text "<message>"');
+  }
+
+  const configPath = args.config || process.env.MD_SLACK_REPLY_CONFIG;
+  if (!configPath) {
+    fail('cannot locate the reply endpoint: set MD_SLACK_REPLY_CONFIG or pass --config');
+  }
+
+  let cfg;
+  try {
+    cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (e) {
+    fail(`reply endpoint not running (could not read ${configPath}): ${e.message}`);
+  }
+  if (!cfg || typeof cfg.port !== 'number' || typeof cfg.token !== 'string') {
+    fail(`malformed reply config at ${configPath}`);
+  }
+
+  const ledgerPath = resolveLedgerPath(args, configPath);
+  const body = JSON.stringify({ channel, thread_ts: thread, text });
+  const req = http.request(
+    {
+      method: 'POST',
+      host: '127.0.0.1',
+      port: cfg.port,
+      path: '/reply',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(body),
+        'x-md-reply-token': cfg.token
+      }
+    },
+    (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        let json = {};
+        try { json = JSON.parse(raw); } catch { /* non-JSON body */ }
+        if (res.statusCode === 200 && json.ok) {
+          // Record this thread in the follow-ledger so the poller pulls the user's
+          // FUTURE replies here (no @-mention needed). `json.ts` is the posted
+          // message ts when the running MD build returns it; otherwise the upsert
+          // baselines on the thread root. Fail-soft: never blocks the success path.
+          upsertBotThread(ledgerPath, {
+            channel, thread_ts: thread,
+            botMsgTs: typeof json.ts === 'string' ? json.ts : undefined
+          });
+          process.stdout.write('Posted reply to Slack thread.\n');
+          process.exit(0);
+        }
+        fail(`reply failed (HTTP ${res.statusCode}): ${json.error || raw || 'unknown error'}`);
+      });
+    }
+  );
+  req.on('error', (e) => fail(`could not reach reply endpoint: ${e.message}`));
+  req.write(body);
+  req.end();
+}
+
+// Run only when invoked directly; exporting the helpers keeps them testable.
+if (require.main === module) main();
+
+module.exports = { parseArgs, tsMaxStr, resolveLedgerPath, upsertBotThread };

--- a/resources/md-slack-upload.cjs
+++ b/resources/md-slack-upload.cjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * md-slack-upload.cjs — share a LOCAL file into a Slack thread, WITHOUT ever
+ * handling the bot token.
+ *
+ * Mirrors md-slack-reply.cjs: the Munder Difflin main process runs a loopback-only
+ * HTTP endpoint (127.0.0.1, never tunneled) that holds the bot token and writes
+ * its `{ port, token }` to a discovery file under userData. This helper POSTs the
+ * file's LOCAL PATH (not its bytes) + the target channel/thread to that endpoint's
+ * `/upload` route; main reads the file and runs Slack's external-upload flow
+ * (files.getUploadURLExternal -> PUT bytes -> files.completeUploadExternal). The
+ * token never appears here, in the prompt, in argv, or in any transcript.
+ *
+ * Usage:
+ *   node md-slack-upload.cjs --channel C123 --thread 1700000000.000100 --file /abs/path.pdf
+ *     [--title "Report"] [--comment "here you go"]
+ *   (optional) --config /abs/path/to/slack-reply.json   (else MD_SLACK_REPLY_CONFIG)
+ */
+'use strict';
+
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+/** Parse `--key value` and `--key=value` pairs from argv. */
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const eq = a.indexOf('=');
+    if (eq !== -1) { out[a.slice(2, eq)] = a.slice(eq + 1); continue; }
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next !== undefined && !next.startsWith('--')) { out[key] = next; i++; }
+    else out[key] = true;
+  }
+  return out;
+}
+
+function fail(msg) {
+  process.stderr.write(`md-slack-upload: ${msg}\n`);
+  process.exit(1);
+}
+
+/** Build the JSON payload the /upload endpoint expects (absolute file path). */
+function buildUploadBody(args) {
+  const channel = args.channel;
+  const thread = args.thread || args.thread_ts;
+  const file = args.file || args.path;
+  if (!channel || !thread || !file || file === true) {
+    return { error: 'required: --channel <id> --thread <ts> --file <abs path>' };
+  }
+  const absPath = path.resolve(String(file));
+  const body = { channel, thread_ts: thread, path: absPath };
+  if (typeof args.title === 'string') body.title = args.title;
+  if (typeof args.filename === 'string') body.filename = args.filename;
+  const comment = args.comment || args.initial_comment;
+  if (typeof comment === 'string') body.initial_comment = comment;
+  return { body, absPath };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const built = buildUploadBody(args);
+  if (built.error) fail(built.error);
+
+  // Fail early with a clear message if the file isn't there (main would 400 anyway).
+  try {
+    const st = fs.statSync(built.absPath);
+    if (!st.isFile()) fail(`not a regular file: ${built.absPath}`);
+  } catch (e) {
+    fail(`cannot read file ${built.absPath}: ${e.message}`);
+  }
+
+  const configPath = args.config || process.env.MD_SLACK_REPLY_CONFIG;
+  if (!configPath) {
+    fail('cannot locate the upload endpoint: set MD_SLACK_REPLY_CONFIG or pass --config');
+  }
+  let cfg;
+  try { cfg = JSON.parse(fs.readFileSync(configPath, 'utf8')); }
+  catch (e) { fail(`reply/upload endpoint not running (could not read ${configPath}): ${e.message}`); }
+  if (!cfg || typeof cfg.port !== 'number' || typeof cfg.token !== 'string') {
+    fail(`malformed reply config at ${configPath}`);
+  }
+
+  const payload = JSON.stringify(built.body);
+  const req = http.request(
+    {
+      method: 'POST', host: '127.0.0.1', port: cfg.port, path: '/upload',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+        'x-md-reply-token': cfg.token
+      }
+    },
+    (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        let json = {};
+        try { json = JSON.parse(raw); } catch { /* non-JSON body */ }
+        if (res.statusCode === 200 && json.ok) {
+          process.stdout.write('Uploaded file to Slack thread.\n');
+          process.exit(0);
+        }
+        fail(`upload failed (HTTP ${res.statusCode}): ${json.error || raw || 'unknown error'}`);
+      });
+    }
+  );
+  req.on('error', (e) => fail(`could not reach upload endpoint: ${e.message}`));
+  req.write(payload);
+  req.end();
+}
+
+// Run only when invoked directly; exporting the helpers keeps them testable.
+if (require.main === module) main();
+
+module.exports = { parseArgs, buildUploadBody };

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -333,6 +333,13 @@ export interface HarnessConfig {
   slackChannelId?: string;
   /** Local HTTP port the webhook server binds to (default 3847). */
   slackPort?: number;
+  /** Poll-only mode for a laptop behind corporate NAT with NO public tunnel.
+   *  When true, the webhook server binds to 127.0.0.1 ONLY and SKIPS opening a
+   *  public tunnel, while the loopback reply endpoint + done-observer still start
+   *  — so a local poller can deliver events AND replies work with no inbound
+   *  exposure. DEFAULT OFF: the classic single-user tunnel setup (Slack pushes to
+   *  a tunnelmole Request URL) is unchanged. */
+  slackPollingOnly?: boolean;
   /** Opt-in: allow APP/VOICE-INITIATED proactive posting into Slack (e.g. the
    *  renderer's "queued" acknowledgement). DEFAULT OFF per the human directive
    *  "stop posting into Slack by default". This does NOT gate the Slack-ORIGIN
@@ -453,6 +460,7 @@ const DEFAULTS: HarnessConfig = {
   slackBotToken: undefined,
   slackChannelId: undefined,
   slackPort: undefined,
+  slackPollingOnly: false,
   slackProactivePosting: false,
   freeflowEnabled: true,
   groqApiKey: undefined,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,7 +34,7 @@ import { MemoryReflector, type ReflectSettings } from './reflect';
 import { PersistStore } from './db';
 import { readAgentUsage, readContextTokens, seedSessionTranscript, resolveSessionCwd } from './transcript';
 import { listIssues, listCIRuns } from './github';
-import { SlackWebhookServer, SlackReplyServer, postSlackReply, type SlackEventFile } from './slack';
+import { SlackWebhookServer, SlackReplyServer, postSlackReply, slackFileHelpers, type SlackEventFile } from './slack';
 import {
   WebhookServer,
   type WebhookDispatch, type WebhookEndpointRef, type WebhookInbound, type WebhookTaskStatus
@@ -1370,6 +1370,98 @@ function slackDoneNotifiedPath(): string {
   return join(app.getPath('userData'), 'slack-done-notified.json');
 }
 
+// ─── Bot-participated thread ledger (durable "the bot replied here") ──────────
+/** Persistent record of every thread the bot has replied in, keyed by thread
+ *  root ts → { channel, lastBotTs, updated }. Two readers depend on it:
+ *   1) startSlackServer() seeds these roots into the webhook server's activated
+ *      set, so a plain human reply (NO @-mention) in a bot thread triggers a run
+ *      even after an app restart (GATE 2);
+ *   2) `md-slack-poller.cjs` reads the SAME file to auto-follow these threads and
+ *      pull their replies via conversations.replies (GATE 1).
+ *  Non-secret by construction — channel id + thread timestamps ONLY, NEVER a
+ *  token. Under userData (out of the repo, out of MemPalace), mode 0600. */
+function slackBotThreadsPath(): string {
+  return join(app.getPath('userData'), 'slack-bot-threads.json');
+}
+/** Cap the ledger so it can't grow without bound; newest-by-`updated` are kept. */
+const BOT_THREADS_MAX = 500;
+/** Drop a bot thread with no activity in the trailing 90 days — stale activations
+ *  are cleaned up so the persisted set (and the poller's follow-set) stay bounded
+ *  in time as well as count. Mirrors MAX_THREAD_AGE_SEC in md-slack-poller.cjs. */
+const BOT_THREAD_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+interface BotThreadEntry { channel: string; lastBotTs?: string; updated: number }
+/** Lazily-loaded in-memory mirror of the ledger. */
+let botThreadLedger: Map<string, BotThreadEntry> | null = null;
+
+/** True when a ledger entry's last activity (max of `updated`, the bot's last
+ *  reply ts, and the thread root ts) is older than the 90-day cutoff. */
+function botThreadStale(threadTs: string, e: BotThreadEntry, nowMs: number): boolean {
+  const lastMs = Math.max(e.updated || 0, (Number(e.lastBotTs) || 0) * 1000, (Number(threadTs) || 0) * 1000);
+  return nowMs - lastMs > BOT_THREAD_MAX_AGE_MS;
+}
+
+/** Numeric max of two Slack decimal-string timestamps (either may be undefined). */
+function maxTsStr(a?: string, b?: string): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return Number(b) > Number(a) ? b : a;
+}
+
+function loadBotThreadLedger(): Map<string, BotThreadEntry> {
+  if (botThreadLedger) return botThreadLedger;
+  const m = new Map<string, BotThreadEntry>();
+  try {
+    const raw = JSON.parse(readFileSync(slackBotThreadsPath(), 'utf8')) as { threads?: Record<string, BotThreadEntry> };
+    const nowMs = Date.now();
+    for (const [ts, e] of Object.entries(raw.threads ?? {})) {
+      if (e && typeof e.channel === 'string') {
+        const entry: BotThreadEntry = {
+          channel: e.channel,
+          lastBotTs: typeof e.lastBotTs === 'string' ? e.lastBotTs : undefined,
+          updated: typeof e.updated === 'number' ? e.updated : 0,
+        };
+        // Skip activations older than 90 days — clean up stale threads on load.
+        if (!botThreadStale(ts, entry, nowMs)) m.set(ts, entry);
+      }
+    }
+  } catch { /* missing or corrupt → start empty */ }
+  botThreadLedger = m;
+  return m;
+}
+
+function persistBotThreadLedger(m: Map<string, BotThreadEntry>): void {
+  // Drop entries past the 90-day cutoff, then cap to the newest BOT_THREADS_MAX.
+  const nowMs = Date.now();
+  for (const [ts, e] of [...m.entries()]) if (botThreadStale(ts, e, nowMs)) m.delete(ts);
+  // Prune to the newest BOT_THREADS_MAX by `updated` before writing.
+  if (m.size > BOT_THREADS_MAX) {
+    const keep = [...m.entries()].sort((a, b) => b[1].updated - a[1].updated).slice(0, BOT_THREADS_MAX);
+    m.clear();
+    for (const [k, v] of keep) m.set(k, v);
+  }
+  const threads: Record<string, BotThreadEntry> = {};
+  for (const [k, v] of m) threads[k] = v;
+  try { writeFileSync(slackBotThreadsPath(), JSON.stringify({ version: 1, threads }), { mode: 0o600 }); }
+  catch (e) { console.error('[slack] could not persist bot-thread ledger:', e); }
+}
+
+/** Record that the bot replied into `thread_ts` of `channel`. Persists the entry
+ *  (so it survives a restart and the poller can follow it) and activates the
+ *  thread on the LIVE webhook server so a subsequent plain reply triggers a run
+ *  right away. `botMsgTs` (the bot's posted message ts) baselines the poller's
+ *  reply cursor to the bot's own reply — so it forwards only NEWER replies, never
+ *  replaying thread history. Best-effort; never throws into the reply path. */
+function recordBotThread(channel: string, thread_ts: string, botMsgTs?: string): void {
+  if (!channel || !thread_ts) return;
+  try {
+    const m = loadBotThreadLedger();
+    const prev = m.get(thread_ts);
+    m.set(thread_ts, { channel, lastBotTs: maxTsStr(prev?.lastBotTs, botMsgTs), updated: Date.now() });
+    persistBotThreadLedger(m);
+    slackServer?.activateThread(thread_ts);
+  } catch (e) { console.error('[slack] recordBotThread failed:', e); }
+}
+
 /** Directory where downloaded Slack attachments are saved (out of repo, out of MemPalace). */
 function slackFilesDir(): string {
   return join(app.getPath('userData'), 'slack-files');
@@ -1411,50 +1503,97 @@ function downloadSlackFile(
       return;
     }
 
-    let urlObj: URL;
-    try {
-      urlObj = new URL(file.url_private);
-    } catch {
-      resolve(null);
-      return;
-    }
-    if (urlObj.protocol !== 'https:') { resolve(null); return; }
+    // Prefer url_private_download; fall back to url_private.
+    const startUrl = slackFileHelpers.slackFileUrl(file);
+    if (!startUrl) { resolve(null); return; }
 
-    const req = httpsRequest(
-      { hostname: urlObj.hostname, path: urlObj.pathname + urlObj.search, method: 'GET',
-        headers: { authorization: `Bearer ${botToken}` } },
-      (res) => {
-        if (res.statusCode && res.statusCode >= 400) {
-          res.resume(); // drain response body
-          resolve(null);
-          return;
-        }
-        let written = 0;
-        let aborted = false;
-        const stream = createWriteStream(destPath);
-        res.on('data', (chunk: Buffer) => {
-          if (aborted) return;
-          written += chunk.length;
-          if (written > SLACK_FILE_MAX_BYTES) {
-            aborted = true;
-            stream.destroy();
-            try { unlinkSync(destPath); } catch { /* best-effort cleanup */ }
-            res.destroy();
-            resolve(null);
+    // A file whose Slack metadata is itself HTML must NOT be rejected by the
+    // stub-guard below (that guard exists to catch a login/redirect page returned
+    // when auth fails — see looksLikeHtmlStub).
+    const expectHtml = /html/i.test(mimetype);
+
+    // Fetch, following redirects. Slack's files-pri URL 302-redirects (to a signed
+    // URL, or — when unauthenticated — to a login page whose 2-line HTML body was
+    // previously written to disk as the "file"). We now FOLLOW the redirect,
+    // re-sending the bot token ONLY to Slack hosts (never leaking it to a signed
+    // CDN target), and refuse to save an HTML auth-redirect stub.
+    const attempt = (rawUrl: string, redirectsLeft: number): void => {
+      let urlObj: URL;
+      try { urlObj = new URL(rawUrl); } catch { resolve(null); return; }
+      if (urlObj.protocol !== 'https:') { resolve(null); return; }
+
+      const headers: Record<string, string> = {};
+      if (slackFileHelpers.isSlackHost(urlObj.hostname)) headers.authorization = `Bearer ${botToken}`;
+
+      const req = httpsRequest(
+        { hostname: urlObj.hostname, path: urlObj.pathname + urlObj.search, method: 'GET', headers },
+        (res) => {
+          const status = res.statusCode ?? 0;
+
+          // Follow 3xx redirects (carry auth only to Slack hosts, via `headers` above).
+          if (status >= 300 && status < 400 && res.headers.location) {
+            res.resume(); // drain
+            if (redirectsLeft <= 0) {
+              console.error('[slack] file download: too many redirects — not saving');
+              resolve(null); return;
+            }
+            let nextUrl: string;
+            try { nextUrl = new URL(res.headers.location, urlObj).toString(); }
+            catch { resolve(null); return; }
+            attempt(nextUrl, redirectsLeft - 1);
             return;
           }
-          stream.write(chunk);
-        });
-        res.on('end', () => {
-          if (aborted) return;
-          stream.end(() => resolve({ path: destPath, name, mimetype }));
-        });
-        res.on('error', () => { stream.destroy(); resolve(null); });
-        stream.on('error', () => { res.destroy(); resolve(null); });
-      }
-    );
-    req.on('error', () => resolve(null));
-    req.end();
+
+          if (status < 200 || status >= 400) {
+            res.resume();
+            console.error(`[slack] file download failed: HTTP ${status} — not saving`);
+            resolve(null); return;
+          }
+
+          const contentType = typeof res.headers['content-type'] === 'string' ? res.headers['content-type'] : undefined;
+          let written = 0;
+          let aborted = false;
+          let sniffed = false;
+          let stream: ReturnType<typeof createWriteStream> | null = null;
+          const bail = (msg: string): void => {
+            aborted = true;
+            try { stream?.destroy(); } catch { /* noop */ }
+            try { unlinkSync(destPath); } catch { /* best-effort cleanup */ }
+            res.destroy();
+            console.error(`[slack] file download: ${msg}`);
+            resolve(null);
+          };
+
+          res.on('data', (chunk: Buffer) => {
+            if (aborted) return;
+            if (!sniffed) {
+              sniffed = true;
+              // Guard: never write a login/auth-redirect HTML stub as the file.
+              // Skipped when the file's own mimetype is HTML (a real .html upload).
+              if (!expectHtml && slackFileHelpers.looksLikeHtmlStub(contentType, chunk)) {
+                bail('received an HTML auth-redirect stub, not the file — check the bot token has files:read and access to this file');
+                return;
+              }
+              stream = createWriteStream(destPath);
+              stream.on('error', () => { res.destroy(); resolve(null); });
+            }
+            written += chunk.length;
+            if (written > SLACK_FILE_MAX_BYTES) { bail('exceeded size cap'); return; }
+            stream!.write(chunk);
+          });
+          res.on('end', () => {
+            if (aborted) return;
+            if (!stream) { console.error('[slack] file download: empty response — not saving'); resolve(null); return; }
+            stream.end(() => resolve({ path: destPath, name, mimetype }));
+          });
+          res.on('error', () => { try { stream?.destroy(); } catch { /* noop */ } resolve(null); });
+        }
+      );
+      req.on('error', () => resolve(null));
+      req.end();
+    };
+
+    attempt(startUrl, slackFileHelpers.SLACK_FILE_MAX_REDIRECTS);
   });
 }
 
@@ -1549,6 +1688,10 @@ async function pollSlackDoneTasks(): Promise<void> {
       if (res.ok) {
         notified.add(t.id);
         persistSlackDoneNotified(notified); // mark-on-success → exactly one delivered reply
+        // The bot just posted into this thread → record it so a later plain reply
+        // triggers a run (and the poller follows the thread). res.ts baselines the
+        // poller's cursor to this reply so only newer replies are forwarded.
+        recordBotThread(slack.channel, slack.thread_ts, res.ts);
       } else if (res.error && TERMINAL_SLACK_ERRORS.has(res.error)) {
         // A permanent config/auth error (e.g. the bot token lacks `chat:write`)
         // will NEVER succeed — record the id so we stop hammering every tick, and
@@ -1592,10 +1735,22 @@ async function startSlackServer(): Promise<{ ok: boolean; url?: string; error?: 
     return { ok: false, error: 'slack disabled or missing signing secret' };
   }
   slackServer?.stop();
+  // Pre-activate every thread the bot has already replied in (persisted ledger),
+  // filtered to the configured channel — so a plain human reply (no @-mention) in
+  // one triggers a run immediately after a restart (GATE 2, survives restart).
+  const seededThreads = [...loadBotThreadLedger().entries()]
+    .filter(([, e]) => !cfg.slackChannelId || e.channel === cfg.slackChannelId)
+    .map(([ts]) => ts);
   slackServer = new SlackWebhookServer({
     port: cfg.slackPort && cfg.slackPort > 0 ? cfg.slackPort : 3847,
     signingSecret: cfg.slackSigningSecret,
     channelId: cfg.slackChannelId,
+    initialActivatedThreads: seededThreads,
+    // Poll-only mode (NAT, no tunnel): bind loopback-only + skip the public
+    // tunnel. `md-slack-poller.cjs` delivers events over 127.0.0.1, and the
+    // reply endpoint + done-observer below still start — so replies work with no
+    // inbound exposure. Default (unset) keeps the classic tunnel push flow.
+    skipTunnel: cfg.slackPollingOnly === true,
     // Fires from the HTTP server's event loop (not the IPC thread); route through
     // liveWebContents() so a message arriving during window teardown can't throw.
     // Downloads any file attachments (bot token stays in main; local paths go to IPC).
@@ -1622,7 +1777,10 @@ async function startSlackServer(): Promise<{ ok: boolean; url?: string; error?: 
   });
   const res = await slackServer.start();
   // ok:false means we never bound the port → drop the instance. ok:true with no
-  // url just means the tunnel is unavailable; the local handler is still live.
+  // url means either poll-only mode (tunnel skipped by design) or the tunnel was
+  // unavailable; either way the local handler is live, so we proceed to bring up
+  // the reply endpoint + done-observer below (this is what makes replies work on
+  // a poll-only, no-tunnel laptop).
   if (!res.ok) { slackServer = null; return res; }
   if (res.url) lastSlackUrl = res.url;
   // Bring up the loopback reply endpoint (token-gated, never tunneled) and drop
@@ -1647,7 +1805,12 @@ async function startSlackReplyServer(): Promise<void> {
     getBotToken: () => readConfig().slackBotToken,
     // An agent posted a DIRECT substantive reply into this thread → record it so the
     // done-summary poller skips it (the poller is a fallback, not a duplicator).
-    onReplied: (thread_ts) => { directlyRepliedThreads.add(thread_ts); }
+    onReplied: (thread_ts, channel, botMsgTs) => {
+      directlyRepliedThreads.add(thread_ts);
+      // Durably record this bot-participated thread: persists activation (so a
+      // plain reply triggers after a restart) and lets the poller follow it.
+      recordBotThread(channel, thread_ts, botMsgTs);
+    }
   });
   const r = await slackReplyServer.start();
   if (!r.ok || r.port === undefined) {

--- a/src/main/slack-trigger.cjs
+++ b/src/main/slack-trigger.cjs
@@ -152,6 +152,9 @@ function shouldTrigger(ev, botUserId, channelId, activatedThreads) {
     .map((f) => ({
       id: f.id,
       url_private: f.url_private,
+      // Preferred fetch URL — forces a file download (Content-Disposition) and is
+      // less likely to bounce through an auth-redirect than url_private.
+      url_private_download: typeof f.url_private_download === 'string' ? f.url_private_download : undefined,
       name: typeof f.name === 'string' ? f.name : undefined,
       mimetype: typeof f.mimetype === 'string' ? f.mimetype : undefined,
       size: typeof f.size === 'number' ? f.size : undefined,
@@ -159,6 +162,47 @@ function shouldTrigger(ev, botUserId, channelId, activatedThreads) {
 
   return { trigger: true, text, files };
 }
+
+// ─── Slack file-download helpers (pure; used by index.ts downloadSlackFile) ───
+// Extracted here so they are unit-testable without importing electron.
+
+/** The URL to fetch for a Slack file — prefer `url_private_download` (forces an
+ *  attachment download and is less likely to bounce through an auth redirect),
+ *  falling back to `url_private`. Returns undefined when neither is present. */
+function slackFileUrl(file) {
+  if (!file) return undefined;
+  const dl = typeof file.url_private_download === 'string' && file.url_private_download ? file.url_private_download : null;
+  const pv = typeof file.url_private === 'string' && file.url_private ? file.url_private : null;
+  return dl || pv || undefined;
+}
+
+/** True only for Slack's own hosts. The bot token is re-sent on a redirect ONLY
+ *  when the target is a Slack host, so it is never leaked to a foreign/CDN host
+ *  (a signed redirect target that must be fetched WITHOUT the Authorization). */
+function isSlackHost(host) {
+  if (typeof host !== 'string' || !host) return false;
+  const h = host.toLowerCase();
+  return h === 'slack.com' || h.endsWith('.slack.com');
+}
+
+/**
+ * Detect an auth-redirect / login HTML stub so it is NEVER saved as the file.
+ * Slack returns a 302 to a login/redirect page (body: `<a href="…redir=…">Found</a>`)
+ * when a files-pri URL is fetched unauthenticated; writing that body is the exact
+ * silent data-loss bug this guards against.
+ * @param {string|undefined} contentType response content-type header
+ * @param {Buffer|string} head the first bytes of the body
+ */
+function looksLikeHtmlStub(contentType, head) {
+  if (typeof contentType === 'string' && /text\/html/i.test(contentType)) return true;
+  const s = (Buffer.isBuffer(head) ? head.slice(0, 512).toString('utf8') : String(head || ''))
+    .trimStart().toLowerCase();
+  return s.startsWith('<!doctype html') || s.startsWith('<html') ||
+         s.startsWith('<head') || s.startsWith('<a href') || s.startsWith('<body');
+}
+
+/** Max redirects to follow before giving up (guards against redirect loops). */
+const SLACK_FILE_MAX_REDIRECTS = 5;
 
 module.exports = {
   shouldTrigger,
@@ -168,4 +212,8 @@ module.exports = {
   ACTIVATED_THREADS_MAX,
   SEEN_EVENTS_MAX,
   MAX_FILES_PER_MESSAGE,
+  slackFileUrl,
+  isSlackHost,
+  looksLikeHtmlStub,
+  SLACK_FILE_MAX_REDIRECTS,
 };

--- a/src/main/slack.ts
+++ b/src/main/slack.ts
@@ -21,6 +21,8 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
+import { basename } from 'node:path';
 // NOTE: `tunnelmole` is an ESM-only package. The Electron main process is bundled
 // as CommonJS, so a static `import` gets externalized into `require('tunnelmole')`
 // and throws ERR_REQUIRE_ESM at load. It is imported dynamically inside
@@ -33,6 +35,10 @@ const {
   ActivatedThreads: _ActivatedThreads,
   SeenEvents: _SeenEvents,
   dedupKey: _dedupKey,
+  slackFileUrl,
+  isSlackHost,
+  looksLikeHtmlStub,
+  SLACK_FILE_MAX_REDIRECTS,
 } = require('./slack-trigger.cjs') as {
     shouldTrigger: (
       ev: SlackPayload['event'],
@@ -43,7 +49,15 @@ const {
     ActivatedThreads: new (maxSize?: number) => _IActivatedThreads;
     SeenEvents: new (maxSize?: number) => _ISeenEvents;
     dedupKey: (ev: SlackPayload['event']) => string;
+    slackFileUrl: (file: { url_private?: string; url_private_download?: string }) => string | undefined;
+    isSlackHost: (host: string) => boolean;
+    looksLikeHtmlStub: (contentType: string | undefined, head: Buffer | string) => boolean;
+    SLACK_FILE_MAX_REDIRECTS: number;
   };
+
+// Re-export the pure Slack file-download helpers (defined in slack-trigger.cjs so
+// they stay unit-testable without electron) for index.ts's downloadSlackFile.
+export const slackFileHelpers = { slackFileUrl, isSlackHost, looksLikeHtmlStub, SLACK_FILE_MAX_REDIRECTS };
 
 interface _IActivatedThreads {
   add(threadTs: string): void;
@@ -61,6 +75,8 @@ interface _ISeenEvents {
 export interface SlackEventFile {
   id?: string;
   url_private: string;
+  /** Preferred download URL (Content-Disposition attachment); may be absent. */
+  url_private_download?: string;
   name?: string;
   mimetype?: string;
   size?: number;
@@ -75,6 +91,17 @@ export interface SlackWebhookServerOptions {
   signingSecret: string;
   /** Optional channel id filter — when set, events from other channels are dropped. */
   channelId?: string;
+  /** Thread roots to pre-activate at startup — the threads the bot has already
+   *  replied in (loaded from the persistent bot-thread ledger). A subsequent
+   *  human reply in one of these threads triggers a run with NO @-mention, and
+   *  the activation survives an app restart. Strictly bot-participated threads,
+   *  so unrelated channel chatter is never activated. */
+  initialActivatedThreads?: string[];
+  /** Poll-only mode: bind the HTTP server to 127.0.0.1 ONLY and DO NOT open a
+   *  public tunnel. Used on a laptop behind NAT where `md-slack-poller.cjs`
+   *  delivers events locally over loopback — no inbound exposure, no tunnel.
+   *  Signature verification is unchanged (still enforced on every request). */
+  skipTunnel?: boolean;
   /** Called once per accepted, de-mentioned message — with the Slack thread
    *  coordinates needed to reply back in the originating thread. May be async
    *  (e.g. to download file attachments before forwarding via IPC). */
@@ -115,6 +142,7 @@ export class SlackWebhookServer {
   private readonly port: number;
   private readonly signingSecret: string;
   private readonly channelId?: string;
+  private readonly skipTunnel: boolean;
   private readonly onMessage: (m: SlackInboundMessage) => void | Promise<void>;
   /** Bot's own Slack user id — learned from `authorizations[].user_id` on the
    *  first event_callback. Used to detect <@BOTID> text mentions. */
@@ -132,15 +160,34 @@ export class SlackWebhookServer {
     this.port = opts.port;
     this.signingSecret = opts.signingSecret;
     this.channelId = opts.channelId?.trim() || undefined;
+    this.skipTunnel = opts.skipTunnel === true;
     this.onMessage = opts.onMessage;
+    // Seed persisted bot-participated threads so a plain reply in one triggers a
+    // run immediately after a restart (before any new @-mention re-populates the
+    // in-memory set).
+    for (const t of opts.initialActivatedThreads ?? []) {
+      if (typeof t === 'string' && t) this.activatedThreads.add(t);
+    }
+  }
+
+  /** Mark a thread root as activated live — called when the bot replies into a
+   *  thread, so subsequent human replies there trigger a run with no @-mention.
+   *  Bounded FIFO (same as @-mention activation); safe to call repeatedly. */
+  activateThread(threadTs: string): void {
+    if (threadTs) this.activatedThreads.add(threadTs);
   }
 
   /**
-   * Bind the local HTTP server, then open a public tunnel to it. The HTTP
-   * handler (the security boundary) is live the instant `listen` resolves; the
-   * tunnel is opened afterwards and is non-fatal — if it can't be established
-   * (offline, loca.lt down, timed out) the server keeps running and we report
-   * the tunnel error without a URL.
+   * Bind the local HTTP server, then (unless `skipTunnel`) open a public tunnel
+   * to it. The HTTP handler (the security boundary) is live the instant `listen`
+   * resolves; the tunnel is opened afterwards and is non-fatal — if it can't be
+   * established (offline, loca.lt down, timed out) the server keeps running and
+   * we report the tunnel error without a URL.
+   *
+   * In `skipTunnel` (poll-only) mode the server binds to 127.0.0.1 ONLY and no
+   * tunnel is opened: `md-slack-poller.cjs` delivers events over loopback, so
+   * there is nothing to expose. It resolves `{ ok: true }` with no URL — the
+   * caller then still brings up the loopback reply endpoint + done-observer.
    */
   async start(): Promise<{ ok: boolean; url?: string; error?: string }> {
     if (this.server) return { ok: false, error: 'already running' };
@@ -151,6 +198,9 @@ export class SlackWebhookServer {
       this.stop();
       return { ok: false, error: `failed to bind port ${this.port}: ${errMsg(e)}` };
     }
+    // Poll-only: no public tunnel by design. The listener (bound to loopback) is
+    // up and verify() is fully enforced; report success with no URL.
+    if (this.skipTunnel) return { ok: true };
     try {
       const url = await this.openTunnel();
       if (!url) throw new Error('tunnelmole returned empty URL');
@@ -176,7 +226,10 @@ export class SlackWebhookServer {
       const server = createServer((req, res) => this.handleRequest(req, res));
       const onError = (e: Error): void => reject(e);
       server.once('error', onError);
-      server.listen(this.port, () => {
+      // Poll-only mode binds to loopback ONLY (never a public listener); tunnel
+      // mode binds all interfaces (undefined host) so tunnelmole can forward in.
+      const host = this.skipTunnel ? '127.0.0.1' : undefined;
+      server.listen(this.port, host, () => {
         server.off('error', onError);
         this.server = server;
         resolve();
@@ -328,6 +381,7 @@ interface SlackPayload {
     files?: {
       id?: string;
       url_private?: string;
+      url_private_download?: string;
       name?: string;
       mimetype?: string;
       size?: number;
@@ -355,7 +409,7 @@ export function postSlackReply(opts: {
   channel: string;
   thread_ts: string;
   text: string;
-}): Promise<{ ok: boolean; error?: string }> {
+}): Promise<{ ok: boolean; error?: string; ts?: string }> {
   return new Promise((resolve) => {
     if (!opts.botToken) { resolve({ ok: false, error: 'missing bot token' }); return; }
     // CLAUSE-1 guard (fix-slack-integration): refuse any send that lacks an
@@ -382,8 +436,10 @@ export function postSlackReply(opts: {
       res.on('data', (c: Buffer) => chunks.push(c));
       res.on('end', () => {
         try {
-          const json = JSON.parse(Buffer.concat(chunks).toString('utf8')) as { ok?: boolean; error?: string };
-          resolve({ ok: json.ok === true, error: json.error });
+          const json = JSON.parse(Buffer.concat(chunks).toString('utf8')) as { ok?: boolean; error?: string; ts?: string };
+          // `ts` is the posted message's timestamp — used by the bot-thread ledger
+          // to baseline the poller's reply cursor to the bot's own last reply.
+          resolve({ ok: json.ok === true, error: json.error, ts: typeof json.ts === 'string' ? json.ts : undefined });
         } catch { resolve({ ok: false, error: 'bad response from Slack' }); }
       });
     });
@@ -392,6 +448,113 @@ export function postSlackReply(opts: {
     req.end();
   });
 }
+
+/** POST form-encoded to a Slack Web API method with a Bearer token. Resolves the
+ *  parsed JSON `{ ok, error?, ... }`. The token appears ONLY in the Authorization
+ *  header — never logged. Shared by the two-step external-upload flow below. */
+function slackApiForm(
+  method: string,
+  botToken: string,
+  params: Record<string, string>
+): Promise<Record<string, unknown> & { ok?: boolean; error?: string }> {
+  return new Promise((resolve) => {
+    const body = new URLSearchParams(params).toString();
+    const req = httpsRequest({
+      method: 'POST', hostname: 'slack.com', path: `/api/${method}`,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+        'content-length': Buffer.byteLength(body),
+        authorization: `Bearer ${botToken}`
+      }
+    }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (c: Buffer) => chunks.push(c));
+      res.on('end', () => {
+        try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf8'))); }
+        catch { resolve({ ok: false, error: `bad response from ${method}` }); }
+      });
+    });
+    req.on('error', (e) => resolve({ ok: false, error: errMsg(e) }));
+    req.write(body);
+    req.end();
+  });
+}
+
+/** POST raw bytes to a Slack `upload_url` (pre-signed — carries NO token). Resolves
+ *  ok on a 2xx. Step 2 of the external-upload flow. */
+function putUploadBytes(uploadUrl: string, buffer: Buffer): Promise<{ ok: boolean; error?: string }> {
+  return new Promise((resolve) => {
+    let u: URL;
+    try { u = new URL(uploadUrl); } catch { resolve({ ok: false, error: 'bad upload_url' }); return; }
+    if (u.protocol !== 'https:') { resolve({ ok: false, error: 'non-https upload_url' }); return; }
+    const req = httpsRequest({
+      method: 'POST', hostname: u.hostname, path: u.pathname + u.search,
+      headers: { 'content-type': 'application/octet-stream', 'content-length': buffer.length }
+    }, (res) => {
+      res.on('data', () => { /* drain */ });
+      res.on('end', () => {
+        const s = res.statusCode ?? 0;
+        resolve(s >= 200 && s < 300 ? { ok: true } : { ok: false, error: `upload HTTP ${s}` });
+      });
+    });
+    req.on('error', (e) => resolve({ ok: false, error: errMsg(e) }));
+    req.write(buffer);
+    req.end();
+  });
+}
+
+/** Slack's CURRENT external-upload flow (files.upload is deprecated):
+ *   1) files.getUploadURLExternal(filename, length) → { upload_url, file_id }
+ *   2) POST the raw bytes to upload_url
+ *   3) files.completeUploadExternal(files=[{id,title}], channel_id, thread_ts) → share in-thread
+ *  The bot token lives in main and is passed in by the caller; it is NEVER logged.
+ *  Resolves `{ ok, error?, file_id? }`. */
+export function uploadSlackFile(opts: {
+  botToken: string;
+  channel: string;
+  thread_ts: string;
+  buffer: Buffer;
+  filename: string;
+  title?: string;
+  initialComment?: string;
+}): Promise<{ ok: boolean; error?: string; file_id?: string }> {
+  return (async (): Promise<{ ok: boolean; error?: string; file_id?: string }> => {
+    if (!opts.botToken) return { ok: false, error: 'missing bot token' };
+    // Same CLAUSE-1 guard as postSlackReply: never share to an implicit destination.
+    if (!opts.channel?.trim() || !opts.thread_ts?.trim()) return { ok: false, error: 'missing explicit channel or thread_ts' };
+    if (!opts.buffer?.length) return { ok: false, error: 'empty file' };
+    const filename = opts.filename || 'file';
+
+    // Step 1 — reserve an upload URL.
+    const g = await slackApiForm('files.getUploadURLExternal', opts.botToken, {
+      filename, length: String(opts.buffer.length)
+    });
+    const uploadUrl = typeof g.upload_url === 'string' ? g.upload_url : '';
+    const fileId = typeof g.file_id === 'string' ? g.file_id : '';
+    if (g.ok !== true || !uploadUrl || !fileId) {
+      return { ok: false, error: g.error ? String(g.error) : 'getUploadURLExternal failed' };
+    }
+
+    // Step 2 — PUT/POST the bytes to the pre-signed URL.
+    const up = await putUploadBytes(uploadUrl, opts.buffer);
+    if (!up.ok) return { ok: false, error: up.error };
+
+    // Step 3 — finalize + share into the thread.
+    const files = JSON.stringify([{ id: fileId, title: opts.title || filename }]);
+    const c = await slackApiForm('files.completeUploadExternal', opts.botToken, {
+      files, channel_id: opts.channel, thread_ts: opts.thread_ts,
+      ...(opts.initialComment ? { initial_comment: opts.initialComment } : {})
+    });
+    if (c.ok !== true) return { ok: false, error: c.error ? String(c.error) : 'completeUploadExternal failed' };
+    return { ok: true, file_id: fileId };
+  })().catch((e) => ({ ok: false, error: errMsg(e) }));
+}
+
+/** Signature of the file-upload function — injectable for tests. */
+export type UploadSlackFileFn = typeof uploadSlackFile;
+
+/** Cap the file main will read from disk + upload (guards main memory; media is small). */
+const UPLOAD_MAX_BYTES = 100 * 1024 * 1024; // 100 MB
 
 /** Per-session shared secret + lazy bot-token accessor for the reply endpoint. */
 export interface SlackReplyServerOptions {
@@ -402,7 +565,10 @@ export interface SlackReplyServerOptions {
   /** Fired with a thread_ts after an agent's DIRECT reply posts successfully through
    *  this loopback. Lets main record that the thread was already answered so the
    *  done-summary poller can skip it (the poller is a fallback, not a duplicator). */
-  onReplied?: (thread_ts: string) => void;
+  onReplied?: (thread_ts: string, channel: string, botMsgTs?: string) => void;
+  /** File-upload implementation — defaults to the real `uploadSlackFile`.
+   *  Injectable so tests can mock Slack without real HTTP. */
+  uploadFn?: UploadSlackFileFn;
 }
 
 /**
@@ -418,12 +584,14 @@ export class SlackReplyServer {
   private server: Server | null = null;
   private readonly token: string;
   private readonly getBotToken: () => string | undefined;
-  private readonly onReplied?: (thread_ts: string) => void;
+  private readonly onReplied?: (thread_ts: string, channel: string, botMsgTs?: string) => void;
+  private readonly uploadFn: UploadSlackFileFn;
 
   constructor(opts: SlackReplyServerOptions) {
     this.token = opts.token;
     this.getBotToken = opts.getBotToken;
     this.onReplied = opts.onReplied;
+    this.uploadFn = opts.uploadFn ?? uploadSlackFile;
   }
 
   /** Bind a loopback port (0 ⇒ OS-assigned). Resolves the actual bound port. */
@@ -454,7 +622,8 @@ export class SlackReplyServer {
   private handle(req: IncomingMessage, res: ServerResponse): void {
     // Defense in depth: even bound loopback-only, refuse any non-loopback peer.
     if (!isLoopback(req.socket.remoteAddress ?? '')) { res.writeHead(403); res.end(); return; }
-    if (req.method !== 'POST' || (req.url ?? '').split('?')[0] !== '/reply') {
+    const route = (req.url ?? '').split('?')[0];
+    if (req.method !== 'POST' || (route !== '/reply' && route !== '/upload')) {
       res.writeHead(404); res.end(); return;
     }
     if (!this.checkToken(req.headers['x-md-reply-token'])) { res.writeHead(401); res.end(); return; }
@@ -465,30 +634,73 @@ export class SlackReplyServer {
     req.on('data', (c: Buffer) => {
       if (aborted) return;
       size += c.length;
+      // Both routes carry only small JSON (the /upload body names a local PATH,
+      // never the file bytes — main reads the file itself), so this cap is fine.
       if (size > MAX_BODY_BYTES) { aborted = true; res.writeHead(413); res.end(); req.destroy(); return; }
       chunks.push(c);
     });
     req.on('end', () => {
       if (aborted) return;
-      let parsed: { channel?: string; thread_ts?: string; text?: string };
+      let parsed: { channel?: string; thread_ts?: string; text?: string; path?: string; title?: string; filename?: string; initial_comment?: string };
       try { parsed = JSON.parse(Buffer.concat(chunks).toString('utf8')); }
       catch { res.writeHead(400); res.end(JSON.stringify({ ok: false, error: 'bad json' })); return; }
       const botToken = this.getBotToken();
       if (!botToken) { res.writeHead(503); res.end(JSON.stringify({ ok: false, error: 'no bot token' })); return; }
+      if (route === '/upload') { this.handleUpload(res, botToken, parsed); return; }
+
       if (!parsed.channel || !parsed.thread_ts || !parsed.text) {
         res.writeHead(400); res.end(JSON.stringify({ ok: false, error: 'channel, thread, text required' })); return;
       }
       const thread_ts = parsed.thread_ts;
-      postSlackReply({ botToken, channel: parsed.channel, thread_ts, text: parsed.text })
+      const channel = parsed.channel;
+      postSlackReply({ botToken, channel, thread_ts, text: parsed.text })
         .then((r) => {
           // A successful DIRECT reply means the agent already answered this thread —
-          // tell main so the done-summary poller treats it as a fallback and skips it.
-          if (r.ok) { try { this.onReplied?.(thread_ts); } catch { /* never break the reply */ } }
+          // tell main so the done-summary poller treats it as a fallback and skips
+          // it, AND so main records this bot-participated thread (persist activation
+          // + let the poller follow it for future replies).
+          if (r.ok) { try { this.onReplied?.(thread_ts, channel, r.ts); } catch { /* never break the reply */ } }
           res.writeHead(r.ok ? 200 : 502, { 'content-type': 'application/json' }); res.end(JSON.stringify(r));
         })
         .catch((e) => { res.writeHead(500); res.end(JSON.stringify({ ok: false, error: errMsg(e) })); });
     });
     req.on('error', () => { if (!aborted) { try { res.writeHead(400); res.end(); } catch { /* socket gone */ } } });
+  }
+
+  /** POST /upload — read a LOCAL file the agent named and share it into a Slack
+   *  thread via the external-upload flow. The agent sends only a path + target;
+   *  the bot token never leaves main. Validates the path is a regular file under
+   *  the size cap before reading it into memory. */
+  private handleUpload(
+    res: ServerResponse,
+    botToken: string,
+    parsed: { channel?: string; thread_ts?: string; path?: string; title?: string; filename?: string; initial_comment?: string }
+  ): void {
+    const { channel, thread_ts, path: filePath, title, filename, initial_comment } = parsed;
+    if (!channel || !thread_ts || !filePath) {
+      res.writeHead(400); res.end(JSON.stringify({ ok: false, error: 'channel, thread, file path required' })); return;
+    }
+    let buffer: Buffer;
+    try {
+      const st = statSync(filePath);
+      if (!st.isFile()) { res.writeHead(400); res.end(JSON.stringify({ ok: false, error: 'not a regular file' })); return; }
+      if (st.size > UPLOAD_MAX_BYTES) { res.writeHead(413); res.end(JSON.stringify({ ok: false, error: 'file too large' })); return; }
+      buffer = readFileSync(filePath);
+    } catch (e) {
+      res.writeHead(400); res.end(JSON.stringify({ ok: false, error: `cannot read file: ${errMsg(e)}` })); return;
+    }
+    this.uploadFn({
+      botToken, channel, thread_ts, buffer,
+      filename: (filename && filename.trim()) || basename(filePath),
+      title, initialComment: initial_comment
+    })
+      .then((r) => {
+        // A shared file means the bot participated in this thread — record it so
+        // the poller follows the thread for the user's future replies (same as /reply).
+        if (r.ok) { try { this.onReplied?.(thread_ts, channel); } catch { /* never break the upload */ } }
+        res.writeHead(r.ok ? 200 : 502, { 'content-type': 'application/json' }); res.end(JSON.stringify(r));
+      })
+      .catch((e) => { res.writeHead(500); res.end(JSON.stringify({ ok: false, error: errMsg(e) })); });
   }
 
   /** Constant-time match of the request's reply token against the session token. */

--- a/test/slack-file-download.test.cjs
+++ b/test/slack-file-download.test.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+// Tests for the Slack file-download guard helpers (slack-trigger.cjs) that stop
+// MD saving a 2-line HTML auth-redirect STUB instead of the real file.
+
+const assert = require('assert');
+const {
+  slackFileUrl,
+  isSlackHost,
+  looksLikeHtmlStub,
+  SLACK_FILE_MAX_REDIRECTS,
+} = require('../src/main/slack-trigger.cjs');
+
+let failures = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  ✓ ${name}`); }
+  catch (err) { failures++; console.log(`  ✗ ${name}\n     ${err.message}`); }
+}
+
+console.log('slack file-download guard tests');
+
+test('slackFileUrl prefers url_private_download, falls back to url_private', () => {
+  assert.strictEqual(
+    slackFileUrl({ url_private: 'https://files.slack.com/a', url_private_download: 'https://files.slack.com/a?dl=1' }),
+    'https://files.slack.com/a?dl=1'
+  );
+  assert.strictEqual(slackFileUrl({ url_private: 'https://files.slack.com/a' }), 'https://files.slack.com/a');
+  assert.strictEqual(slackFileUrl({}), undefined);
+  assert.strictEqual(slackFileUrl(null), undefined);
+});
+
+test('isSlackHost matches only Slack hosts (token never leaks to a foreign host)', () => {
+  assert.strictEqual(isSlackHost('files.slack.com'), true);
+  assert.strictEqual(isSlackHost('slack.com'), true);
+  assert.strictEqual(isSlackHost('spideruci.slack.com'), true);
+  assert.strictEqual(isSlackHost('FILES.SLACK.COM'), true);
+  assert.strictEqual(isSlackHost('evil.com'), false);
+  assert.strictEqual(isSlackHost('slack.com.evil.com'), false);
+  assert.strictEqual(isSlackHost('notslack.com'), false);
+  assert.strictEqual(isSlackHost(''), false);
+  assert.strictEqual(isSlackHost(undefined), false);
+});
+
+test('looksLikeHtmlStub catches the EXACT auth-redirect stub from the bug report', () => {
+  // The literal content the user saw saved to slack-files/.
+  const stub = '<a href="https://spideruci.slack.com/?redir=%2Ffiles-pri%2FT0EXAMPLE0-F123%2Ffoo.md">Found</a>.';
+  assert.strictEqual(looksLikeHtmlStub(undefined, Buffer.from(stub)), true, 'detected by body sniff');
+  assert.strictEqual(looksLikeHtmlStub('text/html; charset=utf-8', Buffer.from(stub)), true, 'detected by content-type');
+});
+
+test('looksLikeHtmlStub flags html content-type and common html body starts', () => {
+  assert.strictEqual(looksLikeHtmlStub('text/html', Buffer.from('anything')), true);
+  assert.strictEqual(looksLikeHtmlStub(undefined, Buffer.from('<!DOCTYPE html><html>...')), true);
+  assert.strictEqual(looksLikeHtmlStub(undefined, Buffer.from('   <html>')), true, 'leading whitespace tolerated');
+  assert.strictEqual(looksLikeHtmlStub(undefined, '<head>'), true, 'accepts string head');
+});
+
+test('looksLikeHtmlStub does NOT flag real binary/text file bodies', () => {
+  assert.strictEqual(looksLikeHtmlStub('image/png', Buffer.from([0x89, 0x50, 0x4e, 0x47])), false);
+  assert.strictEqual(looksLikeHtmlStub('text/markdown', Buffer.from('# A real markdown doc\n\ntext')), false);
+  assert.strictEqual(looksLikeHtmlStub('application/octet-stream', Buffer.from('binary\x00stuff')), false);
+  assert.strictEqual(looksLikeHtmlStub(undefined, Buffer.from('plain text, no markup')), false);
+});
+
+test('inbound covers PDFs + images: real file bodies pass the stub-guard', () => {
+  // The exact symptom (a shared PDF saved as a stub) — a real PDF must NOT be flagged.
+  assert.strictEqual(looksLikeHtmlStub('application/pdf', Buffer.from('%PDF-1.7\n%\xe2\xe3\xcf\xd3\n1 0 obj')), false);
+  // Images (png/jpeg/gif magic bytes) must NOT be flagged.
+  assert.strictEqual(looksLikeHtmlStub('image/png', Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a])), false);
+  assert.strictEqual(looksLikeHtmlStub('image/jpeg', Buffer.from([0xff, 0xd8, 0xff, 0xe0])), false);
+  assert.strictEqual(looksLikeHtmlStub('image/gif', Buffer.from('GIF89a')), false);
+  // But a PDF url that 302s to the login page (html) IS still caught (the bug).
+  assert.strictEqual(looksLikeHtmlStub('text/html', Buffer.from('<a href="https://x.slack.com/?redir=%2Ffiles-pri%2F...pdf">Found</a>')), true);
+});
+
+test('SLACK_FILE_MAX_REDIRECTS is a sane positive bound', () => {
+  assert.ok(Number.isInteger(SLACK_FILE_MAX_REDIRECTS) && SLACK_FILE_MAX_REDIRECTS >= 1 && SLACK_FILE_MAX_REDIRECTS <= 10);
+});
+
+console.log(failures === 0 ? '\nall passed' : `\n${failures} failure(s)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/test/slack-upload.test.cjs
+++ b/test/slack-upload.test.cjs
@@ -1,0 +1,153 @@
+'use strict';
+
+// Tests for OUTBOUND Slack media upload — the tokenless /upload loopback route
+// (SlackReplyServer) + the md-slack-upload.cjs helper's payload building. Slack is
+// mocked via the injectable uploadFn (no real HTTP, no token needed).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const { SlackReplyServer } = loadTs('src/main/slack.ts');
+const { parseArgs, buildUploadBody } = require('../resources/md-slack-upload.cjs');
+
+const TOKEN = 'sekret-reply-token';
+
+function req(port, { body, token = TOKEN, route = '/upload' } = {}) {
+  const raw = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const r = http.request({
+      method: 'POST', hostname: '127.0.0.1', port, path: route, agent: false,
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(raw),
+        ...(token ? { 'x-md-reply-token': token } : {})
+      }
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        let json = null; try { json = JSON.parse(Buffer.concat(chunks).toString('utf8')); } catch { /* */ }
+        resolve({ status: res.statusCode, body: json });
+      });
+    });
+    r.on('error', reject);
+    r.write(raw); r.end();
+  });
+}
+
+async function startServer(opts) {
+  const server = new SlackReplyServer({ token: TOKEN, getBotToken: () => 'xoxb-fake', ...opts });
+  const r = await server.start(0);
+  assert.equal(r.ok, true);
+  return { server, port: r.port };
+}
+
+const CH = 'C0EXAMPLE01';
+const TS = '1788723887.610069';
+
+function tmpFile(contents = 'hello pdf bytes') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mdupload-'));
+  const p = path.join(dir, 'report.pdf');
+  fs.writeFileSync(p, contents);
+  return { dir, p };
+}
+
+// ─── helper payload building ─────────────────────────────────────────────────
+test('buildUploadBody: requires channel/thread/file; resolves abs path; carries title+comment', () => {
+  assert.ok(buildUploadBody(parseArgs(['--channel', CH])).error, 'missing thread/file → error');
+  const { body, absPath } = buildUploadBody(parseArgs(['--channel', CH, '--thread', TS, '--file', '/tmp/x.pdf', '--title', 'R', '--comment', 'hi']));
+  assert.equal(body.channel, CH);
+  assert.equal(body.thread_ts, TS);
+  assert.equal(body.path, path.resolve('/tmp/x.pdf'));
+  assert.equal(absPath, path.resolve('/tmp/x.pdf'));
+  assert.equal(body.title, 'R');
+  assert.equal(body.initial_comment, 'hi');
+});
+
+// ─── /upload route (Slack mocked via uploadFn) ───────────────────────────────
+test('/upload: reads the local file and hands its bytes + target to uploadFn (200)', async () => {
+  const { dir, p } = tmpFile('%PDF-1.7 real pdf content');
+  let captured = null;
+  const uploadFn = async (o) => { captured = o; return { ok: true, file_id: 'F_TEST' }; };
+  const { server, port } = await startServer({ uploadFn });
+  try {
+    const r = await req(port, { body: { channel: CH, thread_ts: TS, path: p, title: 'My Report' } });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.ok, true);
+    assert.equal(r.body.file_id, 'F_TEST');
+    assert.equal(captured.channel, CH);
+    assert.equal(captured.thread_ts, TS);
+    assert.equal(captured.filename, 'report.pdf', 'filename defaults to basename');
+    assert.equal(captured.title, 'My Report');
+    assert.equal(captured.buffer.toString('utf8'), '%PDF-1.7 real pdf content', 'main read the real bytes');
+    assert.equal(captured.botToken, 'xoxb-fake', 'token supplied by main, never by the caller');
+  } finally { server.stop(); fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('/upload: records the thread as bot-participated (onReplied) on success', async () => {
+  const { dir, p } = tmpFile();
+  let replied = null;
+  const { server, port } = await startServer({
+    uploadFn: async () => ({ ok: true, file_id: 'F1' }),
+    onReplied: (thread_ts, channel) => { replied = { thread_ts, channel }; }
+  });
+  try {
+    await req(port, { body: { channel: CH, thread_ts: TS, path: p } });
+    assert.deepEqual(replied, { thread_ts: TS, channel: CH }, 'upload marks the thread followed like a reply');
+  } finally { server.stop(); fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('/upload: missing file path → 400, uploadFn never called', async () => {
+  let called = false;
+  const { server, port } = await startServer({ uploadFn: async () => { called = true; return { ok: true }; } });
+  try {
+    const r = await req(port, { body: { channel: CH, thread_ts: TS } });
+    assert.equal(r.status, 400);
+    assert.equal(called, false);
+  } finally { server.stop(); }
+});
+
+test('/upload: nonexistent file → 400 (never a stub upload)', async () => {
+  let called = false;
+  const { server, port } = await startServer({ uploadFn: async () => { called = true; return { ok: true }; } });
+  try {
+    const r = await req(port, { body: { channel: CH, thread_ts: TS, path: '/no/such/file-xyz.pdf' } });
+    assert.equal(r.status, 400);
+    assert.equal(called, false);
+  } finally { server.stop(); }
+});
+
+test('/upload: wrong reply token → 401', async () => {
+  const { dir, p } = tmpFile();
+  const { server, port } = await startServer({ uploadFn: async () => ({ ok: true }) });
+  try {
+    const r = await req(port, { body: { channel: CH, thread_ts: TS, path: p }, token: 'wrong' });
+    assert.equal(r.status, 401);
+  } finally { server.stop(); fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('/upload: no bot token configured → 503', async () => {
+  const { dir, p } = tmpFile();
+  const server = new SlackReplyServer({ token: TOKEN, getBotToken: () => undefined, uploadFn: async () => ({ ok: true }) });
+  const started = await server.start(0);
+  try {
+    const r = await req(started.port, { body: { channel: CH, thread_ts: TS, path: p } });
+    assert.equal(r.status, 503);
+  } finally { server.stop(); fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('/reply still works after adding the /upload route (no regression)', async () => {
+  // getBotToken returns a fake; postSlackReply will try real Slack and fail — we
+  // only assert routing/validation reached the reply branch (not a 404/401).
+  const { server, port } = await startServer({ uploadFn: async () => ({ ok: true }) });
+  try {
+    const r = await req(port, { route: '/reply', body: { channel: CH, thread_ts: TS } }); // missing text
+    assert.equal(r.status, 400, 'reply validation still runs (missing text)');
+    assert.equal(r.body.error, 'channel, thread, text required');
+  } finally { server.stop(); }
+});


### PR DESCRIPTION
## What & why

Adds Slack **media** support in both directions and closes two silent data-loss bugs.

- **Outbound:** a tokenless helper (`resources/md-slack-upload.cjs`) plus a loopback `/upload`
  route on `SlackReplyServer` let the app share a local file into a Slack thread using Slack's
  external-upload flow. The caller only ever hands over a *local file path* — the bot token
  stays in the main process and is never exposed to the helper or the caller.
- **Inbound:** the file downloader now prefers `url_private_download`, follows Slack-host
  redirects (re-sending auth **only** to `*.slack.com`), and refuses the 2-line HTML
  auth-redirect *stub* it used to save to disk instead of the real file.
- **Reliability:** thread replies now persist a bot-thread ledger so follow-up replies in a
  thread aren't dropped, and `postSlackReply` returns the posted message `ts`.

## Type of change

- [x] Bug fix
- [x] New feature

## Evidence

There is no visible UI for this change (it is Slack transport/reliability in the main process),
so evidence is a terminal capture of the failing behaviour reproduced and then guarded, plus the
focused test suite that goes red→green.

### Before

A file shared into Slack was saved as a 2-line HTML auth-redirect **stub** rather than the real
bytes — the downloader followed the `url_private` redirect to the login page and wrote the HTML
response verbatim:

```
$ cat slack-files/foo.md
<a href="https://<workspace>.slack.com/?redir=%2Ffiles-pri%2F...%2Ffoo.md">Found</a>.
```

And there was **no** outbound path at all — the app could reply with text but could not deliver
a file into a thread.

### After

The guard rejects the HTML stub and only accepts real file bodies; the outbound `/upload` route
reads the real bytes and supplies the token from the main process. Focused suite is green:

```
$ node --test test/slack-upload.test.cjs test/slack-file-download.test.cjs
✔ buildUploadBody: requires channel/thread/file; resolves abs path; carries title+comment
✔ /upload: reads the local file and hands its bytes + target to uploadFn (200)
✔ /upload: records the thread as bot-participated (onReplied) on success
✔ /upload: missing file path → 400, uploadFn never called
✔ /upload: nonexistent file → 400 (never a stub upload)
✔ /upload: wrong reply token → 401
✔ /upload: no bot token configured → 503
✔ /reply still works after adding the /upload route (no regression)
✔ looksLikeHtmlStub catches the EXACT auth-redirect stub from the bug report
ℹ tests 9
ℹ pass 9
ℹ fail 0
```

Manually verified outbound end-to-end: a batch of image files was delivered into a live Slack
thread via the upload helper (helper exits non-zero unless Slack returns HTTP 200 && `ok`, so a
clean exit is genuine delivery, not a stub).

## How I tested it

- OS: macOS
- Steps:
  - `npm run typecheck` — pass (node + web projects).
  - `npm run build` — pass (exit 0).
  - `node --test test/slack-upload.test.cjs test/slack-file-download.test.cjs` — 9/9 pass
    (upload route reads real bytes, token supplied by main not the caller; download guard
    passes real PDF/PNG/JPEG/GIF bodies while catching HTML stubs).
  - Manually: delivered files into a live Slack thread via the upload helper; confirmed the
    thread received the real files.

## Checklist

- [x] Before and after evidence is included above (terminal/test capture — no UI to screenshot).
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes (focused suite: `slack-upload` + `slack-file-download`).
- [x] `npm run build` succeeds.
- [x] This PR is one change (Slack media/reliability).
- [x] I read the diff myself; no debug output, no secrets, no unrelated churn.
