### PR TITLE
Stop the hive router's synchronous git commit from blocking the main thread

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -25,7 +25,7 @@ import {
 } from 'node:fs';
 import { join, dirname, basename, isAbsolute, relative } from 'node:path';
 import { homedir } from 'node:os';
-import { spawnSync, spawn, type ChildProcess } from 'node:child_process';
+import { spawnSync, spawn, execFile, type ChildProcess } from 'node:child_process';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentUsageSample } from './usage';
 import { COMMAND_GROUPS } from '../shared/claudeCommands';
@@ -191,9 +191,8 @@ export interface SpawnInjection {
 
 const HOP_CAP = 12;
 
-function sleepSync(ms: number): void {
-  const sab = new SharedArrayBuffer(4);
-  Atomics.wait(new Int32Array(sab), 0, 0, ms);
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /** Filesystem- and sort-safe timestamp, e.g. 2026-05-30T14-03-11-123Z. */
@@ -643,7 +642,15 @@ export class HiveManager {
     this.writeRuntimeShims();
 
     if (!existsSync(join(root, '.git'))) {
-      this.git(['init', '-q'], root);
+      // Queued onto the same chain commit() uses, not a bare unawaited call:
+      // `git()` is async now, and this init has to actually finish on disk
+      // before the "hive: init" commit below runs (git commit into a
+      // not-yet-initialized repo fails) and before flushCommits() can be
+      // trusted to mean "nothing is still touching this working tree" (a
+      // caller — a test's own teardown, most concretely — that deletes the
+      // hive home right after ensureHive() returns must not race a `git
+      // init` that dropped its promise on the floor).
+      this._commitQueue = this._commitQueue.then(() => this.git(['init', '-q'], root)).then(() => undefined);
       this.commit('hive: init');
     }
   }
@@ -2679,11 +2686,26 @@ export class HiveManager {
   //
   // The gc still happens — this only stops it from outliving the command that
   // triggered it, which is what "single committer" was supposed to mean.
-  private git(args: string[], cwd: string): { ok: boolean; out: string; err: string } {
-    const res = spawnSync('git', ['-c', 'commit.gpgsign=false', '-c', 'gc.autoDetach=false', '-c', 'user.name=Hive', '-c', 'user.email=hive@local', ...args], {
-      cwd, encoding: 'utf8', timeout: 8000
+  //
+  // ASYNC, not spawnSync (#AEON-1493): `git add -A` over the hive's working
+  // tree is what actually costs the ~6s this used to spend on Electron's main
+  // thread, and spawnSync blocks that thread for the whole call. execFile
+  // hands control back to the event loop while git runs. This makes the
+  // single-committer property from the comment above NO LONGER free — spawnSync
+  // was accidentally serializing every caller by blocking the one thread they
+  // all share. `commit()` below now serializes explicitly with a promise
+  // queue; two overlapping git() calls on the same working tree, with
+  // gc.autoDetach=false, is exactly the concurrent-writers-to-.git/objects/
+  // hazard this file's other comment describes, so that queue is load-bearing,
+  // not defensive polish.
+  private git(args: string[], cwd: string): Promise<{ ok: boolean; out: string; err: string }> {
+    return new Promise((resolve) => {
+      execFile('git', ['-c', 'commit.gpgsign=false', '-c', 'gc.autoDetach=false', '-c', 'user.name=Hive', '-c', 'user.email=hive@local', ...args], {
+        cwd, encoding: 'utf8', timeout: 8000
+      }, (error, stdout, stderr) => {
+        resolve({ ok: !error, out: stdout ?? '', err: stderr ?? '' });
+      });
     });
-    return { ok: res.status === 0, out: res.stdout ?? '', err: res.stderr ?? '' };
   }
 
   /** Has the one-time cost-ledger untrack pass run in this process yet? */
@@ -2703,14 +2725,14 @@ export class HiveManager {
    * line alone reads as a fix while the repo goes on growing. The ledger stays
    * on disk, so the cost history the app reads is untouched.
    */
-  private untrackCostLedger(root: string): void {
+  private async untrackCostLedger(root: string): Promise<void> {
     if (this.untrackedCostLedger) return;
     this.untrackedCostLedger = true;
     // Probe before mutating: `rm --cached` on a repo that never tracked it
     // would still rewrite the index on every launch, inside the retry path.
-    const tracked = this.git(['ls-files', '--', 'cost-ledger.jsonl'], root);
+    const tracked = await this.git(['ls-files', '--', 'cost-ledger.jsonl'], root);
     if (!tracked.ok || !tracked.out.trim()) return;
-    this.git(['rm', '--cached', '-q', '--ignore-unmatch', '--', 'cost-ledger.jsonl'], root);
+    await this.git(['rm', '--cached', '-q', '--ignore-unmatch', '--', 'cost-ledger.jsonl'], root);
     console.warn('[hive] untracked the cost ledger from the hive repo');
   }
 
@@ -2730,7 +2752,7 @@ export class HiveManager {
    * `.codex` path from the index. The files stay on disk, so `codex --resume`
    * is unaffected; only their history stops.
    */
-  private untrackCodexHomes(root: string): void {
+  private async untrackCodexHomes(root: string): Promise<void> {
     if (this.untrackedCodexHomes) return;
     this.untrackedCodexHomes = true;
     const agentsDir = join(root, 'agents');
@@ -2740,25 +2762,58 @@ export class HiveManager {
     } catch { /* best-effort */ }
     // Probe before mutating: `rm --cached` on a clean repo would still rewrite
     // the index on every launch, and this runs inside the commit retry path.
-    const tracked = this.git(['ls-files', '--', 'agents/*/.codex'], root);
+    const tracked = await this.git(['ls-files', '--', 'agents/*/.codex'], root);
     if (!tracked.ok || !tracked.out.trim()) return;
-    this.git(['rm', '-r', '--cached', '-q', '--ignore-unmatch', '--', 'agents/*/.codex'], root);
+    await this.git(['rm', '-r', '--cached', '-q', '--ignore-unmatch', '--', 'agents/*/.codex'], root);
     console.warn('[hive] untracked previously-committed Codex homes from the hive repo');
   }
 
-  /** Commit all hive changes. No-op if there is nothing staged. */
-  commit(message: string): void {
+  // Serializes every commit() call onto one chain. Before AEON-1493, spawnSync
+  // blocked the whole main thread, so no two commit() calls could ever run at
+  // once — that was an accident of the blocking primitive, not a property
+  // this class enforced. Making git() async removes that accident, and with
+  // gc.autoDetach=false two real git processes writing into the same
+  // `.git/objects/` at once is exactly the class of race that flag exists to
+  // prevent (see the comment on git() above) — so this queue is what keeps
+  // "single committer" true now that nothing else does it for free. Callers
+  // that don't await commit() (all nine call sites but this one, unchanged)
+  // still get FIFO ordering: the queue runs each commit to completion before
+  // starting the next, in call order.
+  private _commitQueue: Promise<void> = Promise.resolve();
+
+  /** Commit all hive changes. No-op if there is nothing staged. Callers may
+   *  await this for completion, but none needs to — commit() has always been
+   *  fire-and-forget, and the queue above preserves that. */
+  commit(message: string): Promise<void> {
+    this._commitQueue = this._commitQueue.then(() => this.doCommit(message)).catch(() => { /* one failed commit must not wedge the queue for the next one */ });
+    return this._commitQueue;
+  }
+
+  /** Resolves once every commit() queued so far has settled (with
+   *  gc.autoDetach=false, that includes any inline `gc --auto`). Nothing in
+   *  this class needs this — commit() stays fire-and-forget everywhere it is
+   *  called. It exists for a caller about to do something that races an
+   *  in-flight commit's writes to `.git/`, most concretely: deleting the hive
+   *  home a test created. Before AEON-1493 this needed no explicit call,
+   *  because spawnSync made every commit() finish before the function that
+   *  queued it returned; async git() removes that free ordering, so a caller
+   *  that depends on it now has to ask for it. */
+  flushCommits(): Promise<void> {
+    return this._commitQueue;
+  }
+
+  private async doCommit(message: string): Promise<void> {
     const root = this.root();
     if (!root || !existsSync(join(root, '.git'))) return;
-    this.untrackCostLedger(root);
-    this.untrackCodexHomes(root);
+    await this.untrackCostLedger(root);
+    await this.untrackCodexHomes(root);
     for (let attempt = 0; attempt < 5; attempt++) {
       this.clearStaleLock(root);
-      const add = this.git(['add', '-A'], root);
-      const commit = this.git(['commit', '-q', '-m', message], root);
+      const add = await this.git(['add', '-A'], root);
+      const commit = await this.git(['commit', '-q', '-m', message], root);
       if (commit.ok) return;
       if (/nothing to commit/i.test(commit.out + commit.err)) return;
-      if (!add.ok || /index\.lock/i.test(commit.err)) { sleepSync(50 * (attempt + 1)); continue; }
+      if (!add.ok || /index\.lock/i.test(commit.err)) { await sleep(50 * (attempt + 1)); continue; }
       console.warn(`[hive] commit gave up after ${attempt + 1} attempts:`, commit.err || commit.out);
       return;
     }

--- a/test/agent-exit-record.test.cjs
+++ b/test/agent-exit-record.test.cjs
@@ -40,8 +40,11 @@ function readLog(home) {
 
 async function freshHive(t) {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
   return { home, hive };
 }

--- a/test/crush-provider-config.test.cjs
+++ b/test/crush-provider-config.test.cjs
@@ -37,13 +37,16 @@ function proxyBridgeBound(injection, agentDir) {
 
 test('crush provider points CRUSH_GLOBAL_CONFIG at the agent directory', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
 
   const hive = new HiveManager(() => home);
   // ensureAgent on a proxy-tier provider spawns a real hive-proxy sidecar
   // (ChildProcess + two sockets). Without this the handle keeps the test
   // process alive forever and wedges the whole `node --test test/*` run.
   t.after(() => { try { hive.stopAllProxyBridges(); } catch { /* already gone */ } });
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   const injection = await hive.ensureAgent({
     id: 'crush-1',
     name: 'Crush Worker',

--- a/test/hive-cwd.test.cjs
+++ b/test/hive-cwd.test.cjs
@@ -25,8 +25,11 @@ function registryOf(home) {
 
 test('a "~/…" cwd is expanded before it reaches the registry', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
 
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: '~' });
 
@@ -38,8 +41,11 @@ test('a "~/…" cwd is expanded before it reaches the registry', async (t) => {
 
 test('an absolute cwd is unchanged', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
 
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
 
@@ -50,8 +56,11 @@ test('an absolute cwd is unchanged', async (t) => {
 
 test('cwdValidity repairs a "~" left in an older registry', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
 
   // Entries written before the fix are still on disk; reading one must not
   // report it as permanently invalid.

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -32,11 +32,19 @@ function tmpHome(prefix = 'md-hive-node-', root = os.tmpdir()) {
   return fs.mkdtempSync(path.join(root, prefix));
 }
 
+// `hives` collects every HiveManager a caller registers via the returned
+// `registerHive`, so the base-dir teardown can flush all of them first. This
+// helper runs before any HiveManager exists, so it cannot flush what it does
+// not yet know about — registerHive is how a caller hands it that reference.
 function isolatedHomes(t, prefix, root) {
   const base = tmpHome(prefix, root);
   const home = path.join(base, 'user');
   const harness = path.join(base, 'harness');
-  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  const hives = [];
+  t.after(async () => {
+    await Promise.all(hives.map((h) => h.flushCommits()));
+    fs.rmSync(base, { recursive: true, force: true });
+  });
 
   const realHome = process.env.HOME;
   const realProfile = process.env.USERPROFILE;
@@ -47,7 +55,7 @@ function isolatedHomes(t, prefix, root) {
     if (realProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = realProfile;
   });
   assert.equal(os.homedir(), home, 'home redirect failed — aborting before touching the real home');
-  return { home, harness };
+  return { home, harness, registerHive: (h) => hives.push(h) };
 }
 
 const launcherIn = (home) =>
@@ -107,8 +115,11 @@ async function run(cmd, env) {
 
 test('ensureHive writes an executable bundled-node launcher', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
 
   const launcher = launcherIn(home);
@@ -121,8 +132,11 @@ test('ensureHive writes an executable bundled-node launcher', async (t) => {
 
 test('the claude hook + statusLine commands run through the launcher', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
 
   const launcher = launcherIn(home);
@@ -138,8 +152,11 @@ test('the claude hook + statusLine commands run through the launcher', async (t)
 
 test('every hook installer routes through the launcher — none left on bare node', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
 
   // agy and grok install into the USER's home. Redirect it, and refuse to run
@@ -179,6 +196,7 @@ test('Codex hook commands survive a hive path containing spaces', { skip: !POSIX
   const home = isolated.home;
   const harness = `${isolated.harness} space`;
   const hive = new HiveManager(() => harness);
+  isolated.registerHive(hive);
   hive.ensureHive();
   const agentDir = path.join(harness, 'hive', 'agents', 'a1');
   const codexHome = hive.installCodexHooks(agentDir, 'a1');
@@ -224,7 +242,14 @@ test('POSIX Gemini and Antigravity hooks survive a hive path containing spaces',
   const base = fs.mkdtempSync('/tmp/md-provider-space-');
   const home = path.join(base, 'user');
   const harness = path.join(base, 'harness space');
-  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  // `hive` is assigned below, after this closure is created — the closure
+  // reads the variable when the hook RUNS, not when it is registered, so
+  // this still sees the real instance.
+  let hive;
+  t.after(async () => {
+    if (hive) await hive.flushCommits();
+    fs.rmSync(base, { recursive: true, force: true });
+  });
 
   const realHome = process.env.HOME;
   const realProfile = process.env.USERPROFILE;
@@ -236,7 +261,7 @@ test('POSIX Gemini and Antigravity hooks survive a hive path containing spaces',
   });
   assert.equal(os.homedir(), home, 'home redirect failed — aborting before touching the real home');
 
-  const hive = new HiveManager(() => harness);
+  hive = new HiveManager(() => harness);
   hive.ensureHive();
   hive.installAgyHooks();
   hive.installGeminiHooks(path.join(harness, 'hive/agents/a1'));
@@ -277,8 +302,9 @@ test('POSIX Gemini and Antigravity hooks survive a hive path containing spaces',
 });
 
 test('Codex rollouts remain isolated and are visible under the standard scan roots', (t) => {
-  const { home, harness } = isolatedHomes(t);
+  const { home, harness, registerHive } = isolatedHomes(t);
   const hive = new HiveManager(() => harness);
+  registerHive(hive);
   hive.ensureHive();
   const agentDir = path.join(harness, 'hive', 'agents', 'a1');
   const codexHome = path.join(agentDir, '.codex');
@@ -315,7 +341,7 @@ test('Codex rollouts remain isolated and are visible under the standard scan roo
 });
 
 test('bootstrap exposes archived Codex agents without respawning them', (t) => {
-  const { home, harness } = isolatedHomes(t);
+  const { home, harness, registerHive } = isolatedHomes(t);
   const root = path.join(harness, 'hive');
   const agentDir = path.join(root, 'agents', 'a1');
   const sessions = path.join(agentDir, '.codex', 'sessions');
@@ -326,7 +352,9 @@ test('bootstrap exposes archived Codex agents without respawning them', (t) => {
     agents: { a1: { id: 'a1', name: 'A', provider: 'codex', cwd: harness, archived: true } }
   }), 'utf8');
 
-  new HiveManager(() => harness).ensureHive();
+  const hive = new HiveManager(() => harness);
+  registerHive(hive);
+  hive.ensureHive();
 
   assert.equal(fs.lstatSync(sessions).isSymbolicLink(), true,
     'an archived agent is never respawned, so bootstrap must expose its rollouts');
@@ -337,8 +365,9 @@ test('bootstrap exposes archived Codex agents without respawning them', (t) => {
 });
 
 test('a missing exposed directory is repaired on the next spawn', (t) => {
-  const { home, harness } = isolatedHomes(t);
+  const { home, harness, registerHive } = isolatedHomes(t);
   const hive = new HiveManager(() => harness);
+  registerHive(hive);
   hive.ensureHive();
   const agentDir = path.join(harness, 'hive', 'agents', 'a1');
   const sessions = path.join(agentDir, '.codex', 'sessions');
@@ -355,8 +384,9 @@ test('a missing exposed directory is repaired on the next spawn', (t) => {
 });
 
 test('an unsafe agent id cannot escape the Munder scan namespace', (t) => {
-  const { home, harness } = isolatedHomes(t);
+  const { home, harness, registerHive } = isolatedHomes(t);
   const hive = new HiveManager(() => harness);
+  registerHive(hive);
   hive.ensureHive();
   const codexHome = path.join(harness, 'hive', 'agents', 'safe', '.codex');
   const sessions = path.join(codexHome, 'sessions');
@@ -371,8 +401,9 @@ test('an unsafe agent id cannot escape the Munder scan namespace', (t) => {
 });
 
 test('reset cleanup removes only exposed Munder rollouts', (t) => {
-  const { home, harness } = isolatedHomes(t);
+  const { home, harness, registerHive } = isolatedHomes(t);
   const hive = new HiveManager(() => harness);
+  registerHive(hive);
   hive.ensureHive();
   const agentDir = path.join(harness, 'hive', 'agents', 'a1');
   const isolated = path.join(agentDir, '.codex', 'sessions');
@@ -392,8 +423,11 @@ test('reset cleanup removes only exposed Munder rollouts', (t) => {
 
 test('Gemini gets isolated lifecycle settings and an interactive protocol seed', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   const injection = await hive.ensureAgent({
     id: 'gemini-1',
     name: 'Gemini',
@@ -418,8 +452,11 @@ test('Gemini gets isolated lifecycle settings and an interactive protocol seed',
 
 test('a hook fires with NO node on PATH, and its payload reaches HIVE_SOCK', { skip: !POSIX }, async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
 
   const sock = path.join(home, 'hive', 'hooks.sock');

--- a/test/hive-malformed-outbox.test.cjs
+++ b/test/hive-malformed-outbox.test.cjs
@@ -18,9 +18,12 @@ const { HiveManager } = loadTs('src/main/hive.ts');
 
 async function floor(t) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-malformed-outbox-'));
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
-
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
   await hive.ensureAgent({ id: 'god-1', name: 'Michael', provider: 'claude', cwd: home, isGod: true });
   await hive.ensureAgent({ id: 'worker-1', name: 'Creed', provider: 'claude', cwd: home });
 

--- a/test/hive-pi-models.test.cjs
+++ b/test/hive-pi-models.test.cjs
@@ -16,7 +16,13 @@ function tmpHome() {
 async function setupPi(t, { get, id }) {
   const hiveHome = tmpHome();
   const fakeHome = tmpHome();
-  t.after(() => fs.rmSync(hiveHome, { recursive: true, force: true }));
+  // `hive` is assigned below, after this closure is created — the closure
+  // reads the variable when the hook RUNS, not when it is registered.
+  let hive;
+  t.after(async () => {
+    if (hive) await hive.flushCommits();
+    fs.rmSync(hiveHome, { recursive: true, force: true });
+  });
   t.after(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
 
   const realHome = process.env.HOME;
@@ -37,7 +43,7 @@ async function setupPi(t, { get, id }) {
     }
   }
 
-  const hive = new HiveManager(() => hiveHome);
+  hive = new HiveManager(() => hiveHome);
   const injection = await hive.ensureAgent({ id, name: 'Pi Agent', provider: 'pi', cwd: hiveHome });
   return injection.env.PI_CODING_AGENT_DIR;
 }

--- a/test/hive-roster-injection.test.cjs
+++ b/test/hive-roster-injection.test.cjs
@@ -38,8 +38,11 @@ function tmpHome() {
 
 async function floor(t, { steer } = {}) {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'god-1', name: 'Michael', provider: 'claude', cwd: home, isGod: true });
   await hive.ensureAgent({ id: 'jim-1', name: 'Jim', provider: 'claude', cwd: home });
 

--- a/test/hive-runtime-path.test.cjs
+++ b/test/hive-runtime-path.test.cjs
@@ -29,8 +29,11 @@ const SEP = path.delimiter;
 
 async function hiveIn(t) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-runtime-'));
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'a1', name: 'A', provider: 'claude', cwd: home });
   return { home, hive, root: path.join(home, 'hive') };
 }

--- a/test/hive-task-mutation.test.cjs
+++ b/test/hive-task-mutation.test.cjs
@@ -19,8 +19,12 @@ const { HiveManager } = loadTs('src/main/hive.ts');
 
 function floor(t) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-task-mutate-'));
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
-  return new HiveManager(() => home);
+  const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+  return hive;
 }
 
 function card(id, extra = {}) {

--- a/test/hive-unknown-recipient.test.cjs
+++ b/test/hive-unknown-recipient.test.cjs
@@ -25,8 +25,11 @@ const { HiveManager } = loadTs('src/main/hive.ts');
 
 async function floor(t) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-unknown-to-'));
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'god-1', name: 'Michael', provider: 'claude', cwd: home, isGod: true });
   await hive.ensureAgent({ id: 'jim-1', name: 'Jim', provider: 'claude', cwd: home });
   return { home, hive };

--- a/test/hive-windows-prompt.test.cjs
+++ b/test/hive-windows-prompt.test.cjs
@@ -29,8 +29,11 @@ const KG_CLI = path.join('/Applications', 'Munder Difflin.app', 'Contents', 'Res
 
 async function floor(t, opts = {}) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-winprompt-'));
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   const inj = await hive.ensureAgent(
     { id: 'god-1', name: 'Michael', provider: opts.provider ?? 'claude', cwd: home, isGod: true },
     { semanticMemory: true, knowledgeGraph: true, kgCliPath: KG_CLI, ...(opts.injectOpts ?? {}) }

--- a/test/hooks-notification.test.cjs
+++ b/test/hooks-notification.test.cjs
@@ -41,8 +41,11 @@ function tmpHome() {
 
 async function floor(t) {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'jim-1', name: 'Jim', provider: 'claude', cwd: home });
   const server = new HookServer(hive, () => null, () => CONFIG, undefined, undefined);
   const fire = (payload) => server.handle({ agent_id: 'jim-1', session_id: 's1', ...payload });
@@ -103,8 +106,11 @@ test('SubagentStop behaves the same as Stop', async (t) => {
 
 test('notifications setting off suppresses the OS toast but the hook still resolves', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   await hive.ensureAgent({ id: 'jim-1', name: 'Jim', provider: 'claude', cwd: home });
   const server = new HookServer(hive, () => null, () => ({ notifications: false }), undefined, undefined);
   notifications.length = 0;

--- a/test/proxy-bridge-retry.test.cjs
+++ b/test/proxy-bridge-retry.test.cjs
@@ -22,9 +22,12 @@ function spawnCrush(hive) {
 
 test('a bind that fails once and then succeeds leaves the agent fully proxied', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const events = [];
   const hive = new HiveManager(() => home, (ch, p) => { events.push([ch, p]); return true; });
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   const ports = [0, 43210];
   let calls = 0;
   hive.startProxyBridge = async () => { calls++; return ports.shift() ?? 0; };
@@ -40,9 +43,12 @@ test('a bind that fails once and then succeeds leaves the agent fully proxied', 
 
 test('a bind that never succeeds is retried, then surfaced: spawn result, log.jsonl and the renderer', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const events = [];
   const hive = new HiveManager(() => home, (ch, p) => { events.push([ch, p]); return true; });
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   let calls = 0;
   hive.startProxyBridge = async () => { calls++; return 0; };
 

--- a/test/task-ledger.test.cjs
+++ b/test/task-ledger.test.cjs
@@ -125,8 +125,11 @@ test('patching one card leaves its neighbours byte-identical', () => {
 
 test('answering a question through hive.writeTasks preserves the whole board', (t) => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-task-ledger-'));
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   const ledger = () => JSON.parse(fs.readFileSync(path.join(home, 'hive', 'tasks.json'), 'utf8')).tasks;
 
   const second = richCard();
@@ -159,8 +162,11 @@ test('answering a question through hive.writeTasks preserves the whole board', (
 
 test('hive.writeTasks can still empty the ledger', (t) => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'md-task-ledger-del-'));
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
   const ledger = () => JSON.parse(fs.readFileSync(path.join(home, 'hive', 'tasks.json'), 'utf8')).tasks;
 
   hive.writeTasks([richCard(), { id: 'other', title: 'Other', status: 'todo' }]);

--- a/test/tui-theme-hint.test.cjs
+++ b/test/tui-theme-hint.test.cjs
@@ -41,9 +41,12 @@ function proxyBridgeBound(injection, agentDir) {
 
 test('crush: light theme writes options.tui.transparent and COLORFGBG', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
   t.after(() => { try { hive.stopAllProxyBridges(); } catch { /* already gone */ } });
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
 
   const injection = await hive.ensureAgent(
     { id: 'crush-t', name: 'Crush', provider: 'crush', cwd: home },
@@ -58,9 +61,12 @@ test('crush: light theme writes options.tui.transparent and COLORFGBG', async (t
 
 test('crush: dark theme sends the dark hint and still goes transparent', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
   t.after(() => { try { hive.stopAllProxyBridges(); } catch { /* already gone */ } });
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
 
   const injection = await hive.ensureAgent(
     { id: 'crush-d', name: 'Crush', provider: 'crush', cwd: home },
@@ -74,9 +80,12 @@ test('crush: dark theme sends the dark hint and still goes transparent', async (
 
 test('no theme passed: no hint, no options block (old behaviour)', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
   t.after(() => { try { hive.stopAllProxyBridges(); } catch { /* already gone */ } });
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
 
   const injection = await hive.ensureAgent({ id: 'crush-n', name: 'Crush', provider: 'crush', cwd: home });
   assert.equal(injection.env.COLORFGBG, undefined);
@@ -87,8 +96,11 @@ test('no theme passed: no hint, no options block (old behaviour)', async (t) => 
 
 test('opencode: theme lands in the per agent config dir as the system theme', async (t) => {
   const home = tmpHome();
-  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
+  t.after(async () => {
+    await hive.flushCommits();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
 
   const injection = await hive.ensureAgent(
     { id: 'oc-1', name: 'OpenCode', provider: 'opencode', cwd: home },


### PR DESCRIPTION
## Summary

The hive message router runs `git add -A` + `git commit` synchronously (`spawnSync`) on every routed message, in `HiveManager.commit()` / `.git()` (`src/main/hive.ts`). With `gc.autoDetach=false` that also runs `gc --auto` inline. This blocks the Electron main thread for the whole duration of the commit — measured live against a production hive repo at several seconds per routed message, freezing the UI.

`git()` now uses `execFile` instead of `spawnSync`, so the git child process no longer blocks the main thread. `commit()` is serialized through an explicit promise queue (`this._commitQueue`) instead of relying on `spawnSync`'s incidental single-threaded serialization — with `gc.autoDetach=false`, two real git processes racing the same `.git/objects/` is exactly the hazard that flag exists to prevent (see the comment above `git()`), so losing that free serialization without replacing it would have been worse than the freeze it fixes.

Cadence and what gets committed are unchanged — still `add -A`, still one commit per routed batch. This is off-thread, not off-cadence.

A `flushCommits()` method is added so a caller that needs the working tree to be quiescent (most concretely: a test deleting the ephemeral hive home it created) can wait for the queue to drain. Every existing `HiveManager` test's teardown now awaits it before removing its temp dir — with `spawnSync`, a commit always finished before the function that queued it returned, so no test needed to ask for that guarantee explicitly; async `git()` removes that free ordering. One instance of the same bug was in production code, not just tests: `ensureHive()`'s own `git init` call was fire-and-forget and not on the queue, so a caller could observe `ensureHive()` return before `git init` had actually finished on disk — it's queued now too.

Not changed in this PR (flagged as a separate, larger follow-up): the router's `git add -A` could instead pass only the paths each of the 9 `commit()` call sites actually touched. That's independent of the threading fix and touches all 9 sites individually, so I've kept it out of this diff.

### Before

Measured with a standalone Node script (not the full app — the freeze isn't easily screen-recordable) against a real-sized clone of a production hive repo (896 MB, cloned locally so history/tree size matches). It calls `HiveManager.commit()` once (with one new file staged, matching a router commit's shape) and times how long the *synchronous call itself* takes to return — that duration is exactly how long it blocks the calling thread.

```
$ node bench-commit-block.cjs <home> <repo-root-on-main> block
call-returns-in: 1103.6ms
actual-commit-completes-in: (same as above -- synchronous)
```
Two more trials (fresh clones each time): 277.9ms, 263.6ms. All in the hundreds-of-ms-to-second range that matches the reported freeze in kind (the live production repo is larger and dirtier than this clone, which is consistent with the live report being ~6s).

### After

Same script, same-sized fresh clone, against this branch:

```
$ node bench-commit-block.cjs <home> <repo-root-on-this-branch> flush
call-returns-in: 0.0ms
actual-commit-completes-in: 182.8ms
```
Two more trials: 0.0ms / 304.8ms, 0.0ms / 151.4ms. The call returns to the caller immediately every time; the real git work (confirmed still happening, via `flushCommits()`) completes shortly after, off the main thread.

## Rebuild / verify note

This branch only changes `src/main/hive.ts` (+ test files). To verify against a running build:
1. `npm install && npm run build && npm run dist:mac` (or your platform's `dist:*`) from this branch.
2. Install/launch the built app pointed at a real (or copied) hive repo.
3. Route a message and watch for UI responsiveness during the commit — it should no longer visibly freeze. `console.warn('[hive] commit gave up after 5 attempts')` would appear in the main process log if a queued commit ever failed outright (it didn't in any of my local test runs).

No change to what gets committed, the commit message format, or commit cadence — only where the git subprocess's blocking time lands.

## Test plan
- [x] `npm run typecheck` (node + web) — clean
- [x] `npm run test:focused` — 831/834, matching `main`'s 831/834 exactly (the 3 remaining failures are pre-existing/unrelated: SIGILL/exit-signal-forwarding tests, reproduced identically on `main` before this change)
- [x] `npm run build` — clean
- [x] Standalone before/after timing harness against a real-sized (896M) hive repo clone, 3 trials each side (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
