### PR TITLE
site: add the Google Search Console verification file

### DIFF
--- a/docs/google4a7296cf44463a52.html
+++ b/docs/google4a7296cf44463a52.html
@@ -1,0 +1,1 @@
+google-site-verification: google4a7296cf44463a52.html


### PR DESCRIPTION
## Summary

Adds `docs/google4a7296cf44463a52.html`, the file Google Search Console fetches to verify `https://munderdiffl.in/` as a URL prefix property. The property is already added under your Google account and is waiting on this file.

## After merge

Once GitHub Pages serves the file, Jim clicks Verify in Search Console and submits `https://munderdiffl.in/sitemap.xml`. The file has to stay in place after that, or the property drops back to unverified.

## Why the evidence label

This change has nothing to see: it is a one line text file at the site root. It carries the maintainer `no-visual-change` label instead of before and after screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKhjmRPTpdrv1ewjdnhar3
