### PR TITLE
blog: pin six pillar guides above the newest post

### DIFF
--- a/blog/eleventy.config.js
+++ b/blog/eleventy.config.js
@@ -54,6 +54,25 @@ export default function (eleventyConfig) {
       .sort((a, b) => b.date - a.date)
   );
 
+  // Pinned pillar guides (`pinned: true`), in `pinOrder`. They sit above the
+  // newest post on the index and first on their topic page, so a fast publishing
+  // pace never pushes the reference guides off the top.
+  const pinRank = (p) => (p.data.pinned ? (p.data.pinOrder ?? 99) : 1e9);
+  eleventyConfig.addCollection("pinned", (api) =>
+    api
+      .getFilteredByGlob("src/posts/*.md")
+      .filter((p) => !p.data.draft && p.data.pinned)
+      .sort((a, b) => pinRank(a) - pinRank(b) || b.date - a.date)
+  );
+
+  // Everything else, newest first: the index features the first of these.
+  eleventyConfig.addCollection("unpinned", (api) =>
+    api
+      .getFilteredByGlob("src/posts/*.md")
+      .filter((p) => !p.data.draft && !p.data.pinned)
+      .sort((a, b) => b.date - a.date)
+  );
+
   // Topic clusters (categories) — derived from each post's `category` field.
   eleventyConfig.addCollection("categories", (api) => {
     const map = {};
@@ -67,7 +86,7 @@ export default function (eleventyConfig) {
       .map(([name, posts]) => ({
         name,
         slug: slugify(name),
-        posts: posts.sort((a, b) => b.date - a.date),
+        posts: posts.sort((a, b) => pinRank(a) - pinRank(b) || b.date - a.date),
       }))
       .sort((a, b) => b.posts.length - a.posts.length);
   });

--- a/blog/src/_includes/card.njk
+++ b/blog/src/_includes/card.njk
@@ -16,6 +16,7 @@
       <time datetime="{{ p.date | htmlDate }}">{{ p.date | readableDate }}</time>
       <span class="dot" aria-hidden="true"></span>
       <span>{{ p.content | readingTime }} min</span>
+      {%- if d.pinned %}<span class="pin">Pinned</span>{% endif %}
     </div>
     <h3><a href="{{ p.url | u }}">{{ d.title }}</a></h3>
     {% if d.description %}<p class="dek">{{ d.description }}</p>{% endif %}

--- a/blog/src/assets/blog-press.css
+++ b/blog/src/assets/blog-press.css
@@ -289,6 +289,9 @@ a.tag:hover { background: var(--ink); color: var(--paper); }
 .pn .t { font-family: var(--disp); font-weight: 700; line-height: 1.25; }
 .related h2 { font-family: var(--disp); font-weight: 900; font-size: 1.7rem; border-top: 4px solid var(--rule); padding-top: 16px; }
 .related .post-grid { padding: 0; }
+.pinned-title { font-family: var(--disp); font-weight: 900; font-size: 1.7rem; border-top: 4px solid var(--rule); padding-top: 16px; margin: 30px 0 0; }
+.pinned .post-grid { padding-bottom: 28px; }
+.card .meta .pin { background: var(--accent); color: var(--ink); padding: 2px 8px; letter-spacing: 0.08em; }
 
 /* footer (site footer only — .post-foot must stay on the light page ground) */
 footer.site-foot { background: var(--ink); color: var(--paper); margin-top: 48px; }

--- a/blog/src/assets/blog-sunroom.css
+++ b/blog/src/assets/blog-sunroom.css
@@ -327,3 +327,7 @@ footer.site-foot .wrap { padding: 34px 24px; }
 .yt-placeholder .ph-note { font-family: var(--mono); font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; color: #b7b5d8; }
 .yt-placeholder .yt-ph-title { display: block; color: #fff; font-weight: 800; font-size: 16px; max-width: 480px; text-align: center; }
 .yt-placeholder .ph-art { display: grid; gap: 10px; justify-items: center; padding: 20px; }
+
+/* Pinned pillar guides: "Start here" row on the index and a chip on the card. */
+.pinned-title { margin: 28px 0 12px; font-size: 1.5rem; }
+.card .meta .pin { background: var(--yellow, #FFCA54); color: var(--ink, #1A1320); padding: 2px 8px; border-radius: 999px; }

--- a/blog/src/assets/blog.css
+++ b/blog/src/assets/blog.css
@@ -472,3 +472,7 @@ footer { border-top: 2px solid var(--ink); background: var(--cream); margin-top:
   .card, .btn, .chip, .pn { transition: none !important; }
   .card:hover, .btn:hover, .chip:hover, .pn:hover { transform: none !important; }
 }
+
+/* Pinned pillar guides: "Start here" row on the index and a chip on the card. */
+.pinned-title { margin: 28px 0 12px; font-size: 1.5rem; }
+.card .meta .pin { background: var(--yellow, #FFCA54); color: var(--ink, #1A1320); padding: 2px 8px; border-radius: 999px; }

--- a/blog/src/index.njk
+++ b/blog/src/index.njk
@@ -45,15 +45,27 @@ permalink: /index.html
 </header>
 
 {% if posts.length %}
+{%- set rest = collections.unpinned -%}
+{% if collections.pinned.length %}
+<section class="wrap pinned" aria-labelledby="pinned-title">
+  <h2 class="pinned-title" id="pinned-title">Start here</h2>
+  <div class="post-grid">
+    {% for p in collections.pinned %}{% include "card.njk" %}{% endfor %}
+  </div>
+</section>
+{% endif %}
+
+{% if rest.length %}
 <div class="wrap featured">
-  {%- set p = posts[0] -%}
+  {%- set p = rest[0] -%}
   {% include "card.njk" %}
 </div>
+{% endif %}
 
-{% if posts.length > 1 %}
+{% if rest.length > 1 %}
 <section class="wrap">
   <div class="post-grid">
-    {% for p in posts %}{% if not loop.first %}{% include "card.njk" %}{% endif %}{% endfor %}
+    {% for p in rest %}{% if not loop.first %}{% include "card.njk" %}{% endif %}{% endfor %}
   </div>
 </section>
 {% endif %}

--- a/blog/src/posts/best-claude-code-multi-agent-tools.md
+++ b/blog/src/posts/best-claude-code-multi-agent-tools.md
@@ -6,6 +6,8 @@ updated: 2026-09-10
 category: comparisons
 categoryLabel: Comparisons
 type: Non-technical
+pinned: true
+pinOrder: 5
 primaryKeyword: "best claude code multi-agent tools"
 secondaryKeywords: ["claude code multi-agent tool", "best tools to run multiple claude code agents", "claude code agent teams", "crystal nimbalyst", "emdash coding agents", "conductor claude code"]
 tags: ["Comparisons", "Multi-Agent", "Claude Code", "Tools"]

--- a/blog/src/posts/how-to-install-and-use-munder-difflin.md
+++ b/blog/src/posts/how-to-install-and-use-munder-difflin.md
@@ -6,6 +6,8 @@ updated: 2026-09-10
 category: guides
 categoryLabel: Guides
 type: Non-technical
+pinned: true
+pinOrder: 2
 primaryKeyword: "how to install munder difflin"
 secondaryKeywords: ["munder difflin download", "munder difflin setup", "what is a coding agent", "munder difflin windows", "free ai coding agent", "antigravity free", "munder difflin beginner guide"]
 tags: ["Guides", "Getting Started", "Tutorial", "Non-Technical", "Automation"]

--- a/blog/src/posts/manage-multiple-claude-code-sessions.md
+++ b/blog/src/posts/manage-multiple-claude-code-sessions.md
@@ -5,6 +5,8 @@ date: 2026-05-25
 category: guides
 categoryLabel: Guides
 type: Technical
+pinned: true
+pinOrder: 4
 primaryKeyword: "how to manage multiple claude code sessions"
 secondaryKeywords: ["manage claude code sessions", "claude code workflow", "multiple terminals"]
 tags: ["Guides", "Workflow", "Claude Code", "Multi-Agent"]

--- a/blog/src/posts/run-munder-difflin-on-open-models.md
+++ b/blog/src/posts/run-munder-difflin-on-open-models.md
@@ -6,6 +6,8 @@ updated: 2026-09-10
 category: guides
 categoryLabel: Guides
 type: Technical
+pinned: true
+pinOrder: 3
 primaryKeyword: "run ai agents on open source models"
 secondaryKeywords: ["local llm coding agent", "ollama coding agent", "openrouter coding agent", "gpt-oss", "byok open models", "opencode crush pi", "pi models.json ollama"]
 tags: ["Guides", "Local-First", "Open Source", "CLI Agents", "Tutorial"]

--- a/blog/src/posts/what-is-a-multi-agent-harness.md
+++ b/blog/src/posts/what-is-a-multi-agent-harness.md
@@ -6,6 +6,8 @@ updated: 2026-09-10
 category: concepts
 categoryLabel: Concepts
 type: Non-technical
+pinned: true
+pinOrder: 6
 primaryKeyword: "claude code multi-agent"
 secondaryKeywords: ["multi-agent harness", "what is an agent harness", "multi-agent ai framework", "ai agent harness", "claude code agent teams vs harness"]
 tags: ["Concepts", "Multi-Agent", "Claude Code"]

--- a/blog/src/posts/your-first-hour-with-munder-difflin.md
+++ b/blog/src/posts/your-first-hour-with-munder-difflin.md
@@ -6,6 +6,8 @@ updated: 2026-09-10
 category: guides
 categoryLabel: Guides
 type: Non-technical
+pinned: true
+pinOrder: 1
 primaryKeyword: "munder difflin onboarding"
 secondaryKeywords: ["getting started with munder difflin", "munder difflin tutorial", "first hour with a multi-agent harness", "munder difflin setup", "scheduled agent missions", "munder difflin skills"]
 tags: ["Guides", "Onboarding", "Getting Started", "Multi-Agent", "Local-First"]


### PR DESCRIPTION
## What

Posts with `pinned: true` now sit in a "Start here" row at the top of https://munderdiffl.in/blog/, in `pinOrder`, and first on their topic page. Each pinned card carries a small Pinned chip.

## Why

The scheduled blog mission is about to publish up to 4 posts every 4 hours. Today the index features whichever post is newest, so the guides Google already sends readers to would be pushed down every few hours.

## The six pinned guides (merging this signs off the list)

1. your-first-hour-with-munder-difflin
2. how-to-install-and-use-munder-difflin
3. run-munder-difflin-on-open-models
4. manage-multiple-claude-code-sessions
5. best-claude-code-multi-agent-tools
6. what-is-a-multi-agent-harness

Picked from Ryan's PostHog numbers: search visits and download clicks per post. To change the list later, edit `pinned` and `pinOrder` in a post's frontmatter.

## Merge order

This branch sits on top of #485. Merge #485 first. Until then this PR also shows #485's files.

## Notes

- `docs/blog` is not in this PR. The Build blog workflow rebuilds it when this merges.
- Built locally with `npm run build`: 276 files written, 6 pinned cards on the index, pinned guides first on the Guides topic page.

### Before

![Blog index before](https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/pr-evidence-blog-pinned-pillars/v-before-index.jpg)

![Guides topic page before](https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/pr-evidence-blog-pinned-pillars/v-before-topic.jpg)

### After

![Blog index after](https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/pr-evidence-blog-pinned-pillars/v-after-index.jpg)

![Guides topic page after](https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/pr-evidence-blog-pinned-pillars/v-after-topic.jpg)

![Blog index on a phone](https://raw.githubusercontent.com/chaitanyagiri/munder-difflin/pr-evidence-blog-pinned-pillars/after-index-mobile.jpg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKhjmRPTpdrv1ewjdnhar3
