### PR TITLE
fix(provider): preserve explicit Gemini approval stance

### DIFF
--- a/src/shared/agentProvider.ts
+++ b/src/shared/agentProvider.ts
@@ -293,6 +293,9 @@ export const AGENT_PROVIDER_PRESETS: AgentProviderPreset[] = [
     // `--yolo` is deprecated upstream; approval-mode is the current spelling.
     autoModeFlag: '--approval-mode=yolo',
     autoFlag: '--approval-mode=yolo',
+    // Gemini rejects combining either legacy yolo alias with --approval-mode.
+    // Treat every spelling as an explicit stance so the request remains owner.
+    autoStanceTokens: ['--yolo', '-y'],
     supportsModel: true,
     modelFlag: '--model',
     hiveAware: false,
@@ -688,15 +691,30 @@ export function argsWithAutoModeFlag(args: string[], autoMode: boolean, provider
   return [...args, ...flag.trim().split(/\s+/)];
 }
 
+/** Return a CLI option's identity while preserving positional values verbatim. */
+function cliOptionName(token: string): string {
+  const trimmed = token.trim();
+  if (!trimmed.startsWith('-')) return trimmed;
+  const equals = trimmed.indexOf('=');
+  return equals > 0 ? trimmed.slice(0, equals) : trimmed;
+}
+
 /** True when argv already states a permission posture for this provider: the
- *  auto flag's leading token, or any of the preset's `autoStanceTokens`. Token
- *  match, not substring — copilot's flag starts with `-s`. */
+ *  auto flag's leading option, or any of the preset's `autoStanceTokens`.
+ *  Compare normalized option identity (not prefix) and stop at `--`, after
+ *  which option-looking tokens are positional literals. */
 export function hasAutoModeStance(args: string[], provider: AgentProvider): boolean {
   const preset = providerPreset(provider);
   const flag = preset.autoModeFlag ?? '';
   const lead = flag.trim().split(/\s+/)[0];
-  const stance = new Set([...(lead ? [lead] : []), ...(preset.autoStanceTokens ?? [])]);
-  return args.some((a) => stance.has(a));
+  const stance = new Set(
+    [...(lead ? [lead] : []), ...(preset.autoStanceTokens ?? [])].map(cliOptionName)
+  );
+  for (const arg of args) {
+    if (arg === '--') break;
+    if (stance.has(cliOptionName(arg))) return true;
+  }
+  return false;
 }
 
 /** Returns any env vars the provider needs for non-interactive / first-run suppression. */

--- a/test/agent-provider.test.cjs
+++ b/test/agent-provider.test.cjs
@@ -93,6 +93,44 @@ test('codex preset still resolves (no regression)', () => {
   assert.strictEqual(ap.providerPreset('codex').defaultCommand, 'codex');
 });
 
+test('gemini approval-mode values are explicit auto-mode stances', () => {
+  for (const mode of ['default', 'auto_edit', 'yolo', 'plan', 'future_mode', '']) {
+    assert.strictEqual(
+      ap.hasAutoModeStance([`--approval-mode=${mode}`], 'gemini'),
+      true,
+      `--approval-mode=${mode}`
+    );
+  }
+  assert.strictEqual(ap.hasAutoModeStance(['--approval-mode', 'plan'], 'gemini'), true);
+});
+
+test('gemini legacy yolo aliases are explicit auto-mode stances', () => {
+  for (const alias of ['--yolo', '-y']) {
+    assert.strictEqual(ap.hasAutoModeStance([alias], 'gemini'), true, alias);
+    assert.deepStrictEqual(ap.argsWithAutoModeFlag([alias], true, 'gemini'), [alias], alias);
+  }
+});
+
+test('auto-mode stance matching respects option identity and the argv terminator', () => {
+  assert.strictEqual(ap.hasAutoModeStance(['--approval-mode-extra=plan'], 'gemini'), false);
+  assert.strictEqual(ap.hasAutoModeStance(['--', '--approval-mode=plan'], 'gemini'), false);
+  assert.strictEqual(ap.hasAutoModeStance(['--model', 'pro', '--', '--approval-mode=plan'], 'gemini'), false);
+  assert.strictEqual(ap.hasAutoModeStance(['--approval-mode=plan', '--', 'hello'], 'gemini'), true);
+
+  // Existing providers share the option-identity behavior without prefix matches.
+  assert.strictEqual(ap.hasAutoModeStance(['--permission-mode=plan'], 'claude'), true);
+  assert.strictEqual(ap.hasAutoModeStance(['--sandbox=read-only'], 'codex'), true);
+  assert.strictEqual(ap.hasAutoModeStance(['--summarize'], 'copilot'), false);
+});
+
+test('gemini global auto-mode only fills an absent approval stance', () => {
+  assert.deepStrictEqual(
+    ap.argsWithAutoModeFlag(['--approval-mode=plan'], true, 'gemini'),
+    ['--approval-mode=plan']
+  );
+  assert.deepStrictEqual(ap.argsWithAutoModeFlag([], true, 'gemini'), ['--approval-mode=yolo']);
+});
+
 if (failures > 0) {
   console.log(`\n${failures} test(s) failed`);
   process.exit(1);

--- a/test/worker-launch.test.cjs
+++ b/test/worker-launch.test.cjs
@@ -53,6 +53,43 @@ test('an explicit --permission-mode in the request always wins over auto-mode', 
   assert.deepEqual(l.args, ['--permission-mode', 'plan']);
 });
 
+test('gemini explicit approval modes win over global auto-mode', () => {
+  for (const mode of ['default', 'auto_edit', 'yolo', 'plan', 'future_mode']) {
+    const l = launch({ requestCommand: `gemini --approval-mode=${mode}`, autoMode: true });
+    assert.equal(l.command, `gemini --approval-mode=${mode}`);
+    assert.deepEqual(l.args, [`--approval-mode=${mode}`]);
+  }
+
+  const spaced = launch({ requestCommand: 'gemini --approval-mode plan', autoMode: true });
+  assert.equal(spaced.command, 'gemini --approval-mode plan');
+  assert.deepEqual(spaced.args, ['--approval-mode', 'plan']);
+});
+
+test('gemini legacy yolo aliases win over global auto-mode', () => {
+  // Gemini rejects combining --yolo/-y with --approval-mode, so auto-mode must
+  // not append the modern spelling over an explicit legacy stance.
+  for (const stance of ['--yolo', '-y']) {
+    const l = launch({ requestCommand: `gemini ${stance}`, autoMode: true });
+    assert.equal(l.command, `gemini ${stance}`);
+    assert.deepEqual(l.args, [stance]);
+  }
+});
+
+test('gemini still inherits global auto-mode when no approval stance is present', () => {
+  assert.deepEqual(
+    launch({ requestCommand: 'gemini', autoMode: true }).args,
+    ['--approval-mode=yolo']
+  );
+  assert.deepEqual(
+    launch({ requestCommand: 'gemini --model pro', autoMode: true }).args,
+    ['--model', 'pro', '--approval-mode=yolo']
+  );
+  assert.deepEqual(
+    launch({ requestCommand: 'gemini --approval-mode-extra=plan', autoMode: true }).args,
+    ['--approval-mode-extra=plan', '--approval-mode=yolo']
+  );
+});
+
 test('auto-mode OFF appends nothing', () => {
   assert.deepEqual(launch({ requestCommand: 'claude', autoMode: false }).args, []);
   assert.deepEqual(launch({ requestCommand: 'codex', autoMode: false }).args, []);


### PR DESCRIPTION
## What & why

Global Auto Mode did not recognize Gemini `--approval-mode=<value>` arguments as an existing approval stance, so an explicit mode such as `plan` could receive an additional `--approval-mode=yolo`.

Gemini's legacy `--yolo` and `-y` aliases could also receive the modern approval flag, creating a combination that Gemini CLI rejects. This change matches auto mode by CLI option identity, treats the legacy aliases as explicit stances, and stops stance detection at the first `--` argument terminator while preserving the normal auto mode fallback when no stance is present.

Closes #483 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

On main, Global Auto Mode appended `--approval-mode=yolo` even when Gemini already had an explicit approval stance.

`--approval-mode=plan` received a second approval mode, and the legacy `--yolo` form received the conflicting modern flag.

<img width="633" height="108" alt="Image" src="https://github.com/user-attachments/assets/7ce2e146-9eee-4389-969e-804b4030fb02" />

### After

On the fixed revision, explicit Gemini approval stances are preserved.

`--approval-mode=plan`, `--yolo`, and `-y` remain unchanged, while a command with no explicit approval stance still inherits `--approval-mode=yolo`.

<img width="618" height="177" alt="2026-09-09-164601" src="https://github.com/user-attachments/assets/ce64cb66-66c3-4756-89fb-3e85b4985461" />

## How I tested it

- OS: Windows 11
- Steps:
  - Ran the same `buildWorkerLaunch()` reproduction before and after the change.
  - Verified `gemini --approval-mode=plan` remains unchanged.
  - Verified `gemini --yolo` and `gemini -y` remain unchanged.
  - Verified `gemini --model pro` still receives `--approval-mode=yolo`.
  - Ran `node test/agent-provider.test.cjs`: PASS.
  - Ran `node --test test/worker-launch.test.cjs`: 17/17 PASS.
  - Ran `npm run typecheck`: PASS.
  - Ran `npm run build`: PASS.
  - Ran `git diff --check`: PASS.
  - Ran the full `npm run test:focused` suite. The Gemini regressions pass, while the suite still reports existing unrelated Windows/sandbox failures involving symlink `EPERM`, temporary HOME handling, and existing static assertions.

<img width="680" height="515" alt="2026-09-09-164706" src="https://github.com/user-attachments/assets/87e22eb9-dd40-4845-90e5-4aec6c9db49b" />

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.