### PR TITLE
perf(hive): run hive-node on a real system node when one exists

### DIFF
--- a/src/main/hive.ts
+++ b/src/main/hive.ts
@@ -38,6 +38,8 @@ import {
   type AgentProvider
 } from '../shared/agentProvider';
 import { MCP_CATALOG } from '../shared/mcpCatalog';
+import { resolveCommand } from './shellEnv';
+import { detectNodeVersion, nodeIsUsable } from './nodeInstall';
 import { selectBroadcastTargets } from '../shared/broadcast';
 import { preferredAgentRole } from '../shared/agentRole';
 import { mergeTaskLedger } from '../shared/taskLedger';
@@ -462,6 +464,11 @@ export class HiveManager {
    * agents a `$HIVE_NODE` they can invoke directly (running the Electron binary
    * WITHOUT the env var would launch a second app window, not a script).
    *
+   * A real system node is PREFERRED when one is installed and new enough (see
+   * systemNode) — it starts far faster than the Electron binary, which matters
+   * because this launcher runs once per hook and once per hive CLI call.
+   * Electron remains the fallback and the guarantee.
+   *
    * Rewritten on every bootstrap, so an app update/move re-bakes execPath.
    */
   private nodeLauncherPath(): string | null {
@@ -470,16 +477,57 @@ export class HiveManager {
     return join(root, 'bin', process.platform === 'win32' ? 'hive-node.cmd' : 'hive-node');
   }
 
+  /** Memoised result of systemNode() — null means "probed, found nothing".
+   *  undefined means "not probed yet". The probe spawns `where`/`which` plus
+   *  `node --version`, and writeNodeLauncher runs on every bootstrap. */
+  private systemNodeCache: string | null | undefined;
+
+  /** An absolute path to a REAL, new-enough system node, or null.
+   *
+   *  Preferred over Electron-as-node for the launcher. `hive-node` is invoked
+   *  once per hook AND once per hive CLI call an agent makes, and each call
+   *  cold-starts whatever binary is baked in. Electron's binary is ~178MB
+   *  against node's ~87MB, and it starts materially slower (measured on Windows
+   *  11: ~225ms vs ~132ms per call). At a few calls per second per agent, with
+   *  several agents live, that difference is most of the machine's process-churn
+   *  load — every spawn is kernel work and a fresh image for the AV scanner.
+   *
+   *  Null when nothing usable is found. Callers then fall back to Electron,
+   *  which is ALWAYS present (it is us) and is the entire reason this launcher
+   *  exists: a hook's bare `PATH=/usr/bin:/bin` has no nvm/volta/Homebrew node,
+   *  so `node <shim>` exits 127 there. That guarantee is preserved untouched —
+   *  this only takes the faster path when we can prove it works. */
+  private systemNode(): string | null {
+    if (this.systemNodeCache !== undefined) return this.systemNodeCache;
+    let found: string | null = null;
+    try {
+      // resolveCommand returns its argument UNCHANGED when nothing was found,
+      // so a bare 'node' back means "not on PATH" — never bake that in, it is
+      // precisely the 127 this launcher exists to prevent.
+      const resolved = resolveCommand('node');
+      if (resolved && isAbsolute(resolved) && existsSync(resolved)) {
+        if (nodeIsUsable(detectNodeVersion(resolved))) found = resolved;
+      }
+    } catch { /* any probe failure means "cannot vouch" → Electron */ }
+    this.systemNodeCache = found;
+    return found;
+  }
+
   /** Write the launcher described above. Best-effort: on failure callers fall
    *  back to bare `node`, i.e. exactly the pre-fix behavior. */
   private writeNodeLauncher(): void {
     const p = this.nodeLauncherPath();
     if (!p) return;
     try {
+      const node = this.systemNode();
       if (process.platform === 'win32') {
-        writeFileSync(p, `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`, 'utf8');
+        writeFileSync(p, node
+          ? `@echo off\r\n"${node}" %*\r\n`
+          : `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`, 'utf8');
       } else {
-        writeFileSync(p, `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${process.execPath}" "$@"\n`, 'utf8');
+        writeFileSync(p, node
+          ? `#!/bin/sh\nexec "${node}" "$@"\n`
+          : `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${process.execPath}" "$@"\n`, 'utf8');
         chmodSync(p, 0o755);
       }
     } catch (e) {

--- a/test/hive-hook-node.test.cjs
+++ b/test/hive-hook-node.test.cjs
@@ -105,7 +105,7 @@ async function run(cmd, env) {
   });
 }
 
-test('ensureHive writes an executable bundled-node launcher', async (t) => {
+test('ensureHive writes an executable node launcher that really runs node', async (t) => {
   const home = tmpHome();
   t.after(() => fs.rmSync(home, { recursive: true, force: true }));
   const hive = new HiveManager(() => home);
@@ -114,9 +114,35 @@ test('ensureHive writes an executable bundled-node launcher', async (t) => {
   const launcher = launcherIn(home);
   assert.equal(fs.existsSync(launcher), true);
   const body = fs.readFileSync(launcher, 'utf8');
-  assert.match(body, /ELECTRON_RUN_AS_NODE=1/, 'without this the binary opens a second app window');
-  assert.ok(body.includes(process.execPath), 'execPath is re-baked each bootstrap so an app move/update heals');
   if (POSIX) assert.ok(fs.statSync(launcher).mode & 0o111, 'must be executable');
+
+  // Two legal shapes. A real system node is preferred (it cold-starts far
+  // faster, and this launcher runs once per hook AND per hive CLI call);
+  // Electron-as-node is the fallback that makes the launcher work at all on a
+  // machine whose node is invisible to a hook's bare PATH.
+  const baked = body.match(/"([^"]+)"/)?.[1];
+  assert.ok(baked, `launcher bakes no quoted binary path: ${body}`);
+  assert.equal(path.isAbsolute(baked), true, 'a bare name would exit 127 from a hook');
+  assert.equal(fs.existsSync(baked), true, `baked binary does not exist: ${baked}`);
+
+  // Branch on the BODY, not on process.execPath: under `node --test` execPath
+  // is already node, so it cannot tell the two shapes apart. In the packaged
+  // app it is electron.exe.
+  if (/ELECTRON_RUN_AS_NODE/.test(body)) {
+    assert.match(body, /ELECTRON_RUN_AS_NODE=1/, 'without =1 the binary opens a second app window');
+    assert.equal(baked, process.execPath, 'the Electron fallback must bake our own binary');
+  }
+
+  // Whichever branch was taken, the launcher must actually execute JS. Run a
+  // real script file rather than `-e`: that is how the launcher is used (every
+  // hook is `<launcher> "<shim>.cjs"`), and it avoids cmd.exe eating quotes.
+  const probe = path.join(home, 'launcher-probe.cjs');
+  fs.writeFileSync(probe, 'process.stdout.write("ok");\n', 'utf8');
+  const out = require('node:child_process').execFileSync(
+    launcher, [`"${probe}"`],
+    { encoding: 'utf8', timeout: 20_000, shell: true }
+  );
+  assert.equal(out.trim(), 'ok', 'the launcher does not run JavaScript');
 });
 
 test('the claude hook + statusLine commands run through the launcher', async (t) => {


### PR DESCRIPTION
## The problem

`hive-node` is invoked once per hook **and** once per hive CLI call an agent makes, and it baked Electron's own binary unconditionally (`ELECTRON_RUN_AS_NODE=1`). Every one of those calls cold-starts a ~178 MB Electron image where an ~87 MB `node` would do.

Measured on Windows 11 with Node 24.14.1:

| Runtime | Image | Cold start |
|---|---|---|
| `ELECTRON_RUN_AS_NODE=1 electron.exe` | 177.7 MB | **225 ms/call** |
| `node.exe` v24.14.1 | 87.2 MB | **132 ms/call** |

That cost multiplies by every live agent. Profiling a 4-agent hive on Windows, the machine sat at 100% CPU across 12 cores while **per-process sampling accounted for only 26.4% of it** — the consumers were being created and destroyed between samples:

```
177 new processes in 16.6s  =  10.7 process creations/second
   51 x conhost.exe   40 x bash.exe   38 x electron.exe   32 x taskkill.exe

kernel (privileged) 57%   vs   user 46.1%
```

Kernel time exceeding user time is the signature — process creation is kernel work. One hive call costs four process creations (`bash` + `conhost` + `cmd` + `electron`), which accounts for all four of the top churn names at once.

Both hive scripts (`hive-proxy.cjs`, `cth-hook.cjs`) contain zero `require('electron')` — they are pure Node, so the Electron image buys nothing on a machine that has a usable `node`.

## The change

`writeNodeLauncher()` now prefers an absolute, new-enough system node, found through helpers that already exist in the codebase — `resolveCommand()` from `shellEnv` plus `detectNodeVersion()`/`nodeIsUsable()` from `nodeInstall` — and falls back to the Electron form unchanged when none is found. The probe is memoised because the launcher is rewritten on every bootstrap.

```diff
- `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`
+ node ? `@echo off\r\n"${node}" %*\r\n`
+      : `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`
```

**The 127-exit guarantee this launcher exists for is preserved.** A hook's bare `PATH=/usr/bin:/bin` has no nvm/volta/Homebrew node, and `resolveCommand` returns its argument UNCHANGED when nothing was found — so a bare `node` is explicitly rejected rather than baked in. On a machine with no usable node the generated file is byte-identical to before.

`writeRuntimeShims` is deliberately untouched: that directory is *appended* to PATH, so a user's own node already wins there, and Electron-as-node remains the correct last resort for a machine with no node at all.

## Results, measured under load

Same floor, agents actively working both times:

| Metric | Before | After |
|---|---|---|
| Process churn | 10.7/sec (4 agents) | 19.2/sec (5 agents + ephemeral workers) |
| `electron.exe` spawns in the churn mix | 38 per 16.6 s | **0** — now `node.exe` at the same rate |
| **Kernel (privileged) CPU** | **57%** | **7.2%** |
| User CPU | 46.1% | 6.4% |
| **Total system CPU** | **100%** | **13.9%** |

The churn rate went *up* — the patch reduces the cost per process creation, not the count — and the machine still dropped from pegged to 14%. The kernel-time signature that identified the problem is gone.

Confirmed in the running app rather than only in tests; the shim the app generates on bootstrap is now:

```bat
@echo off
"C:\Program Files\nodejs\node.exe" %*
```

with live hive calls observed going through it:

```
bash.exe -c "hive-node.cmd" "cth-hook.cjs" --status
node.exe "C:\Program Files\nodejs\node.exe" cth-hook.cjs --status
```

Caveat, stated plainly: the two runs are not a controlled A/B — different tasks and different background load — and a second change (scoping an MCP server out of global registration) landed on the same machine. The direction and the kernel/user split are unambiguous; the exact multiple is not.

## Tests

The existing test pinned the Electron form and so could not survive this. It now asserts the **contract** instead: the baked path must be absolute, must exist, must actually execute JavaScript, and must set `ELECTRON_RUN_AS_NODE=1` if and only if it baked Electron's own binary. It cannot branch on `process.execPath`, which under `node --test` is already node.

Verified on Windows 11 with Node 24.14.1:

- `npm run typecheck:node` — exit 0
- `test/hive-hook-node.test.cjs` — 9 pass, 0 fail, 3 skipped (POSIX-only)
- Full suite **with** this change: 834 tests — **794 pass, 32 fail**, 8 skipped
- Full suite **at HEAD without it**: 834 tests — **794 pass, 32 fail**, 8 skipped

Identical, so no regressions. The baseline was run explicitly rather than assumed; those 32 failures pre-exist and are mostly `EPERM: operation not permitted, symlink` on a box with no symlink privilege.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018G23U4REaWqqijR6ZXca5n
