### PR TITLE
feat: editable god command in onboarding

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -211,6 +211,11 @@ export interface HarnessConfig {
   /** The model GOD runs on. Unset falls back to the provider preset's
    *  `recommendedOrchestratorModel`, then MODEL_GOD. Default 'claude-opus-4-8'. */
   godModel?: string;
+  /** Hand-edited GOD spawn command from the onboarding orchestrator step (the
+   *  same editable-command affordance Add Agent offers per worker). Unset/empty
+   *  = build from godProvider/godModel/autoMode at spawn; a non-empty value is
+   *  the literal spawn string (per-agent override, Add Agent semantics). */
+  godCommand?: string;
   /** Per-server consent state for the default MCP bundle, keyed by catalog id.
    *  Seeded from MCP_CATALOG (safe-readonly ON, write/secret OFF); the user flips
    *  these in Settings. A server is wired into an agent only when enabled here. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -273,6 +273,9 @@ export interface HarnessConfig {
    *  'claude' / 'claude-opus-4-8'. Mirrors src/main/config.ts. */
   godProvider?: AgentProvider;
   godModel?: string;
+  /** Hand-edited GOD spawn command (onboarding orchestrator step). Unset/empty
+   *  = build from godProvider/godModel/autoMode at spawn. Mirrors src/main/config.ts. */
+  godCommand?: string;
   /** Per-server consent for the default MCP bundle, keyed by catalog id. Mirrors
    *  src/main/config.ts. */
   mcpDefaults?: { [id: string]: { enabled: boolean } };

--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -5,7 +5,7 @@ import { PixelButton } from './PixelButton';
 import { Icon, type IconName } from './Icon';
 import { SpritePortrait } from './SpritePortrait';
 import { ProviderLogo } from './ProviderLogo';
-import { modelsForProvider, onboardingEngineChoices, type AgentProvider, type HarnessConfig } from '@/store/config';
+import { modelsForProvider, onboardingEngineChoices, buildSpawnCommand, type AgentProvider, type HarnessConfig } from '@/store/config';
 import { providerPreset } from '@shared/agentProvider';
 import {
   classifyEngineAvailability, engineAvailabilityBadge, engineAvailabilityMessage, engineBlocksOnboarding
@@ -87,6 +87,18 @@ const PROVIDER_BLURB_KEYS: Partial<Record<AgentProvider, string>> = {
   cursor: 'onboarding.providerBlurb.cursor'
 };
 
+// The exact spawn string for the chosen god provider+model — the same
+// buildSpawnCommand Add Agent hires through, so the onboarding command input
+// previews what Michael will actually boot with. Onboarding has no stored
+// config yet, so the provider preset's own binary stands in for defaultCommand.
+function buildGodCommand(provider: AgentProvider, model: string | undefined, auto: boolean): string {
+  return buildSpawnCommand(
+    { defaultCommand: providerPreset(provider).defaultCommand, autoMode: auto },
+    model,
+    provider
+  );
+}
+
 export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const { t } = useTranslation();
   // Onboarding runs before god exists in the store, so read the persisted name.
@@ -107,6 +119,15 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const [godModel, setGodModel] = useState<string | undefined>(
     providerPreset('claude').recommendedOrchestratorModel
   );
+  // Editable spawn command ported from Add Agent's engine step (`opencode` for
+  // the opencode engine, editable to pin a model, auto mode, etc.). Untouched =
+  // undefined at finish() so the spawn builds from the CURRENT
+  // provider+model+autoMode (the permissions step after this one can still flip
+  // autoMode); the first hand-edit wins and later picks leave it alone.
+  const [godCommand, setGodCommand] = useState<string>(
+    buildGodCommand('claude', providerPreset('claude').recommendedOrchestratorModel, true)
+  );
+  const [commandTouched, setCommandTouched] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const [busy, setBusy] = useState(false);
 
@@ -224,6 +245,10 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
       autoMode,
       godProvider,
       godModel,
+      // A hand-edited command rides along as the god's per-agent override
+      // (Add Agent semantics); untouched stays undefined so useHive builds the
+      // spawn from the final provider+model+autoMode at boot.
+      godCommand: commandTouched ? (godCommand.trim() || undefined) : undefined,
       telemetryEnabled: shareStats
     });
     setBusy(false);
@@ -445,6 +470,9 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                             // Reset the model to the new provider's recommended pick so the
                             // dropdown below always shows a valid model for the chosen engine.
                             setGodModel(p.recommendedOrchestratorModel);
+                            // Keep the command preview in sync until the user hand-edits
+                            // it — first edit wins (Add Agent semantics).
+                            if (!commandTouched) setGodCommand(buildGodCommand(p.id, p.recommendedOrchestratorModel, autoMode));
                           }}
                           style={{ width: 16, height: 16, flexShrink: 0 }}
                         />
@@ -549,7 +577,11 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   <div style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>{t('onboarding.orchestrator.model')}</div>
                   <select
                     value={godModel ?? ''}
-                    onChange={(e) => setGodModel(e.target.value || undefined)}
+                    onChange={(e) => {
+                      const next = e.target.value || undefined;
+                      setGodModel(next);
+                      if (!commandTouched) setGodCommand(buildGodCommand(godProvider, next, autoMode));
+                    }}
                     style={inputStyle}
                   >
                     {modelsForProvider(godProvider).map((m) => (
@@ -559,6 +591,20 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   <div style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>
                     {t('onboarding.orchestrator.modelNote')}
                   </div>
+                </div>
+                {/* Editable spawn command, ported from Add Agent's engine step:
+                    same input, same i18n keys (addAgent.command/commandAuto —
+                    already translated, so no new locale keys), same source of
+                    truth for the actual spawn. */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <div style={{ fontSize: 12, color: 'var(--cth-ink-500)' }}>
+                    {autoMode && providerPreset(godProvider).autoFlag ? t('addAgent.commandAuto') : t('addAgent.command')}
+                  </div>
+                  <input
+                    value={godCommand}
+                    onChange={(e) => { setGodCommand(e.target.value); setCommandTouched(true); }}
+                    style={inputStyle}
+                  />
                 </div>
               </>
             )}

--- a/src/renderer/src/hooks/useHive.ts
+++ b/src/renderer/src/hooks/useHive.ts
@@ -398,7 +398,9 @@ export function useHive(config: HarnessConfig | null): void {
 
       const godProvider = config.godProvider ?? 'claude';
       const godModel = config.godModel;
-      const command = buildSpawnCommand(config, godModel, godProvider);
+      // A hand-edited onboarding command wins literally (same override semantics
+      // as a worker's per-agent command); otherwise build from provider+model.
+      const command = (config.godCommand ?? '').trim() || buildSpawnCommand(config, godModel, godProvider);
       const [exe, ...args] = tokenizeCommand(command.trim());
       const res = await window.cth.spawnPty({
         id: GOD_PTY,

--- a/src/renderer/src/store/config.ts
+++ b/src/renderer/src/store/config.ts
@@ -76,6 +76,11 @@ export interface HarnessConfig {
    *  'claude' / 'claude-opus-4-8'. Mirrors src/main/config.ts. */
   godProvider?: AgentProvider;
   godModel?: string;
+  /** Hand-edited GOD spawn command (onboarding orchestrator step). Unset/empty
+   *  = build from godProvider/godModel/autoMode at spawn; non-empty wins
+   *  literally (same override semantics as a worker's per-agent command).
+   *  Mirrors src/main/config.ts. */
+  godCommand?: string;
   /** Per-server consent for the default MCP bundle, keyed by catalog id (mirrors
    *  src/main/config.ts; seeded from MCP_CATALOG). */
   mcpDefaults?: { [id: string]: { enabled: boolean } };


### PR DESCRIPTION
## What & why

Adds an editable Agent command field to the OnboardingWizard orchestrator step, mirroring the existing Add Agent command override, for the first-run god agent. Adds an optional `godCommand` config key (undefined by default, so autoMode backend ordering is preserved) plus an honor-line so the god agent respects the saved command on subsequent runs.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

### Before

On main, the onboarding orchestrator step has no command field: the first-run god agent always uses the default command with no way to override it during setup.

### After

The orchestrator step shows an editable command field under the model selector, saved to the optional `godCommand` key and honored on later runs. No screenshots — headless environment, so visual diff is described honestly instead of faked.

## How I tested it

- OS: Linux (Omarchy)
- Steps:
  - `npm run typecheck` — passes (typecheck:node + typecheck:web clean)
  - `npm run test:focused` — passes (844 tests, 844 pass, 0 fail)

## Checklist

- [x] **Before and after evidence is attached above**, under both headings.
- [x] `npm run typecheck` passes.
- [x] `npm run test:focused` passes.
- [x] `npm run build` succeeds.
- [x] This PR is **one change**. Unrelated fixes belong in their own PR.
- [x] I read the diff myself before opening this, and there is no debug output, commented-out code, or unrelated formatting churn in it.
- [x] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors, spacing, or fonts.
- [x] If I added art, it's my own or compatibly licensed, and listed in `ATTRIBUTION.md`.