### PR TITLE
Feat/agent chat

### DIFF
--- a/src/main/chatTranscript.ts
+++ b/src/main/chatTranscript.ts
@@ -1,0 +1,124 @@
+import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
+import { isInboxNudge } from '../shared/hiveNudge';
+import { isCompactionCommand } from '../shared/providerAutomation';
+
+/** One plain-text turn extracted from a Claude Code transcript — a user prompt
+ * or an assistant reply, with every tool_use/tool_result block stripped out.
+ * This is the "desktop-app view": just the conversation, none of the raw TUI
+ * noise (spinners, tool logs, box drawing) the terminal panel shows. */
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  text: string;
+  ts: number;
+}
+
+/** Bounds how many turns a single tab keeps in memory/render — a long-running
+ * agent's transcript can hold thousands; the chat tab only needs recent ones. */
+const MAX_MESSAGES = 300;
+
+interface TailEntry {
+  size: number;
+  mtimeMs: number;
+  /** Bytes parsed so far — always ends on a newline boundary, mirroring the
+   * usage tailer in transcript.ts so a torn trailing line is simply re-read
+   * once the writer completes it. */
+  offset: number;
+  messages: ChatMessage[];
+}
+
+const tailCache = new Map<string, TailEntry>();
+/** Soft bound; when crossed, the oldest-inserted half is dropped (entries
+ * rebuild on demand). Mirrors USAGE_CACHE_MAX in transcript.ts. */
+const TAIL_CACHE_MAX = 512;
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block && typeof block === 'object' && (block as { type?: unknown }).type === 'text') {
+      const text = (block as { text?: unknown }).text;
+      if (typeof text === 'string' && text.trim()) parts.push(text.trim());
+    }
+  }
+  return parts.join('\n\n');
+}
+
+/** Parse complete JSONL lines into chat turns, appending to `out`. A record
+ * whose content is ONLY tool_use/tool_result blocks yields no text and is
+ * skipped — that is exactly the raw tool traffic the chat view exists to hide. */
+function parseChatLines(text: string, out: ChatMessage[]): void {
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let rec: { type?: unknown; message?: { content?: unknown }; timestamp?: unknown };
+    try {
+      rec = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (rec.type !== 'user' && rec.type !== 'assistant') continue;
+    const body = extractText(rec.message?.content);
+    if (!body) continue;
+    // The inbox-wake nudge and a /compact command are typed into the pty by the
+    // app itself (mail poll / context-cap trigger), not by the human — same text
+    // shape as a real prompt once it lands in the transcript, so the only way to
+    // recognize it here is the fixed pattern each one shares (see hiveNudge.ts /
+    // providerAutomation.ts, which the message queue already dedupes against).
+    if (rec.type === 'user' && (isInboxNudge(body) || isCompactionCommand(body))) continue;
+    const parsedTs = typeof rec.timestamp === 'string' ? Date.parse(rec.timestamp) : NaN;
+    out.push({ role: rec.type, text: body, ts: Number.isFinite(parsedTs) ? parsedTs : Date.now() });
+  }
+}
+
+/** Read the plain-text conversation out of a live Claude Code transcript,
+ * tailed incrementally like readAgentUsage's per-file cache: unchanged
+ * size+mtime is a cache hit, growth parses only the appended bytes, and a
+ * shrink (rewrite) forces a full re-parse. Returns at most MAX_MESSAGES,
+ * newest last. */
+export function readChatTranscript(transcriptPath: string): ChatMessage[] {
+  try {
+    if (!existsSync(transcriptPath)) return [];
+    const st = statSync(transcriptPath);
+    const cached = tailCache.get(transcriptPath);
+    if (cached && cached.size === st.size && cached.mtimeMs === st.mtimeMs) return cached.messages;
+
+    const fromScratch = !cached || st.size < cached.offset;
+    const entry: TailEntry = fromScratch
+      ? { size: st.size, mtimeMs: st.mtimeMs, offset: 0, messages: [] }
+      : { size: st.size, mtimeMs: st.mtimeMs, offset: cached!.offset, messages: [...cached!.messages] };
+
+    const fd = openSync(transcriptPath, 'r');
+    try {
+      const len = st.size - entry.offset;
+      if (len > 0) {
+        const buf = Buffer.alloc(len);
+        const read = readSync(fd, buf, 0, len, entry.offset);
+        const text = buf.subarray(0, read).toString('utf8');
+        const lastNl = text.lastIndexOf('\n');
+        if (lastNl !== -1) {
+          const complete = text.slice(0, lastNl + 1);
+          parseChatLines(complete, entry.messages);
+          entry.offset += Buffer.byteLength(complete, 'utf8');
+        }
+      }
+    } finally {
+      closeSync(fd);
+    }
+
+    if (entry.messages.length > MAX_MESSAGES) {
+      entry.messages = entry.messages.slice(entry.messages.length - MAX_MESSAGES);
+    }
+    tailCache.set(transcriptPath, entry);
+    if (tailCache.size > TAIL_CACHE_MAX) {
+      let drop = tailCache.size - TAIL_CACHE_MAX / 2;
+      for (const k of tailCache.keys()) {
+        if (drop-- <= 0) break;
+        tailCache.delete(k);
+      }
+    }
+    return entry.messages;
+  } catch {
+    return [];
+  }
+}

--- a/src/main/chatTranscript.ts
+++ b/src/main/chatTranscript.ts
@@ -1,6 +1,7 @@
 import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
 import { isInboxNudge } from '../shared/hiveNudge';
 import { isCompactionCommand } from '../shared/providerAutomation';
+import { isHiveIdentityPrompt } from '../shared/hivePrompt';
 
 /** One plain-text turn extracted from a Claude Code transcript — a user prompt
  * or an assistant reply, with every tool_use/tool_result block stripped out.
@@ -13,8 +14,26 @@ export interface ChatMessage {
 }
 
 /** Bounds how many turns a single tab keeps in memory/render — a long-running
- * agent's transcript can hold thousands; the chat tab only needs recent ones. */
-const MAX_MESSAGES = 300;
+ * agent's transcript can hold thousands; the chat tab only needs recent ones.
+ * Exported so every provider's reader caps at the same depth. */
+export const MAX_CHAT_MESSAGES = 300;
+
+/**
+ * Is this user turn the HARNESS talking, rather than the human?
+ *
+ * Three things the app types into an agent land in the transcript shaped exactly
+ * like a typed prompt, and the Chat tab must show none of them:
+ *   - the identity/protocol brief injected at spawn (`--prompt`, for every
+ *     provider that cannot take it as a system prompt),
+ *   - the inbox-wake nudge the mail poll queues,
+ *   - the `/compact` the context cap triggers.
+ * Each predicate lives with the code that WRITES that text (hivePrompt.ts /
+ * hiveNudge.ts / providerAutomation.ts — the same ones the message queue dedupes
+ * against), so a reworded nudge cannot leave a stale copy behind here.
+ */
+export function isAppGeneratedPrompt(text: string): boolean {
+  return isHiveIdentityPrompt(text) || isInboxNudge(text) || isCompactionCommand(text);
+}
 
 interface TailEntry {
   size: number;
@@ -60,12 +79,7 @@ function parseChatLines(text: string, out: ChatMessage[]): void {
     if (rec.type !== 'user' && rec.type !== 'assistant') continue;
     const body = extractText(rec.message?.content);
     if (!body) continue;
-    // The inbox-wake nudge and a /compact command are typed into the pty by the
-    // app itself (mail poll / context-cap trigger), not by the human — same text
-    // shape as a real prompt once it lands in the transcript, so the only way to
-    // recognize it here is the fixed pattern each one shares (see hiveNudge.ts /
-    // providerAutomation.ts, which the message queue already dedupes against).
-    if (rec.type === 'user' && (isInboxNudge(body) || isCompactionCommand(body))) continue;
+    if (rec.type === 'user' && isAppGeneratedPrompt(body)) continue;
     const parsedTs = typeof rec.timestamp === 'string' ? Date.parse(rec.timestamp) : NaN;
     out.push({ role: rec.type, text: body, ts: Number.isFinite(parsedTs) ? parsedTs : Date.now() });
   }
@@ -74,7 +88,7 @@ function parseChatLines(text: string, out: ChatMessage[]): void {
 /** Read the plain-text conversation out of a live Claude Code transcript,
  * tailed incrementally like readAgentUsage's per-file cache: unchanged
  * size+mtime is a cache hit, growth parses only the appended bytes, and a
- * shrink (rewrite) forces a full re-parse. Returns at most MAX_MESSAGES,
+ * shrink (rewrite) forces a full re-parse. Returns at most MAX_CHAT_MESSAGES,
  * newest last. */
 export function readChatTranscript(transcriptPath: string): ChatMessage[] {
   try {
@@ -106,8 +120,8 @@ export function readChatTranscript(transcriptPath: string): ChatMessage[] {
       closeSync(fd);
     }
 
-    if (entry.messages.length > MAX_MESSAGES) {
-      entry.messages = entry.messages.slice(entry.messages.length - MAX_MESSAGES);
+    if (entry.messages.length > MAX_CHAT_MESSAGES) {
+      entry.messages = entry.messages.slice(entry.messages.length - MAX_CHAT_MESSAGES);
     }
     tailCache.set(transcriptPath, entry);
     if (tailCache.size > TAIL_CACHE_MAX) {

--- a/src/main/chatTranscript.ts
+++ b/src/main/chatTranscript.ts
@@ -3,10 +3,10 @@ import { isInboxNudge } from '../shared/hiveNudge';
 import { isCompactionCommand } from '../shared/providerAutomation';
 import { isHiveIdentityPrompt } from '../shared/hivePrompt';
 
-/** One plain-text turn extracted from a Claude Code transcript — a user prompt
- * or an assistant reply, with every tool_use/tool_result block stripped out.
- * This is the "desktop-app view": just the conversation, none of the raw TUI
- * noise (spinners, tool logs, box drawing) the terminal panel shows. */
+/** One plain-text turn extracted from an agent's transcript — a user prompt or
+ * an assistant reply, with every tool_use/tool_result block stripped out. This
+ * is the "desktop-app view": just the conversation, none of the raw TUI noise
+ * (spinners, tool logs, box drawing) the terminal panel shows. */
 export interface ChatMessage {
   role: 'user' | 'assistant';
   text: string;
@@ -35,6 +35,10 @@ export function isAppGeneratedPrompt(text: string): boolean {
   return isHiveIdentityPrompt(text) || isInboxNudge(text) || isCompactionCommand(text);
 }
 
+/** Turn one parsed JSONL record into a chat turn, or null to skip it. Each
+ * provider's transcript has its own record shape; the tailer below is shared. */
+export type ChatRecordParser = (rec: unknown) => ChatMessage | null;
+
 interface TailEntry {
   size: number;
   mtimeMs: number;
@@ -50,47 +54,61 @@ const tailCache = new Map<string, TailEntry>();
  * rebuild on demand). Mirrors USAGE_CACHE_MAX in transcript.ts. */
 const TAIL_CACHE_MAX = 512;
 
-function extractText(content: unknown): string {
+/** Concatenate the `text` of every text-bearing block. Claude Code's blocks are
+ * `{type:'text', text}`; Codex's are `{type:'input_text'|'output_text', text}`.
+ * Anything without a string `text` — tool_use, tool_result, images — is exactly
+ * the traffic the Chat tab exists to hide, so it contributes nothing. */
+export function textOfBlocks(content: unknown): string {
   if (typeof content === 'string') return content.trim();
   if (!Array.isArray(content)) return '';
   const parts: string[] = [];
   for (const block of content) {
-    if (block && typeof block === 'object' && (block as { type?: unknown }).type === 'text') {
-      const text = (block as { text?: unknown }).text;
-      if (typeof text === 'string' && text.trim()) parts.push(text.trim());
-    }
+    if (!block || typeof block !== 'object') continue;
+    const { type, text } = block as { type?: unknown; text?: unknown };
+    if (typeof type === 'string' && /text$/.test(type) && typeof text === 'string' && text.trim()) parts.push(text.trim());
   }
   return parts.join('\n\n');
 }
 
-/** Parse complete JSONL lines into chat turns, appending to `out`. A record
- * whose content is ONLY tool_use/tool_result blocks yields no text and is
- * skipped — that is exactly the raw tool traffic the chat view exists to hide. */
-function parseChatLines(text: string, out: ChatMessage[]): void {
+function tsOf(value: unknown): number {
+  const parsed = typeof value === 'string' ? Date.parse(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+/** Claude Code's JSONL: `{type:'user'|'assistant', message:{content}, timestamp}`.
+ * A record whose content is ONLY tool_use/tool_result blocks yields no text and
+ * is skipped — that is exactly the raw tool traffic the chat view exists to hide. */
+export const parseClaudeRecord: ChatRecordParser = (rec) => {
+  const r = rec as { type?: unknown; message?: { content?: unknown }; timestamp?: unknown };
+  if (r.type !== 'user' && r.type !== 'assistant') return null;
+  const body = textOfBlocks(r.message?.content);
+  if (!body) return null;
+  if (r.type === 'user' && isAppGeneratedPrompt(body)) return null;
+  return { role: r.type, text: body, ts: tsOf(r.timestamp) };
+};
+
+/** Parse complete JSONL lines into chat turns, appending to `out`. */
+function parseChatLines(text: string, parse: ChatRecordParser, out: ChatMessage[]): void {
   for (const line of text.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    let rec: { type?: unknown; message?: { content?: unknown }; timestamp?: unknown };
+    let rec: unknown;
     try {
       rec = JSON.parse(trimmed);
     } catch {
       continue;
     }
-    if (rec.type !== 'user' && rec.type !== 'assistant') continue;
-    const body = extractText(rec.message?.content);
-    if (!body) continue;
-    if (rec.type === 'user' && isAppGeneratedPrompt(body)) continue;
-    const parsedTs = typeof rec.timestamp === 'string' ? Date.parse(rec.timestamp) : NaN;
-    out.push({ role: rec.type, text: body, ts: Number.isFinite(parsedTs) ? parsedTs : Date.now() });
+    const msg = parse(rec);
+    if (msg) out.push(msg);
   }
 }
 
-/** Read the plain-text conversation out of a live Claude Code transcript,
- * tailed incrementally like readAgentUsage's per-file cache: unchanged
- * size+mtime is a cache hit, growth parses only the appended bytes, and a
- * shrink (rewrite) forces a full re-parse. Returns at most MAX_CHAT_MESSAGES,
- * newest last. */
-export function readChatTranscript(transcriptPath: string): ChatMessage[] {
+/** Read the plain-text conversation out of a live JSONL transcript, tailed
+ * incrementally like readAgentUsage's per-file cache: unchanged size+mtime is a
+ * cache hit, growth parses only the appended bytes, and a shrink (rewrite)
+ * forces a full re-parse. Returns at most MAX_CHAT_MESSAGES, newest last. The
+ * cache is keyed by path, so one file is only ever read with one parser. */
+export function tailChatJsonl(transcriptPath: string, parse: ChatRecordParser): ChatMessage[] {
   try {
     if (!existsSync(transcriptPath)) return [];
     const st = statSync(transcriptPath);
@@ -112,7 +130,7 @@ export function readChatTranscript(transcriptPath: string): ChatMessage[] {
         const lastNl = text.lastIndexOf('\n');
         if (lastNl !== -1) {
           const complete = text.slice(0, lastNl + 1);
-          parseChatLines(complete, entry.messages);
+          parseChatLines(complete, parse, entry.messages);
           entry.offset += Buffer.byteLength(complete, 'utf8');
         }
       }
@@ -135,4 +153,10 @@ export function readChatTranscript(transcriptPath: string): ChatMessage[] {
   } catch {
     return [];
   }
+}
+
+/** The Claude Code transcript behind the Chat tab — the path every Claude hook
+ * payload carries as `transcript_path`. */
+export function readChatTranscript(transcriptPath: string): ChatMessage[] {
+  return tailChatJsonl(transcriptPath, parseClaudeRecord);
 }

--- a/src/main/codexTranscript.ts
+++ b/src/main/codexTranscript.ts
@@ -1,0 +1,97 @@
+/**
+ * The Chat tab's Codex reader.
+ *
+ * Codex keeps a JSONL "rollout" per session under its CODEX_HOME —
+ * `sessions/YYYY/MM/DD/rollout-<started>-<sessionId>.jsonl` — and the hive gives
+ * every codex agent a private CODEX_HOME (`<agentDir>/.codex`, see
+ * installCodexHooks), so an agent's whole history sits in one directory tree we
+ * already own. Same tailer as the Claude reader; only the record shape differs:
+ *
+ *   {"type":"response_item","payload":{"type":"message","role":"user"|"assistant"|"developer",
+ *     "content":[{"type":"input_text"|"output_text","text":"…"}]}, "timestamp":"…"}
+ *
+ * plus tool calls, reasoning, token counts and event markers under other
+ * `type`s, none of which is a conversation turn.
+ */
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  type ChatMessage, type ChatRecordParser, isAppGeneratedPrompt, tailChatJsonl, textOfBlocks
+} from './chatTranscript';
+
+/**
+ * Codex's OWN injected user turns — text it puts in the user seat that no human
+ * typed: the repo's AGENTS.md (headed `# AGENTS.md instructions for <path>`, or
+ * wrapped in `<user_instructions>` on older builds) and the environment block.
+ * Each begins with a fixed marker at column 0, so a human message that merely
+ * mentions AGENTS.md is untouched. The hive's own injections (brief, nudge,
+ * /compact) are the shared isAppGeneratedPrompt's business.
+ */
+export function isCodexInjectedPrompt(text: string): boolean {
+  return /^(# AGENTS\.md instructions\b|<user_instructions>|<environment_context>)/.test(text);
+}
+
+/** `developer` is Codex's system-prompt seat (skills, tool guidance) and never
+ * a conversation turn; anything else outside user/assistant is ignored too. */
+export const parseCodexRecord: ChatRecordParser = (rec) => {
+  const r = rec as {
+    type?: unknown; timestamp?: unknown;
+    payload?: { type?: unknown; role?: unknown; content?: unknown };
+  };
+  if (r.type !== 'response_item' || !r.payload || r.payload.type !== 'message') return null;
+  const role = r.payload.role;
+  if (role !== 'user' && role !== 'assistant') return null;
+  const body = textOfBlocks(r.payload.content);
+  if (!body) return null;
+  if (role === 'user' && (isAppGeneratedPrompt(body) || isCodexInjectedPrompt(body))) return null;
+  const parsed = typeof r.timestamp === 'string' ? Date.parse(r.timestamp) : NaN;
+  return { role, text: body, ts: Number.isFinite(parsed) ? parsed : Date.now() };
+};
+
+function walkRollouts(dir: string, out: string[]): void {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) walkRollouts(p, out);
+    else if (e.isFile() && /^rollout-.*\.jsonl$/.test(e.name)) out.push(p);
+  }
+}
+
+/**
+ * Which rollout is this agent's current conversation?
+ *
+ * Codex names the file after the session id, and that id reaches the app on
+ * every hook payload (`session_id`, recorded by the hook server and persisted in
+ * the registry), so a known id is an exact match. Without one — hooks not yet
+ * fired, or a session that predates them — the most recently written rollout in
+ * the agent's own CODEX_HOME is the right guess: the home is per agent, so
+ * nothing else writes there.
+ */
+export function resolveCodexRollout(codexHome: string, sessionId?: string): string | null {
+  const sessions = join(codexHome, 'sessions');
+  if (!existsSync(sessions)) return null;
+  const files: string[] = [];
+  walkRollouts(sessions, files);
+  if (!files.length) return null;
+  if (sessionId) {
+    const exact = files.find((f) => f.endsWith(`-${sessionId}.jsonl`));
+    if (exact) return exact;
+  }
+  let newest = files[0];
+  let newestMs = -1;
+  for (const f of files) {
+    try {
+      const ms = statSync(f).mtimeMs;
+      if (ms > newestMs) { newestMs = ms; newest = f; }
+    } catch { /* vanished between walk and stat */ }
+  }
+  return newest;
+}
+
+/** Plain user/assistant turns of a codex agent's live session — the data behind
+ * its Chat tab. Empty until Codex has written the first rollout line. */
+export function readCodexChat(codexHome: string, sessionId?: string): ChatMessage[] {
+  const rollout = resolveCodexRollout(codexHome, sessionId);
+  return rollout ? tailChatJsonl(rollout, parseCodexRecord) : [];
+}

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -43,6 +43,7 @@ import { preferredAgentRole } from '../shared/agentRole';
 import { mergeTaskLedger } from '../shared/taskLedger';
 import { expandTilde } from './fs';
 import { resolveGodName } from '../shared/godIdentity';
+import { HIVE_PROTOCOL_HEADING } from '../shared/hivePrompt';
 
 /** The subset of HarnessConfig the hive consumes for the default-MCP merge.
  *  Kept as a local shape so hive.ts never imports the foundation-owned config
@@ -1497,7 +1498,7 @@ export class HiveManager {
       `You are "${meta.name}" (${meta.id}), an autonomous agent in a collaborating hive of Claude agents.`,
       `Your private workspace is ${dir}. The shared hive is ${root}. Full protocol: ${inRoot('PROTOCOL.md')}.`,
       '',
-      'HIVE PROTOCOL — follow it every task:',
+      HIVE_PROTOCOL_HEADING,
       `1. At the START of a task, read ${inDir('memory.md')} and EVERY file in ${inDir('inbox')} (messages other agents sent you). After handling an inbox message, move its file into ${inDir('inbox', '.done')}.`,
       `2. Record durable facts, decisions, and context by appending to ${inDir('memory.md')}.`,
       `3. To ask another agent for something or share information, write ONE message JSON into ${inDir('outbox')} (schema in PROTOCOL.md). NEVER write into another agent's folder — the orchestrator delivers your outbox.`,
@@ -3127,13 +3128,24 @@ function post(payload) {
 export const HiveBridge = async () => {
   return {
     event: async (input) => {
-      try { if (input && input.event && input.event.type === 'session.idle') post({ hook_event_name: 'Stop' }); } catch (e) {}
+      try {
+        const ev = input && input.event;
+        if (!ev) return;
+        const sid = (ev.properties && ev.properties.sessionID) || null;
+        if (ev.type === 'session.idle') post({ hook_event_name: 'Stop', session_id: sid });
+        // Not a lifecycle boundary — just the earliest carrier of the session id,
+        // so the Chat tab can find this session in OpenCode's store before the
+        // first turn ever ends. Sent as Status: the HookServer's Status arm is
+        // pure telemetry (it returns before the HALT gate and the loop breaker),
+        // and the session id is captured for every payload shape ahead of it.
+        else if (ev.type === 'message.updated' && sid) post({ hook_event_name: 'Status', session_id: sid });
+      } catch (e) {}
     },
     'tool.execute.before': async (input) => {
-      try { post({ hook_event_name: 'PreToolUse', tool_name: input && (input.tool || input.name) }); } catch (e) {}
+      try { post({ hook_event_name: 'PreToolUse', tool_name: input && (input.tool || input.name), session_id: input && input.sessionID }); } catch (e) {}
     },
     'tool.execute.after': async (input) => {
-      try { post({ hook_event_name: 'PostToolUse', tool_name: input && (input.tool || input.name) }); } catch (e) {}
+      try { post({ hook_event_name: 'PostToolUse', tool_name: input && (input.tool || input.name), session_id: input && input.sessionID }); } catch (e) {}
     }
   };
 };

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -55,6 +55,7 @@ export class HookServer {
    *  Lets the harness read per-agent telemetry (e.g. current context size)
    *  even when several agents share one cwd. */
   private transcriptPaths = new Map<string, string>();
+  private sessionIds = new Map<string, string>();
   /** agentId → the latest context-window accounting from the statusLine shim
    *  (current tokens + the REAL window size — 200k vs 1M, which nothing else
    *  exposes). The renderer already gets this pushed live on `hive:contextUpdate`;
@@ -142,6 +143,13 @@ export class HookServer {
     return this.transcriptPaths.get(agentId);
   }
 
+  /** The provider session id of an agent's CURRENT session, if any hook has
+   *  fired. For a CLI that stores its conversation itself (OpenCode), this is
+   *  the key into that store — the counterpart of `transcriptPath` above. */
+  sessionId(agentId: string): string | undefined {
+    return this.sessionIds.get(agentId);
+  }
+
   /** The latest context-window accounting for an agent (current tokens + the real
    *  window size), or undefined if no statusLine tick has fired for it yet. */
   contextFor(agentId: string): { tokens: number; limit: number; ts: number } | undefined {
@@ -154,6 +162,15 @@ export class HookServer {
     this.onEvent?.(agentId, event, p.message);
     if (agentId && typeof p.transcript_path === 'string' && p.transcript_path) {
       this.transcriptPaths.set(agentId, p.transcript_path);
+    }
+    // Same rationale as transcript_path above, for the providers that have no
+    // transcript FILE: the session id is how the Chat tab finds the conversation
+    // in the CLI's own store (OpenCode keeps it in SQLite, keyed by session).
+    // Captured here — before the Status early-return — so every payload shape
+    // feeds it, and kept OUT of the registry: `recordSession` below owns that,
+    // and this lane is read-only telemetry that must not touch the resume key.
+    if (agentId && typeof p.session_id === 'string' && p.session_id) {
+      this.sessionIds.set(agentId, p.session_id);
     }
 
     // Status-line payloads carry the session's EXACT context accounting —

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,7 @@ import { PersistStore } from './db';
 import { readAgentUsage, readContextTokens, seedSessionTranscript, resolveSessionCwd } from './transcript';
 import { readChatTranscript } from './chatTranscript';
 import { readOpenCodeChat } from './opencodeTranscript';
+import { readCodexChat } from './codexTranscript';
 import { chatSourceOf } from '../shared/agentProvider';
 import { listIssues, listCIRuns } from './github';
 import { SlackWebhookServer, SlackReplyServer, postSlackReply, type SlackEventFile } from './slack';
@@ -3869,23 +3870,29 @@ ipcMain.handle('hive:agentContext', (_evt, agentId: unknown) => {
 // The "Chat" tab's data source — the clean, desktop-app-style view of what the
 // terminal panel shows as a raw, scrolling TUI. WHERE the conversation lives is
 // per-provider, and that is the whole branch below: Claude Code hands every hook
-// the path of a JSONL transcript (the same file the context gauge tails), while
-// OpenCode keeps its turns in its own SQLite store, addressed by session id.
-// Anything else has neither and returns empty — the tab then says so, which is
-// honest, and the Terminal tab remains the full record for that agent.
+// the path of a JSONL transcript (the same file the context gauge tails), OpenCode
+// keeps its turns in its own SQLite store addressed by session id, and Codex
+// writes a JSONL rollout named after the session id into the private CODEX_HOME
+// the hive gives each codex agent. Anything else has no reader yet and returns
+// null — the tab then says so, which is honest, and the Terminal tab remains the
+// full record for that agent.
 // `null` and `[]` are different answers and the tab renders them differently:
-// null means this CLI keeps nothing the app can read, so waiting is pointless;
+// null means nothing here can read this CLI's history, so waiting is pointless;
 // [] means the source exists and is still empty (hooks not fired yet, or a
 // session that genuinely has no turns).
 ipcMain.handle('hive:agentChat', (_evt, agentId: unknown) => {
   if (typeof agentId !== 'string') return null;
   const rec = hive.registry().agents[agentId];
   const source = chatSourceOf(rec?.provider);
-  if (source === 'opencode') {
-    // The plugin-reported id is exact; the registry's is the same id persisted
-    // across an app restart, and the cwd is the last resort for a session that
-    // was already running before either was learned.
-    return readOpenCodeChat(hookServer.sessionId(agentId) ?? rec?.sessionId, rec?.cwd);
+  // For both stores the hook-reported id is exact and the registry's is the same
+  // id persisted across an app restart; each reader has its own last resort for
+  // a session that was already running before either was learned.
+  const sessionId = hookServer.sessionId(agentId) ?? rec?.sessionId;
+  if (source === 'opencode') return readOpenCodeChat(sessionId, rec?.cwd);
+  if (source === 'codex') {
+    // Same directory installCodexHooks() points CODEX_HOME at for this agent.
+    const root = hive.root();
+    return root ? readCodexChat(join(root, 'agents', agentId, '.codex'), sessionId) : [];
   }
   if (source !== 'transcript') return null;
   const tp = hookServer.transcriptPath(agentId);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import { KnowledgeManager } from './knowledge';
 import { MemoryReflector, type ReflectSettings } from './reflect';
 import { PersistStore } from './db';
 import { readAgentUsage, readContextTokens, seedSessionTranscript, resolveSessionCwd } from './transcript';
+import { readChatTranscript } from './chatTranscript';
 import { listIssues, listCIRuns } from './github';
 import { SlackWebhookServer, SlackReplyServer, postSlackReply, type SlackEventFile } from './slack';
 import {
@@ -3862,6 +3863,16 @@ ipcMain.handle('hive:agentContext', (_evt, agentId: unknown) => {
   const tp = hookServer.transcriptPath(agentId);
   if (!tp) return null;
   return readContextTokens(tp) ?? 0;
+});
+// The "Chat" tab's data source: the same transcript path the context gauge
+// already reads, but parsed into plain user/assistant turns instead of a
+// token count — the clean, desktop-app-style view of what the terminal panel
+// shows as a raw, scrolling TUI.
+ipcMain.handle('hive:agentChat', (_evt, agentId: unknown) => {
+  if (typeof agentId !== 'string') return [];
+  const tp = hookServer.transcriptPath(agentId);
+  if (!tp) return [];
+  return readChatTranscript(tp);
 });
 
 // A consolidated, NON-SENSITIVE per-agent directory for the voice read-layer

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,8 @@ import { MemoryReflector, type ReflectSettings } from './reflect';
 import { PersistStore } from './db';
 import { readAgentUsage, readContextTokens, seedSessionTranscript, resolveSessionCwd } from './transcript';
 import { readChatTranscript } from './chatTranscript';
+import { readOpenCodeChat } from './opencodeTranscript';
+import { chatSourceOf } from '../shared/agentProvider';
 import { listIssues, listCIRuns } from './github';
 import { SlackWebhookServer, SlackReplyServer, postSlackReply, type SlackEventFile } from './slack';
 import {
@@ -3864,12 +3866,28 @@ ipcMain.handle('hive:agentContext', (_evt, agentId: unknown) => {
   if (!tp) return null;
   return readContextTokens(tp) ?? 0;
 });
-// The "Chat" tab's data source: the same transcript path the context gauge
-// already reads, but parsed into plain user/assistant turns instead of a
-// token count — the clean, desktop-app-style view of what the terminal panel
-// shows as a raw, scrolling TUI.
+// The "Chat" tab's data source — the clean, desktop-app-style view of what the
+// terminal panel shows as a raw, scrolling TUI. WHERE the conversation lives is
+// per-provider, and that is the whole branch below: Claude Code hands every hook
+// the path of a JSONL transcript (the same file the context gauge tails), while
+// OpenCode keeps its turns in its own SQLite store, addressed by session id.
+// Anything else has neither and returns empty — the tab then says so, which is
+// honest, and the Terminal tab remains the full record for that agent.
+// `null` and `[]` are different answers and the tab renders them differently:
+// null means this CLI keeps nothing the app can read, so waiting is pointless;
+// [] means the source exists and is still empty (hooks not fired yet, or a
+// session that genuinely has no turns).
 ipcMain.handle('hive:agentChat', (_evt, agentId: unknown) => {
-  if (typeof agentId !== 'string') return [];
+  if (typeof agentId !== 'string') return null;
+  const rec = hive.registry().agents[agentId];
+  const source = chatSourceOf(rec?.provider);
+  if (source === 'opencode') {
+    // The plugin-reported id is exact; the registry's is the same id persisted
+    // across an app restart, and the cwd is the last resort for a session that
+    // was already running before either was learned.
+    return readOpenCodeChat(hookServer.sessionId(agentId) ?? rec?.sessionId, rec?.cwd);
+  }
+  if (source !== 'transcript') return null;
   const tp = hookServer.transcriptPath(agentId);
   if (!tp) return [];
   return readChatTranscript(tp);

--- a/src/main/opencodeTranscript.ts
+++ b/src/main/opencodeTranscript.ts
@@ -1,0 +1,159 @@
+/**
+ * The Chat tab's second reader: OpenCode.
+ *
+ * Claude Code writes a JSONL transcript file and hands its path to every hook,
+ * which is what `chatTranscript.ts` tails. OpenCode has no such file — it keeps
+ * the whole conversation in ONE SQLite database under its data dir, split across
+ * `message` (one row per turn, role in a JSON blob) and `part` (one row per
+ * content block: text, reasoning, tool call, step marker). So the Chat tab reads
+ * it with a query instead of a tail, and everything downstream — the ChatMessage
+ * shape, the "this text is the app's, not the human's" filter — is shared with
+ * the Claude reader so both tabs behave identically.
+ *
+ * READ-ONLY, always. OpenCode is the only writer of this database and it is live
+ * while we read; the connection is opened `readonly` so a bug here can never
+ * corrupt an agent's history, and WAL means our reads never block its writes.
+ */
+import Database from 'better-sqlite3';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { type ChatMessage, MAX_CHAT_MESSAGES, isAppGeneratedPrompt } from './chatTranscript';
+
+/** Where OpenCode keeps its store. It follows the XDG data convention on every
+ *  platform, Windows included (observed: `%USERPROFILE%\.local\share\opencode`),
+ *  so the per-agent `OPENCODE_CONFIG_DIR` the harness sets does NOT move it —
+ *  config and data are separate, and every agent shares this one database. */
+function dbPath(): string | null {
+  const xdg = process.env.XDG_DATA_HOME?.trim();
+  const roots = xdg ? [xdg, join(homedir(), '.local', 'share')] : [join(homedir(), '.local', 'share')];
+  for (const root of roots) {
+    const p = join(root, 'opencode', 'opencode.db');
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+/** One handle for the process, reopened after any failure. Opening a SQLite
+ *  connection is not free and the Chat tab polls; a stale handle is the only
+ *  thing worth guarding against, and a closed/deleted database throws on use,
+ *  which `read` turns back into a reopen. */
+let handle: Database.Database | null = null;
+let handlePath: string | null = null;
+
+function connect(): Database.Database | null {
+  const p = dbPath();
+  if (!p) return null;
+  if (handle && handlePath === p) return handle;
+  try { handle?.close(); } catch { /* noop */ }
+  handle = new Database(p, { readonly: true, fileMustExist: true });
+  handlePath = p;
+  return handle;
+}
+
+function drop(): void {
+  try { handle?.close(); } catch { /* noop */ }
+  handle = null;
+  handlePath = null;
+}
+
+/** Windows path comparison: OpenCode stores `C:/Users/…` while the registry
+ *  holds `C:\Users\…`, and neither case nor a trailing separator is meaningful. */
+function samePath(a: string, b: string): boolean {
+  const norm = (s: string) => s.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  return norm(a) === norm(b);
+}
+
+/**
+ * Which OpenCode session belongs to this agent?
+ *
+ * `sessionId` — learned from the bridge plugin, which stamps it on every payload
+ * it posts — is exact, and the only answer that stays right when two agents run
+ * in the SAME directory. The cwd match is the fallback for a session that
+ * started before the plugin reported anything (an agent already running when the
+ * app was updated): newest session in that directory wins, which is right for
+ * one agent per directory and a guess for more than one.
+ */
+function resolveSession(db: Database.Database, sessionId?: string, cwd?: string): string | null {
+  if (sessionId?.startsWith('ses_')) {
+    const hit = db.prepare('SELECT id FROM session WHERE id = ?').get(sessionId) as { id: string } | undefined;
+    if (hit) return hit.id;
+  }
+  if (!cwd) return null;
+  const rows = db.prepare(
+    'SELECT id, directory FROM session WHERE directory IS NOT NULL ORDER BY time_updated DESC LIMIT 200'
+  ).all() as { id: string; directory: string }[];
+  for (const r of rows) if (samePath(r.directory, cwd)) return r.id;
+  return null;
+}
+
+interface CacheEntry { session: string; updated: number; messages: ChatMessage[] }
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Read an agent's OpenCode conversation as plain turns.
+ *
+ * Only `text` parts are selected, IN SQL: a session's `tool` parts carry entire
+ * file reads and command outputs, so pulling every part into memory to throw
+ * most of it away would make each poll cost megabytes. `reasoning` parts are
+ * dropped for the same reason the Claude reader drops thinking blocks — the tab
+ * shows what was said, not how it was arrived at — and `synthetic` parts are
+ * OpenCode's own turn-continuation nudges, which are exactly what this tab
+ * exists to hide.
+ */
+export function readOpenCodeChat(sessionId?: string, cwd?: string): ChatMessage[] {
+  let db: Database.Database | null;
+  try {
+    db = connect();
+  } catch {
+    drop();
+    return [];
+  }
+  if (!db) return [];
+
+  try {
+    const session = resolveSession(db, sessionId, cwd);
+    if (!session) return [];
+
+    // `time_updated` on the session row moves on every write, so one indexed
+    // lookup tells us whether the (much larger) turn query can be skipped. This
+    // is the WAL-safe equivalent of the size+mtime check the Claude tailer uses:
+    // a WAL commit need not touch the database file's own mtime.
+    const meta = db.prepare('SELECT time_updated FROM session WHERE id = ?').get(session) as
+      { time_updated: number } | undefined;
+    const updated = meta?.time_updated ?? 0;
+    const cached = cache.get(session);
+    if (cached && cached.updated === updated) return cached.messages;
+
+    const rows = db.prepare(`
+      SELECT json_extract(m.data, '$.role')  AS role,
+             json_extract(p.data, '$.text')  AS text,
+             p.time_created                  AS ts
+        FROM part p
+        JOIN message m ON m.id = p.message_id
+       WHERE p.session_id = ?
+         AND json_extract(p.data, '$.type') = 'text'
+         AND json_extract(p.data, '$.synthetic') IS NULL
+       ORDER BY p.time_created DESC
+       LIMIT ?
+    `).all(session, MAX_CHAT_MESSAGES) as { role: string; text: string | null; ts: number }[];
+
+    const messages: ChatMessage[] = [];
+    for (const r of rows.reverse()) {
+      if (r.role !== 'user' && r.role !== 'assistant') continue;
+      const body = (r.text ?? '').trim();
+      if (!body) continue;
+      if (r.role === 'user' && isAppGeneratedPrompt(body)) continue;
+      messages.push({ role: r.role, text: body, ts: r.ts });
+    }
+
+    cache.set(session, { session, updated, messages });
+    return messages;
+  } catch {
+    // A schema change, a JSON1-less build, or a handle that outlived its file.
+    // Dropping the handle makes the next poll reconnect; an empty tab is the
+    // right failure mode either way.
+    drop();
+    return [];
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -440,6 +440,14 @@ export interface AgentUsage {
   model?: string;
 }
 
+/** One plain-text conversation turn, tool traffic stripped out. Mirrors
+ * ChatMessage in main/chatTranscript.ts. */
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  text: string;
+  ts: number;
+}
+
 /** Live cumulative cost/token snapshot from the OTel collector (the locked
  *  cross-lane seam). PII-free by construction. Mirrors telemetry.ts. */
 export interface AgentUsageSample {
@@ -1013,6 +1021,11 @@ const api = {
    *  have fired at least once (the transcript path is learned from them). */
   agentContext: (agentId: string): Promise<number | null> =>
     ipcRenderer.invoke('hive:agentContext', agentId),
+  /** Plain user/assistant turns from an agent's live transcript, tool traffic
+   *  stripped out — the data behind the Chat tab. Empty until the agent's
+   *  hooks have fired at least once (same precondition as agentContext). */
+  agentChat: (agentId: string): Promise<ChatMessage[]> =>
+    ipcRenderer.invoke('hive:agentChat', agentId),
 
   // ─── Live telemetry (OTel collector — the usage-provider seam + spans) ──────
   /** Live cumulative usage for an agent (OTel-preferred, transcript fallback). */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1021,10 +1021,12 @@ const api = {
    *  have fired at least once (the transcript path is learned from them). */
   agentContext: (agentId: string): Promise<number | null> =>
     ipcRenderer.invoke('hive:agentContext', agentId),
-  /** Plain user/assistant turns from an agent's live transcript, tool traffic
-   *  stripped out — the data behind the Chat tab. Empty until the agent's
-   *  hooks have fired at least once (same precondition as agentContext). */
-  agentChat: (agentId: string): Promise<ChatMessage[]> =>
+  /** Plain user/assistant turns from an agent's live conversation, tool traffic
+   *  stripped out — the data behind the Chat tab. `[]` while the source exists
+   *  but is still empty (a Claude agent whose hooks have not fired yet, same
+   *  precondition as agentContext); `null` when this provider keeps no
+   *  conversation the app can read, so the tab must stop implying one is coming. */
+  agentChat: (agentId: string): Promise<ChatMessage[] | null> =>
     ipcRenderer.invoke('hive:agentChat', agentId),
 
   // ─── Live telemetry (OTel collector — the usage-provider seam + spans) ──────

--- a/src/renderer/src/components/AgentDetailPanel.tsx
+++ b/src/renderer/src/components/AgentDetailPanel.tsx
@@ -15,6 +15,7 @@ import { ToolWaterfall } from './ToolWaterfall';
 import { AgentControlStrip } from './AgentControlStrip';
 import { EditAgentModal } from './EditAgentModal';
 import { GitTab } from './GitTab';
+import { ChatView } from './ChatView';
 import { Icon } from './Icon';
 import { AgentNameEditor } from './AgentNameEditor';
 import { useStore, type Agent } from '@/store/store';
@@ -271,6 +272,10 @@ export function AgentDetailPanel({ agent }: AgentDetailPanelProps) {
               {t('agentDetail.noPtyDesc')}
             </EmptyTab>
           )
+        )}
+
+        {sidebarTab === 'chat' && (
+          <ChatView agent={agent} />
         )}
 
         {sidebarTab === 'git' && (

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -1,0 +1,102 @@
+/**
+ * CHAT — the "desktop app" view of an agent: just its replies, not the raw
+ * scrolling TUI the Terminal tab shows (spinners, tool-call lines, box
+ * drawing). Reads main/chatTranscript.ts's parsed user/assistant turns via
+ * `window.cth.agentChat`, which strips every tool_use/tool_result block out
+ * before it ever reaches the renderer.
+ *
+ * Polling, not a push channel: chat turns land at human pace (seconds, not the
+ * byte-by-byte rate a pty streams at), and the transcript tailer in main is
+ * already cheap on repeat reads (offset-cached, like the usage reconciler).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MarkdownPreview } from '@/markdown/MarkdownPreview';
+import { useRtl } from '@/i18n/useDirection';
+import { MessageQueueComposer } from './MessageQueueComposer';
+import type { Agent } from '@/store/store';
+
+const POLL_MS = 1500;
+
+/** Mirrors ChatMessage in main/chatTranscript.ts and preload/index.ts — kept as
+ * its own copy because renderer, preload and main compile as separate
+ * programs (tsconfig.web.json / tsconfig.node.json). */
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  text: string;
+  ts: number;
+}
+
+export function ChatView({ agent }: { agent: Agent }) {
+  const { t } = useTranslation();
+  const rtl = useRtl();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Only auto-follow new turns while the reader is already at the bottom —
+  // scrolling up to reread history must not get yanked back down.
+  const atBottomRef = useRef(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const next = await window.cth.agentChat(agent.id);
+        if (!cancelled) setMessages(next);
+      } catch { /* keep last good */ }
+    };
+    void poll();
+    const id = setInterval(poll, POLL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [agent.id]);
+
+  useEffect(() => {
+    if (!atBottomRef.current) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  return (
+    <div style={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      <div
+        ref={scrollRef}
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 32;
+        }}
+        style={{
+          flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--cth-paper-200)',
+          padding: 10, display: 'flex', flexDirection: 'column', gap: 8,
+          fontFamily: 'var(--cth-font-mono)'
+        }}
+      >
+        {messages.length === 0 && (
+          <div style={{ textAlign: 'center', padding: '24px 12px', color: 'var(--cth-ink-500)', fontSize: 12 }}>
+            {t('commandCenter.noChat')}
+          </div>
+        )}
+        {messages.map((m, i) => {
+          const mine = m.role === 'assistant';
+          return (
+            <div
+              key={`${m.ts}-${i}`}
+              dir={rtl ? 'auto' : undefined}
+              style={{
+                alignSelf: mine ? 'flex-start' : 'flex-end',
+                maxWidth: '85%',
+                background: mine ? 'var(--cth-paper-100)' : `var(--cth-${agent.accent})`,
+                color: mine ? 'var(--cth-ink-900)' : 'var(--cth-on-accent)',
+                boxShadow: 'inset 0 0 0 1px var(--cth-ink-100)',
+                padding: '6px 10px', fontSize: 14, lineHeight: '19px'
+              }}
+            >
+              <MarkdownPreview source={m.text} variant="card" />
+            </div>
+          );
+        })}
+      </div>
+      {/* Same queue the Terminal tab uses: typed here lands in the pty exactly
+          like a Terminal-tab message, just via a form instead of a raw prompt. */}
+      <MessageQueueComposer agent={agent} />
+    </div>
+  );
+}

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -30,7 +30,10 @@ interface ChatMessage {
 export function ChatView({ agent }: { agent: Agent }) {
   const { t } = useTranslation();
   const rtl = useRtl();
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  // null = this provider keeps no readable conversation (see chatSourceOf);
+  // [] = there is a source and it has nothing in it yet. Undefined only until
+  // the first poll answers, so the tab never flashes an empty state at load.
+  const [messages, setMessages] = useState<ChatMessage[] | null | undefined>(undefined);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // Only auto-follow new turns while the reader is already at the bottom —
   // scrolling up to reread history must not get yanked back down.
@@ -69,12 +72,17 @@ export function ChatView({ agent }: { agent: Agent }) {
           fontFamily: 'var(--cth-font-mono)'
         }}
       >
-        {messages.length === 0 && (
+        {messages && messages.length === 0 && (
           <div style={{ textAlign: 'center', padding: '24px 12px', color: 'var(--cth-ink-500)', fontSize: 12 }}>
             {t('commandCenter.noChat')}
           </div>
         )}
-        {messages.map((m, i) => {
+        {messages === null && (
+          <div style={{ textAlign: 'center', padding: '24px 12px', color: 'var(--cth-ink-500)', fontSize: 12 }}>
+            {t('commandCenter.noChatSource', { name: agent.name })}
+          </div>
+        )}
+        {(messages ?? []).map((m, i) => {
           const mine = m.role === 'assistant';
           return (
             <div

--- a/src/renderer/src/components/CommandCenterPanel.tsx
+++ b/src/renderer/src/components/CommandCenterPanel.tsx
@@ -8,6 +8,7 @@ import { PtyTerminalView } from './PtyTerminalView';
 import { MessageQueueComposer } from './MessageQueueComposer';
 import { TasksKanban } from './TasksKanban';
 import { AskMeTab } from './AskMeTab';
+import { ChatView } from './ChatView';
 import { TriggersTab } from './triggers/TriggersTab';
 import { TriggerHistoryTab } from './triggers/TriggerHistoryTab';
 import { WorkersTab } from './WorkersTab';
@@ -46,7 +47,7 @@ import { useRtl } from '@/i18n/useDirection';
 // Both the AskMe (#human) tab and the Triggers tab live here. Triggers replaced
 // the old Schedules tab: schedules are now one of four trigger types, and the
 // whole surface lives in ./triggers (see src/shared/triggers.ts for the contract).
-type CCTab = 'terminal' | 'floor' | 'tasks' | 'human' | 'triggers' | 'trigger-history'
+type CCTab = 'terminal' | 'chat' | 'floor' | 'tasks' | 'human' | 'triggers' | 'trigger-history'
   | 'memory' | 'graph' | 'activity' | 'skills' | 'workers';
 
 /** Fallback denominator for the per-agent token meter when no floor token budget
@@ -67,6 +68,7 @@ interface GHIssue {
 /** Canonical tab order. Not every entry is always shown — see `visibleTabs`. */
 const TABS: { key: CCTab; labelKey: string; icon: Parameters<typeof Icon>[0]['name'] }[] = [
   { key: 'terminal', labelKey: 'commandCenter.tabs.terminal', icon: 'terminal' },
+  { key: 'chat', labelKey: 'commandCenter.tabs.chat', icon: 'chat' },
   { key: 'floor', labelKey: 'commandCenter.tabs.floor', icon: 'mcp' },
   { key: 'tasks', labelKey: 'commandCenter.tabs.tasks', icon: 'check' },
   { key: 'human', labelKey: 'commandCenter.tabs.human', icon: 'bell' },
@@ -319,6 +321,7 @@ export function CommandCenterPanel({ agent, fullscreen = false }: { agent: Agent
             <Centered>{t('commandCenter.noTerminal', { name: agent.name })}</Centered>
           )
         )}
+        {tab === 'chat' && <ChatView agent={agent} />}
         {tab === 'floor' && <FloorTab seed={dispatchSeed} />}
         {tab === 'tasks' && <TasksKanban />}
         {tab === 'human' && <AskMeTab />}

--- a/src/renderer/src/components/Icon.tsx
+++ b/src/renderer/src/components/Icon.tsx
@@ -5,7 +5,7 @@ import { CSSProperties } from 'react';
 
 export type IconName =
   | 'gear' | 'plus' | 'x' | 'check' | 'arrow-right' | 'pause' | 'play'
-  | 'bell' | 'folder' | 'terminal' | 'code' | 'web' | 'mcp' | 'sparkle'
+  | 'bell' | 'folder' | 'terminal' | 'chat' | 'code' | 'web' | 'mcp' | 'sparkle'
   | 'expand' | 'minimize' | 'clock' | 'mic' | 'ledger' | 'info' | 'sidebar'
   | 'image' | 'edit' | 'git';
 
@@ -78,6 +78,13 @@ const paths: Record<IconName, IconDef> = {
   terminal: {
     accentColor: 'var(--cth-mint)',
     ink:   'M1 2h14v12H1V2zm1 1v10h12V3H2zm1 2h1v1h1v1h1v1H5v1H4v1H3V9h1V8h1V7H4V6H3V5zm5 5h4v1H8v-1z'
+  },
+  // Speech bubble, evenodd frame + a two-step tail (same cutout trick as
+  // terminal/mcp), with three "reply" dots inside — sits next to `terminal`
+  // as the clean-conversation counterpart to its raw TUI.
+  chat: {
+    accentColor: 'var(--cth-mint)',
+    ink:   'M1 2h13v9H4v3H3v-3H1V2zm1 1v7h11V3H2zM4 6h1v2H4zM7 6h1v2H7zM10 6h1v2H10z'
   },
   // The branch graph, which is what git's own mark is: a trunk with two commit
   // nodes and one branch arcing off into a third. Drawn at the same hairline

--- a/src/renderer/src/components/SidebarTabs.tsx
+++ b/src/renderer/src/components/SidebarTabs.tsx
@@ -7,6 +7,7 @@ import { Icon, type IconName } from './Icon';
 // full Monaco editor + file tree, which superseded the read-only browser.
 const TABS: { key: SidebarTab; labelKey: string; icon: IconName }[] = [
   { key: 'terminal', labelKey: 'sidebar.terminal', icon: 'terminal' },
+  { key: 'chat', labelKey: 'sidebar.chat', icon: 'chat' },
   { key: 'git',      labelKey: 'sidebar.git',      icon: 'code' },
   { key: 'messages', labelKey: 'sidebar.messages', icon: 'bell' },
   { key: 'traces',   labelKey: 'sidebar.traces',   icon: 'web' }

--- a/src/renderer/src/i18n/locales/ar.json
+++ b/src/renderer/src/i18n/locales/ar.json
@@ -404,6 +404,7 @@
     "terminalFullscreen": "الطرفية مفتوحة بملء الشاشة. اضغط Esc لإعادتها.",
     "noTerminal": "{{name}} ليس لديه طرفية حيّة.",
     "noChat": "لا توجد محادثة بعد.",
+    "noChatSource": "واجهة {{name}} لا تحتفظ بمحادثة يمكن للتطبيق قراءتها — السجل الكامل في تبويب الطرفية.",
     "dispatchViaMichael": "إرسال — عبر {{godName}}",
     "suggestedOwner": "المالك المقترَح",
     "michaelDecides": "{{godName}} يقرّر",

--- a/src/renderer/src/i18n/locales/ar.json
+++ b/src/renderer/src/i18n/locales/ar.json
@@ -127,6 +127,7 @@
   },
   "sidebar": {
     "terminal": "الطرفية",
+    "chat": "المحادثة",
     "git": "git",
     "messages": "الرسائل",
     "traces": "التتبّع"
@@ -388,6 +389,7 @@
     "ide": "بيئة التطوير",
     "tabs": {
       "terminal": "الطرفية",
+      "chat": "المحادثة",
       "floor": "المراقبة",
       "tasks": "المهام",
       "human": "اسألني",
@@ -401,6 +403,7 @@
     },
     "terminalFullscreen": "الطرفية مفتوحة بملء الشاشة. اضغط Esc لإعادتها.",
     "noTerminal": "{{name}} ليس لديه طرفية حيّة.",
+    "noChat": "لا توجد محادثة بعد.",
     "dispatchViaMichael": "إرسال — عبر {{godName}}",
     "suggestedOwner": "المالك المقترَح",
     "michaelDecides": "{{godName}} يقرّر",

--- a/src/renderer/src/i18n/locales/ar.json
+++ b/src/renderer/src/i18n/locales/ar.json
@@ -404,7 +404,7 @@
     "terminalFullscreen": "الطرفية مفتوحة بملء الشاشة. اضغط Esc لإعادتها.",
     "noTerminal": "{{name}} ليس لديه طرفية حيّة.",
     "noChat": "لا توجد محادثة بعد.",
-    "noChatSource": "واجهة {{name}} لا تحتفظ بمحادثة يمكن للتطبيق قراءتها — السجل الكامل في تبويب الطرفية.",
+    "noChatSource": "الدردشة لا تستطيع قراءة واجهة {{name}} بعد — السجل الكامل في تبويب الطرفية.",
     "dispatchViaMichael": "إرسال — عبر {{godName}}",
     "suggestedOwner": "المالك المقترَح",
     "michaelDecides": "{{godName}} يقرّر",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -404,6 +404,7 @@
     "terminalFullscreen": "Terminal is open in fullscreen. Press Esc to bring it back.",
     "noTerminal": "{{name}} has no live terminal.",
     "noChat": "No conversation yet.",
+    "noChatSource": "{{name}}'s CLI keeps no conversation this app can read — the terminal tab has the full record.",
     "dispatchViaMichael": "DISPATCH — VIA {{godName}}",
     "suggestedOwner": "SUGGESTED OWNER",
     "michaelDecides": "{{godName}} decides",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -404,7 +404,7 @@
     "terminalFullscreen": "Terminal is open in fullscreen. Press Esc to bring it back.",
     "noTerminal": "{{name}} has no live terminal.",
     "noChat": "No conversation yet.",
-    "noChatSource": "{{name}}'s CLI keeps no conversation this app can read — the terminal tab has the full record.",
+    "noChatSource": "Chat cannot read {{name}}'s CLI yet — the terminal tab has the full record.",
     "dispatchViaMichael": "DISPATCH — VIA {{godName}}",
     "suggestedOwner": "SUGGESTED OWNER",
     "michaelDecides": "{{godName}} decides",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -127,6 +127,7 @@
   },
   "sidebar": {
     "terminal": "terminal",
+    "chat": "chat",
     "git": "git",
     "messages": "messages",
     "traces": "traces"
@@ -388,6 +389,7 @@
     "ide": "IDE",
     "tabs": {
       "terminal": "terminal",
+      "chat": "chat",
       "floor": "monitor",
       "tasks": "tasks",
       "human": "ask me",
@@ -401,6 +403,7 @@
     },
     "terminalFullscreen": "Terminal is open in fullscreen. Press Esc to bring it back.",
     "noTerminal": "{{name}} has no live terminal.",
+    "noChat": "No conversation yet.",
     "dispatchViaMichael": "DISPATCH — VIA {{godName}}",
     "suggestedOwner": "SUGGESTED OWNER",
     "michaelDecides": "{{godName}} decides",

--- a/src/renderer/src/i18n/locales/zh-CN.json
+++ b/src/renderer/src/i18n/locales/zh-CN.json
@@ -404,7 +404,7 @@
     "terminalFullscreen": "终端已全屏打开。按 Esc 返回。",
     "noTerminal": "{{name}} 没有实时终端。",
     "noChat": "还没有对话。",
-    "noChatSource": "{{name}} 的 CLI 没有本应用可读取的对话记录 — 完整记录在终端标签页。",
+    "noChatSource": "对话还无法读取 {{name}} 的 CLI — 完整记录在终端标签页。",
     "dispatchViaMichael": "派发——经由 {{godName}}",
     "suggestedOwner": "建议负责人",
     "michaelDecides": "{{godName}} 决定",

--- a/src/renderer/src/i18n/locales/zh-CN.json
+++ b/src/renderer/src/i18n/locales/zh-CN.json
@@ -404,6 +404,7 @@
     "terminalFullscreen": "终端已全屏打开。按 Esc 返回。",
     "noTerminal": "{{name}} 没有实时终端。",
     "noChat": "还没有对话。",
+    "noChatSource": "{{name}} 的 CLI 没有本应用可读取的对话记录 — 完整记录在终端标签页。",
     "dispatchViaMichael": "派发——经由 {{godName}}",
     "suggestedOwner": "建议负责人",
     "michaelDecides": "{{godName}} 决定",

--- a/src/renderer/src/i18n/locales/zh-CN.json
+++ b/src/renderer/src/i18n/locales/zh-CN.json
@@ -127,6 +127,7 @@
   },
   "sidebar": {
     "terminal": "终端",
+    "chat": "对话",
     "git": "Git",
     "messages": "消息",
     "traces": "追踪"
@@ -388,6 +389,7 @@
     "ide": "IDE",
     "tabs": {
       "terminal": "终端",
+      "chat": "对话",
       "floor": "监控",
       "tasks": "任务",
       "human": "问我",
@@ -401,6 +403,7 @@
     },
     "terminalFullscreen": "终端已全屏打开。按 Esc 返回。",
     "noTerminal": "{{name}} 没有实时终端。",
+    "noChat": "还没有对话。",
     "dispatchViaMichael": "派发——经由 {{godName}}",
     "suggestedOwner": "建议负责人",
     "michaelDecides": "{{godName}} 决定",

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -159,7 +159,7 @@ export interface QueuedMessage {
 // 'files' retired in v0.3.4 (the per-agent IDE button superseded it) — a
 // persisted 'files' selection falls back to 'terminal' on load. 'git' added in
 // v0.3.4: at-a-glance branch/status/log without opening the IDE.
-export type SidebarTab = 'terminal' | 'messages' | 'traces' | 'git';
+export type SidebarTab = 'terminal' | 'chat' | 'messages' | 'traces' | 'git';
 
 /** Lifecycle of the god agent ("Michael") bootstrap on launch.
  *  'booting' until his PTY is confirmed live, then 'ready' (or 'failed' if the
@@ -623,7 +623,7 @@ const initialSidebarWidth = (() => {
 const initialSidebarTab: SidebarTab = (() => {
   try {
     const v = window.localStorage.getItem(LS_SIDEBAR_TAB);
-    if (v === 'terminal' || v === 'messages' || v === 'traces' || v === 'git') return v;
+    if (v === 'terminal' || v === 'chat' || v === 'messages' || v === 'traces' || v === 'git') return v;
   } catch { /* noop */ }
   return 'terminal';
 })();

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -620,19 +620,22 @@ export function isHiveAwareProvider(provider: AgentProvider | undefined): boolea
  *    Code natively; Antigravity because its shim forwards `transcriptPath`.
  *  - 'opencode'   — no transcript file; the turns live in OpenCode's own SQLite
  *    store, read by `main/opencodeTranscript.ts` and addressed by session id.
+ *  - 'codex'      — a JSONL rollout per session under the agent's private
+ *    CODEX_HOME, named after the session id, read by `main/codexTranscript.ts`.
  *  - null         — no reader HERE yet. Not a claim that the CLI keeps no
- *    history: Codex, for one, writes a perfectly readable `rollout-*.jsonl`
- *    per session under its CODEX_HOME (role + text, live) and still returns
- *    null, because nothing in this app reads that file yet. The tab says so
- *    rather than sitting on an empty "nothing yet", which is the same silent
- *    dead end for the user either way.
+ *    history — Codex kept one all along and sat in this bucket until its reader
+ *    existed. The tab says so rather than sitting on an empty "nothing yet",
+ *    which is the same silent dead end for the user either way.
  *
  * A provider moves out of `null` by gaining a reader, not by declaring one here:
  * this table only reports what `hive:agentChat` is actually able to answer, so
  * it must never be read as a statement about the CLI itself.
  */
-export function chatSourceOf(provider: AgentProvider | undefined): 'transcript' | 'opencode' | null {
+export type ChatSource = 'transcript' | 'opencode' | 'codex';
+
+export function chatSourceOf(provider: AgentProvider | undefined): ChatSource | null {
   if (provider === 'opencode') return 'opencode';
+  if (provider === 'codex') return 'codex';
   if (provider === undefined || provider === 'claude' || provider === 'antigravity') return 'transcript';
   return null;
 }

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -612,6 +612,27 @@ export function isHiveAwareProvider(provider: AgentProvider | undefined): boolea
   return providerPreset(provider ?? 'claude').hiveAware;
 }
 
+/**
+ * Where the Chat tab can read this provider's conversation from, if anywhere.
+ *
+ *  - 'transcript' — the CLI writes a Claude-shaped JSONL transcript and reports
+ *    its path on every hook, so `main/chatTranscript.ts` can tail it. Claude
+ *    Code natively; Antigravity because its shim forwards `transcriptPath`.
+ *  - 'opencode'   — no transcript file; the turns live in OpenCode's own SQLite
+ *    store, read by `main/opencodeTranscript.ts` and addressed by session id.
+ *  - null         — nothing to read. The tab says so rather than sitting on an
+ *    empty "nothing yet", which is the same silent dead end for the user
+ *    whether the CLI keeps no readable history or the app cannot find it.
+ *
+ * A provider moves out of `null` by gaining a reader, not by declaring one here:
+ * this table only reports what `hive:agentChat` is actually able to answer.
+ */
+export function chatSourceOf(provider: AgentProvider | undefined): 'transcript' | 'opencode' | null {
+  if (provider === 'opencode') return 'opencode';
+  if (provider === undefined || provider === 'claude' || provider === 'antigravity') return 'transcript';
+  return null;
+}
+
 /** Whether the router may deliver inbox mail to this provider (else bounce to
  *  the god). True when lifecycle status supports guarded idle delivery; false
  *  for hookless custom commands. */

--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -620,12 +620,16 @@ export function isHiveAwareProvider(provider: AgentProvider | undefined): boolea
  *    Code natively; Antigravity because its shim forwards `transcriptPath`.
  *  - 'opencode'   — no transcript file; the turns live in OpenCode's own SQLite
  *    store, read by `main/opencodeTranscript.ts` and addressed by session id.
- *  - null         — nothing to read. The tab says so rather than sitting on an
- *    empty "nothing yet", which is the same silent dead end for the user
- *    whether the CLI keeps no readable history or the app cannot find it.
+ *  - null         — no reader HERE yet. Not a claim that the CLI keeps no
+ *    history: Codex, for one, writes a perfectly readable `rollout-*.jsonl`
+ *    per session under its CODEX_HOME (role + text, live) and still returns
+ *    null, because nothing in this app reads that file yet. The tab says so
+ *    rather than sitting on an empty "nothing yet", which is the same silent
+ *    dead end for the user either way.
  *
  * A provider moves out of `null` by gaining a reader, not by declaring one here:
- * this table only reports what `hive:agentChat` is actually able to answer.
+ * this table only reports what `hive:agentChat` is actually able to answer, so
+ * it must never be read as a statement about the CLI itself.
  */
 export function chatSourceOf(provider: AgentProvider | undefined): 'transcript' | 'opencode' | null {
   if (provider === 'opencode') return 'opencode';

--- a/src/shared/hivePrompt.ts
+++ b/src/shared/hivePrompt.ts
@@ -1,0 +1,33 @@
+/**
+ * The hive identity/protocol brief — the block the harness injects at spawn so a
+ * fresh CLI knows who it is and how the hive works, and the predicate that
+ * recognises it again later.
+ *
+ * For a hiveAware provider (Claude) the brief rides in as
+ * `--append-system-prompt`, so it never appears as a conversation turn. Every
+ * other provider takes it through `initialPromptFlag` (`--prompt`, `-p`, …),
+ * which makes it the session's FIRST USER MESSAGE — indistinguishable, in the
+ * transcript, from something the human typed. The Chat tab shows what people
+ * said to each other, so it has to be able to tell them apart; that is what the
+ * marker below is for.
+ *
+ * Shared between main and renderer; keep it dependency-free.
+ */
+
+/** Fixed header of the protocol section, present in every brief the harness
+ *  builds (`buildIdentity` in main/hive.ts composes the block around it). It is
+ *  the recognition anchor, so the builder MUST take it from here rather than
+ *  spelling it out again — a drifted copy would silently unhide the brief. */
+export const HIVE_PROTOCOL_HEADING = 'HIVE PROTOCOL — follow it every task:';
+
+/**
+ * Is this text the harness's own identity brief rather than a human prompt?
+ *
+ * Matches the protocol heading anywhere in the text: the lines around it carry
+ * the agent's name, workspace paths and duty, so they differ per agent and per
+ * spawn, while the heading is fixed. Mirrors `isInboxNudge` / `isCompactionCommand`
+ * — recognise the app's COMMAND, not one instance of it.
+ */
+export function isHiveIdentityPrompt(text: string): boolean {
+  return text.includes(HIVE_PROTOCOL_HEADING);
+}

--- a/test/chat-transcript.test.cjs
+++ b/test/chat-transcript.test.cjs
@@ -163,9 +163,10 @@ test('the hook server keeps the session id out of the registry', () => {
 test('a provider with no readable conversation is reported, not left waiting', () => {
   const { chatSourceOf } = loadTs('src/shared/agentProvider.ts');
   assert.equal(chatSourceOf('opencode'), 'opencode');
+  assert.equal(chatSourceOf('codex'), 'codex');
   assert.equal(chatSourceOf('claude'), 'transcript');
   assert.equal(chatSourceOf('antigravity'), 'transcript');  // its shim forwards transcriptPath
-  for (const p of ['codex', 'grok', 'kimi', 'gemini', 'qwen', 'crush', 'pi', 'copilot', 'cursor', 'custom']) {
+  for (const p of ['grok', 'kimi', 'gemini', 'qwen', 'crush', 'pi', 'copilot', 'cursor', 'custom']) {
     assert.equal(chatSourceOf(p), null, p);
   }
 
@@ -173,4 +174,76 @@ test('a provider with no readable conversation is reported, not left waiting', (
   // If that ever stops, the tab goes back to a permanently empty "nothing yet".
   const agyShim = read('src/main/hive.ts').split('const AGY_HOOK_SHIM = `')[1] ?? '';
   assert.match(agyShim, /transcript_path: agy\.transcriptPath/);
+});
+
+// — the Codex reader —
+//
+// Codex writes `sessions/YYYY/MM/DD/rollout-<started>-<sessionId>.jsonl` under
+// the agent's private CODEX_HOME. The shapes below are copied from a live
+// reviewer's rollout, not invented.
+
+const { readCodexChat, resolveCodexRollout, isCodexInjectedPrompt } = loadTs('src/main/codexTranscript.ts');
+
+const codexMsg = (role, text, ts, kind = role === 'assistant' ? 'output_text' : 'input_text') => JSON.stringify({
+  timestamp: new Date(ts).toISOString(), ordinal: ts, type: 'response_item',
+  payload: { type: 'message', role, content: [{ type: kind, text }] }
+}) + '\n';
+const codexOther = (type, payload, ts) => JSON.stringify({ timestamp: new Date(ts).toISOString(), type, payload }) + '\n';
+
+function codexHome(rollouts) {
+  // rollouts: [{ sessionId, started, body, mtimeMs? }]
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-codex-'));
+  const day = path.join(home, 'sessions', '2026', '09', '08');
+  fs.mkdirSync(day, { recursive: true });
+  for (const r of rollouts) {
+    const p = path.join(day, `rollout-${r.started}-${r.sessionId}.jsonl`);
+    fs.writeFileSync(p, r.body, 'utf8');
+    if (r.mtimeMs) fs.utimesSync(p, r.mtimeMs / 1000, r.mtimeMs / 1000);
+  }
+  return home;
+}
+
+test("Codex's own injections are hidden, a human message that mentions them is not", () => {
+  assert.equal(isCodexInjectedPrompt('# AGENTS.md instructions for C:\\repo\n\n<INSTRUCTIONS>…'), true);
+  assert.equal(isCodexInjectedPrompt('<user_instructions>\n# rules\n</user_instructions>'), true);
+  assert.equal(isCodexInjectedPrompt('<environment_context>\n  <cwd>C:\\repo</cwd>\n</environment_context>'), true);
+  assert.equal(isCodexInjectedPrompt('kannst du die AGENTS.md instructions kurz zusammenfassen?'), false);
+});
+
+test('a Codex rollout yields only the human prompts and the replies', () => {
+  const sid = '01a08233-72ea-7481-98c9-ef954a56aadb';
+  const home = codexHome([{ sessionId: sid, started: '2026-09-08T20-06-44', body: [
+    codexOther('session_meta', { session_id: sid, cwd: 'C:\\repo' }, 1),
+    codexMsg('developer', '<skills_instructions>\n## Skills\n…', 2),          // Codex's system seat
+    codexMsg('user', '# AGENTS.md instructions for C:\\repo\n\n<INSTRUCTIONS>…', 3), // Codex-injected
+    codexMsg('user', brief('Reviewer', 'reviewer-mtsv9w0o'), 4),                 // hive-injected
+    codexOther('turn_context', { cwd: 'C:\\repo' }, 5),
+    codexOther('event_msg', { type: 'task_started' }, 6),
+    codexMsg('user', inboxNudgeText(['2026-09-08T18-20-46-108Z-ede403']), 7),    // hive nudge
+    codexMsg('user', 'alles in ordnung ?', 8),
+    codexOther('response_item', { type: 'custom_tool_call', name: 'shell', input: 'git status' }, 9),
+    codexOther('response_item', { type: 'reasoning', summary: [{ type: 'summary_text', text: 'thinking' }] }, 10),
+    codexMsg('assistant', 'Ja, ich bin lauffähig. Inbox abgearbeitet.', 11),
+    codexOther('token_usage_record', { total: 1 }, 12)
+  ].join('') }]);
+
+  assert.deepEqual(readCodexChat(home, sid).map((m) => [m.role, m.text]), [
+    ['user', 'alles in ordnung ?'],
+    ['assistant', 'Ja, ich bin lauffähig. Inbox abgearbeitet.']
+  ]);
+});
+
+test('the rollout is found by session id first, newest-written second', () => {
+  const now = Date.now();
+  const home = codexHome([
+    { sessionId: 'aaaa-old', started: '2026-09-08T18-11-31', body: codexMsg('user', 'old', 1), mtimeMs: now - 60_000 },
+    { sessionId: 'bbbb-current', started: '2026-09-08T20-06-44', body: codexMsg('user', 'current', 2), mtimeMs: now },
+    // Newest on disk but NOT this agent's session: a session id must beat mtime.
+    { sessionId: 'cccc-newest', started: '2026-09-08T20-30-00', body: codexMsg('user', 'newest', 3), mtimeMs: now + 60_000 }
+  ]);
+  assert.match(resolveCodexRollout(home, 'bbbb-current'), /-bbbb-current\.jsonl$/);
+  assert.match(resolveCodexRollout(home, undefined), /-cccc-newest\.jsonl$/, 'no id → newest write wins');
+  assert.match(resolveCodexRollout(home, 'zzzz-unknown'), /-cccc-newest\.jsonl$/, 'unknown id → newest write');
+  assert.equal(resolveCodexRollout(path.join(os.tmpdir(), 'md-codex-nope'), 'x'), null);
+  assert.deepEqual(readCodexChat(path.join(os.tmpdir(), 'md-codex-nope'), 'x'), []);
 });

--- a/test/chat-transcript.test.cjs
+++ b/test/chat-transcript.test.cjs
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * The Chat tab shows the conversation — what the human typed and what the agent
+ * answered — and nothing else. Two things can break that promise, and both are
+ * silent when they do:
+ *
+ *   1. Text the HARNESS types into an agent looks exactly like a human prompt
+ *      once it reaches the transcript: the identity/protocol brief injected at
+ *      spawn, the inbox-wake nudge, the `/compact` from the context cap. Only a
+ *      fixed pattern tells them apart, so each pattern is pinned here together
+ *      with the writer that produces it — a reworded brief that stops matching
+ *      would put a wall of protocol text back in the user's chat window.
+ *
+ *   2. The transcript is FULL of tool traffic (file reads, command output). A
+ *      reader that stops stripping it does not fail, it just floods the tab.
+ *
+ * The OpenCode half of the tab cannot be exercised here (its reader opens
+ * better-sqlite3, a native module built for Electron's ABI), so what this file
+ * can hold for it is the seam the whole feature hangs from: the bridge plugin
+ * reporting a session id. Without it there is no way to find the conversation
+ * in OpenCode's store, and the tab is empty for every OpenCode agent.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const loadTs = require('./load-ts.cjs');
+
+const root = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
+
+const { isAppGeneratedPrompt, readChatTranscript } = loadTs('src/main/chatTranscript.ts');
+const { HIVE_PROTOCOL_HEADING, isHiveIdentityPrompt } = loadTs('src/shared/hivePrompt.ts');
+const { inboxNudgeText } = loadTs('src/shared/hiveNudge.ts');
+
+// A brief in the shape buildIdentity() emits: per-agent name/paths around the
+// one fixed heading. Two different agents share nothing BUT that heading, which
+// is why it is the anchor.
+const brief = (name, id) => [
+  `You are "${name}" (${id}), an autonomous agent in a collaborating hive of Claude agents.`,
+  `Your private workspace is C:\\hive\\agents\\${id}. The shared hive is C:\\hive.`,
+  '',
+  HIVE_PROTOCOL_HEADING,
+  '1. At the START of a task, read memory.md and EVERY file in inbox.',
+  'Env vars available to you: AGENT_ID, AGENT_NAME, HIVE_ROOT, AGENT_DIR.'
+].join('\n');
+
+// — what the app types is not what the human said —
+
+test('the spawn brief is recognised whatever agent it was built for', () => {
+  for (const [name, id] of [['Michael', 'god'], ['Andi', 'dev1-mtsv8xwb'], ['أليكس', 'rev-1']]) {
+    assert.equal(isHiveIdentityPrompt(brief(name, id)), true, `${name}/${id}`);
+    assert.equal(isAppGeneratedPrompt(brief(name, id)), true, `${name}/${id}`);
+  }
+});
+
+test('the identity builder takes the heading from the shared marker', () => {
+  // The predicate above matches a literal. If hive.ts spells that literal out a
+  // second time, the two drift on the first reword and the brief silently
+  // reappears in every non-Claude agent's chat window.
+  const hive = read('src/main/hive.ts');
+  assert.match(hive, /import \{ HIVE_PROTOCOL_HEADING \} from '\.\.\/shared\/hivePrompt'/);
+  assert.match(hive, /^\s*HIVE_PROTOCOL_HEADING,$/m);
+  assert.equal(hive.includes(`'${HIVE_PROTOCOL_HEADING}'`), false,
+    'hive.ts still hardcodes the protocol heading next to the shared marker');
+});
+
+test('the nudge and the compaction command are filtered too', () => {
+  assert.equal(isAppGeneratedPrompt(inboxNudgeText([])), true);
+  assert.equal(isAppGeneratedPrompt(inboxNudgeText(['2026-09-08T13-48-02-836Z-f8d047'])), true);
+  assert.equal(isAppGeneratedPrompt('/compact keep the auth decisions'), true);
+});
+
+test('an ordinary prompt is never mistaken for one of them', () => {
+  for (const human of [
+    'bist du bereit ? sind alle agenten am laufen ?',
+    'read your inbox please',                 // the nudge's subject, not its text
+    'we should compact this function',        // mentions it, does not command it
+    'what does the hive protocol say about reviews?'
+  ]) {
+    assert.equal(isAppGeneratedPrompt(human), false, human);
+  }
+});
+
+// — the reader itself —
+
+const line = (type, content, ts) => JSON.stringify({
+  type, message: { content }, timestamp: new Date(ts).toISOString()
+}) + '\n';
+
+function fixture(name, body) {
+  const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'md-chat-')), name);
+  fs.writeFileSync(p, body, 'utf8');
+  return p;
+}
+
+test('tool traffic is stripped and only real turns survive', () => {
+  const p = fixture('t.jsonl', [
+    line('user', brief('Michael', 'god'), 1),
+    line('user', [{ type: 'text', text: 'wie weit bist du ?' }], 2),
+    // A turn that is nothing but a tool call, and a tool result coming back —
+    // the bulk of any real transcript, and none of it a conversation turn.
+    line('assistant', [{ type: 'tool_use', name: 'Read', input: { file: 'a.ts' } }], 3),
+    line('user', [{ type: 'tool_result', content: 'file contents' }], 4),
+    line('assistant', [{ type: 'text', text: '11 von 33 Schritten.' }], 5),
+    line('user', inboxNudgeText(['abc']), 6),
+    line('summary', 'not a turn at all', 7)
+  ].join(''));
+
+  assert.deepEqual(readChatTranscript(p).map((m) => [m.role, m.text]), [
+    ['user', 'wie weit bist du ?'],
+    ['assistant', '11 von 33 Schritten.']
+  ]);
+});
+
+test('a torn trailing line is picked up once the writer completes it', () => {
+  // The reader tails a file another process is appending to, so it must never
+  // parse a half-written line — nor lose it.
+  const p = fixture('grow.jsonl', line('user', [{ type: 'text', text: 'eins' }], 1));
+  fs.appendFileSync(p, '{"type":"assistant","message":{"content":[{"type":"te');
+  assert.deepEqual(readChatTranscript(p).map((m) => m.text), ['eins']);
+
+  fs.appendFileSync(p, 'xt","text":"zwei"}]},"timestamp":"2026-09-08T00:00:02.000Z"}\n');
+  assert.deepEqual(readChatTranscript(p).map((m) => m.text), ['eins', 'zwei']);
+});
+
+test('a missing transcript is an empty conversation, not a crash', () => {
+  assert.deepEqual(readChatTranscript(path.join(os.tmpdir(), 'md-chat-nope', 'x.jsonl')), []);
+});
+
+// — the OpenCode seam —
+
+test('the bridge plugin reports the session id on every payload it posts', () => {
+  // OpenCode keeps its turns in its own store, addressed by session id; the
+  // plugin is the only thing that knows which session an agent is in. Dropping
+  // the field empties the Chat tab for every OpenCode agent, and nothing else
+  // in the app notices, because the id has no other consumer.
+  const plugin = read('src/main/hive.ts').split('const OPENCODE_PLUGIN = `')[1] ?? '';
+  assert.notEqual(plugin, '', 'OPENCODE_PLUGIN template not found');
+  for (const hook of ['tool.execute.before', 'tool.execute.after']) {
+    const body = plugin.split(`'${hook}'`)[1]?.slice(0, 400) ?? '';
+    assert.match(body, /session_id: input && input\.sessionID/, hook);
+  }
+  assert.match(plugin, /session\.idle'\) post\(\{ hook_event_name: 'Stop', session_id: sid \}\)/);
+});
+
+test('the hook server keeps the session id out of the registry', () => {
+  // recordSession() owns the registry's resume key. The chat lane only reads, so
+  // it captures the id into its own map — before the Status early-return, so a
+  // telemetry-only payload still carries it.
+  const hooks = read('src/main/hooks.ts');
+  const capture = hooks.indexOf('this.sessionIds.set(agentId, p.session_id)');
+  const statusArm = hooks.indexOf("if (event === 'Status')");
+  const record = hooks.indexOf('this.hive.recordSession(agentId, p.session_id)');
+  assert.ok(capture > 0 && statusArm > 0 && record > 0, 'expected all three call sites');
+  assert.ok(capture < statusArm, 'session id must be captured before the Status early-return');
+  assert.ok(statusArm < record, 'recordSession must stay behind the Status early-return');
+});
+
+test('a provider with no readable conversation is reported, not left waiting', () => {
+  const { chatSourceOf } = loadTs('src/shared/agentProvider.ts');
+  assert.equal(chatSourceOf('opencode'), 'opencode');
+  assert.equal(chatSourceOf('claude'), 'transcript');
+  assert.equal(chatSourceOf('antigravity'), 'transcript');  // its shim forwards transcriptPath
+  for (const p of ['codex', 'grok', 'kimi', 'gemini', 'qwen', 'crush', 'pi', 'copilot', 'cursor', 'custom']) {
+    assert.equal(chatSourceOf(p), null, p);
+  }
+
+  // Antigravity is in the readable set ONLY because its shim reports the path.
+  // If that ever stops, the tab goes back to a permanently empty "nothing yet".
+  const agyShim = read('src/main/hive.ts').split('const AGY_HOOK_SHIM = `')[1] ?? '';
+  assert.match(agyShim, /transcript_path: agy\.transcriptPath/);
+});


### PR DESCRIPTION
## What & why

An agent's only visible surface was its raw TUI: spinners, tool-call lines, box drawing, and the harness's own injected text scrolling past. There was no way to just read what an agent said, or to reply without driving a terminal. This adds a Chat tab beside Terminal for every agent — god and worker alike — showing the plain user/assistant turns and nothing else, with the same message queue underneath so a reply typed here reaches the agent exactly as a Terminal-tab message does.

Where the conversation lives turns out to be per-provider, and that is most of the work. Claude Code hands every hook the path of a JSONL transcript, so that one is tailed incrementally (offset-cached, like the existing usage reconciler). OpenCode writes no transcript file at all — it keeps every turn in one SQLite database — so its bridge plugin now stamps the session id on each payload it posts, and a second reader queries that database read-only. Codex writes a JSONL rollout per session under its own `CODEX_HOME`, named after the session id, and a third reader tails that. All three strip every tool call / tool result block before anything crosses the IPC boundary; only Claude's and Codex's readers share code (`tailChatJsonl` in `chatTranscript.ts` does the incremental, torn-line-safe tailing, each provider supplies its own record parser), OpenCode's SQL query needs none of that.

The remaining piece is deciding what counts as the human talking. Several things the app or the CLI itself types into an agent arrive shaped exactly like a real prompt:
- the hive's identity/protocol brief injected at spawn (for every provider that cannot take it as a system prompt, it goes in through `--prompt` and lands as the session's first user message — a wall of harness text sitting in the chat window),
- the inbox-wake nudge,
- the `/compact` from the context cap,
- Codex's own injections on top of those — the repo's `AGENTS.md` block and its `<environment_context>` block, and its `developer`-role seat (skills/tool guidance), which is never a conversation turn at all.

Each is recognised by a predicate that lives with the code that writes it, so a reword cannot leave a stale copy behind in the reader.

A provider with no reader at all (codex was this, briefly, mid-series) gets an honest "Chat cannot read this CLI's history yet" rather than a permanent, misleading "No conversation yet." — the code and the string both say "not read yet", never "keeps no history", because that would be false for a CLI like Codex that always kept one.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

<!-- Screenshot: an OpenCode agent's Chat tab showing "No conversation yet."
     and a Codex agent's Chat tab showing "Chat cannot read this CLI's history
     yet." while each one's Terminal tab shows the same agent mid-conversation
     with several exchanged messages. -->

### After

<!-- Screenshot: the same two agents, same tabs, same window size and theme,
     now each listing their exchange as chat bubbles — with the spawn brief,
     the inbox nudges, and (for Codex) the AGENTS.md block absent. -->

OpenCode reader against a live agent's database, before and after the filters:

```
resolved session: ses_f7e3acaafffeNWXQ2d2eNGGrBX
turns: 18
  assistant | Floor rotation handled. Summary: ...
  user      | bist du bereit ? sind alle agenten am laufen ?
  assistant | Ich bin bereit — aber alle drei Agenten sind noch nicht am Laufen: ...
  user      | wie weit bist du ?
  assistant | Sprint "KI-Gegner" — Stand: ...
```

Codex reader against a live reviewer's `CODEX_HOME`, resolved the way `hive:agentChat` resolves it:

```
registry sessionId: 01a08233-72ea-7481-98c9-ef954a56aadb
resolved rollout  : rollout-2026-09-08T20-06-44-01a08233-72ea-7481-98c9-ef954a56aadb.jsonl
turns: 21
  …
  20:55:57 user      | alles in ordnung ?
  20:56:03 assistant | Ja, der Review-Ablauf funktioniert wieder. Alle Urteile sind verbucht, …
  21:05:07 user      | alles in ordnung ?
  21:05:12 assistant | Ja, bei mir ist alles in Ordnung. Die Inbox war zuletzt leer, …
  21:32:49 user      | alle in ordnung ?
  21:32:54 assistant | Ja, bei mir läuft alles. Die Inbox ist gerade geprüft und leer. …
```

That rollout's user seat also held the `# AGENTS.md instructions` block, the hive brief on every resume (five times), and the inbox nudges; 17 `developer` records are Codex's skills/tool guidance. None of it came through — only the human's three prompts and the replies. The Claude reader was checked the same way against a live transcript: spawn brief and tool traffic stripped, both human messages present.

## How I tested it

- OS: Windows 11 (10.0.26200)
- Steps:
  1. `npm run typecheck` — both programs clean.
  2. `npm run test:focused` — 847 tests, 811 pass. The 28 failures are pre-existing on `main` (Windows symlink/EPERM suites); same set, same count, verified by running the suite on `main` for comparison.
  3. `npm run build` — succeeds.
  4. Ran the OpenCode reader's exact SQL against the live `opencode.db` of a running agent: session resolved, 18 turns returned, filters confirmed. Confirmed separately that `better-sqlite3` opens that live WAL database read-only under Electron's own runtime (`npx electron`), since the module is built for Electron's ABI and cannot be exercised from plain node.
  5. Ran the Claude reader against a live Claude Code transcript: 19 turns, tool traffic stripped, human messages present.
  6. Read a live Codex reviewer's rollout record by record to learn the real shape before writing the parser (`response_item/message` roles and content block types), then ran the finished reader against that same `CODEX_HOME` — output above.
  7. New tests in `test/chat-transcript.test.cjs` (16) cover the shared filters, the tool-stripping, a torn trailing line during a tail, the OpenCode/Codex seams the feature hangs from, Codex's own injected-prompt patterns, and rollout resolution (session id first, newest-write fallback second).

Not covered: the IPC-to-UI path is exercised only by typechecks, not by a click-through in the packaged app.

## Credit (optional)

Discord:

X:

## Checklist

- [ ] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.
