### PR TITLE
Fix/windows hook 83 lookup

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -1204,7 +1204,19 @@ export class HiveManager {
   private hookSettings(shim: string, cwd: string, cfg: McpDefaultsMap, theme?: 'light' | 'dark', writableDirs: string[] = []): unknown {
     // Bundled node, NOT bare `node` — see nodeLauncherPath(). Claude runs each of
     // these through `sh -c` with a stripped PATH, where `node` is often absent.
-    const cmd = this.nodeRun(shim);
+    //
+    // On Windows that shell is cmd.exe, and the quoted form does NOT survive it:
+    // `cmd /c "A" "B"` strips the outer pair of quotes off the whole line and then
+    // re-reads it from the middle of the launcher's own path, so every hook of
+    // every Claude agent whose hive home contains a space — the default one does —
+    // died with
+    //   'C:\Users\…\Documents\Munder' is not recognized as an internal or external command
+    // Hooks are non-blocking, so nothing failed loudly: the agent kept working
+    // while live status, cost, the Stop-driven inbox drain, and the transcript
+    // path behind the Chat tab all quietly stopped arriving. Take the same short
+    // path codex/agy/pi/gemini already take — no space, so no quotes, so nothing
+    // for a shell to re-split.
+    const cmd = process.platform === 'win32' ? this.nodeRunUnquoted(shim) : this.nodeRun(shim);
     const entry = (matcher?: string) => ({
       ...(matcher ? { matcher } : {}),
       hooks: [{ type: 'command', command: cmd }]
@@ -2448,8 +2460,14 @@ export class HiveManager {
         ...(matcher ? { matcher } : {}),
         // Let Grok apply its event-aware defaults (5s normally, 600s for Stop).
         // Grok is a HOOK bridge (not a proxy sidecar), so it is hit by the same
-        // `node: command not found` 127 — bundled node here too.
-        hooks: [{ type: 'command', command: this.nodeRun(shim) }]
+        // `node: command not found` 127 — bundled node here too. And by the same
+        // Windows space problem as Claude above: nodeRunUnquoted's own comment
+        // already lists grok among the providers it covers, but this call site
+        // never took it.
+        hooks: [{
+          type: 'command',
+          command: process.platform === 'win32' ? this.nodeRunUnquoted(shim) : this.nodeRun(shim)
+        }]
       });
       const hooks = {
         PreToolUse: [tool('.*')],

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -26,6 +26,7 @@ import {
 import { join, dirname, basename, isAbsolute, relative } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync, spawn, type ChildProcess } from 'node:child_process';
+import { joinCommandLine } from '../shared/commandLine';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentUsageSample } from './usage';
 import { COMMAND_GROUPS } from '../shared/claudeCommands';
@@ -567,9 +568,40 @@ export class HiveManager {
 
   /** Same, but UNQUOTED — only for configs or platforms that cannot preserve
    *  embedded quotes. POSIX JSON hook configs must use nodeRun() because the
-   *  user-selected hive path may legitimately contain spaces. */
+   *  user-selected hive path may legitimately contain spaces.
+   *
+   *  On Windows the paths are first reduced to their 8.3 SHORT form, because
+   *  unquoted is only safe while nothing contains a space — and the DEFAULT
+   *  harness home does: `Documents\Munder Difflin`. Codex/agy/grok therefore
+   *  shipped a hook line that cmd splits at the space, so every hook of every
+   *  non-Claude agent died with `'C:\Users\...\Documents\Munder' is not
+   *  recognized` (exit 1) and took live status, cost and the Stop-driven inbox
+   *  drain with it. A short path has no space, so it needs no quotes and keeps
+   *  the .cmd shape #350 asked for. Quoting is only the last resort, for a
+   *  volume with 8.3 disabled — a command that cannot run is worse than one
+   *  that may meet a shell stack it dislikes. */
   private nodeRunUnquoted(script: string, ...args: string[]): string {
-    return [this.nodeLauncher() ?? 'node', script, ...args].join(' ');
+    const launcher = this.nodeLauncher() ?? 'node';
+    return joinCommandLine([this.shortenForShell(launcher), this.shortenForShell(script), ...args]);
+  }
+
+  /** Windows 8.3 short form of `p`, or `p` unchanged when it needs no shortening
+   *  (no space), is not Windows, or the volume has 8.3 names disabled. Memoized:
+   *  every resolution costs a `cmd` spawn and the same handful of paths are asked
+   *  for on each agent spawn. */
+  private shortPathCache = new Map<string, string>();
+  private shortenForShell(p: string): string {
+    if (process.platform !== 'win32' || !p.includes(' ')) return p;
+    const hit = this.shortPathCache.get(p);
+    if (hit !== undefined) return hit;
+    let out = p;
+    try {
+      const res = spawnSync('cmd', ['/d', '/c', `for %I in ("${p}") do @echo %~sI`], { encoding: 'utf8' });
+      const short = (res.stdout ?? '').trim();
+      if (short && !short.includes(' ') && existsSync(short)) out = short;
+    } catch { /* fall through to the original path */ }
+    this.shortPathCache.set(p, out);
+    return out;
   }
 
   /** One proxy sidecar per live proxy-tier agent, keyed by agentId. Spawned in

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -588,7 +588,20 @@ export class HiveManager {
   /** Windows 8.3 short form of `p`, or `p` unchanged when it needs no shortening
    *  (no space), is not Windows, or the volume has 8.3 names disabled. Memoized:
    *  every resolution costs a `cmd` spawn and the same handful of paths are asked
-   *  for on each agent spawn. */
+   *  for on each agent spawn.
+   *
+   *  THE QUOTES COME FROM THE ENVIRONMENT, not from the command line, and that is
+   *  the whole trick. `for %I in (<set>)` splits its set on spaces, so the path
+   *  has to be quoted — but a `"` inside a spawn argument never reaches cmd.exe
+   *  intact: Node escapes it as `\"` (MSVCRT convention) and cmd, which has no
+   *  backslash escape, reads the line as garbage. Measured on the default hive
+   *  home, the as-written call returned
+   *    C:\"C:\Users\fardi\Documents\Munder Difflin\hive\bin\hive-node.cmd\"
+   *  which has a space, fails the guard below, and falls back to the long path —
+   *  so the lookup could NEVER succeed in the only case it is called for (a path
+   *  with a space). Expanding `%HIVE_SHORT_SRC%` inside cmd sidesteps Node's
+   *  argument escaping entirely: the command line we pass contains no quote at
+   *  all, and cmd substitutes one already-quoted token before `for` parses it. */
   private shortPathCache = new Map<string, string>();
   private shortenForShell(p: string): string {
     if (process.platform !== 'win32' || !p.includes(' ')) return p;
@@ -596,10 +609,23 @@ export class HiveManager {
     if (hit !== undefined) return hit;
     let out = p;
     try {
-      const res = spawnSync('cmd', ['/d', '/c', `for %I in ("${p}") do @echo %~sI`], { encoding: 'utf8' });
+      const res = spawnSync('cmd', ['/d', '/c', 'for %I in (%HIVE_SHORT_SRC%) do @echo %~sI'], {
+        encoding: 'utf8',
+        env: { ...process.env, HIVE_SHORT_SRC: `"${p}"` }
+      });
       const short = (res.stdout ?? '').trim();
       if (short && !short.includes(' ') && existsSync(short)) out = short;
     } catch { /* fall through to the original path */ }
+    if (out === p) {
+      // 8.3 is disabled on this volume. The command line below then gets quoted,
+      // which cmd accepts and PowerShell — the shell Codex runs hooks through on
+      // Windows — rejects outright ("Unexpected token" at the second path, because
+      // a line STARTING with a quoted string is parsed as an expression). Nothing
+      // downstream reports that: every hook just exits 1. Say it once, here.
+      console.error(`[hive] no 8.3 short name for ${p} — hook commands must be quoted, `
+        + 'which PowerShell-hosted hooks (codex) will refuse. Move the harness home '
+        + 'to a path without spaces, or enable 8.3 names on this volume.');
+    }
     this.shortPathCache.set(p, out);
     return out;
   }

--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -459,9 +459,12 @@ export class HiveManager {
    *
    * A wrapper SCRIPT rather than an inline `ELECTRON_RUN_AS_NODE=1 "<exe>" …`
    * prefix because that prefix is POSIX-sh syntax — it is a hard error under
-   * cmd.exe, which is what runs hook commands on Windows. The wrapper also gives
-   * agents a `$HIVE_NODE` they can invoke directly (running the Electron binary
-   * WITHOUT the env var would launch a second app window, not a script).
+   * cmd.exe and PowerShell, which host the codex/agy/pi/gemini hooks on Windows.
+   * (Claude Code is the exception: it hosts hooks in Git Bash on every platform,
+   * so its Windows hook takes the inline prefix after all — see nodeRunSh.) The
+   * wrapper also gives agents a `$HIVE_NODE` they can invoke directly (running
+   * the Electron binary WITHOUT the env var would launch a second app window,
+   * not a script).
    *
    * Rewritten on every bootstrap, so an app update/move re-bakes execPath.
    */
@@ -471,16 +474,33 @@ export class HiveManager {
     return join(root, 'bin', process.platform === 'win32' ? 'hive-node.cmd' : 'hive-node');
   }
 
+  /** The POSIX launcher's path — on every platform. On POSIX it IS
+   *  nodeLauncherPath(); on Windows it is written ALONGSIDE the .cmd, for the
+   *  one hook host there that is a POSIX shell (Claude Code's Git Bash — see
+   *  nodeRunSh). */
+  private posixLauncherPath(): string | null {
+    const root = this.root();
+    return root ? join(root, 'bin', 'hive-node') : null;
+  }
+
   /** Write the launcher described above. Best-effort: on failure callers fall
    *  back to bare `node`, i.e. exactly the pre-fix behavior. */
   private writeNodeLauncher(): void {
     const p = this.nodeLauncherPath();
     if (!p) return;
     try {
+      // Forward slashes inside the sh script on every platform: bash keeps them,
+      // Windows accepts them, and a backslash is the one character sh treats
+      // specially even inside double quotes.
+      const posixBody = `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${process.execPath.replace(/\\/g, '/')}" "$@"\n`;
       if (process.platform === 'win32') {
         writeFileSync(p, `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`, 'utf8');
+        // No chmod: Git Bash runs a shebang script off NTFS regardless of mode
+        // bits (verified), and chmodSync is a no-op there anyway.
+        const posix = this.posixLauncherPath();
+        if (posix) writeFileSync(posix, posixBody, 'utf8');
       } else {
-        writeFileSync(p, `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${process.execPath}" "$@"\n`, 'utf8');
+        writeFileSync(p, posixBody, 'utf8');
         chmodSync(p, 0o755);
       }
     } catch (e) {
@@ -566,9 +586,28 @@ export class HiveManager {
     return [launcher ? `"${launcher}"` : 'node', `"${script}"`, ...args].join(' ');
   }
 
-  /** Same, but UNQUOTED — only for configs or platforms that cannot preserve
-   *  embedded quotes. POSIX JSON hook configs must use nodeRun() because the
-   *  user-selected hive path may legitimately contain spaces.
+  /** nodeRun for a hook that a POSIX shell runs ON WINDOWS — Claude Code hosts
+   *  its hooks in Git Bash there. Same shape as POSIX nodeRun (the sh launcher,
+   *  double-quoted, so a space stays inside one argument) with two Windows
+   *  adjustments: forward slashes, because bash treats a backslash outside
+   *  quotes as an escape and Windows accepts either separator; and the POSIX
+   *  launcher rather than the .cmd one, because bash runs a .cmd by handing the
+   *  whole line to cmd.exe, whose `/c "A" "B"` quote stripping is exactly the
+   *  failure this avoids. Wrong for cmd.exe or PowerShell-hosted hooks — those
+   *  keep nodeRunUnquoted below. Falls back to the launcher's own body inline
+   *  (also bash-correct) if the script is somehow missing. */
+  private nodeRunSh(script: string, ...args: string[]): string {
+    const fwd = (p: string) => p.replace(/\\/g, '/');
+    const posix = this.posixLauncherPath();
+    const launcher = posix && existsSync(posix)
+      ? `"${fwd(posix)}"`
+      : `ELECTRON_RUN_AS_NODE=1 "${fwd(process.execPath)}"`;
+    return [launcher, `"${fwd(script)}"`, ...args].join(' ');
+  }
+
+  /** Same as nodeRun, but UNQUOTED — only for configs or platforms that cannot
+   *  preserve embedded quotes. POSIX JSON hook configs must use nodeRun() because
+   *  the user-selected hive path may legitimately contain spaces.
    *
    *  On Windows the paths are first reduced to their 8.3 SHORT form, because
    *  unquoted is only safe while nothing contains a space — and the DEFAULT
@@ -1205,18 +1244,24 @@ export class HiveManager {
     // Bundled node, NOT bare `node` — see nodeLauncherPath(). Claude runs each of
     // these through `sh -c` with a stripped PATH, where `node` is often absent.
     //
-    // On Windows that shell is cmd.exe, and the quoted form does NOT survive it:
-    // `cmd /c "A" "B"` strips the outer pair of quotes off the whole line and then
-    // re-reads it from the middle of the launcher's own path, so every hook of
-    // every Claude agent whose hive home contains a space — the default one does —
-    // died with
-    //   'C:\Users\…\Documents\Munder' is not recognized as an internal or external command
-    // Hooks are non-blocking, so nothing failed loudly: the agent kept working
-    // while live status, cost, the Stop-driven inbox drain, and the transcript
-    // path behind the Chat tab all quietly stopped arriving. Take the same short
-    // path codex/agy/pi/gemini already take — no space, so no quotes, so nothing
-    // for a shell to re-split.
-    const cmd = process.platform === 'win32' ? this.nodeRunUnquoted(shim) : this.nodeRun(shim);
+    // ON EVERY PLATFORM. Claude Code on Windows runs hooks through Git Bash, not
+    // cmd.exe — its own transcript records the failure as
+    //   /usr/bin/bash: line 1: C:UsersfardiDOCUME~1MUNDER~1hivebinHIVE-N~1.CMD: command not found
+    // so the two Windows shapes the other providers use both die here: the
+    // unquoted short path loses every backslash to bash, and the quoted
+    // `hive-node.cmd` form makes bash hop through cmd.exe to run the .cmd, where
+    // `cmd /c "A" "B"` strips the outer quotes and re-splits at the space in
+    // `Munder Difflin` ('C:\Users\…\Documents\Munder' is not recognized). Hooks are
+    // non-blocking, so nothing failed loudly: the agent kept working while live
+    // status, cost, the Stop-driven inbox drain, and the transcript path behind
+    // the Chat tab all quietly stopped arriving.
+    //
+    // A bash-hosted hook gets a bash-shaped command: the POSIX `hive-node` sh
+    // launcher (written alongside the .cmd on Windows), forward slashes (bash
+    // keeps those; Windows accepts them) and ordinary double quotes around the
+    // paths. No .cmd, no cmd.exe hop, no 8.3. Measured against Git Bash in a
+    // directory with a space: exit 0, env and arguments intact.
+    const cmd = process.platform === 'win32' ? this.nodeRunSh(shim) : this.nodeRun(shim);
     const entry = (matcher?: string) => ({
       ...(matcher ? { matcher } : {}),
       hooks: [{ type: 'command', command: cmd }]
@@ -2460,14 +2505,8 @@ export class HiveManager {
         ...(matcher ? { matcher } : {}),
         // Let Grok apply its event-aware defaults (5s normally, 600s for Stop).
         // Grok is a HOOK bridge (not a proxy sidecar), so it is hit by the same
-        // `node: command not found` 127 — bundled node here too. And by the same
-        // Windows space problem as Claude above: nodeRunUnquoted's own comment
-        // already lists grok among the providers it covers, but this call site
-        // never took it.
-        hooks: [{
-          type: 'command',
-          command: process.platform === 'win32' ? this.nodeRunUnquoted(shim) : this.nodeRun(shim)
-        }]
+        // `node: command not found` 127 — bundled node here too.
+        hooks: [{ type: 'command', command: this.nodeRun(shim) }]
       });
       const hooks = {
         PreToolUse: [tool('.*')],

--- a/src/shared/commandLine.ts
+++ b/src/shared/commandLine.ts
@@ -15,3 +15,15 @@ export function tokenizeCommand(command: string): string[] {
   while ((m = re.exec(command)) !== null) out.push(m[1] ?? m[2] ?? m[3]);
   return out;
 }
+
+/** Join a launcher and its arguments into ONE command-line string for a hook
+ *  config, quoting only the parts that actually need it.
+ *
+ *  Hook configs take a command as a single string, so every part that contains
+ *  a space has to survive whatever shell the agent CLI hands it to. Quoting
+ *  parts that need nothing is not harmless on Windows — that is what the
+ *  unquoted Codex/agy/grok variant exists to avoid — so this quotes per part
+ *  rather than wholesale. */
+export function joinCommandLine(parts: string[]): string {
+  return parts.map((part) => (/\s/.test(part) ? `"${part}"` : part)).join(' ');
+}

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -10,8 +10,15 @@
  * must route through it.
  *
  * A wrapper SCRIPT rather than an inline `ELECTRON_RUN_AS_NODE=1 "<exe>" …`
- * prefix, because that prefix is POSIX-sh syntax and a hard error under cmd.exe —
- * which is what runs hook commands on Windows.
+ * prefix, because that prefix is POSIX-sh syntax and a hard error under cmd.exe
+ * and PowerShell — which host the codex/agy/pi/gemini hooks on Windows.
+ *
+ * Claude Code hosts its hooks in Git Bash on EVERY platform, Windows included.
+ * There the .cmd launcher is the wrong one (bash runs a .cmd through cmd.exe,
+ * whose quote stripping re-splits a path with a space), so Windows writes the
+ * POSIX `hive-node` alongside `hive-node.cmd` and Claude's commands take that
+ * one, with forward slashes. Both are "the launcher" for the purposes below:
+ * either way the command runs the bundled node, never a bare `node`.
  */
 
 const test = require('node:test');
@@ -81,7 +88,14 @@ function hookCommandsUnder(home) {
   return found.filter((c) => shim.test(c));
 }
 
-const usesLauncher = (cmd, launcher) => cmd.startsWith(launcher) || cmd.startsWith(`"${launcher}"`);
+const usesLauncher = (cmd, launcher) => {
+  if (cmd.startsWith(launcher) || cmd.startsWith(`"${launcher}"`)) return true;
+  if (POSIX) return false;
+  // Windows, bash-hosted (Claude): the POSIX launcher next to the .cmd, spelled
+  // with forward slashes because that is how bash has to see it.
+  const posix = path.join(path.dirname(launcher), 'hive-node').replace(/\\/g, '/');
+  return cmd.startsWith(`"${posix}"`);
+};
 
 async function run(cmd, env) {
   return new Promise((resolve) => {

--- a/test/hook-command-line.test.cjs
+++ b/test/hook-command-line.test.cjs
@@ -1,0 +1,27 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const loadTs = require('./load-ts.cjs');
+
+const { joinCommandLine, tokenizeCommand } = loadTs('src/shared/commandLine.ts');
+
+test('joinCommandLine quotes only the parts that carry a space', () => {
+  // The Windows hook line that shipped broken: unquoted is fine until a part
+  // contains a space, and the DEFAULT harness home has one.
+  assert.equal(
+    joinCommandLine(['C:\\hive\\bin\\hive-node.cmd', 'C:\\hive\\bin\\cth-hook.cjs']),
+    'C:\\hive\\bin\\hive-node.cmd C:\\hive\\bin\\cth-hook.cjs',
+    'nothing to quote - the .cmd shape #350 asked for is preserved verbatim'
+  );
+  assert.equal(
+    joinCommandLine(['C:\\Users\\a\\Documents\\Munder Difflin\\bin\\hive-node.cmd', 'C:\\hive\\bin\\cth-hook.cjs']),
+    '"C:\\Users\\a\\Documents\\Munder Difflin\\bin\\hive-node.cmd" C:\\hive\\bin\\cth-hook.cjs'
+  );
+  assert.equal(joinCommandLine(['node', 'C:\\hive\\bin\\cth-hook.cjs', 'SessionStart']), 'node C:\\hive\\bin\\cth-hook.cjs SessionStart');
+});
+
+test('a joined hook command splits back into its original parts', () => {
+  const parts = ['C:\\Program Files\\node.exe', 'C:\\Munder Difflin\\hook.cjs', 'Stop'];
+  assert.deepEqual(tokenizeCommand(joinCommandLine(parts)), parts);
+});

--- a/test/windows-hook-shortpath.test.cjs
+++ b/test/windows-hook-shortpath.test.cjs
@@ -70,7 +70,53 @@ test('the quoted fallback is what breaks PowerShell, so it stays the last resort
   assert.match(body, /joinCommandLine\(\[this\.shortenForShell\(launcher\), this\.shortenForShell\(script\)/);
 });
 
+test('every Windows hook config takes the short path, Claude and grok included', () => {
+  // Claude was the one provider left on the quoted form, and it is the provider
+  // most agents run. Its hooks died on every event with
+  //   'C:\\Users\\…\\Documents\\Munder' is not recognized …
+  // because cmd.exe strips the OUTER pair of quotes off `cmd /c "A" "B"` and then
+  // re-reads the line from the middle of the launcher's own path. Hooks are
+  // non-blocking, so nothing failed loudly: the agent kept working while live
+  // status, cost, the Stop-driven inbox drain and the Chat tab's transcript path
+  // all stopped arriving.
+  const sites = [...source.matchAll(/this\.nodeRun\(shim[^)]*\)/g)]
+    .map((m) => source.slice(Math.max(0, m.index - 120), m.index + m[0].length))
+    .filter((ctx) => !/win32'\s*\?[\s\S]*$/.test(ctx.slice(ctx.length - 200)));
+  const unguarded = sites.filter((ctx) => !ctx.includes("win32"));
+  assert.deepEqual(unguarded, [],
+    'a hook command still uses the quoted nodeRun() with no win32 short-path branch');
+});
+
 // — the technique, against the real cmd.exe —
+
+test('cmd.exe runs the short form and chokes on the quoted one',
+  { skip: win ? false : 'Windows-only: cmd.exe quote stripping' }, (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'md hook '));
+    const launcher = path.join(dir, 'launch.cmd');
+    const arg = path.join(dir, 'shim.cjs');
+    fs.writeFileSync(launcher, '@echo off\r\nexit /b 0\r\n', 'utf8');
+    fs.writeFileSync(arg, '// probe\n', 'utf8');
+
+    const shortOf = (p) => {
+      const r = spawnSync('cmd', ['/d', '/c', 'for %I in (%S%) do @echo %~sI'],
+        { encoding: 'utf8', env: { ...process.env, S: `"${p}"` } });
+      return (r.stdout || '').trim();
+    };
+    const runLine = (line) => spawnSync('cmd', ['/d', '/c', line],
+      { encoding: 'utf8', windowsVerbatimArguments: true });
+
+    const quoted = runLine(`"${launcher}" "${arg}"`);
+    assert.notEqual(quoted.status, 0,
+      'cmd suddenly accepts the quoted form — re-check whether the short path is still needed');
+    assert.match(quoted.stderr || '', /is not recognized/);
+
+    const s = shortOf(launcher);
+    if (!s || s.includes(' ') || !fs.existsSync(s)) {
+      t.skip(`8.3 names unavailable on ${path.parse(dir).root}`);
+      return;
+    }
+    assert.equal(runLine(`${s} ${shortOf(arg)}`).status, 0, 'the short form must run');
+  });
 
 test('cmd returns a usable 8.3 name only when the quotes come from the environment',
   { skip: win ? false : 'Windows-only: 8.3 short names' }, (t) => {

--- a/test/windows-hook-shortpath.test.cjs
+++ b/test/windows-hook-shortpath.test.cjs
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * The 8.3 lookup that keeps Windows hook commands quote-free.
+ *
+ * A hook command is written into a provider's config and run by that provider's
+ * shell. Codex uses PowerShell on Windows, and PowerShell parses a line that
+ * STARTS with a quoted string as an expression, not a command:
+ *
+ *   "C:\…\hive-node.cmd" "C:\…\cth-hook.cjs"
+ *    → Unexpected token '"C:\…\cth-hook.cjs"' in expression or statement
+ *
+ * so every hook of every codex/agy/grok agent exits 1 — and nothing surfaces it
+ * except the provider's own TUI. `shortenForShell` exists to make that line
+ * quote-free by reducing each path to its 8.3 short form, which has no space.
+ *
+ * It could not do it. It asked cmd for the short name with the path quoted
+ * INSIDE the spawn argument, and a `"` never survives that trip: Node escapes it
+ * as `\"` (the MSVCRT convention) and cmd.exe, which has no backslash escape,
+ * parses the line as garbage. Since the function only runs for paths that
+ * contain a space, it failed in 100% of its calls and silently returned the long
+ * path — the exact input the quoting fallback then produced a broken command
+ * from. The fix moves the quotes into an environment variable, so the command
+ * line handed to cmd contains no quote at all.
+ *
+ * The behavioural half of this file therefore checks the TECHNIQUE against the
+ * real cmd.exe, because the bug lived entirely in that boundary and no amount of
+ * reading the source revealed it.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const win = process.platform === 'win32';
+const source = fs.readFileSync(path.join(__dirname, '..', 'src/main/hive.ts'), 'utf8');
+
+/** The body of shortenForShell, isolated from the rest of hive.ts (which pulls
+ *  in electron and cannot be loaded here). */
+function shortenBody() {
+  const start = source.indexOf('private shortenForShell(p: string): string {');
+  assert.notEqual(start, -1, 'shortenForShell not found in hive.ts');
+  return source.slice(start, source.indexOf('\n  }', start));
+}
+
+test('the path reaches cmd through the environment, never as a quoted argument', () => {
+  const body = shortenBody();
+  assert.match(body, /HIVE_SHORT_SRC/, 'the env-var indirection is gone');
+  const spawnArg = body.match(/'\/d', '\/c', ('[^']*')/);
+  assert.ok(spawnArg, 'could not find the cmd command line');
+  assert.equal(spawnArg[1].includes('"'), false,
+    `the cmd command line embeds a quote again: ${spawnArg[1]} — Node escapes it as \\" and cmd cannot read it`);
+});
+
+test('a failed lookup is reported instead of silently producing a broken hook', () => {
+  // The whole cost of this bug was that nothing said anything: hooks just
+  // exited 1, for hours, with the app reporting the agent as healthy.
+  assert.match(shortenBody(), /console\.error\(/);
+});
+
+test('the quoted fallback is what breaks PowerShell, so it stays the last resort', () => {
+  // Pins the ordering the fix depends on: nodeRunUnquoted shortens FIRST and
+  // only joinCommandLine (which quotes anything with a space) sees the result.
+  const start = source.indexOf('private nodeRunUnquoted(');
+  assert.notEqual(start, -1);
+  const body = source.slice(start, source.indexOf('\n  }', start));
+  assert.match(body, /joinCommandLine\(\[this\.shortenForShell\(launcher\), this\.shortenForShell\(script\)/);
+});
+
+// — the technique, against the real cmd.exe —
+
+test('cmd returns a usable 8.3 name only when the quotes come from the environment',
+  { skip: win ? false : 'Windows-only: 8.3 short names' }, (t) => {
+    // A directory whose name contains a space is the only case that ever calls
+    // the function, and the only case the old code got wrong.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'md hook '));
+    const file = path.join(dir, 'cth-hook.cjs');
+    fs.writeFileSync(file, '// probe\n', 'utf8');
+    const usable = (out) => {
+      const s = (out || '').trim();
+      return !!s && !s.includes(' ') && fs.existsSync(s);
+    };
+
+    const viaEnv = spawnSync('cmd', ['/d', '/c', 'for %I in (%HIVE_SHORT_SRC%) do @echo %~sI'], {
+      encoding: 'utf8',
+      env: { ...process.env, HIVE_SHORT_SRC: `"${file}"` }
+    });
+    if (!usable(viaEnv.stdout)) {
+      // 8.3 generation is a per-volume policy; with it off, no technique works
+      // and the app falls back to quoting (and now says so). Nothing to assert.
+      t.skip(`8.3 names unavailable on ${path.parse(dir).root}`);
+      return;
+    }
+
+    const inlineQuotes = spawnSync('cmd', ['/d', '/c', `for %I in ("${file}") do @echo %~sI`], { encoding: 'utf8' });
+    assert.equal(usable(inlineQuotes.stdout), false,
+      'the old inline-quote form suddenly works — if Node changed its cmd escaping, '
+      + 'simplify shortenForShell deliberately rather than by accident');
+  });
+
+test('the command line the fix produces is quote-free, which is what PowerShell needs',
+  { skip: win ? false : 'Windows-only: 8.3 short names' }, (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'md hook '));
+    const file = path.join(dir, 'cth-hook.cjs');
+    fs.writeFileSync(file, '// probe\n', 'utf8');
+
+    const res = spawnSync('cmd', ['/d', '/c', 'for %I in (%HIVE_SHORT_SRC%) do @echo %~sI'], {
+      encoding: 'utf8',
+      env: { ...process.env, HIVE_SHORT_SRC: `"${file}"` }
+    });
+    const short = (res.stdout || '').trim();
+    if (!short || short.includes(' ') || !fs.existsSync(short)) {
+      t.skip(`8.3 names unavailable on ${path.parse(dir).root}`);
+      return;
+    }
+    // joinCommandLine only quotes a part that contains whitespace, so a short
+    // path yields a bare first token — the thing PowerShell needs to treat the
+    // line as a command at all.
+    const { joinCommandLine } = require('./load-ts.cjs')('src/shared/commandLine.ts');
+    const line = joinCommandLine([short, short]);
+    assert.equal(line.includes('"'), false, line);
+
+    const parsed = spawnSync('powershell',
+      ['-NoProfile', '-Command', '$l=[Console]::In.ReadToEnd(); try { $null=[ScriptBlock]::Create($l); "OK" } catch { "FAIL" }'],
+      { encoding: 'utf8', input: line });
+    assert.equal((parsed.stdout || '').trim(), 'OK', `PowerShell rejected: ${line}`);
+  });

--- a/test/windows-hook-shortpath.test.cjs
+++ b/test/windows-hook-shortpath.test.cjs
@@ -26,6 +26,12 @@
  * The behavioural half of this file therefore checks the TECHNIQUE against the
  * real cmd.exe, because the bug lived entirely in that boundary and no amount of
  * reading the source revealed it.
+ *
+ * Claude Code is the odd one out: it hosts hooks in Git Bash on Windows, where
+ * BOTH Windows shapes fail — the quoted .cmd form via bash's cmd.exe hop, the
+ * unquoted short form because bash eats backslashes. Its hook is bash-shaped
+ * instead (nodeRunSh), and the bash tests below pin that against the real
+ * bash.exe for the same reason.
  */
 
 const test = require('node:test');
@@ -70,21 +76,33 @@ test('the quoted fallback is what breaks PowerShell, so it stays the last resort
   assert.match(body, /joinCommandLine\(\[this\.shortenForShell\(launcher\), this\.shortenForShell\(script\)/);
 });
 
-test('every Windows hook config takes the short path, Claude and grok included', () => {
-  // Claude was the one provider left on the quoted form, and it is the provider
-  // most agents run. Its hooks died on every event with
-  //   'C:\\Users\\…\\Documents\\Munder' is not recognized …
-  // because cmd.exe strips the OUTER pair of quotes off `cmd /c "A" "B"` and then
-  // re-reads the line from the middle of the launcher's own path. Hooks are
-  // non-blocking, so nothing failed loudly: the agent kept working while live
-  // status, cost, the Stop-driven inbox drain and the Chat tab's transcript path
-  // all stopped arriving.
-  const sites = [...source.matchAll(/this\.nodeRun\(shim[^)]*\)/g)]
-    .map((m) => source.slice(Math.max(0, m.index - 120), m.index + m[0].length))
-    .filter((ctx) => !/win32'\s*\?[\s\S]*$/.test(ctx.slice(ctx.length - 200)));
-  const unguarded = sites.filter((ctx) => !ctx.includes("win32"));
-  assert.deepEqual(unguarded, [],
-    'a hook command still uses the quoted nodeRun() with no win32 short-path branch');
+test("Claude's Windows hook is bash-shaped: POSIX launcher, forward slashes, no .cmd", () => {
+  // Claude Code hosts its hooks in Git Bash on Windows too. Its own transcript
+  // recorded both Windows shapes failing there:
+  //   quoted .cmd  → bash hands the .cmd to cmd.exe, whose `/c "A" "B"` quote
+  //                  stripping re-splits at the space:
+  //                  'C:\Users\…\Documents\Munder' is not recognized …
+  //   short 8.3    → bash eats every backslash of an unquoted path:
+  //                  /usr/bin/bash: line 1: C:UsersfardiDOCUME~1…HIVE-N~1.CMD: command not found
+  // So hookSettings must hand bash a bash command, and neither of the two.
+  const start = source.indexOf('private hookSettings(');
+  assert.notEqual(start, -1);
+  const body = source.slice(start, source.indexOf('\n  }', start));
+  assert.match(body, /process\.platform === 'win32' \? this\.nodeRunSh\(shim\) : this\.nodeRun\(shim\)/,
+    'hookSettings no longer routes the Windows hook through nodeRunSh');
+
+  const sh = source.indexOf('private nodeRunSh(');
+  assert.notEqual(sh, -1, 'nodeRunSh is gone');
+  const shBody = source.slice(sh, source.indexOf('\n  }', sh));
+  assert.match(shBody, /this\.posixLauncherPath\(\)/, 'nodeRunSh must route through the POSIX launcher');
+  assert.match(shBody, /replace\(\/\\\\\/g, '\/'\)/, 'lost the forward-slash conversion');
+  assert.equal(shBody.includes('nodeLauncherPath()'), false, 'nodeRunSh must not route through the .cmd launcher');
+
+  // And the POSIX launcher has to exist on Windows for that to work.
+  const w = source.indexOf('private writeNodeLauncher(');
+  const wBody = source.slice(w, source.indexOf('\n  }', w));
+  assert.match(wBody, /if \(posix\) writeFileSync\(posix, posixBody, 'utf8'\)/,
+    'Windows no longer writes the POSIX hive-node alongside hive-node.cmd');
 });
 
 // — the technique, against the real cmd.exe —
@@ -116,6 +134,37 @@ test('cmd.exe runs the short form and chokes on the quoted one',
       return;
     }
     assert.equal(runLine(`${s} ${shortOf(arg)}`).status, 0, 'the short form must run');
+  });
+
+const gitBash = ['C:\\Program Files\\Git\\bin\\bash.exe', 'C:\\Program Files (x86)\\Git\\bin\\bash.exe']
+  .find((p) => fs.existsSync(p));
+
+test('under Git Bash only the bash-shaped command survives a path with a space',
+  { skip: win ? (gitBash ? false : 'Git Bash not installed') : 'Windows-only: Git Bash hook host' }, () => {
+    // The dir has a space, like the default hive home. The launcher wraps the
+    // test runner's own node: the claim under test is the SHAPE — a POSIX sh
+    // launcher, forward slashes, quotes — not which binary sits behind it.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'md hook '));
+    const fwd = (p) => p.replace(/\\/g, '/');
+    const script = path.join(dir, 'probe.cjs');
+    fs.writeFileSync(script, 'process.stdout.write("ran " + (process.env.ELECTRON_RUN_AS_NODE || "no-env") + " " + process.argv.slice(2).join(","));\n', 'utf8');
+    const posixLauncher = path.join(dir, 'hive-node');
+    // Exactly the body writeNodeLauncher writes, with node standing in for Electron.
+    fs.writeFileSync(posixLauncher, `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${fwd(process.execPath)}" "$@"\n`, 'utf8');
+    const cmdLauncher = path.join(dir, 'launch.cmd');
+    fs.writeFileSync(cmdLauncher, '@echo off\r\nexit /b 0\r\n', 'utf8');
+    const bash = (line) => spawnSync(gitBash, ['-c', line], { encoding: 'utf8', input: '{}' });
+
+    // The shape nodeRunSh emits — no chmod, as on a real Windows install.
+    const ok = bash(`"${fwd(posixLauncher)}" "${fwd(script)}" --status`);
+    assert.equal(ok.status, 0, ok.stderr);
+    assert.equal(ok.stdout.trim(), 'ran 1 --status', 'env or argument did not survive the launcher');
+
+    // The two shapes the other providers use, which is what Claude used to get.
+    const quotedCmd = bash(`"${fwd(cmdLauncher)}" "${fwd(script)}"`);
+    assert.notEqual(quotedCmd.status, 0, 'bash now runs a quoted .cmd with a spaced path — re-check the design');
+    const unquotedBackslash = bash(`${script} x`);
+    assert.equal(unquotedBackslash.status, 127, 'bash stopped eating unquoted backslashes — re-check the design');
   });
 
 test('cmd returns a usable 8.3 name only when the quotes come from the environment',


### PR DESCRIPTION
## What & why

On Windows, with a harness home whose path contains a space, hook commands do not run. The default home is `Documents\Munder Difflin`, so this is the out-of-the-box state, and it hits Claude, Codex, agy, pi, gemini and grok agents alike. Hooks are non-blocking, so nothing fails loudly: the agent keeps working and looks healthy, while live status, cost, the `Stop`-driven inbox drain and the transcript path the Chat tab reads all quietly stop arriving. The only place it shows is the agent's own TUI.

Three shells host hooks on Windows, and the quoted `"…\hive-node.cmd" "…\cth-hook.cjs"` form loses in every one of them, each for its own reason:

- **cmd.exe** (agy, pi, gemini) strips the outer pair of quotes off `cmd /c "A" "B"` and re-reads the line from the middle of the launcher's own path → `'C:\Users\…\Documents\Munder' is not recognized as an internal or external command`.
- **PowerShell** (Codex) parses a line that *starts* with a quoted string as an expression, not a command → `Unexpected token '"C:\…\cth-hook.cjs"' … At line:1 char:66`, char 66 being exactly where the second quoted path begins.
- **Git Bash** (Claude Code — on Windows too) runs a `.cmd` by handing the line to cmd.exe, so it inherits the cmd.exe failure above verbatim. And the obvious alternative, an unquoted 8.3 short path, fails differently there: bash treats a backslash outside quotes as an escape, so `C:\Users\…\HIVE-N~1.CMD` arrives as `C:UsersfardiDOCUME~1MUNDER~1hivebinHIVE-N~1.CMD: command not found`.

So there are two fixes, one per shell family.

For **cmd.exe and PowerShell** the answer is a command with no space and therefore no quotes: the 8.3 short path. `3cf1c999` reduces hook paths to it. `119eab6c` makes that lookup actually work — it asked cmd for the short name with the path quoted inside the spawn argument, and a `"` does not survive that trip: Node escapes it as `\"` (the MSVCRT convention) and cmd.exe, which has no backslash escape, reads the line as garbage. Since the function is only ever called for a path that HAS a space, it failed in 100% of its calls and silently returned the long path. The quotes now come from an environment variable, so nothing Node escapes ever reaches cmd.

For **Git Bash** the answer is a bash command. `68852a57` tried the short path for Claude and moved its failure from exit 1 to exit 127; `e2cdb51d` corrects that. Windows now writes the POSIX `hive-node` sh launcher alongside `hive-node.cmd`, and Claude's hook commands take that one, double-quoted with forward slashes. No cmd.exe hop, no dependence on 8.3, and the launcher invariant the existing hook tests pin still holds. Grok, which the intermediate commit had also moved to the short path without evidence of its hook shell, is back on the form it had.

Where 8.3 is disabled on the volume the cmd/PowerShell path still has to quote — but it now logs once instead of leaving a wall of `Hook failed` as the only evidence.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

<!-- Capture of a Claude agent's terminal showing "PostToolUse:Bash hook error /
     Failed with non-blocking status code: 'C:\Users\...\Documents\Munder' is not
     recognized", and the same agent's Chat tab reading "No conversation yet."
     Plus a codex agent's TUI repeating "Hook failed / hook exited with code 1". -->

The generated commands, and what each host shell does with them:

```
Claude  settings.json : "C:\…\hive-node.cmd" "C:\…\cth-hook.cjs"
  Git Bash → cmd.exe  exit 1   'C:\Users\fardi\Documents\Munder' is not recognized as an
                               internal or external command

Codex   config.toml   : "\"C:\\…\\hive-node.cmd\" \"C:\\…\\cth-hook.cjs\""
  PowerShell          exit 1   At line:1 char:66
                               Unexpected token '"C:\…\cth-hook.cjs"' in expression or statement.
```

The 8.3 lookup that was meant to prevent both, measured as shipped:

```
AS-SHIPPED  -> "C:\\\"C:Users\fardiDocumentsMunder Difflinhive\binhive-node.cmd\\\""
accepted?   -> false
```

And the short path handed to Claude anyway, as Claude Code itself recorded it in the transcript (`hook_non_blocking_error`, 19:06:09Z):

```
/usr/bin/bash: line 1: C:UsersfardiDOCUME~1MUNDER~1hivebinHIVE-N~1.CMD: command not found
```

### After

<!-- The same agents, same steps: no hook errors in either terminal, and the
     Claude agent's Chat tab now listing the conversation. -->

Codex / cmd.exe hosts:

```
hook command : C:\Users\fardi\DOCUME~1\MUNDER~1\hive\bin\HIVE-N~1.CMD C:\Users\fardi\DOCUME~1\MUNDER~1\hive\bin\cth-hook.cjs
cmd.exe      exit=0
PowerShell   parse OK, exit=0
```

Claude / Git Bash host, same directory with a space, every shape side by side:

```
quoted hive-node.cmd, forward slashes    exit=1    '…\Munder' is not recognized
short 8.3, backslashes                   exit=127  command not found
short 8.3, forward slashes               exit=0
quoted POSIX hive-node, forward slashes  exit=0    env and arguments intact   ← what Claude now gets
```

## How I tested it

- OS: Windows 11 (10.0.26200); Windows PowerShell 5.1, cmd.exe, Git Bash 2.50; default harness home `C:\Users\<me>\Documents\Munder Difflin` (contains a space)
- Steps:
  1. Read the `settings.json` and `config.toml` the running app had just generated for a live Claude agent and a live codex agent. Confirmed the codex parser error's `char:66` matches the generated line byte for byte, and reproduced the Claude error verbatim by running its exact command through cmd.exe.
  2. Reproduced the 8.3 lookup as shipped from node — returned the garbage above, so the guard rejects it and the long path survives.
  3. After the short-path change, read Claude Code's OWN record of the result in the agent's transcript: `hook_non_blocking_error` with the `/usr/bin/bash: … command not found` stderr, and a `stop_hook_summary` naming the short-path command. That is what established Git Bash as Claude's hook host on Windows.
  4. Ran every candidate shape through `bash.exe -c` in a directory with a space, with no `AGENT_ID`/`HIVE_SOCK` so the shim no-ops rather than posting into a live hive — table above.
  5. Confirmed Git Bash executes a `#!/bin/sh` launcher off NTFS with no mode bits set (chmod is a no-op there), so the Windows-side POSIX launcher needs no chmod.
  6. Reverted the Claude call site by hand and re-ran the guard test to confirm it fails on regression, then restored it.
  7. **End to end, against the live app.** Started the app on this branch, let it write both launchers, spawned a Claude worker through a hive spawn request so the app generated its `settings.json` with the new command, then ran real Claude Code headless with exactly that hooks block against the app's live named pipe:
     ```
     claude -p "Reply with exactly: OK hooks" --settings <app-generated hooks> → exit 0, "OK hooks"
     transcript 399124f3-….jsonl: hook_non_blocking_error records: 0
     hive/log.jsonl: {"kind":"session","agentId":"worker-hookprobe-…","sessionId":"399124f3-…"}
     ```
     The last line is the app's `recordSession`, which only runs on a received hook payload, carrying the same session id Claude named its transcript after — so bash → POSIX launcher → shim → pipe → HookServer round-tripped, which is the link that had been dead.
  8. `npm run typecheck` clean, `npm run build` succeeds.
  9. `npm run test:focused` — 844 tests, 808 pass. Baseline on `main` is 834/798/28; this branch adds 10 tests and 10 passes with the same 28 pre-existing Windows symlink/EPERM failures.

New tests in `test/windows-hook-shortpath.test.cjs` (8). Five are behavioural, run
against the real cmd.exe, PowerShell and bash.exe, because every one of these bugs
lived at a shell boundary that reading the source did not reveal. Two of them
assert the OLD shapes still fail under their shells — so if a shell ever changes
its quoting rules, simplifying this becomes a deliberate decision rather than an
accident. `test/hive-hook-node.test.cjs` learned that on Windows "the launcher"
is either of the two.

Not covered: a volume with 8.3 disabled. The cmd/PowerShell path still quotes
there, and is now reported rather than silent, but I had no such volume to test on.

## Credit (optional)

Discord:

X:

## Checklist

- [ ] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.
