### PR TITLE
fix(linux): clamp window to display work area, bump version to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "munder-difflin",
-  "version": "0.4.6",
+  "version": "0.5.2",
   "private": true,
-  "description": "Clones for you and your team, working 24/7 — a free, local-first multi-agent harness that turns the CLI coding agent you already run into a clone of you, coordinating an office of agents on your machine.",
+  "description": "Clones for you and your team, working 24/7 \u2014 a free, local-first multi-agent harness that turns the CLI coding agent you already run into a clone of you, coordinating an office of agents on your machine.",
   "main": "out/main/index.js",
   "author": "Chaitanya Giri",
   "homepage": "https://munderdiffl.in/",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2127,18 +2127,34 @@ function stopWebhookServer(): void {
 /** The persisted main-window geometry (kv key `window.bounds`). */
 interface WindowBounds { x?: number; y?: number; width: number; height: number }
 
-const DEFAULT_WIN = { width: 1440, height: 900 };
-const MIN_WIN = { width: 1280, height: 800 };
+/** Absolute minimum the window can ever shrink to. */
+const MIN_WIN = { width: 900, height: 600 };
 
-/** Validate + clamp restored bounds: enforce the minimum size, and drop a
- *  position that no longer lands on any connected display (monitor unplugged) so
- *  the window can't open off-screen. Returns null for unusable input. */
+/** Compute the primary display's work area (excludes taskbars/panels).
+ *  Called lazily so `screen` is ready. Falls back to safe values if the
+ *  API is unavailable (e.g. headless CI). */
+function getWorkAreaBounds(): { width: number; height: number; wa: Electron.Rectangle } {
+  try {
+    const wa = screen.getPrimaryDisplay().workArea;
+    return { width: wa.width, height: wa.height, wa };
+  } catch {
+    return { width: 1280, height: 720, wa: { x: 0, y: 0, width: 1280, height: 720 } };
+  }
+}
+
+/** Validate + clamp restored bounds against the actual display work area so
+ *  that previously-saved oversized bounds can never produce a window that
+ *  overflows behind a taskbar on small screens (e.g. 1440×810 laptops).
+ *  Also enforces the absolute minimum size and drops a position that no
+ *  longer lands on any connected display. */
 function clampBounds(b: unknown): WindowBounds | null {
   if (!b || typeof b !== 'object') return null;
   const r = b as Partial<WindowBounds>;
   if (typeof r.width !== 'number' || typeof r.height !== 'number') return null;
-  const width = Math.max(MIN_WIN.width, Math.round(r.width));
-  const height = Math.max(MIN_WIN.height, Math.round(r.height));
+  // Cap to the current work area first, then enforce the absolute floor.
+  const { width: maxW, height: maxH } = getWorkAreaBounds();
+  const width  = Math.min(maxW, Math.max(MIN_WIN.width,  Math.round(r.width)));
+  const height = Math.min(maxH, Math.max(MIN_WIN.height, Math.round(r.height)));
   if (typeof r.x !== 'number' || typeof r.y !== 'number') return { width, height };
   const x = Math.round(r.x), y = Math.round(r.y);
   // Keep the position only if the window rect overlaps some display's work area.
@@ -2286,12 +2302,25 @@ function createWindow(opts: { floor?: boolean } = {}): BrowserWindow {
   const cascade = isFloor ? floorCascade() : null;
   const geom = cascade ?? saved;
 
+  // Derive initial size from the work area so the window always fits within
+  // the usable screen space (between taskbar panels) on any display, including
+  // small laptop screens like 1440×810 where system panels consume ~80 px.
+  const { width: waW, height: waH, wa } = getWorkAreaBounds();
+  const defaultW = Math.min(waW, 1440);
+  const defaultH = Math.min(waH, 900);
+  const initialW = Math.min(waW, geom?.width  ?? defaultW);
+  const initialH = Math.min(waH, geom?.height ?? defaultH);
+  // Centre in the work area when no saved position is available.
+  const initialX = (geom?.x !== undefined) ? geom.x : Math.round(wa.x + (waW - initialW) / 2);
+  const initialY = (geom?.y !== undefined) ? geom.y : Math.round(wa.y + (waH - initialH) / 2);
+
   const win = new BrowserWindow({
-    width: geom?.width ?? DEFAULT_WIN.width,
-    height: geom?.height ?? DEFAULT_WIN.height,
-    ...(geom && geom.x !== undefined && geom.y !== undefined ? { x: geom.x, y: geom.y } : {}),
+    width: initialW,
+    height: initialH,
+    x: initialX,
+    y: initialY,
     minWidth: MIN_WIN.width,
-    minHeight: MIN_WIN.height,
+    minHeight: Math.min(MIN_WIN.height, waH),
     title: isFloor ? 'Munder Difflin — Floor' : 'Munder Difflin',
     backgroundColor: '#FFF8E7',
     titleBarStyle: 'hiddenInset',


### PR DESCRIPTION
On small displays (e.g. 1440x810 laptops) the previous static defaults (DEFAULT_WIN: 1440x900, MIN_WIN: 1280x800) produced windows taller than the available work area after subtracting top/bottom system panels (~80px), causing the bottom AgentStrip and queue to be clipped behind the taskbar.

Changes:
- Remove static DEFAULT_WIN / MIN_WIN height constants
- Add getWorkAreaBounds() that reads screen.getPrimaryDisplay().workArea at runtime, so the limit always matches the actual usable screen pixels
- Fix clampBounds() to cap width/height to workArea (previously it only enforced a floor, never a ceiling — saved oversized bounds survived)
- Fix createWindow() to derive initial size from workArea and centre the window when no valid saved position exists
- Lower absolute minimum to 900x600 for more flexibility on small screens
- Bump package.json version from 0.4.6 to 0.5.2 to match the release tag

Fixes bottom-cutoff on 1440x810 and similar displays running Linux with visible taskbar panels (Zorin OS, Ubuntu, etc.).

<!-- Thanks for contributing to Munder Difflin.

     Read this line before you go further: a PR without a BEFORE and an AFTER
     is not reviewable and will not be merged. The `PR evidence` check runs the
     moment you open this and will tell you if it is missing. Keep the `Before`
     and `After` headings below exactly as they are — the check reads them. -->

## What & why

<!-- What changed, and why it needed to. Two or three sentences beats a
     bullet list of file names — we can read the diff, we cannot read your
     reasoning. If this fixes an issue, link it: Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Build / CI

## Evidence

<!-- REQUIRED. Drag images or a screen recording directly under each heading —
     GitHub uploads them inline. Both headings must have something under them.

     No visible UI? You still owe evidence. Record the failing behaviour and
     then the same steps passing: a terminal capture, a log diff, a test that
     goes from red to green. "It has no UI" is not an exemption.

     Truly nothing observable, like a CI tweak or a typo? Say so in
     "What & why" and ask a maintainer for the `no-visual-change` label. -->

### Before
<img width="1440" height="810" alt="before" src="https://github.com/user-attachments/assets/d7758e38-3a00-43c4-81f5-a59264e01ead" />


<!-- The problem, as it exists on main right now. -->

### After
<img width="1440" height="810" alt="after" src="https://github.com/user-attachments/assets/da0a3941-706c-429f-bc34-ada650d1c0ae" />


<!-- The same view or the same steps, with your change applied.
     Same window size, same theme, same data — a reviewer should be able to
     flip between the two and see only what you changed. -->

## How I tested it

<!-- The actual steps you ran, on which OS. Not "tested locally". -->

- OS:
- Steps:

## Credit (optional)

<!-- Both are optional and neither affects whether this merges.

     Discord gets you the `employee of the month` role when this lands. Join
     first so we can find you: https://discord.gg/SEDzP5ZPk5

     X is so we can credit you by name when we post about what shipped. Leave it
     blank if you would rather we did not. -->

Discord:

X:

## Checklist

- [ ] **Before and after evidence is attached above**, under both headings.
- [ ] `npm run typecheck` passes.
- [ ] `npm run test:focused` passes.
- [ ] `npm run build` succeeds.
- [ ] This PR is **one change**. Unrelated fixes belong in their own PR.
- [ ] I read the diff myself before opening this, and there is no debug output,
      commented-out code, or unrelated formatting churn in it.
- [ ] Any new UI derives from `DESIGN.md` / `tokens.ts` — no ad-hoc colors,
      spacing, or fonts.
- [ ] If I added art, it's my own or compatibly licensed, and listed in
      `ATTRIBUTION.md`.
